### PR TITLE
feat(distribution): add RegistryClient with auth framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,13 +3,19 @@
 version = 4
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
- "untrusted",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -26,10 +32,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -56,12 +74,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -77,7 +133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -87,10 +143,92 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "getrandom"
@@ -99,9 +237,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -109,6 +249,224 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "itoa"
@@ -122,8 +480,20 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -133,6 +503,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +525,18 @@ checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
@@ -155,7 +552,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -171,11 +568,41 @@ name = "ocync-distribution"
 version = "0.1.0"
 dependencies = [
  "aws-lc-rs",
+ "base64",
+ "dirs",
  "hex",
+ "olpc-cjson",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror",
+ "tokio",
+ "tracing",
+ "url",
 ]
+
+[[package]]
+name = "olpc-cjson"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083"
+dependencies = [
+ "serde",
+ "serde_json",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -201,10 +628,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -213,6 +664,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -231,6 +737,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rand"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +773,125 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted 0.9.0",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scopeguard"
@@ -289,6 +943,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +971,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,8 +989,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -329,6 +1013,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -352,6 +1056,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,7 +1094,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -380,16 +1109,163 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -407,10 +1283,125 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
 
 [[package]]
 name = "windows-sys"
@@ -422,16 +1413,248 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,25 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +107,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,20 +142,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "errno"
-version = "0.3.14"
+name = "equivalent"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -136,12 +175,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -149,6 +204,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -185,6 +251,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -221,6 +288,37 @@ dependencies = [
  "wasip2",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -268,6 +366,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,9 +381,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -431,6 +537,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +591,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,15 +607,6 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -525,6 +638,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "ocync"
 version = "0.1.0"
 dependencies = [
@@ -546,6 +669,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "wiremock",
 ]
 
 [[package]]
@@ -553,29 +677,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -716,13 +817,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
+name = "regex"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
- "bitflags",
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -833,12 +954,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,16 +1013,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
 
 [[package]]
 name = "slab"
@@ -1028,9 +1133,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -1452,6 +1555,29 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
- "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -86,27 +85,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -503,15 +481,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,9 +538,7 @@ version = "0.1.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
- "dirs",
  "hex",
- "olpc-cjson",
  "reqwest",
  "serde",
  "serde_json",
@@ -582,27 +549,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "olpc-cjson"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083"
-dependencies = [
- "serde",
- "serde_json",
- "unicode-normalization",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -775,17 +725,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,7 +775,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -878,7 +817,7 @@ checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -1183,19 +1122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1218,21 +1145,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,12 @@ license = "Apache-2.0"
 repository = "https://github.com/clowdhaus/ocync"
 
 [workspace.dependencies]
-aws-lc-rs = "1"
-hex = "0.4"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-thiserror = "2"
-tokio = { version = "1", features = ["full"] }
+aws-lc-rs = { version = "1", default-features = false, features = ["aws-lc-sys"] }
+hex = { version = "0.4", default-features = false, features = ["alloc"] }
+serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
+serde_json = { version = "1", default-features = false, features = ["alloc"] }
+thiserror = { version = "2", default-features = false }
+tokio = { version = "1", default-features = false }
 ocync-distribution = { path = "crates/ocync-distribution" }
 
 [workspace.lints.rust]
@@ -43,4 +43,4 @@ workspace = true
 
 [dependencies]
 ocync-distribution.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/ocync-distribution/Cargo.toml
+++ b/crates/ocync-distribution/Cargo.toml
@@ -12,17 +12,15 @@ workspace = true
 
 [dependencies]
 aws-lc-rs.workspace = true
+base64 = { version = "0.22", default-features = false, features = ["alloc"] }
 hex.workspace = true
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-olpc-cjson = "0.1"
-tracing = "0.1"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
 tokio = { workspace = true, features = ["sync", "time"] }
-base64 = "0.22"
-dirs = "6"
-url = "2"
+tracing = { version = "0.1", default-features = false }
+url = { version = "2", default-features = false }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/ocync-distribution/Cargo.toml
+++ b/crates/ocync-distribution/Cargo.toml
@@ -24,4 +24,4 @@ url = { version = "2", default-features = false }
 
 [dev-dependencies]
 serde_json.workspace = true
-tokio = { workspace = true, features = ["full", "test-util"] }
+tokio = { workspace = true, features = ["sync", "time", "test-util", "macros", "rt"] }

--- a/crates/ocync-distribution/Cargo.toml
+++ b/crates/ocync-distribution/Cargo.toml
@@ -24,4 +24,5 @@ url = { version = "2", default-features = false }
 
 [dev-dependencies]
 serde_json.workspace = true
-tokio = { workspace = true, features = ["sync", "time", "test-util", "macros", "rt"] }
+tokio = { workspace = true, features = ["sync", "time", "test-util", "macros", "rt-multi-thread"] }
+wiremock = "0.6"

--- a/crates/ocync-distribution/Cargo.toml
+++ b/crates/ocync-distribution/Cargo.toml
@@ -16,9 +16,8 @@ hex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-olpc-cjson.workspace = true
-tracing.workspace = true
-hex = "0.4"
+olpc-cjson = "0.1"
+tracing = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
 tokio = { workspace = true, features = ["sync", "time"] }
 base64 = "0.22"

--- a/crates/ocync-distribution/Cargo.toml
+++ b/crates/ocync-distribution/Cargo.toml
@@ -16,6 +16,15 @@ hex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+olpc-cjson.workspace = true
+tracing.workspace = true
+hex = "0.4"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
+tokio = { workspace = true, features = ["sync", "time"] }
+base64 = "0.22"
+dirs = "6"
+url = "2"
 
 [dev-dependencies]
 serde_json.workspace = true
+tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/ocync-distribution/src/auth/anonymous.rs
+++ b/crates/ocync-distribution/src/auth/anonymous.rs
@@ -1,0 +1,1 @@
+// Anonymous auth provider — implemented in next commit.

--- a/crates/ocync-distribution/src/auth/anonymous.rs
+++ b/crates/ocync-distribution/src/auth/anonymous.rs
@@ -1,3 +1,5 @@
+use std::future::Future;
+use std::pin::Pin;
 use std::time::Duration;
 
 use serde::Deserialize;
@@ -35,7 +37,17 @@ impl AuthProvider for AnonymousAuth {
         "anonymous"
     }
 
-    async fn get_token(&self, scopes: &[Scope]) -> Result<Token, DistributionError> {
+    fn get_token(
+        &self,
+        scopes: &[Scope],
+    ) -> Pin<Box<dyn Future<Output = Result<Token, DistributionError>> + Send + '_>> {
+        let scopes = scopes.to_vec();
+        Box::pin(async move { self.get_token_inner(&scopes).await })
+    }
+}
+
+impl AnonymousAuth {
+    async fn get_token_inner(&self, scopes: &[Scope]) -> Result<Token, DistributionError> {
         // Check cached token first.
         {
             let cached = self.cached_token.read().await;
@@ -57,9 +69,7 @@ impl AuthProvider for AnonymousAuth {
 
         Ok(token)
     }
-}
 
-impl AnonymousAuth {
     /// Ping the registry's `/v2/` endpoint, parse the WWW-Authenticate header,
     /// then exchange for a token.
     async fn exchange_token(&self, scopes: &[Scope]) -> Result<Token, DistributionError> {

--- a/crates/ocync-distribution/src/auth/anonymous.rs
+++ b/crates/ocync-distribution/src/auth/anonymous.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use tokio::sync::RwLock;
 
 use super::{AuthProvider, Scope, Token};
-use crate::error::DistributionError;
+use crate::error::Error;
 
 /// Anonymous auth provider that performs the Docker token-exchange flow.
 ///
@@ -22,7 +22,16 @@ pub struct AnonymousAuth {
     cached_token: RwLock<Option<Token>>,
 }
 
+impl std::fmt::Debug for AnonymousAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AnonymousAuth")
+            .field("registry", &self.registry)
+            .finish_non_exhaustive()
+    }
+}
+
 impl AnonymousAuth {
+    /// Create a new anonymous auth provider for the given registry.
     pub fn new(registry: impl Into<String>, http: reqwest::Client) -> Self {
         Self {
             registry: registry.into(),
@@ -40,14 +49,14 @@ impl AuthProvider for AnonymousAuth {
     fn get_token(
         &self,
         scopes: &[Scope],
-    ) -> Pin<Box<dyn Future<Output = Result<Token, DistributionError>> + Send + '_>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Token, Error>> + Send + '_>> {
         let scopes = scopes.to_vec();
         Box::pin(async move { self.get_token_inner(&scopes).await })
     }
 }
 
 impl AnonymousAuth {
-    async fn get_token_inner(&self, scopes: &[Scope]) -> Result<Token, DistributionError> {
+    async fn get_token_inner(&self, scopes: &[Scope]) -> Result<Token, Error> {
         // Check cached token first.
         {
             let cached = self.cached_token.read().await;
@@ -72,7 +81,7 @@ impl AnonymousAuth {
 
     /// Ping the registry's `/v2/` endpoint, parse the WWW-Authenticate header,
     /// then exchange for a token.
-    async fn exchange_token(&self, scopes: &[Scope]) -> Result<Token, DistributionError> {
+    async fn exchange_token(&self, scopes: &[Scope]) -> Result<Token, Error> {
         let v2_url = format!("https://{}/v2/", self.registry);
         let resp = self.http.get(&v2_url).send().await?;
 
@@ -85,23 +94,21 @@ impl AnonymousAuth {
             .headers()
             .get("www-authenticate")
             .and_then(|v| v.to_str().ok())
-            .ok_or_else(|| DistributionError::AuthFailed {
+            .ok_or_else(|| Error::AuthFailed {
                 registry: self.registry.clone(),
                 reason: "401 response missing WWW-Authenticate header".into(),
             })?;
 
-        let challenge =
-            WwwAuthenticate::parse(www_auth).map_err(|reason| DistributionError::AuthFailed {
-                registry: self.registry.clone(),
-                reason,
-            })?;
+        let challenge = WwwAuthenticate::parse(www_auth).map_err(|reason| Error::AuthFailed {
+            registry: self.registry.clone(),
+            reason,
+        })?;
 
         // Build token request URL.
-        let mut url =
-            reqwest::Url::parse(&challenge.realm).map_err(|e| DistributionError::AuthFailed {
-                registry: self.registry.clone(),
-                reason: format!("invalid realm URL: {e}"),
-            })?;
+        let mut url = reqwest::Url::parse(&challenge.realm).map_err(|e| Error::AuthFailed {
+            registry: self.registry.clone(),
+            reason: format!("invalid realm URL: {e}"),
+        })?;
 
         {
             let mut query = url.query_pairs_mut();
@@ -125,7 +132,7 @@ impl AnonymousAuth {
         let token_value = token_resp
             .token
             .or(token_resp.access_token)
-            .ok_or_else(|| DistributionError::AuthFailed {
+            .ok_or_else(|| Error::AuthFailed {
                 registry: self.registry.clone(),
                 reason: "token response missing both 'token' and 'access_token' fields".into(),
             })?;

--- a/crates/ocync-distribution/src/auth/anonymous.rs
+++ b/crates/ocync-distribution/src/auth/anonymous.rs
@@ -1,3 +1,5 @@
+//! Anonymous auth provider using the Docker token-exchange flow.
+
 use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;

--- a/crates/ocync-distribution/src/auth/anonymous.rs
+++ b/crates/ocync-distribution/src/auth/anonymous.rs
@@ -1,11 +1,12 @@
 //! Anonymous auth provider using the Docker token-exchange flow.
 
+use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
 
 use serde::Deserialize;
-use tokio::sync::RwLock;
+use tokio::sync::Mutex;
 
 use super::{AuthProvider, Scope, Token};
 use crate::error::Error;
@@ -14,32 +15,55 @@ use crate::error::Error;
 ///
 /// When a registry responds with `401 Unauthorized` and a `WWW-Authenticate: Bearer ...`
 /// header, this provider extracts the realm/service and exchanges them for an anonymous
-/// token. Tokens are cached until they expire or need refreshing.
+/// token. Tokens are cached per-scope and coalesced under a mutex to prevent thundering
+/// herd.
 pub struct AnonymousAuth {
-    /// The registry host (e.g. `registry-1.docker.io`).
-    registry: String,
+    /// The registry base URL (e.g. `https://registry-1.docker.io`).
+    base_url: String,
     /// HTTP client for token requests.
     http: reqwest::Client,
-    /// Cached token (shared across concurrent requests).
-    cached_token: RwLock<Option<Token>>,
+    /// Cached tokens keyed by sorted scope strings.
+    cache: Mutex<HashMap<String, Token>>,
 }
 
 impl std::fmt::Debug for AnonymousAuth {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AnonymousAuth")
-            .field("registry", &self.registry)
+            .field("base_url", &self.base_url)
             .finish_non_exhaustive()
     }
 }
 
 impl AnonymousAuth {
-    /// Create a new anonymous auth provider for the given registry.
+    /// Create a new anonymous auth provider for the given registry hostname.
+    ///
+    /// Uses HTTPS by default. For non-HTTPS registries (e.g. local development),
+    /// use [`AnonymousAuth::with_base_url`].
     pub fn new(registry: impl Into<String>, http: reqwest::Client) -> Self {
+        let registry = registry.into();
         Self {
-            registry: registry.into(),
+            base_url: format!("https://{registry}"),
             http,
-            cached_token: RwLock::new(None),
+            cache: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Create a new anonymous auth provider with an explicit base URL.
+    ///
+    /// Use this for registries that don't use HTTPS (e.g. `http://localhost:5000`).
+    pub fn with_base_url(base_url: impl Into<String>, http: reqwest::Client) -> Self {
+        Self {
+            base_url: base_url.into(),
+            http,
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Build a cache key from a set of scopes.
+    fn cache_key(scopes: &[Scope]) -> String {
+        let mut parts: Vec<String> = scopes.iter().map(|s| s.to_string()).collect();
+        parts.sort();
+        parts.join(" ")
     }
 }
 
@@ -55,28 +79,32 @@ impl AuthProvider for AnonymousAuth {
         let scopes = scopes.to_vec();
         Box::pin(async move { self.get_token_inner(&scopes).await })
     }
+
+    fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async move {
+            let mut cache = self.cache.lock().await;
+            cache.clear();
+        })
+    }
 }
 
 impl AnonymousAuth {
     async fn get_token_inner(&self, scopes: &[Scope]) -> Result<Token, Error> {
-        // Check cached token first.
-        {
-            let cached = self.cached_token.read().await;
-            if let Some(ref token) = *cached {
-                if !token.should_refresh() {
-                    return Ok(token.clone());
-                }
+        let key = Self::cache_key(scopes);
+
+        // Hold the mutex for the entire check-then-fetch to prevent thundering herd.
+        let mut cache = self.cache.lock().await;
+
+        // Check cache with scope awareness.
+        if let Some(token) = cache.get(&key) {
+            if !token.should_refresh() {
+                return Ok(token.clone());
             }
         }
 
         // Need a fresh token — perform the exchange.
         let token = self.exchange_token(scopes).await?;
-
-        // Cache it.
-        {
-            let mut cached = self.cached_token.write().await;
-            *cached = Some(token.clone());
-        }
+        cache.insert(key, token.clone());
 
         Ok(token)
     }
@@ -84,7 +112,7 @@ impl AnonymousAuth {
     /// Ping the registry's `/v2/` endpoint, parse the WWW-Authenticate header,
     /// then exchange for a token.
     async fn exchange_token(&self, scopes: &[Scope]) -> Result<Token, Error> {
-        let v2_url = format!("https://{}/v2/", self.registry);
+        let v2_url = format!("{}/v2/", self.base_url);
         let resp = self.http.get(&v2_url).send().await?;
 
         if resp.status().is_success() {
@@ -97,18 +125,18 @@ impl AnonymousAuth {
             .get("www-authenticate")
             .and_then(|v| v.to_str().ok())
             .ok_or_else(|| Error::AuthFailed {
-                registry: self.registry.clone(),
+                registry: self.base_url.clone(),
                 reason: "401 response missing WWW-Authenticate header".into(),
             })?;
 
         let challenge = WwwAuthenticate::parse(www_auth).map_err(|reason| Error::AuthFailed {
-            registry: self.registry.clone(),
+            registry: self.base_url.clone(),
             reason,
         })?;
 
         // Build token request URL.
         let mut url = reqwest::Url::parse(&challenge.realm).map_err(|e| Error::AuthFailed {
-            registry: self.registry.clone(),
+            registry: self.base_url.clone(),
             reason: format!("invalid realm URL: {e}"),
         })?;
 
@@ -135,7 +163,7 @@ impl AnonymousAuth {
             .token
             .or(token_resp.access_token)
             .ok_or_else(|| Error::AuthFailed {
-                registry: self.registry.clone(),
+                registry: self.base_url.clone(),
                 reason: "token response missing both 'token' and 'access_token' fields".into(),
             })?;
 
@@ -150,22 +178,25 @@ impl AnonymousAuth {
 
 /// Parsed `WWW-Authenticate: Bearer realm="...",service="..."` header.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WwwAuthenticate {
+struct WwwAuthenticate {
     /// The token endpoint URL.
-    pub realm: String,
+    realm: String,
     /// The service name (optional).
-    pub service: Option<String>,
+    service: Option<String>,
 }
 
 impl WwwAuthenticate {
     /// Parse a `WWW-Authenticate` header value.
     ///
     /// Only `Bearer` challenges are supported. Returns an error string on failure.
-    pub fn parse(header: &str) -> Result<Self, String> {
+    fn parse(header: &str) -> Result<Self, String> {
         let header = header.trim();
 
         // Must start with "Bearer " (case-insensitive).
-        if !header[..6].eq_ignore_ascii_case("bearer") || header.as_bytes().get(6) != Some(&b' ') {
+        if header.len() < 7
+            || !header[..6].eq_ignore_ascii_case("bearer")
+            || header.as_bytes()[6] != b' '
+        {
             return Err(format!(
                 "unsupported WWW-Authenticate scheme (expected Bearer): {header}"
             ));
@@ -218,13 +249,13 @@ fn split_params(s: &str) -> Vec<&str> {
 
 /// Token response from a registry auth endpoint.
 #[derive(Debug, Deserialize)]
-pub struct TokenResponse {
+struct TokenResponse {
     /// The token (Docker Hub uses this field).
-    pub token: Option<String>,
+    token: Option<String>,
     /// Alternative field name (some registries use this).
-    pub access_token: Option<String>,
+    access_token: Option<String>,
     /// Token lifetime in seconds.
-    pub expires_in: Option<u64>,
+    expires_in: Option<u64>,
 }
 
 #[cfg(test)]
@@ -308,5 +339,55 @@ mod tests {
         let parts = split_params(r#"realm="https://example.com/a,b",service="test""#);
         assert_eq!(parts.len(), 2);
         assert!(parts[0].contains("a,b"));
+    }
+
+    #[test]
+    fn parse_www_authenticate_empty_string() {
+        let result = WwwAuthenticate::parse("");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_www_authenticate_short_strings() {
+        for input in ["B", "Be", "Bea", "Bear", "Beare", "Bearer"] {
+            let result = WwwAuthenticate::parse(input);
+            assert!(result.is_err(), "expected Err for input: {input:?}");
+        }
+    }
+
+    #[test]
+    fn parse_www_authenticate_whitespace_only() {
+        let result = WwwAuthenticate::parse("   ");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_www_authenticate_bearer_space_only() {
+        // "Bearer " trims to "Bearer" (6 chars) — rejected as too short
+        let result = WwwAuthenticate::parse("Bearer ");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_www_authenticate_with_scope_param() {
+        let header = r#"Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:library/nginx:pull""#;
+        let parsed = WwwAuthenticate::parse(header).unwrap();
+        assert_eq!(parsed.realm, "https://auth.docker.io/token");
+        assert_eq!(parsed.service.as_deref(), Some("registry.docker.io"));
+    }
+
+    #[test]
+    fn parse_www_authenticate_extra_whitespace() {
+        let header = r#"Bearer  realm="https://auth.example.com/token" , service="svc" "#;
+        let parsed = WwwAuthenticate::parse(header).unwrap();
+        assert_eq!(parsed.realm, "https://auth.example.com/token");
+        assert_eq!(parsed.service.as_deref(), Some("svc"));
+    }
+
+    #[test]
+    fn parse_www_authenticate_realm_with_query_params() {
+        let header = r#"Bearer realm="https://auth.example.com/token?foo=bar&baz=1",service="svc""#;
+        let parsed = WwwAuthenticate::parse(header).unwrap();
+        assert!(parsed.realm.contains("foo=bar"));
     }
 }

--- a/crates/ocync-distribution/src/auth/anonymous.rs
+++ b/crates/ocync-distribution/src/auth/anonymous.rs
@@ -1,1 +1,293 @@
-// Anonymous auth provider — implemented in next commit.
+use std::time::Duration;
+
+use serde::Deserialize;
+use tokio::sync::RwLock;
+
+use super::{AuthProvider, Scope, Token};
+use crate::error::DistributionError;
+
+/// Anonymous auth provider that performs the Docker token-exchange flow.
+///
+/// When a registry responds with `401 Unauthorized` and a `WWW-Authenticate: Bearer ...`
+/// header, this provider extracts the realm/service and exchanges them for an anonymous
+/// token. Tokens are cached until they expire or need refreshing.
+pub struct AnonymousAuth {
+    /// The registry host (e.g. `registry-1.docker.io`).
+    registry: String,
+    /// HTTP client for token requests.
+    http: reqwest::Client,
+    /// Cached token (shared across concurrent requests).
+    cached_token: RwLock<Option<Token>>,
+}
+
+impl AnonymousAuth {
+    pub fn new(registry: impl Into<String>, http: reqwest::Client) -> Self {
+        Self {
+            registry: registry.into(),
+            http,
+            cached_token: RwLock::new(None),
+        }
+    }
+}
+
+impl AuthProvider for AnonymousAuth {
+    fn name(&self) -> &'static str {
+        "anonymous"
+    }
+
+    async fn get_token(&self, scopes: &[Scope]) -> Result<Token, DistributionError> {
+        // Check cached token first.
+        {
+            let cached = self.cached_token.read().await;
+            if let Some(ref token) = *cached {
+                if !token.should_refresh() {
+                    return Ok(token.clone());
+                }
+            }
+        }
+
+        // Need a fresh token — perform the exchange.
+        let token = self.exchange_token(scopes).await?;
+
+        // Cache it.
+        {
+            let mut cached = self.cached_token.write().await;
+            *cached = Some(token.clone());
+        }
+
+        Ok(token)
+    }
+}
+
+impl AnonymousAuth {
+    /// Ping the registry's `/v2/` endpoint, parse the WWW-Authenticate header,
+    /// then exchange for a token.
+    async fn exchange_token(&self, scopes: &[Scope]) -> Result<Token, DistributionError> {
+        let v2_url = format!("https://{}/v2/", self.registry);
+        let resp = self.http.get(&v2_url).send().await?;
+
+        if resp.status().is_success() {
+            // No auth required — return a dummy token.
+            return Ok(Token::new(""));
+        }
+
+        let www_auth = resp
+            .headers()
+            .get("www-authenticate")
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| DistributionError::AuthFailed {
+                registry: self.registry.clone(),
+                reason: "401 response missing WWW-Authenticate header".into(),
+            })?;
+
+        let challenge =
+            WwwAuthenticate::parse(www_auth).map_err(|reason| DistributionError::AuthFailed {
+                registry: self.registry.clone(),
+                reason,
+            })?;
+
+        // Build token request URL.
+        let mut url =
+            reqwest::Url::parse(&challenge.realm).map_err(|e| DistributionError::AuthFailed {
+                registry: self.registry.clone(),
+                reason: format!("invalid realm URL: {e}"),
+            })?;
+
+        {
+            let mut query = url.query_pairs_mut();
+            if let Some(ref service) = challenge.service {
+                query.append_pair("service", service);
+            }
+            for scope in scopes {
+                query.append_pair("scope", &scope.to_string());
+            }
+        }
+
+        let token_resp = self
+            .http
+            .get(url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<TokenResponse>()
+            .await?;
+
+        let token_value = token_resp
+            .token
+            .or(token_resp.access_token)
+            .ok_or_else(|| DistributionError::AuthFailed {
+                registry: self.registry.clone(),
+                reason: "token response missing both 'token' and 'access_token' fields".into(),
+            })?;
+
+        let token = match token_resp.expires_in {
+            Some(secs) if secs > 0 => Token::with_ttl(token_value, Duration::from_secs(secs)),
+            _ => Token::new(token_value),
+        };
+
+        Ok(token)
+    }
+}
+
+/// Parsed `WWW-Authenticate: Bearer realm="...",service="..."` header.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WwwAuthenticate {
+    /// The token endpoint URL.
+    pub realm: String,
+    /// The service name (optional).
+    pub service: Option<String>,
+}
+
+impl WwwAuthenticate {
+    /// Parse a `WWW-Authenticate` header value.
+    ///
+    /// Only `Bearer` challenges are supported. Returns an error string on failure.
+    pub fn parse(header: &str) -> Result<Self, String> {
+        let header = header.trim();
+
+        // Must start with "Bearer " (case-insensitive).
+        if !header[..6].eq_ignore_ascii_case("bearer") || header.as_bytes().get(6) != Some(&b' ') {
+            return Err(format!(
+                "unsupported WWW-Authenticate scheme (expected Bearer): {header}"
+            ));
+        }
+
+        let params = &header[7..];
+        let mut realm = None;
+        let mut service = None;
+
+        for part in split_params(params) {
+            let part = part.trim();
+            if let Some((key, value)) = part.split_once('=') {
+                let key = key.trim().to_ascii_lowercase();
+                let value = value.trim().trim_matches('"');
+                match key.as_str() {
+                    "realm" => realm = Some(value.to_owned()),
+                    "service" => service = Some(value.to_owned()),
+                    _ => {} // Ignore unknown parameters.
+                }
+            }
+        }
+
+        let realm = realm.ok_or("WWW-Authenticate Bearer missing 'realm' parameter")?;
+
+        Ok(Self { realm, service })
+    }
+}
+
+/// Split parameter string on commas, respecting quoted strings.
+fn split_params(s: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut in_quotes = false;
+
+    for (i, ch) in s.char_indices() {
+        match ch {
+            '"' => in_quotes = !in_quotes,
+            ',' if !in_quotes => {
+                parts.push(&s[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    if start < s.len() {
+        parts.push(&s[start..]);
+    }
+    parts
+}
+
+/// Token response from a registry auth endpoint.
+#[derive(Debug, Deserialize)]
+pub struct TokenResponse {
+    /// The token (Docker Hub uses this field).
+    pub token: Option<String>,
+    /// Alternative field name (some registries use this).
+    pub access_token: Option<String>,
+    /// Token lifetime in seconds.
+    pub expires_in: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_www_authenticate_bearer() {
+        let header = r#"Bearer realm="https://auth.docker.io/token",service="registry.docker.io""#;
+        let parsed = WwwAuthenticate::parse(header).unwrap();
+        assert_eq!(parsed.realm, "https://auth.docker.io/token");
+        assert_eq!(parsed.service.as_deref(), Some("registry.docker.io"));
+    }
+
+    #[test]
+    fn parse_www_authenticate_no_service() {
+        let header = r#"Bearer realm="https://ghcr.io/token""#;
+        let parsed = WwwAuthenticate::parse(header).unwrap();
+        assert_eq!(parsed.realm, "https://ghcr.io/token");
+        assert!(parsed.service.is_none());
+    }
+
+    #[test]
+    fn parse_www_authenticate_case_insensitive() {
+        let header = r#"BEARER realm="https://auth.example.com/token",service="example""#;
+        let parsed = WwwAuthenticate::parse(header).unwrap();
+        assert_eq!(parsed.realm, "https://auth.example.com/token");
+        assert_eq!(parsed.service.as_deref(), Some("example"));
+    }
+
+    #[test]
+    fn parse_www_authenticate_basic_is_error() {
+        let header = r#"Basic realm="Registry""#;
+        let result = WwwAuthenticate::parse(header);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("unsupported"));
+    }
+
+    #[test]
+    fn parse_www_authenticate_missing_realm() {
+        let header = r#"Bearer service="registry.docker.io""#;
+        let result = WwwAuthenticate::parse(header);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("realm"));
+    }
+
+    #[test]
+    fn token_response_with_token_field() {
+        let json = r#"{"token": "abc123", "expires_in": 300}"#;
+        let resp: TokenResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.token.as_deref(), Some("abc123"));
+        assert!(resp.access_token.is_none());
+        assert_eq!(resp.expires_in, Some(300));
+    }
+
+    #[test]
+    fn token_response_with_access_token_field() {
+        let json = r#"{"access_token": "xyz789"}"#;
+        let resp: TokenResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.token.is_none());
+        assert_eq!(resp.access_token.as_deref(), Some("xyz789"));
+        assert!(resp.expires_in.is_none());
+    }
+
+    #[test]
+    fn token_response_with_both_fields() {
+        let json = r#"{"token": "primary", "access_token": "fallback", "expires_in": 600}"#;
+        let resp: TokenResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.token.as_deref(), Some("primary"));
+        assert_eq!(resp.access_token.as_deref(), Some("fallback"));
+    }
+
+    #[test]
+    fn split_params_basic() {
+        let parts = split_params(r#"realm="https://example.com",service="test""#);
+        assert_eq!(parts.len(), 2);
+    }
+
+    #[test]
+    fn split_params_with_comma_in_quotes() {
+        let parts = split_params(r#"realm="https://example.com/a,b",service="test""#);
+        assert_eq!(parts.len(), 2);
+        assert!(parts[0].contains("a,b"));
+    }
+}

--- a/crates/ocync-distribution/src/auth/docker.rs
+++ b/crates/ocync-distribution/src/auth/docker.rs
@@ -1,0 +1,1 @@
+// Docker config auth — implemented in a later commit.

--- a/crates/ocync-distribution/src/auth/docker.rs
+++ b/crates/ocync-distribution/src/auth/docker.rs
@@ -7,7 +7,7 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use serde::Deserialize;
 
 use super::Credentials;
-use crate::error::DistributionError;
+use crate::error::Error;
 
 /// Docker Hub hostnames that all resolve to the same credential entry.
 const DOCKER_HUB_ALIASES: &[&str] = &[
@@ -46,22 +46,22 @@ pub struct AuthEntry {
 
 impl DockerConfig {
     /// Load from the default Docker config path (`~/.docker/config.json`).
-    pub fn load_default() -> Result<Self, DistributionError> {
+    pub fn load_default() -> Result<Self, Error> {
         let path = default_config_path()
-            .ok_or_else(|| DistributionError::Other("unable to determine home directory".into()))?;
+            .ok_or_else(|| Error::Other("unable to determine home directory".into()))?;
         Self::load_from(&path)
     }
 
     /// Load from a specific file path.
-    pub fn load_from(path: &Path) -> Result<Self, DistributionError> {
+    pub fn load_from(path: &Path) -> Result<Self, Error> {
         let contents = std::fs::read_to_string(path).map_err(|e| {
-            DistributionError::Other(format!(
+            Error::Other(format!(
                 "failed to read docker config at {}: {e}",
                 path.display()
             ))
         })?;
         serde_json::from_str(&contents).map_err(|e| {
-            DistributionError::Other(format!(
+            Error::Other(format!(
                 "failed to parse docker config at {}: {e}",
                 path.display()
             ))
@@ -76,7 +76,7 @@ impl DockerConfig {
 pub fn resolve_from_docker_config(
     config: &DockerConfig,
     registry: &str,
-) -> Result<Option<Credentials>, DistributionError> {
+) -> Result<Option<Credentials>, Error> {
     // Try static auths first.
     if let Some(creds) = lookup_auths(config, registry)? {
         return Ok(Some(creds));
@@ -107,10 +107,7 @@ pub fn resolve_from_docker_config(
 }
 
 /// Look up static credentials from the `auths` map.
-fn lookup_auths(
-    config: &DockerConfig,
-    registry: &str,
-) -> Result<Option<Credentials>, DistributionError> {
+fn lookup_auths(config: &DockerConfig, registry: &str) -> Result<Option<Credentials>, Error> {
     // Direct match.
     if let Some(entry) = config.auths.get(registry) {
         if let Some(creds) = entry_to_credentials(entry)? {
@@ -160,7 +157,7 @@ fn lookup_cred_helper(config: &DockerConfig, registry: &str) -> Option<String> {
 }
 
 /// Convert an `AuthEntry` to `Credentials`.
-fn entry_to_credentials(entry: &AuthEntry) -> Result<Option<Credentials>, DistributionError> {
+fn entry_to_credentials(entry: &AuthEntry) -> Result<Option<Credentials>, Error> {
     // Prefer the `auth` field (base64 encoded).
     if let Some(ref encoded) = entry.auth {
         if !encoded.is_empty() {
@@ -181,25 +178,21 @@ fn entry_to_credentials(entry: &AuthEntry) -> Result<Option<Credentials>, Distri
 }
 
 /// Decode a base64-encoded `username:password` string.
-pub fn decode_auth(encoded: &str) -> Result<(String, String), DistributionError> {
-    let decoded = BASE64
-        .decode(encoded)
-        .map_err(|e| DistributionError::AuthFailed {
-            registry: String::new(),
-            reason: format!("invalid base64 in auth field: {e}"),
-        })?;
+pub fn decode_auth(encoded: &str) -> Result<(String, String), Error> {
+    let decoded = BASE64.decode(encoded).map_err(|e| Error::AuthFailed {
+        registry: String::new(),
+        reason: format!("invalid base64 in auth field: {e}"),
+    })?;
 
-    let text = String::from_utf8(decoded).map_err(|e| DistributionError::AuthFailed {
+    let text = String::from_utf8(decoded).map_err(|e| Error::AuthFailed {
         registry: String::new(),
         reason: format!("auth field is not valid UTF-8: {e}"),
     })?;
 
-    let (username, password) =
-        text.split_once(':')
-            .ok_or_else(|| DistributionError::AuthFailed {
-                registry: String::new(),
-                reason: "auth field does not contain ':'".into(),
-            })?;
+    let (username, password) = text.split_once(':').ok_or_else(|| Error::AuthFailed {
+        registry: String::new(),
+        reason: "auth field does not contain ':'".into(),
+    })?;
 
     Ok((username.to_owned(), password.to_owned()))
 }
@@ -207,7 +200,7 @@ pub fn decode_auth(encoded: &str) -> Result<(String, String), DistributionError>
 /// Execute a Docker credential helper and return the credentials.
 ///
 /// Runs `docker-credential-{helper} get` with the registry on stdin.
-fn run_credential_helper(helper: &str, registry: &str) -> Result<Credentials, DistributionError> {
+fn run_credential_helper(helper: &str, registry: &str) -> Result<Credentials, Error> {
     let program = format!("docker-credential-{helper}");
 
     let output = Command::new(&program)
@@ -223,14 +216,14 @@ fn run_credential_helper(helper: &str, registry: &str) -> Result<Credentials, Di
             }
             child.wait_with_output()
         })
-        .map_err(|e| DistributionError::CredentialHelperFailed {
+        .map_err(|e| Error::CredentialHelperFailed {
             helper: program.clone(),
             reason: format!("failed to execute: {e}"),
         })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(DistributionError::CredentialHelperFailed {
+        return Err(Error::CredentialHelperFailed {
             helper: program,
             reason: format!("exited with {}: {}", output.status, stderr.trim()),
         });
@@ -244,12 +237,11 @@ fn run_credential_helper(helper: &str, registry: &str) -> Result<Credentials, Di
         secret: String,
     }
 
-    let resp: HelperResponse = serde_json::from_slice(&output.stdout).map_err(|e| {
-        DistributionError::CredentialHelperFailed {
+    let resp: HelperResponse =
+        serde_json::from_slice(&output.stdout).map_err(|e| Error::CredentialHelperFailed {
             helper: program,
             reason: format!("invalid JSON response: {e}"),
-        }
-    })?;
+        })?;
 
     Ok(Credentials::Basic {
         username: resp.username,

--- a/crates/ocync-distribution/src/auth/docker.rs
+++ b/crates/ocync-distribution/src/auth/docker.rs
@@ -180,7 +180,7 @@ fn entry_to_credentials(entry: &AuthEntry) -> Result<Option<Credentials>, Error>
 }
 
 /// Decode a base64-encoded `username:password` string.
-pub fn decode_auth(encoded: &str) -> Result<(String, String), Error> {
+fn decode_auth(encoded: &str) -> Result<(String, String), Error> {
     let decoded = BASE64.decode(encoded).map_err(|e| Error::AuthFailed {
         registry: String::new(),
         reason: format!("invalid base64 in auth field: {e}"),
@@ -447,5 +447,84 @@ mod tests {
         assert!(is_docker_hub("https://index.docker.io/v1/"));
         assert!(!is_docker_hub("ghcr.io"));
         assert!(!is_docker_hub("quay.io"));
+    }
+
+    #[test]
+    fn empty_auth_field_returns_none() {
+        let json = r#"{
+            "auths": {
+                "ghcr.io": { "auth": "" }
+            }
+        }"#;
+        let config: DockerConfig = serde_json::from_str(json).unwrap();
+        let result = resolve_from_docker_config(&config, "ghcr.io").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn empty_auth_object_returns_none() {
+        let json = r#"{
+            "auths": {
+                "ghcr.io": {}
+            }
+        }"#;
+        let config: DockerConfig = serde_json::from_str(json).unwrap();
+        let result = resolve_from_docker_config(&config, "ghcr.io").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn decode_auth_empty_password() {
+        let encoded = BASE64.encode("user:");
+        let (user, pass) = decode_auth(&encoded).unwrap();
+        assert_eq!(user, "user");
+        assert_eq!(pass, "");
+    }
+
+    #[test]
+    fn decode_auth_empty_username() {
+        let encoded = BASE64.encode(":password");
+        let (user, pass) = decode_auth(&encoded).unwrap();
+        assert_eq!(user, "");
+        assert_eq!(pass, "password");
+    }
+
+    #[test]
+    fn config_with_unknown_fields_ignored() {
+        let json = r#"{
+            "auths": {},
+            "experimental": "enabled",
+            "proxies": { "default": {} },
+            "stackOrchestrator": "swarm"
+        }"#;
+        let config: DockerConfig = serde_json::from_str(json).unwrap();
+        assert!(config.auths.is_empty());
+    }
+
+    #[test]
+    fn cred_helper_docker_hub_alias_lookup() {
+        let json = r#"{
+            "credHelpers": {
+                "https://index.docker.io/v1/": "desktop"
+            }
+        }"#;
+        let config: DockerConfig = serde_json::from_str(json).unwrap();
+        let helper = lookup_cred_helper(&config, "docker.io");
+        assert_eq!(helper.as_deref(), Some("desktop"));
+    }
+
+    #[test]
+    fn creds_store_not_checked_when_auths_match() {
+        let json = r#"{
+            "auths": {
+                "ghcr.io": { "auth": "dXNlcjpwYXNz" }
+            },
+            "credsStore": "desktop"
+        }"#;
+        let config: DockerConfig = serde_json::from_str(json).unwrap();
+        let creds = resolve_from_docker_config(&config, "ghcr.io")
+            .unwrap()
+            .unwrap();
+        assert!(matches!(creds, Credentials::Basic { username, .. } if username == "user"));
     }
 }

--- a/crates/ocync-distribution/src/auth/docker.rs
+++ b/crates/ocync-distribution/src/auth/docker.rs
@@ -1,3 +1,5 @@
+//! Docker `config.json` credential resolution and helper execution.
+
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;

--- a/crates/ocync-distribution/src/auth/docker.rs
+++ b/crates/ocync-distribution/src/auth/docker.rs
@@ -1,1 +1,457 @@
-// Docker config auth — implemented in a later commit.
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use serde::Deserialize;
+
+use super::Credentials;
+use crate::error::DistributionError;
+
+/// Docker Hub hostnames that all resolve to the same credential entry.
+const DOCKER_HUB_ALIASES: &[&str] = &[
+    "docker.io",
+    "index.docker.io",
+    "registry-1.docker.io",
+    "https://index.docker.io/v1/",
+    "https://index.docker.io/v2/",
+];
+
+/// Deserialized `~/.docker/config.json`.
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+pub struct DockerConfig {
+    /// Static credentials keyed by registry hostname.
+    pub auths: HashMap<String, AuthEntry>,
+    /// Credential helpers keyed by registry hostname.
+    #[serde(rename = "credHelpers")]
+    pub cred_helpers: HashMap<String, String>,
+    /// Default credential store (e.g. "desktop", "osxkeychain").
+    #[serde(rename = "credsStore")]
+    pub creds_store: Option<String>,
+}
+
+/// A single auth entry from the `auths` map.
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+pub struct AuthEntry {
+    /// Base64-encoded `username:password`.
+    pub auth: Option<String>,
+    /// Username (when stored separately).
+    pub username: Option<String>,
+    /// Password (when stored separately).
+    pub password: Option<String>,
+}
+
+impl DockerConfig {
+    /// Load from the default Docker config path (`~/.docker/config.json`).
+    pub fn load_default() -> Result<Self, DistributionError> {
+        let path = default_config_path()
+            .ok_or_else(|| DistributionError::Other("unable to determine home directory".into()))?;
+        Self::load_from(&path)
+    }
+
+    /// Load from a specific file path.
+    pub fn load_from(path: &Path) -> Result<Self, DistributionError> {
+        let contents = std::fs::read_to_string(path).map_err(|e| {
+            DistributionError::Other(format!(
+                "failed to read docker config at {}: {e}",
+                path.display()
+            ))
+        })?;
+        serde_json::from_str(&contents).map_err(|e| {
+            DistributionError::Other(format!(
+                "failed to parse docker config at {}: {e}",
+                path.display()
+            ))
+        })
+    }
+}
+
+/// Resolve credentials for a registry from a Docker config.
+///
+/// Checks `auths` first (static credentials), then `credHelpers`, then the
+/// default `credsStore`. Handles Docker Hub hostname normalization.
+pub fn resolve_from_docker_config(
+    config: &DockerConfig,
+    registry: &str,
+) -> Result<Option<Credentials>, DistributionError> {
+    // Try static auths first.
+    if let Some(creds) = lookup_auths(config, registry)? {
+        return Ok(Some(creds));
+    }
+
+    // Try credential helpers.
+    if let Some(helper) = lookup_cred_helper(config, registry) {
+        let creds = run_credential_helper(&helper, registry)?;
+        return Ok(Some(creds));
+    }
+
+    // Try default credential store.
+    if let Some(ref store) = config.creds_store {
+        match run_credential_helper(store, registry) {
+            Ok(creds) => return Ok(Some(creds)),
+            Err(_) => {
+                // Default store may not have creds for this registry — not an error.
+                tracing::debug!(
+                    registry,
+                    store,
+                    "default credential store had no credentials"
+                );
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+/// Look up static credentials from the `auths` map.
+fn lookup_auths(
+    config: &DockerConfig,
+    registry: &str,
+) -> Result<Option<Credentials>, DistributionError> {
+    // Direct match.
+    if let Some(entry) = config.auths.get(registry) {
+        if let Some(creds) = entry_to_credentials(entry)? {
+            return Ok(Some(creds));
+        }
+    }
+
+    // Try with/without https:// prefix.
+    let with_scheme = format!("https://{registry}");
+    if let Some(entry) = config.auths.get(&with_scheme) {
+        if let Some(creds) = entry_to_credentials(entry)? {
+            return Ok(Some(creds));
+        }
+    }
+
+    // Docker Hub aliases — if the requested registry is any Docker Hub alias,
+    // try all other aliases.
+    if is_docker_hub(registry) {
+        for alias in DOCKER_HUB_ALIASES {
+            if let Some(entry) = config.auths.get(*alias) {
+                if let Some(creds) = entry_to_credentials(entry)? {
+                    return Ok(Some(creds));
+                }
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+/// Look up a credential helper for the given registry.
+fn lookup_cred_helper(config: &DockerConfig, registry: &str) -> Option<String> {
+    if let Some(helper) = config.cred_helpers.get(registry) {
+        return Some(helper.clone());
+    }
+
+    // Docker Hub aliases.
+    if is_docker_hub(registry) {
+        for alias in DOCKER_HUB_ALIASES {
+            if let Some(helper) = config.cred_helpers.get(*alias) {
+                return Some(helper.clone());
+            }
+        }
+    }
+
+    None
+}
+
+/// Convert an `AuthEntry` to `Credentials`.
+fn entry_to_credentials(entry: &AuthEntry) -> Result<Option<Credentials>, DistributionError> {
+    // Prefer the `auth` field (base64 encoded).
+    if let Some(ref encoded) = entry.auth {
+        if !encoded.is_empty() {
+            let (username, password) = decode_auth(encoded)?;
+            return Ok(Some(Credentials::Basic { username, password }));
+        }
+    }
+
+    // Fall back to separate username/password fields.
+    if let (Some(username), Some(password)) = (&entry.username, &entry.password) {
+        return Ok(Some(Credentials::Basic {
+            username: username.clone(),
+            password: password.clone(),
+        }));
+    }
+
+    Ok(None)
+}
+
+/// Decode a base64-encoded `username:password` string.
+pub fn decode_auth(encoded: &str) -> Result<(String, String), DistributionError> {
+    let decoded = BASE64
+        .decode(encoded)
+        .map_err(|e| DistributionError::AuthFailed {
+            registry: String::new(),
+            reason: format!("invalid base64 in auth field: {e}"),
+        })?;
+
+    let text = String::from_utf8(decoded).map_err(|e| DistributionError::AuthFailed {
+        registry: String::new(),
+        reason: format!("auth field is not valid UTF-8: {e}"),
+    })?;
+
+    let (username, password) =
+        text.split_once(':')
+            .ok_or_else(|| DistributionError::AuthFailed {
+                registry: String::new(),
+                reason: "auth field does not contain ':'".into(),
+            })?;
+
+    Ok((username.to_owned(), password.to_owned()))
+}
+
+/// Execute a Docker credential helper and return the credentials.
+///
+/// Runs `docker-credential-{helper} get` with the registry on stdin.
+fn run_credential_helper(helper: &str, registry: &str) -> Result<Credentials, DistributionError> {
+    let program = format!("docker-credential-{helper}");
+
+    let output = Command::new(&program)
+        .arg("get")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                stdin.write_all(registry.as_bytes())?;
+            }
+            child.wait_with_output()
+        })
+        .map_err(|e| DistributionError::CredentialHelperFailed {
+            helper: program.clone(),
+            reason: format!("failed to execute: {e}"),
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(DistributionError::CredentialHelperFailed {
+            helper: program,
+            reason: format!("exited with {}: {}", output.status, stderr.trim()),
+        });
+    }
+
+    #[derive(Deserialize)]
+    struct HelperResponse {
+        #[serde(rename = "Username")]
+        username: String,
+        #[serde(rename = "Secret")]
+        secret: String,
+    }
+
+    let resp: HelperResponse = serde_json::from_slice(&output.stdout).map_err(|e| {
+        DistributionError::CredentialHelperFailed {
+            helper: program,
+            reason: format!("invalid JSON response: {e}"),
+        }
+    })?;
+
+    Ok(Credentials::Basic {
+        username: resp.username,
+        password: resp.secret,
+    })
+}
+
+/// Check if a hostname is a Docker Hub alias.
+fn is_docker_hub(registry: &str) -> bool {
+    DOCKER_HUB_ALIASES
+        .iter()
+        .any(|alias| registry == *alias || registry == alias.trim_start_matches("https://"))
+}
+
+/// Get the default Docker config path.
+fn default_config_path() -> Option<PathBuf> {
+    // Check DOCKER_CONFIG env var first.
+    if let Ok(dir) = std::env::var("DOCKER_CONFIG") {
+        return Some(PathBuf::from(dir).join("config.json"));
+    }
+    dirs::home_dir().map(|h| h.join(".docker").join("config.json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_config_with_auths() {
+        let json = r#"{
+            "auths": {
+                "ghcr.io": {
+                    "auth": "dXNlcjpwYXNz"
+                },
+                "https://index.docker.io/v1/": {
+                    "auth": "ZG9ja2VyOnNlY3JldA=="
+                }
+            }
+        }"#;
+        let config: DockerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.auths.len(), 2);
+        assert!(config.auths.contains_key("ghcr.io"));
+    }
+
+    #[test]
+    fn decode_auth_valid() {
+        // "user:pass" base64-encoded
+        let (user, pass) = decode_auth("dXNlcjpwYXNz").unwrap();
+        assert_eq!(user, "user");
+        assert_eq!(pass, "pass");
+    }
+
+    #[test]
+    fn decode_auth_with_colon_in_password() {
+        // "user:pa:ss" base64-encoded
+        let encoded = BASE64.encode("user:pa:ss");
+        let (user, pass) = decode_auth(&encoded).unwrap();
+        assert_eq!(user, "user");
+        assert_eq!(pass, "pa:ss");
+    }
+
+    #[test]
+    fn decode_auth_invalid_base64() {
+        let result = decode_auth("not-valid-base64!!!");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn decode_auth_no_colon() {
+        // "userpass" (no colon) base64-encoded
+        let encoded = BASE64.encode("userpass");
+        let result = decode_auth(&encoded);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn lookup_exact_match() {
+        let json = r#"{
+            "auths": {
+                "ghcr.io": { "auth": "dXNlcjpwYXNz" }
+            }
+        }"#;
+        let config: DockerConfig = serde_json::from_str(json).unwrap();
+        let creds = resolve_from_docker_config(&config, "ghcr.io")
+            .unwrap()
+            .unwrap();
+        assert!(
+            matches!(creds, Credentials::Basic { username, password } if username == "user" && password == "pass")
+        );
+    }
+
+    #[test]
+    fn lookup_with_scheme_prefix() {
+        let json = r#"{
+            "auths": {
+                "https://ghcr.io": { "auth": "dXNlcjpwYXNz" }
+            }
+        }"#;
+        let config: DockerConfig = serde_json::from_str(json).unwrap();
+        let creds = resolve_from_docker_config(&config, "ghcr.io")
+            .unwrap()
+            .unwrap();
+        assert!(matches!(creds, Credentials::Basic { .. }));
+    }
+
+    #[test]
+    fn lookup_not_found() {
+        let json = r#"{
+            "auths": {
+                "ghcr.io": { "auth": "dXNlcjpwYXNz" }
+            }
+        }"#;
+        let config: DockerConfig = serde_json::from_str(json).unwrap();
+        let result = resolve_from_docker_config(&config, "quay.io").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn lookup_docker_hub_alias() {
+        let json = r#"{
+            "auths": {
+                "https://index.docker.io/v1/": { "auth": "ZG9ja2VyOnNlY3JldA==" }
+            }
+        }"#;
+        let config: DockerConfig = serde_json::from_str(json).unwrap();
+
+        // Look up via "docker.io" — should find the creds stored under the full URL alias.
+        let creds = resolve_from_docker_config(&config, "docker.io")
+            .unwrap()
+            .unwrap();
+        assert!(matches!(&creds, Credentials::Basic { username, .. } if username == "docker"));
+
+        // Also via "registry-1.docker.io".
+        let creds = resolve_from_docker_config(&config, "registry-1.docker.io")
+            .unwrap()
+            .unwrap();
+        assert!(matches!(creds, Credentials::Basic { .. }));
+    }
+
+    #[test]
+    fn parse_config_with_cred_helpers() {
+        let json = r#"{
+            "credHelpers": {
+                "123456789012.dkr.ecr.us-east-1.amazonaws.com": "ecr-login",
+                "gcr.io": "gcloud"
+            }
+        }"#;
+        let config: DockerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.cred_helpers.len(), 2);
+        assert_eq!(
+            config
+                .cred_helpers
+                .get("123456789012.dkr.ecr.us-east-1.amazonaws.com")
+                .unwrap(),
+            "ecr-login"
+        );
+    }
+
+    #[test]
+    fn parse_config_with_creds_store() {
+        let json = r#"{
+            "credsStore": "desktop"
+        }"#;
+        let config: DockerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.creds_store.as_deref(), Some("desktop"));
+    }
+
+    #[test]
+    fn empty_config() {
+        let json = "{}";
+        let config: DockerConfig = serde_json::from_str(json).unwrap();
+        assert!(config.auths.is_empty());
+        assert!(config.cred_helpers.is_empty());
+        assert!(config.creds_store.is_none());
+    }
+
+    #[test]
+    fn entry_with_separate_username_password() {
+        let json = r#"{
+            "auths": {
+                "custom.io": {
+                    "username": "myuser",
+                    "password": "mypass"
+                }
+            }
+        }"#;
+        let config: DockerConfig = serde_json::from_str(json).unwrap();
+        let creds = resolve_from_docker_config(&config, "custom.io")
+            .unwrap()
+            .unwrap();
+        assert!(
+            matches!(&creds, Credentials::Basic { username, password } if username == "myuser" && password == "mypass")
+        );
+    }
+
+    #[test]
+    fn is_docker_hub_variants() {
+        assert!(is_docker_hub("docker.io"));
+        assert!(is_docker_hub("index.docker.io"));
+        assert!(is_docker_hub("registry-1.docker.io"));
+        assert!(is_docker_hub("https://index.docker.io/v1/"));
+        assert!(!is_docker_hub("ghcr.io"));
+        assert!(!is_docker_hub("quay.io"));
+    }
+}

--- a/crates/ocync-distribution/src/auth/docker.rs
+++ b/crates/ocync-distribution/src/auth/docker.rs
@@ -262,7 +262,7 @@ fn default_config_path() -> Option<PathBuf> {
     if let Ok(dir) = std::env::var("DOCKER_CONFIG") {
         return Some(PathBuf::from(dir).join("config.json"));
     }
-    dirs::home_dir().map(|h| h.join(".docker").join("config.json"))
+    std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".docker").join("config.json"))
 }
 
 #[cfg(test)]

--- a/crates/ocync-distribution/src/auth/mod.rs
+++ b/crates/ocync-distribution/src/auth/mod.rs
@@ -1,0 +1,239 @@
+pub mod anonymous;
+pub mod docker;
+
+use std::fmt;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use crate::error::DistributionError;
+
+/// Minimum remaining lifetime before a token should be proactively refreshed.
+const REFRESH_THRESHOLD: Duration = Duration::from_secs(15 * 60);
+
+/// OAuth2-style scope for registry token requests.
+///
+/// Format: `repository:<name>:<actions>` where actions is a comma-separated
+/// list (e.g. `pull`, `push`, `pull,push`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Scope {
+    pub repository: String,
+    pub actions: Vec<Action>,
+}
+
+impl Scope {
+    pub fn new(repository: impl Into<String>, actions: Vec<Action>) -> Self {
+        Self {
+            repository: repository.into(),
+            actions,
+        }
+    }
+
+    /// Convenience constructor for a pull-only scope.
+    pub fn pull(repository: impl Into<String>) -> Self {
+        Self::new(repository, vec![Action::Pull])
+    }
+
+    /// Convenience constructor for pull+push scope.
+    pub fn pull_push(repository: impl Into<String>) -> Self {
+        Self::new(repository, vec![Action::Pull, Action::Push])
+    }
+}
+
+impl fmt::Display for Scope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let actions: Vec<&str> = self.actions.iter().map(Action::as_str).collect();
+        write!(f, "repository:{}:{}", self.repository, actions.join(","))
+    }
+}
+
+/// An action that can be performed on a repository.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Action {
+    Pull,
+    Push,
+}
+
+impl Action {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pull => "pull",
+            Self::Push => "push",
+        }
+    }
+}
+
+impl fmt::Display for Action {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A bearer token with optional expiry tracking.
+#[derive(Debug, Clone)]
+pub struct Token {
+    /// The raw bearer token string.
+    value: String,
+    /// When this token expires (if known).
+    expires_at: Option<Instant>,
+}
+
+impl Token {
+    /// Create a token that never expires.
+    pub fn new(value: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+            expires_at: None,
+        }
+    }
+
+    /// Create a token with a known time-to-live.
+    pub fn with_ttl(value: impl Into<String>, ttl: Duration) -> Self {
+        Self {
+            value: value.into(),
+            expires_at: Some(Instant::now() + ttl),
+        }
+    }
+
+    /// Create a token that expires at a specific instant.
+    pub fn with_expiry(value: impl Into<String>, expires_at: Instant) -> Self {
+        Self {
+            value: value.into(),
+            expires_at: Some(expires_at),
+        }
+    }
+
+    /// The raw bearer token value.
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    /// Whether this token has already expired.
+    pub fn is_expired(&self) -> bool {
+        self.expires_at.is_some_and(|exp| Instant::now() >= exp)
+    }
+
+    /// Whether this token should be refreshed soon (less than 15 minutes remaining).
+    pub fn should_refresh(&self) -> bool {
+        match self.expires_at {
+            Some(exp) => {
+                let now = Instant::now();
+                now >= exp || exp.duration_since(now) < REFRESH_THRESHOLD
+            }
+            None => false,
+        }
+    }
+}
+
+/// Credentials for authenticating to a registry.
+#[derive(Debug, Clone)]
+pub enum Credentials {
+    /// HTTP Basic authentication.
+    Basic { username: String, password: String },
+    /// A pre-existing bearer token.
+    Bearer(String),
+    /// A file containing a token (read on demand).
+    TokenFile(PathBuf),
+}
+
+/// Trait for providers that can obtain authentication tokens for registries.
+///
+/// Implementations must be `Send + Sync` for use across async tasks.
+pub trait AuthProvider: Send + Sync {
+    /// Human-readable name of this provider (e.g. "anonymous", "docker-config").
+    fn name(&self) -> &'static str;
+
+    /// Obtain a bearer token valid for the given scopes.
+    fn get_token(
+        &self,
+        scopes: &[Scope],
+    ) -> impl std::future::Future<Output = Result<Token, DistributionError>> + Send;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scope_display_single_action() {
+        let scope = Scope::pull("library/nginx");
+        assert_eq!(scope.to_string(), "repository:library/nginx:pull");
+    }
+
+    #[test]
+    fn scope_display_multiple_actions() {
+        let scope = Scope::pull_push("myuser/myrepo");
+        assert_eq!(scope.to_string(), "repository:myuser/myrepo:pull,push");
+    }
+
+    #[test]
+    fn scope_equality() {
+        let a = Scope::pull("repo");
+        let b = Scope::pull("repo");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn action_display() {
+        assert_eq!(Action::Pull.to_string(), "pull");
+        assert_eq!(Action::Push.to_string(), "push");
+    }
+
+    #[test]
+    fn token_no_expiry_never_expired() {
+        let token = Token::new("abc123");
+        assert_eq!(token.value(), "abc123");
+        assert!(!token.is_expired());
+        assert!(!token.should_refresh());
+    }
+
+    #[test]
+    fn token_with_long_ttl_not_expired() {
+        let token = Token::with_ttl("abc123", Duration::from_secs(3600));
+        assert!(!token.is_expired());
+        assert!(!token.should_refresh());
+    }
+
+    #[test]
+    fn token_with_zero_ttl_is_expired() {
+        let token = Token::with_expiry("abc123", Instant::now() - Duration::from_secs(1));
+        assert!(token.is_expired());
+        assert!(token.should_refresh());
+    }
+
+    #[test]
+    fn token_within_refresh_threshold() {
+        // 10 minutes remaining — less than the 15-minute threshold
+        let token = Token::with_ttl("abc123", Duration::from_secs(600));
+        assert!(!token.is_expired());
+        assert!(token.should_refresh());
+    }
+
+    #[test]
+    fn token_beyond_refresh_threshold() {
+        // 20 minutes remaining — above the 15-minute threshold
+        let token = Token::with_ttl("abc123", Duration::from_secs(1200));
+        assert!(!token.is_expired());
+        assert!(!token.should_refresh());
+    }
+
+    #[test]
+    fn credentials_basic_variant() {
+        let creds = Credentials::Basic {
+            username: "user".into(),
+            password: "pass".into(),
+        };
+        assert!(matches!(creds, Credentials::Basic { .. }));
+    }
+
+    #[test]
+    fn credentials_bearer_variant() {
+        let creds = Credentials::Bearer("token123".into());
+        assert!(matches!(creds, Credentials::Bearer(_)));
+    }
+
+    #[test]
+    fn credentials_token_file_variant() {
+        let creds = Credentials::TokenFile(PathBuf::from("/tmp/token"));
+        assert!(matches!(creds, Credentials::TokenFile(_)));
+    }
+}

--- a/crates/ocync-distribution/src/auth/mod.rs
+++ b/crates/ocync-distribution/src/auth/mod.rs
@@ -2,7 +2,9 @@ pub mod anonymous;
 pub mod docker;
 
 use std::fmt;
+use std::future::Future;
 use std::path::PathBuf;
+use std::pin::Pin;
 use std::time::{Duration, Instant};
 
 use crate::error::DistributionError;
@@ -137,16 +139,20 @@ pub enum Credentials {
 
 /// Trait for providers that can obtain authentication tokens for registries.
 ///
+/// Uses `Pin<Box<dyn Future>>` for object safety, allowing `Box<dyn AuthProvider>`.
 /// Implementations must be `Send + Sync` for use across async tasks.
 pub trait AuthProvider: Send + Sync {
     /// Human-readable name of this provider (e.g. "anonymous", "docker-config").
     fn name(&self) -> &'static str;
 
     /// Obtain a bearer token valid for the given scopes.
+    ///
+    /// The `scopes` slice is converted to owned data before the future is created,
+    /// so callers don't need to worry about borrow lifetimes.
     fn get_token(
         &self,
         scopes: &[Scope],
-    ) -> impl std::future::Future<Output = Result<Token, DistributionError>> + Send;
+    ) -> Pin<Box<dyn Future<Output = Result<Token, DistributionError>> + Send + '_>>;
 }
 
 #[cfg(test)]

--- a/crates/ocync-distribution/src/auth/mod.rs
+++ b/crates/ocync-distribution/src/auth/mod.rs
@@ -7,7 +7,6 @@ pub mod docker;
 
 use std::fmt;
 use std::future::Future;
-use std::path::PathBuf;
 use std::pin::Pin;
 use std::time::{Duration, Instant};
 
@@ -146,10 +145,6 @@ pub enum Credentials {
         /// The password or token.
         password: String,
     },
-    /// A pre-existing bearer token.
-    Bearer(String),
-    /// A file containing a token (read on demand).
-    TokenFile(PathBuf),
 }
 
 /// Trait for providers that can obtain authentication tokens for registries.
@@ -168,6 +163,13 @@ pub trait AuthProvider: Send + Sync {
         &self,
         scopes: &[Scope],
     ) -> Pin<Box<dyn Future<Output = Result<Token, Error>> + Send + '_>>;
+
+    /// Invalidate any cached tokens, forcing the next `get_token` call to
+    /// perform a fresh exchange.
+    ///
+    /// Called by the client when a request returns 401, indicating the
+    /// current token was rejected by the registry.
+    fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
 }
 
 #[cfg(test)]
@@ -244,17 +246,5 @@ mod tests {
             password: "pass".into(),
         };
         assert!(matches!(creds, Credentials::Basic { .. }));
-    }
-
-    #[test]
-    fn credentials_bearer_variant() {
-        let creds = Credentials::Bearer("token123".into());
-        assert!(matches!(creds, Credentials::Bearer(_)));
-    }
-
-    #[test]
-    fn credentials_token_file_variant() {
-        let creds = Credentials::TokenFile(PathBuf::from("/tmp/token"));
-        assert!(matches!(creds, Credentials::TokenFile(_)));
     }
 }

--- a/crates/ocync-distribution/src/auth/mod.rs
+++ b/crates/ocync-distribution/src/auth/mod.rs
@@ -1,4 +1,8 @@
+//! Authentication providers and token management for OCI registries.
+
+/// Anonymous token-exchange authentication.
 pub mod anonymous;
+/// Docker config.json credential resolution.
 pub mod docker;
 
 use std::fmt;
@@ -7,7 +11,7 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::time::{Duration, Instant};
 
-use crate::error::DistributionError;
+use crate::error::Error;
 
 /// Minimum remaining lifetime before a token should be proactively refreshed.
 const REFRESH_THRESHOLD: Duration = Duration::from_secs(15 * 60);
@@ -18,11 +22,14 @@ const REFRESH_THRESHOLD: Duration = Duration::from_secs(15 * 60);
 /// list (e.g. `pull`, `push`, `pull,push`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Scope {
+    /// The repository this scope applies to.
     pub repository: String,
+    /// The actions requested (e.g. pull, push).
     pub actions: Vec<Action>,
 }
 
 impl Scope {
+    /// Create a scope for the given repository and actions.
     pub fn new(repository: impl Into<String>, actions: Vec<Action>) -> Self {
         Self {
             repository: repository.into(),
@@ -51,11 +58,14 @@ impl fmt::Display for Scope {
 /// An action that can be performed on a repository.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Action {
+    /// Read-only access to a repository.
     Pull,
+    /// Write access to a repository.
     Push,
 }
 
 impl Action {
+    /// Return the string representation of this action.
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Pull => "pull",
@@ -130,7 +140,12 @@ impl Token {
 #[derive(Debug, Clone)]
 pub enum Credentials {
     /// HTTP Basic authentication.
-    Basic { username: String, password: String },
+    Basic {
+        /// The username.
+        username: String,
+        /// The password or token.
+        password: String,
+    },
     /// A pre-existing bearer token.
     Bearer(String),
     /// A file containing a token (read on demand).
@@ -152,7 +167,7 @@ pub trait AuthProvider: Send + Sync {
     fn get_token(
         &self,
         scopes: &[Scope],
-    ) -> Pin<Box<dyn Future<Output = Result<Token, DistributionError>> + Send + '_>>;
+    ) -> Pin<Box<dyn Future<Output = Result<Token, Error>> + Send + '_>>;
 }
 
 #[cfg(test)]

--- a/crates/ocync-distribution/src/client.rs
+++ b/crates/ocync-distribution/src/client.rs
@@ -144,7 +144,7 @@ impl RegistryClient {
     /// Perform an authenticated GET request.
     ///
     /// Acquires a semaphore permit, attaches auth headers, and retries once
-    /// on 401 (refreshing the token).
+    /// on 401 (invalidating the cached token first).
     pub async fn get(
         &self,
         repository: &str,
@@ -162,8 +162,11 @@ impl RegistryClient {
             return classify_response(resp, &self.base_url, repository).await;
         }
 
-        // 401 — refresh token and retry once.
-        tracing::debug!(url = %url, "got 401, refreshing auth token");
+        // 401 — invalidate cached token and retry once.
+        tracing::debug!(url = %url, "got 401, invalidating token and retrying");
+        if let Some(ref auth) = self.auth {
+            auth.invalidate().await;
+        }
         let resp = self.send_get(&url, &scopes, accept).await?;
         classify_response(resp, &self.base_url, repository).await
     }
@@ -182,7 +185,11 @@ impl RegistryClient {
             return classify_response(resp, &self.base_url, repository).await;
         }
 
-        tracing::debug!(url = %url, "got 401, refreshing auth token");
+        // 401 — invalidate cached token and retry once.
+        tracing::debug!(url = %url, "got 401, invalidating token and retrying");
+        if let Some(ref auth) = self.auth {
+            auth.invalidate().await;
+        }
         let resp = self.send_head(&url, &scopes).await?;
         classify_response(resp, &self.base_url, repository).await
     }
@@ -225,16 +232,6 @@ impl RegistryClient {
         }
 
         Ok(headers)
-    }
-
-    /// The underlying HTTP client (for advanced use).
-    pub fn http(&self) -> &reqwest::Client {
-        &self.http
-    }
-
-    /// A reference to the concurrency semaphore.
-    pub fn semaphore(&self) -> &Arc<Semaphore> {
-        &self.semaphore
     }
 }
 
@@ -279,7 +276,7 @@ fn build_v2_url(base: &Url) -> Result<Url, Error> {
 }
 
 /// Construct a URL for `/v2/{repository}/{path}`.
-pub fn build_url(base: &Url, repository: &str, path: &str) -> Result<Url, Error> {
+pub(crate) fn build_url(base: &Url, repository: &str, path: &str) -> Result<Url, Error> {
     let full_path = format!("/v2/{repository}/{path}");
     base.join(&full_path)
         .map_err(|e| Error::Other(format!("failed to build URL '{full_path}': {e}")))
@@ -373,7 +370,7 @@ mod tests {
             .max_concurrent(4)
             .build()
             .unwrap();
-        assert_eq!(client.semaphore().available_permits(), 4);
+        assert_eq!(client.semaphore.available_permits(), 4);
     }
 
     #[test]

--- a/crates/ocync-distribution/src/client.rs
+++ b/crates/ocync-distribution/src/client.rs
@@ -1,3 +1,5 @@
+//! HTTP client for a single OCI registry endpoint.
+
 use std::sync::Arc;
 
 use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue};

--- a/crates/ocync-distribution/src/client.rs
+++ b/crates/ocync-distribution/src/client.rs
@@ -1,0 +1,370 @@
+use std::sync::Arc;
+
+use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue};
+use tokio::sync::Semaphore;
+use url::Url;
+
+use crate::auth::{AuthProvider, Scope};
+use crate::error::DistributionError;
+
+const DEFAULT_MAX_CONCURRENT: usize = 8;
+const DEFAULT_CHUNK_SIZE: usize = 8 * 1024 * 1024; // 8 MiB
+const USER_AGENT_VALUE: &str = concat!("ocync/", env!("CARGO_PKG_VERSION"));
+
+/// Builder for [`RegistryClient`].
+pub struct RegistryClientBuilder {
+    url: Url,
+    auth: Option<Box<dyn AuthProvider>>,
+    max_concurrent: usize,
+    chunk_size: usize,
+}
+
+impl RegistryClientBuilder {
+    /// Create a new builder for the given registry URL.
+    ///
+    /// The URL should be the base registry URL (e.g. `https://registry-1.docker.io`).
+    pub fn new(url: Url) -> Self {
+        Self {
+            url,
+            auth: None,
+            max_concurrent: DEFAULT_MAX_CONCURRENT,
+            chunk_size: DEFAULT_CHUNK_SIZE,
+        }
+    }
+
+    /// Set the authentication provider.
+    pub fn auth(mut self, auth: impl AuthProvider + 'static) -> Self {
+        self.auth = Some(Box::new(auth));
+        self
+    }
+
+    /// Set the authentication provider from a boxed trait object.
+    pub fn auth_boxed(mut self, auth: Box<dyn AuthProvider>) -> Self {
+        self.auth = Some(auth);
+        self
+    }
+
+    /// Set the maximum number of concurrent requests.
+    pub fn max_concurrent(mut self, n: usize) -> Self {
+        self.max_concurrent = n;
+        self
+    }
+
+    /// Set the chunk size for blob uploads (in bytes).
+    pub fn chunk_size(mut self, size: usize) -> Self {
+        self.chunk_size = size;
+        self
+    }
+
+    /// Build the registry client.
+    pub fn build(self) -> Result<RegistryClient, DistributionError> {
+        let http = reqwest::Client::builder()
+            .user_agent(USER_AGENT_VALUE)
+            .build()?;
+
+        Ok(RegistryClient {
+            base_url: self.url,
+            http,
+            auth: self.auth,
+            semaphore: Arc::new(Semaphore::new(self.max_concurrent)),
+            chunk_size: self.chunk_size,
+        })
+    }
+}
+
+/// HTTP client for a single OCI registry.
+///
+/// Each `RegistryClient` targets one registry host and owns its auth provider
+/// and concurrency semaphore. Construct via [`RegistryClientBuilder`].
+pub struct RegistryClient {
+    base_url: Url,
+    http: reqwest::Client,
+    auth: Option<Box<dyn AuthProvider>>,
+    semaphore: Arc<Semaphore>,
+    chunk_size: usize,
+}
+
+impl RegistryClient {
+    /// Create a builder for this client.
+    pub fn builder(url: Url) -> RegistryClientBuilder {
+        RegistryClientBuilder::new(url)
+    }
+
+    /// The base URL of this registry.
+    pub fn base_url(&self) -> &Url {
+        &self.base_url
+    }
+
+    /// The configured chunk size for blob uploads.
+    pub fn chunk_size(&self) -> usize {
+        self.chunk_size
+    }
+
+    /// Ping the registry's `/v2/` endpoint.
+    ///
+    /// Returns `Ok(())` if the registry responds with 200 or 401 (which confirms
+    /// the endpoint exists and speaks the OCI Distribution protocol).
+    pub async fn ping(&self) -> Result<(), DistributionError> {
+        let url = build_v2_url(&self.base_url)?;
+        let resp = self.http.get(url).send().await?;
+        let status = resp.status();
+
+        if status.is_success() || status.as_u16() == 401 {
+            Ok(())
+        } else {
+            let message = resp.text().await.unwrap_or_default();
+            Err(DistributionError::RegistryError {
+                status: status.as_u16(),
+                message,
+            })
+        }
+    }
+
+    /// Perform an authenticated GET request.
+    ///
+    /// Acquires a semaphore permit, attaches auth headers, and retries once
+    /// on 401 (refreshing the token).
+    pub async fn get(
+        &self,
+        repository: &str,
+        path: &str,
+        accept: Option<&str>,
+    ) -> Result<reqwest::Response, DistributionError> {
+        let url = build_url(&self.base_url, repository, path)?;
+        let _permit = self.semaphore.acquire().await.expect("semaphore closed");
+
+        let scopes = [Scope::pull(repository)];
+
+        // First attempt.
+        let resp = self.send_get(&url, &scopes, accept).await?;
+        if resp.status().as_u16() != 401 {
+            return classify_response(resp, &self.base_url, repository).await;
+        }
+
+        // 401 — refresh token and retry once.
+        tracing::debug!(url = %url, "got 401, refreshing auth token");
+        let resp = self.send_get(&url, &scopes, accept).await?;
+        classify_response(resp, &self.base_url, repository).await
+    }
+
+    /// Perform an authenticated HEAD request.
+    ///
+    /// Same retry logic as [`get`](Self::get).
+    pub async fn head(
+        &self,
+        repository: &str,
+        path: &str,
+    ) -> Result<reqwest::Response, DistributionError> {
+        let url = build_url(&self.base_url, repository, path)?;
+        let _permit = self.semaphore.acquire().await.expect("semaphore closed");
+
+        let scopes = [Scope::pull(repository)];
+
+        let resp = self.send_head(&url, &scopes).await?;
+        if resp.status().as_u16() != 401 {
+            return classify_response(resp, &self.base_url, repository).await;
+        }
+
+        tracing::debug!(url = %url, "got 401, refreshing auth token");
+        let resp = self.send_head(&url, &scopes).await?;
+        classify_response(resp, &self.base_url, repository).await
+    }
+
+    /// Internal: send a GET with auth headers.
+    async fn send_get(
+        &self,
+        url: &Url,
+        scopes: &[Scope],
+        accept: Option<&str>,
+    ) -> Result<reqwest::Response, DistributionError> {
+        let mut headers = self.auth_headers(scopes).await?;
+        if let Some(accept) = accept {
+            if let Ok(val) = HeaderValue::from_str(accept) {
+                headers.insert(ACCEPT, val);
+            }
+        }
+
+        Ok(self.http.get(url.clone()).headers(headers).send().await?)
+    }
+
+    /// Internal: send a HEAD with auth headers.
+    async fn send_head(
+        &self,
+        url: &Url,
+        scopes: &[Scope],
+    ) -> Result<reqwest::Response, DistributionError> {
+        let headers = self.auth_headers(scopes).await?;
+        Ok(self.http.head(url.clone()).headers(headers).send().await?)
+    }
+
+    /// Build auth headers for a request.
+    async fn auth_headers(&self, scopes: &[Scope]) -> Result<HeaderMap, DistributionError> {
+        let mut headers = HeaderMap::new();
+
+        if let Some(ref auth) = self.auth {
+            let token = auth.get_token(scopes).await?;
+            let value = token.value();
+            if !value.is_empty() {
+                let header_value = HeaderValue::from_str(&format!("Bearer {value}"))
+                    .map_err(|e| DistributionError::Other(format!("invalid auth header: {e}")))?;
+                headers.insert(AUTHORIZATION, header_value);
+            }
+        }
+
+        Ok(headers)
+    }
+
+    /// The underlying HTTP client (for advanced use).
+    pub fn http(&self) -> &reqwest::Client {
+        &self.http
+    }
+
+    /// A reference to the concurrency semaphore.
+    pub fn semaphore(&self) -> &Arc<Semaphore> {
+        &self.semaphore
+    }
+}
+
+/// Classify an HTTP response into success/error.
+async fn classify_response(
+    resp: reqwest::Response,
+    base_url: &Url,
+    repository: &str,
+) -> Result<reqwest::Response, DistributionError> {
+    let status = resp.status();
+
+    if status.is_success() {
+        return Ok(resp);
+    }
+
+    let registry = base_url.host_str().unwrap_or("unknown").to_owned();
+
+    match status.as_u16() {
+        401 => Err(DistributionError::Unauthorized { registry }),
+        403 => Err(DistributionError::Forbidden {
+            registry,
+            repository: repository.to_owned(),
+        }),
+        404 => {
+            let message = resp.text().await.unwrap_or_default();
+            Err(DistributionError::NotFound(message))
+        }
+        _ => {
+            let message = resp.text().await.unwrap_or_default();
+            Err(DistributionError::RegistryError {
+                status: status.as_u16(),
+                message,
+            })
+        }
+    }
+}
+
+/// Construct a URL for the `/v2/` endpoint.
+fn build_v2_url(base: &Url) -> Result<Url, DistributionError> {
+    base.join("/v2/")
+        .map_err(|e| DistributionError::Other(format!("failed to build /v2/ URL: {e}")))
+}
+
+/// Construct a URL for `/v2/{repository}/{path}`.
+pub fn build_url(base: &Url, repository: &str, path: &str) -> Result<Url, DistributionError> {
+    let full_path = format!("/v2/{repository}/{path}");
+    base.join(&full_path)
+        .map_err(|e| DistributionError::Other(format!("failed to build URL '{full_path}': {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_base_url() -> Url {
+        Url::parse("https://registry-1.docker.io").unwrap()
+    }
+
+    #[test]
+    fn build_url_manifests() {
+        let url = build_url(&test_base_url(), "library/nginx", "manifests/latest").unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://registry-1.docker.io/v2/library/nginx/manifests/latest"
+        );
+    }
+
+    #[test]
+    fn build_url_blobs() {
+        let url = build_url(&test_base_url(), "library/nginx", "blobs/sha256:abc123").unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://registry-1.docker.io/v2/library/nginx/blobs/sha256:abc123"
+        );
+    }
+
+    #[test]
+    fn build_url_tags_list() {
+        let url = build_url(&test_base_url(), "clowdhaus/ocync", "tags/list").unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://registry-1.docker.io/v2/clowdhaus/ocync/tags/list"
+        );
+    }
+
+    #[test]
+    fn build_url_nested_repository() {
+        let url = build_url(
+            &Url::parse("https://ghcr.io").unwrap(),
+            "clowdhaus/ocync/subpath",
+            "manifests/v1.0",
+        )
+        .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://ghcr.io/v2/clowdhaus/ocync/subpath/manifests/v1.0"
+        );
+    }
+
+    #[test]
+    fn build_url_with_port() {
+        let base = Url::parse("http://localhost:5000").unwrap();
+        let url = build_url(&base, "myrepo", "manifests/latest").unwrap();
+        assert_eq!(
+            url.as_str(),
+            "http://localhost:5000/v2/myrepo/manifests/latest"
+        );
+    }
+
+    #[test]
+    fn build_v2_url_basic() {
+        let url = build_v2_url(&test_base_url()).unwrap();
+        assert_eq!(url.as_str(), "https://registry-1.docker.io/v2/");
+    }
+
+    #[test]
+    fn builder_defaults() {
+        let client = RegistryClient::builder(test_base_url()).build().unwrap();
+        assert_eq!(client.base_url().as_str(), "https://registry-1.docker.io/");
+        assert_eq!(client.chunk_size(), DEFAULT_CHUNK_SIZE);
+        assert!(client.auth.is_none());
+    }
+
+    #[test]
+    fn builder_custom_chunk_size() {
+        let client = RegistryClient::builder(test_base_url())
+            .chunk_size(4 * 1024 * 1024)
+            .build()
+            .unwrap();
+        assert_eq!(client.chunk_size(), 4 * 1024 * 1024);
+    }
+
+    #[test]
+    fn builder_custom_concurrency() {
+        let client = RegistryClient::builder(test_base_url())
+            .max_concurrent(4)
+            .build()
+            .unwrap();
+        assert_eq!(client.semaphore().available_permits(), 4);
+    }
+
+    #[test]
+    fn user_agent_value() {
+        assert!(USER_AGENT_VALUE.starts_with("ocync/"));
+    }
+}

--- a/crates/ocync-distribution/src/client.rs
+++ b/crates/ocync-distribution/src/client.rs
@@ -5,7 +5,7 @@ use tokio::sync::Semaphore;
 use url::Url;
 
 use crate::auth::{AuthProvider, Scope};
-use crate::error::DistributionError;
+use crate::error::Error;
 
 const DEFAULT_MAX_CONCURRENT: usize = 8;
 const DEFAULT_CHUNK_SIZE: usize = 8 * 1024 * 1024; // 8 MiB
@@ -17,6 +17,16 @@ pub struct RegistryClientBuilder {
     auth: Option<Box<dyn AuthProvider>>,
     max_concurrent: usize,
     chunk_size: usize,
+}
+
+impl std::fmt::Debug for RegistryClientBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegistryClientBuilder")
+            .field("url", &self.url)
+            .field("max_concurrent", &self.max_concurrent)
+            .field("chunk_size", &self.chunk_size)
+            .finish_non_exhaustive()
+    }
 }
 
 impl RegistryClientBuilder {
@@ -57,7 +67,7 @@ impl RegistryClientBuilder {
     }
 
     /// Build the registry client.
-    pub fn build(self) -> Result<RegistryClient, DistributionError> {
+    pub fn build(self) -> Result<RegistryClient, Error> {
         let http = reqwest::Client::builder()
             .user_agent(USER_AGENT_VALUE)
             .build()?;
@@ -84,6 +94,15 @@ pub struct RegistryClient {
     chunk_size: usize,
 }
 
+impl std::fmt::Debug for RegistryClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegistryClient")
+            .field("base_url", &self.base_url)
+            .field("chunk_size", &self.chunk_size)
+            .finish_non_exhaustive()
+    }
+}
+
 impl RegistryClient {
     /// Create a builder for this client.
     pub fn builder(url: Url) -> RegistryClientBuilder {
@@ -104,7 +123,7 @@ impl RegistryClient {
     ///
     /// Returns `Ok(())` if the registry responds with 200 or 401 (which confirms
     /// the endpoint exists and speaks the OCI Distribution protocol).
-    pub async fn ping(&self) -> Result<(), DistributionError> {
+    pub async fn ping(&self) -> Result<(), Error> {
         let url = build_v2_url(&self.base_url)?;
         let resp = self.http.get(url).send().await?;
         let status = resp.status();
@@ -113,7 +132,7 @@ impl RegistryClient {
             Ok(())
         } else {
             let message = resp.text().await.unwrap_or_default();
-            Err(DistributionError::RegistryError {
+            Err(Error::RegistryError {
                 status: status.as_u16(),
                 message,
             })
@@ -129,7 +148,7 @@ impl RegistryClient {
         repository: &str,
         path: &str,
         accept: Option<&str>,
-    ) -> Result<reqwest::Response, DistributionError> {
+    ) -> Result<reqwest::Response, Error> {
         let url = build_url(&self.base_url, repository, path)?;
         let _permit = self.semaphore.acquire().await.expect("semaphore closed");
 
@@ -150,11 +169,7 @@ impl RegistryClient {
     /// Perform an authenticated HEAD request.
     ///
     /// Same retry logic as [`get`](Self::get).
-    pub async fn head(
-        &self,
-        repository: &str,
-        path: &str,
-    ) -> Result<reqwest::Response, DistributionError> {
+    pub async fn head(&self, repository: &str, path: &str) -> Result<reqwest::Response, Error> {
         let url = build_url(&self.base_url, repository, path)?;
         let _permit = self.semaphore.acquire().await.expect("semaphore closed");
 
@@ -176,7 +191,7 @@ impl RegistryClient {
         url: &Url,
         scopes: &[Scope],
         accept: Option<&str>,
-    ) -> Result<reqwest::Response, DistributionError> {
+    ) -> Result<reqwest::Response, Error> {
         let mut headers = self.auth_headers(scopes).await?;
         if let Some(accept) = accept {
             if let Ok(val) = HeaderValue::from_str(accept) {
@@ -188,17 +203,13 @@ impl RegistryClient {
     }
 
     /// Internal: send a HEAD with auth headers.
-    async fn send_head(
-        &self,
-        url: &Url,
-        scopes: &[Scope],
-    ) -> Result<reqwest::Response, DistributionError> {
+    async fn send_head(&self, url: &Url, scopes: &[Scope]) -> Result<reqwest::Response, Error> {
         let headers = self.auth_headers(scopes).await?;
         Ok(self.http.head(url.clone()).headers(headers).send().await?)
     }
 
     /// Build auth headers for a request.
-    async fn auth_headers(&self, scopes: &[Scope]) -> Result<HeaderMap, DistributionError> {
+    async fn auth_headers(&self, scopes: &[Scope]) -> Result<HeaderMap, Error> {
         let mut headers = HeaderMap::new();
 
         if let Some(ref auth) = self.auth {
@@ -206,7 +217,7 @@ impl RegistryClient {
             let value = token.value();
             if !value.is_empty() {
                 let header_value = HeaderValue::from_str(&format!("Bearer {value}"))
-                    .map_err(|e| DistributionError::Other(format!("invalid auth header: {e}")))?;
+                    .map_err(|e| Error::Other(format!("invalid auth header: {e}")))?;
                 headers.insert(AUTHORIZATION, header_value);
             }
         }
@@ -230,7 +241,7 @@ async fn classify_response(
     resp: reqwest::Response,
     base_url: &Url,
     repository: &str,
-) -> Result<reqwest::Response, DistributionError> {
+) -> Result<reqwest::Response, Error> {
     let status = resp.status();
 
     if status.is_success() {
@@ -240,18 +251,18 @@ async fn classify_response(
     let registry = base_url.host_str().unwrap_or("unknown").to_owned();
 
     match status.as_u16() {
-        401 => Err(DistributionError::Unauthorized { registry }),
-        403 => Err(DistributionError::Forbidden {
+        401 => Err(Error::Unauthorized { registry }),
+        403 => Err(Error::Forbidden {
             registry,
             repository: repository.to_owned(),
         }),
         404 => {
             let message = resp.text().await.unwrap_or_default();
-            Err(DistributionError::NotFound(message))
+            Err(Error::NotFound(message))
         }
         _ => {
             let message = resp.text().await.unwrap_or_default();
-            Err(DistributionError::RegistryError {
+            Err(Error::RegistryError {
                 status: status.as_u16(),
                 message,
             })
@@ -260,16 +271,16 @@ async fn classify_response(
 }
 
 /// Construct a URL for the `/v2/` endpoint.
-fn build_v2_url(base: &Url) -> Result<Url, DistributionError> {
+fn build_v2_url(base: &Url) -> Result<Url, Error> {
     base.join("/v2/")
-        .map_err(|e| DistributionError::Other(format!("failed to build /v2/ URL: {e}")))
+        .map_err(|e| Error::Other(format!("failed to build /v2/ URL: {e}")))
 }
 
 /// Construct a URL for `/v2/{repository}/{path}`.
-pub fn build_url(base: &Url, repository: &str, path: &str) -> Result<Url, DistributionError> {
+pub fn build_url(base: &Url, repository: &str, path: &str) -> Result<Url, Error> {
     let full_path = format!("/v2/{repository}/{path}");
     base.join(&full_path)
-        .map_err(|e| DistributionError::Other(format!("failed to build URL '{full_path}': {e}")))
+        .map_err(|e| Error::Other(format!("failed to build URL '{full_path}': {e}")))
 }
 
 #[cfg(test)]

--- a/crates/ocync-distribution/src/digest.rs
+++ b/crates/ocync-distribution/src/digest.rs
@@ -183,4 +183,48 @@ mod tests {
         set.insert(d1.clone());
         assert!(set.contains(&d2));
     }
+
+    #[test]
+    fn parse_sha512() {
+        let hex = "a".repeat(128);
+        let input = format!("sha512:{hex}");
+        let d: Digest = input.parse().unwrap();
+        assert_eq!(d.algorithm(), "sha512");
+        assert_eq!(d.hex().len(), 128);
+    }
+
+    #[test]
+    fn parse_unknown_algorithm() {
+        let hex = "a".repeat(96);
+        let input = format!("sha384:{hex}");
+        let d: Digest = input.parse().unwrap();
+        assert_eq!(d.algorithm(), "sha384");
+    }
+
+    #[test]
+    fn uppercase_hex_accepted() {
+        let hex = "A".repeat(64);
+        let input = format!("sha256:{hex}");
+        let d: Digest = input.parse().unwrap();
+        assert_eq!(d.hex(), hex);
+    }
+
+    #[test]
+    fn leading_colon_error() {
+        let r = ":abcdef".parse::<Digest>();
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn display_preserves_original() {
+        let input = TEST_DIGEST;
+        let d: Digest = input.parse().unwrap();
+        assert_eq!(d.to_string(), input);
+    }
+
+    #[test]
+    fn deserialize_non_string_errors() {
+        let result: Result<Digest, _> = serde_json::from_str("123");
+        assert!(result.is_err());
+    }
 }

--- a/crates/ocync-distribution/src/error.rs
+++ b/crates/ocync-distribution/src/error.rs
@@ -43,6 +43,39 @@ pub enum Error {
     #[error("manifest deserialization failed: {0}")]
     ManifestParse(#[from] serde_json::Error),
 
+    #[error("authentication failed for registry '{registry}': {reason}")]
+    AuthFailed { registry: String, reason: String },
+
+    #[error("auth provider '{provider}' not compiled; rebuild with --features {feature}")]
+    ProviderNotCompiled {
+        provider: &'static str,
+        feature: &'static str,
+    },
+
+    #[error("no credentials found for registry '{registry}'")]
+    NoCredentials { registry: String },
+
+    #[error("credential helper '{helper}' failed: {reason}")]
+    CredentialHelperFailed { helper: String, reason: String },
+
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("registry returned {status}: {message}")]
+    RegistryError { status: u16, message: String },
+
+    #[error("registry returned 401 Unauthorized for {registry}")]
+    Unauthorized { registry: String },
+
+    #[error("registry returned 403 Forbidden for {registry}/{repository}")]
+    Forbidden {
+        registry: String,
+        repository: String,
+    },
+
+    #[error("not found: {0}")]
+    NotFound(String),
+
     /// Catch-all for errors without a dedicated variant.
     #[error("{0}")]
     Other(String),

--- a/crates/ocync-distribution/src/error.rs
+++ b/crates/ocync-distribution/src/error.rs
@@ -43,36 +43,70 @@ pub enum Error {
     #[error("manifest deserialization failed: {0}")]
     ManifestParse(#[from] serde_json::Error),
 
+    /// Authentication with the registry failed.
     #[error("authentication failed for registry '{registry}': {reason}")]
-    AuthFailed { registry: String, reason: String },
+    AuthFailed {
+        /// The registry that rejected authentication.
+        registry: String,
+        /// Why authentication failed.
+        reason: String,
+    },
 
+    /// An auth provider requires a feature that was not compiled in.
     #[error("auth provider '{provider}' not compiled; rebuild with --features {feature}")]
     ProviderNotCompiled {
+        /// The provider name (e.g. `"ecr"`).
         provider: &'static str,
+        /// The Cargo feature required.
         feature: &'static str,
     },
 
+    /// No credentials were found for the target registry.
     #[error("no credentials found for registry '{registry}'")]
-    NoCredentials { registry: String },
+    NoCredentials {
+        /// The registry hostname.
+        registry: String,
+    },
 
+    /// An external credential helper process failed.
     #[error("credential helper '{helper}' failed: {reason}")]
-    CredentialHelperFailed { helper: String, reason: String },
+    CredentialHelperFailed {
+        /// The credential helper command.
+        helper: String,
+        /// Why the helper failed.
+        reason: String,
+    },
 
+    /// An HTTP request to the registry failed.
     #[error("HTTP request failed: {0}")]
     Http(#[from] reqwest::Error),
 
+    /// The registry returned an unexpected HTTP status.
     #[error("registry returned {status}: {message}")]
-    RegistryError { status: u16, message: String },
+    RegistryError {
+        /// The HTTP status code.
+        status: u16,
+        /// The response body.
+        message: String,
+    },
 
+    /// The registry returned 401 Unauthorized.
     #[error("registry returned 401 Unauthorized for {registry}")]
-    Unauthorized { registry: String },
+    Unauthorized {
+        /// The registry hostname.
+        registry: String,
+    },
 
+    /// The registry returned 403 Forbidden.
     #[error("registry returned 403 Forbidden for {registry}/{repository}")]
     Forbidden {
+        /// The registry hostname.
         registry: String,
+        /// The repository that was denied.
         repository: String,
     },
 
+    /// The requested resource was not found.
     #[error("not found: {0}")]
     NotFound(String),
 

--- a/crates/ocync-distribution/src/lib.rs
+++ b/crates/ocync-distribution/src/lib.rs
@@ -1,5 +1,6 @@
 //! OCI distribution client library — types, authentication, and registry operations.
 
+pub mod auth;
 pub mod digest;
 pub mod error;
 pub mod reference;

--- a/crates/ocync-distribution/src/lib.rs
+++ b/crates/ocync-distribution/src/lib.rs
@@ -1,6 +1,8 @@
 //! OCI distribution client library — types, authentication, and registry operations.
 
+/// Authentication providers and token management.
 pub mod auth;
+/// OCI registry HTTP client.
 pub mod client;
 pub mod digest;
 pub mod error;

--- a/crates/ocync-distribution/src/lib.rs
+++ b/crates/ocync-distribution/src/lib.rs
@@ -1,12 +1,14 @@
 //! OCI distribution client library — types, authentication, and registry operations.
 
 pub mod auth;
+pub mod client;
 pub mod digest;
 pub mod error;
 pub mod reference;
 pub mod sha256;
 pub mod spec;
 
+pub use client::RegistryClient;
 pub use digest::Digest;
 pub use error::Error;
 pub use reference::Reference;

--- a/crates/ocync-distribution/src/reference.rs
+++ b/crates/ocync-distribution/src/reference.rs
@@ -323,4 +323,56 @@ mod tests {
         let r2: Reference = serde_json::from_str(&json).unwrap();
         assert_eq!(r, r2);
     }
+
+    #[test]
+    fn deeply_nested_repository() {
+        let r: Reference = "ghcr.io/a/b/c/d/e/f:tag".parse().unwrap();
+        assert_eq!(r.registry(), "ghcr.io");
+        assert_eq!(r.repository(), "a/b/c/d/e/f");
+        assert_eq!(r.tag(), Some("tag"));
+    }
+
+    #[test]
+    fn ip_address_with_port() {
+        let r: Reference = "192.168.1.1:5000/repo:tag".parse().unwrap();
+        assert_eq!(r.registry(), "192.168.1.1:5000");
+        assert_eq!(r.repository(), "repo");
+        assert_eq!(r.tag(), Some("tag"));
+    }
+
+    #[test]
+    fn localhost_without_port() {
+        let r: Reference = "localhost/repo:tag".parse().unwrap();
+        assert_eq!(r.registry(), "localhost");
+        assert_eq!(r.repository(), "repo");
+        assert_eq!(r.tag(), Some("tag"));
+    }
+
+    #[test]
+    fn tag_with_special_chars() {
+        let r: Reference = "ghcr.io/repo:v1.0-beta.1_rc".parse().unwrap();
+        assert_eq!(r.tag(), Some("v1.0-beta.1_rc"));
+    }
+
+    #[test]
+    fn single_char_components() {
+        let r: Reference = "a.io/b:c".parse().unwrap();
+        assert_eq!(r.registry(), "a.io");
+        assert_eq!(r.repository(), "b");
+        assert_eq!(r.tag(), Some("c"));
+    }
+
+    #[test]
+    fn trailing_colon_empty_tag() {
+        let r: Reference = "ghcr.io/repo:".parse().unwrap();
+        assert!(r.tag().is_none());
+    }
+
+    #[test]
+    fn docker_hub_nested_user_repo() {
+        let r: Reference = "myuser/myrepo:latest".parse().unwrap();
+        assert_eq!(r.registry(), "docker.io");
+        assert_eq!(r.repository(), "myuser/myrepo");
+        assert_eq!(r.tag(), Some("latest"));
+    }
 }

--- a/crates/ocync-distribution/tests/auth_anonymous.rs
+++ b/crates/ocync-distribution/tests/auth_anonymous.rs
@@ -1,0 +1,283 @@
+//! Integration tests for anonymous auth token exchange using mock HTTP servers.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ocync_distribution::auth::anonymous::AnonymousAuth;
+use ocync_distribution::auth::{AuthProvider, Scope};
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Start a mock server that responds to `/v2/` with a 401 + WWW-Authenticate
+/// challenge pointing to `{mock_server}/token` as the realm.
+async fn setup_auth_server() -> MockServer {
+    let server = MockServer::start().await;
+
+    let challenge = format!(
+        r#"Bearer realm="http://{}/token",service="test.registry.io""#,
+        server.address()
+    );
+    Mock::given(method("GET"))
+        .and(path("/v2/"))
+        .respond_with(ResponseTemplate::new(401).insert_header("www-authenticate", challenge))
+        .mount(&server)
+        .await;
+
+    server
+}
+
+/// Mount a token endpoint that returns a token with given value and TTL.
+async fn mount_token_endpoint(server: &MockServer, token_value: &str, expires_in: u64) {
+    let body = serde_json::json!({
+        "token": token_value,
+        "expires_in": expires_in
+    });
+    Mock::given(method("GET"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .mount(server)
+        .await;
+}
+
+/// Mount a token endpoint that returns a specific token for a specific scope.
+async fn mount_scoped_token_endpoint(
+    server: &MockServer,
+    scope: &str,
+    token_value: &str,
+    expires_in: u64,
+) {
+    let body = serde_json::json!({
+        "token": token_value,
+        "expires_in": expires_in
+    });
+    Mock::given(method("GET"))
+        .and(path("/token"))
+        .and(query_param("scope", scope))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn token_exchange_basic_flow() {
+    let server = setup_auth_server().await;
+    mount_token_endpoint(&server, "test-token-123", 3600).await;
+
+    let auth = AnonymousAuth::with_base_url(server.uri(), reqwest::Client::new());
+    let scopes = [Scope::pull("library/nginx")];
+    let token = auth.get_token(&scopes).await.unwrap();
+
+    assert_eq!(token.value(), "test-token-123");
+    assert!(!token.is_expired());
+}
+
+#[tokio::test]
+async fn cached_token_reused_for_same_scope() {
+    let server = setup_auth_server().await;
+
+    let body = serde_json::json!({ "token": "cached-token", "expires_in": 3600 });
+    Mock::given(method("GET"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let auth = AnonymousAuth::with_base_url(server.uri(), reqwest::Client::new());
+    let scopes = [Scope::pull("library/nginx")];
+
+    let t1 = auth.get_token(&scopes).await.unwrap();
+    let t2 = auth.get_token(&scopes).await.unwrap();
+
+    assert_eq!(t1.value(), t2.value());
+}
+
+#[tokio::test]
+async fn different_scopes_get_different_tokens() {
+    let server = setup_auth_server().await;
+
+    mount_scoped_token_endpoint(
+        &server,
+        "repository:library/nginx:pull",
+        "nginx-token",
+        3600,
+    )
+    .await;
+    mount_scoped_token_endpoint(
+        &server,
+        "repository:myuser/myrepo:pull,push",
+        "myrepo-token",
+        3600,
+    )
+    .await;
+
+    let auth = AnonymousAuth::with_base_url(server.uri(), reqwest::Client::new());
+
+    let t1 = auth
+        .get_token(&[Scope::pull("library/nginx")])
+        .await
+        .unwrap();
+    let t2 = auth
+        .get_token(&[Scope::pull_push("myuser/myrepo")])
+        .await
+        .unwrap();
+
+    assert_eq!(t1.value(), "nginx-token");
+    assert_eq!(t2.value(), "myrepo-token");
+}
+
+#[tokio::test]
+async fn scope_upgrade_fetches_new_token() {
+    let server = setup_auth_server().await;
+
+    mount_scoped_token_endpoint(&server, "repository:myrepo:pull", "pull-token", 3600).await;
+    mount_scoped_token_endpoint(&server, "repository:myrepo:pull,push", "push-token", 3600).await;
+
+    let auth = AnonymousAuth::with_base_url(server.uri(), reqwest::Client::new());
+
+    let t1 = auth.get_token(&[Scope::pull("myrepo")]).await.unwrap();
+    let t2 = auth.get_token(&[Scope::pull_push("myrepo")]).await.unwrap();
+
+    assert_eq!(t1.value(), "pull-token");
+    assert_eq!(t2.value(), "push-token");
+}
+
+#[tokio::test]
+async fn invalidate_clears_cache() {
+    let server = setup_auth_server().await;
+
+    let body = serde_json::json!({ "token": "fresh-token", "expires_in": 3600 });
+    Mock::given(method("GET"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let auth = AnonymousAuth::with_base_url(server.uri(), reqwest::Client::new());
+    let scopes = [Scope::pull("library/nginx")];
+
+    let _ = auth.get_token(&scopes).await.unwrap();
+    auth.invalidate().await;
+    let _ = auth.get_token(&scopes).await.unwrap();
+}
+
+#[tokio::test]
+async fn concurrent_requests_coalesce() {
+    let server = setup_auth_server().await;
+
+    let body = serde_json::json!({ "token": "coalesced", "expires_in": 3600 });
+    Mock::given(method("GET"))
+        .and(path("/token"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(&body)
+                .set_delay(Duration::from_millis(100)),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let auth = Arc::new(AnonymousAuth::with_base_url(
+        server.uri(),
+        reqwest::Client::new(),
+    ));
+    let scopes = vec![Scope::pull("library/nginx")];
+
+    let mut handles = Vec::new();
+    for _ in 0..20 {
+        let auth = auth.clone();
+        let scopes = scopes.clone();
+        handles.push(tokio::spawn(async move {
+            auth.get_token(&scopes).await.unwrap()
+        }));
+    }
+
+    for handle in handles {
+        let token = handle.await.unwrap();
+        assert_eq!(token.value(), "coalesced");
+    }
+}
+
+#[tokio::test]
+async fn no_auth_required_returns_empty_token() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v2/"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let auth = AnonymousAuth::with_base_url(server.uri(), reqwest::Client::new());
+    let token = auth.get_token(&[Scope::pull("repo")]).await.unwrap();
+
+    assert_eq!(token.value(), "");
+}
+
+#[tokio::test]
+async fn missing_www_authenticate_header_errors() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v2/"))
+        .respond_with(ResponseTemplate::new(401))
+        .mount(&server)
+        .await;
+
+    let auth = AnonymousAuth::with_base_url(server.uri(), reqwest::Client::new());
+    let result = auth.get_token(&[Scope::pull("repo")]).await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("WWW-Authenticate"), "error was: {err}");
+}
+
+#[tokio::test]
+async fn token_response_missing_both_fields_errors() {
+    let server = setup_auth_server().await;
+
+    Mock::given(method("GET"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .mount(&server)
+        .await;
+
+    let auth = AnonymousAuth::with_base_url(server.uri(), reqwest::Client::new());
+    let result = auth.get_token(&[Scope::pull("repo")]).await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn token_with_access_token_field() {
+    let server = setup_auth_server().await;
+
+    let body = serde_json::json!({ "access_token": "alt-token", "expires_in": 300 });
+    Mock::given(method("GET"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .mount(&server)
+        .await;
+
+    let auth = AnonymousAuth::with_base_url(server.uri(), reqwest::Client::new());
+    let token = auth.get_token(&[Scope::pull("repo")]).await.unwrap();
+
+    assert_eq!(token.value(), "alt-token");
+}
+
+#[tokio::test]
+async fn token_endpoint_error_propagates() {
+    let server = setup_auth_server().await;
+
+    Mock::given(method("GET"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("internal error"))
+        .mount(&server)
+        .await;
+
+    let auth = AnonymousAuth::with_base_url(server.uri(), reqwest::Client::new());
+    let result = auth.get_token(&[Scope::pull("repo")]).await;
+
+    assert!(result.is_err());
+}

--- a/crates/ocync-distribution/tests/client_integration.rs
+++ b/crates/ocync-distribution/tests/client_integration.rs
@@ -1,0 +1,359 @@
+//! Integration tests for `RegistryClient` using mock HTTP servers.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use ocync_distribution::Error;
+use ocync_distribution::auth::{AuthProvider, Scope, Token};
+use ocync_distribution::client::RegistryClientBuilder;
+use url::Url;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// A mock auth provider that tracks token requests and invalidation calls.
+struct MockAuth {
+    token_value: String,
+    invalidate_count: AtomicU32,
+}
+
+impl MockAuth {
+    fn new(token: &str) -> Self {
+        Self {
+            token_value: token.to_owned(),
+            invalidate_count: AtomicU32::new(0),
+        }
+    }
+}
+
+impl AuthProvider for MockAuth {
+    fn name(&self) -> &'static str {
+        "mock"
+    }
+
+    fn get_token(
+        &self,
+        _scopes: &[Scope],
+    ) -> Pin<Box<dyn Future<Output = Result<Token, Error>> + Send + '_>> {
+        let token = Token::new(self.token_value.clone());
+        Box::pin(async move { Ok(token) })
+    }
+
+    fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        self.invalidate_count.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async {})
+    }
+}
+
+/// A mock auth provider that returns a different token value after each invalidation.
+struct RotatingMockAuth {
+    call_count: AtomicU32,
+}
+
+impl RotatingMockAuth {
+    fn new() -> Self {
+        Self {
+            call_count: AtomicU32::new(0),
+        }
+    }
+}
+
+impl AuthProvider for RotatingMockAuth {
+    fn name(&self) -> &'static str {
+        "rotating-mock"
+    }
+
+    fn get_token(
+        &self,
+        _scopes: &[Scope],
+    ) -> Pin<Box<dyn Future<Output = Result<Token, Error>> + Send + '_>> {
+        let count = self.call_count.fetch_add(1, Ordering::SeqCst);
+        let token_value = format!("token-{count}");
+        Box::pin(async move { Ok(Token::new(token_value)) })
+    }
+
+    fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async {})
+    }
+}
+
+fn mock_base_url(server: &MockServer) -> Url {
+    Url::parse(&server.uri()).unwrap()
+}
+
+#[tokio::test]
+async fn get_success_no_retry() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v2/library/nginx/manifests/latest"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("manifest-body"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let auth = MockAuth::new("good-token");
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .auth(auth)
+        .build()
+        .unwrap();
+
+    let resp = client
+        .get("library/nginx", "manifests/latest", None)
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn get_401_triggers_invalidate_and_retry() {
+    let server = MockServer::start().await;
+
+    // First call: 401, second call: 200
+    Mock::given(method("GET"))
+        .and(path("/v2/library/nginx/manifests/latest"))
+        .respond_with(ResponseTemplate::new(401))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v2/library/nginx/manifests/latest"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("success"))
+        .mount(&server)
+        .await;
+
+    let auth = MockAuth::new("test-token");
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .auth(auth)
+        .build()
+        .unwrap();
+
+    let resp = client
+        .get("library/nginx", "manifests/latest", None)
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn get_double_401_returns_unauthorized() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v2/repo/manifests/latest"))
+        .respond_with(ResponseTemplate::new(401))
+        .mount(&server)
+        .await;
+
+    let auth = MockAuth::new("bad-token");
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .auth(auth)
+        .build()
+        .unwrap();
+
+    let result = client.get("repo", "manifests/latest", None).await;
+    assert!(matches!(result, Err(Error::Unauthorized { .. })));
+}
+
+#[tokio::test]
+async fn get_401_retry_only_happens_once() {
+    let server = MockServer::start().await;
+
+    // Always returns 401 — client should try exactly twice (initial + 1 retry)
+    Mock::given(method("GET"))
+        .and(path("/v2/repo/manifests/latest"))
+        .respond_with(ResponseTemplate::new(401))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let auth = RotatingMockAuth::new();
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .auth(auth)
+        .build()
+        .unwrap();
+
+    let result = client.get("repo", "manifests/latest", None).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn get_403_returns_forbidden() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v2/private/repo/manifests/latest"))
+        .respond_with(ResponseTemplate::new(403))
+        .mount(&server)
+        .await;
+
+    let auth = MockAuth::new("token");
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .auth(auth)
+        .build()
+        .unwrap();
+
+    let result = client.get("private/repo", "manifests/latest", None).await;
+    assert!(matches!(result, Err(Error::Forbidden { .. })));
+}
+
+#[tokio::test]
+async fn get_404_returns_not_found() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v2/repo/manifests/nonexistent"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+        .mount(&server)
+        .await;
+
+    let auth = MockAuth::new("token");
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .auth(auth)
+        .build()
+        .unwrap();
+
+    let result = client.get("repo", "manifests/nonexistent", None).await;
+    assert!(matches!(result, Err(Error::NotFound(_))));
+}
+
+#[tokio::test]
+async fn get_500_returns_registry_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v2/repo/manifests/latest"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("internal error"))
+        .mount(&server)
+        .await;
+
+    let auth = MockAuth::new("token");
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .auth(auth)
+        .build()
+        .unwrap();
+
+    let result = client.get("repo", "manifests/latest", None).await;
+    assert!(matches!(
+        result,
+        Err(Error::RegistryError { status: 500, .. })
+    ));
+}
+
+#[tokio::test]
+async fn no_auth_provider_sends_no_header() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v2/repo/manifests/latest"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("public"))
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .build()
+        .unwrap();
+
+    let resp = client.get("repo", "manifests/latest", None).await.unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn ping_success() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v2/"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .build()
+        .unwrap();
+
+    client.ping().await.unwrap();
+}
+
+#[tokio::test]
+async fn ping_401_is_ok() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v2/"))
+        .respond_with(ResponseTemplate::new(401))
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .build()
+        .unwrap();
+
+    client.ping().await.unwrap();
+}
+
+#[tokio::test]
+async fn ping_500_is_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v2/"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("down"))
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .build()
+        .unwrap();
+
+    let result = client.ping().await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn head_401_triggers_retry() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("HEAD"))
+        .and(path("/v2/repo/manifests/latest"))
+        .respond_with(ResponseTemplate::new(401))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("HEAD"))
+        .and(path("/v2/repo/manifests/latest"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let auth = MockAuth::new("token");
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .auth(auth)
+        .build()
+        .unwrap();
+
+    let resp = client.head("repo", "manifests/latest").await.unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn head_double_401_returns_unauthorized() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("HEAD"))
+        .and(path("/v2/repo/manifests/latest"))
+        .respond_with(ResponseTemplate::new(401))
+        .mount(&server)
+        .await;
+
+    let auth = MockAuth::new("bad-token");
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .auth(auth)
+        .build()
+        .unwrap();
+
+    let result = client.head("repo", "manifests/latest").await;
+    assert!(matches!(result, Err(Error::Unauthorized { .. })));
+}


### PR DESCRIPTION
## Summary
- Add `AuthProvider` trait with `Token`, `Scope`, `Credentials` types and `invalidate()` for pluggable registry authentication with cache control
- Implement anonymous auth provider with scope-keyed token caching (`Mutex<HashMap>`) and thundering-herd prevention
- Implement Docker config.json credential resolution (static auths, credential helpers, Docker Hub hostname normalization)
- Add `RegistryClient` with builder pattern, per-registry concurrency semaphore, authenticated requests, and 401 retry with token invalidation
- Add `wiremock`-based integration tests for auth flows and client error classification

## Test plan
- [x] 139 tests passing (24 new: 12 wiremock integration tests for auth, 12 for client, plus unit test edge cases)
- [x] `cargo clippy -p ocync-distribution --tests -- -D warnings` clean
- [x] `cargo fmt -p ocync-distribution -- --check` clean
- [x] `cargo test -p ocync-distribution` — all 139 pass

Depends on: #1