### PR TITLE
feat(distribution): add registry operations with typed APIs and batch optimization design

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,7 +683,10 @@ version = "0.1.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
+ "bytes",
+ "futures-util",
  "hex",
+ "olpc-cjson",
  "reqwest",
  "serde",
  "serde_json",
@@ -702,6 +705,17 @@ dependencies = [
  "semver",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "olpc-cjson"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083"
+dependencies = [
+ "serde",
+ "serde_json",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1286,6 +1300,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,6 @@ dependencies = [
  "futures-util",
  "hex",
  "http",
- "olpc-cjson",
  "reqwest",
  "serde",
  "serde_json",
@@ -706,17 +705,6 @@ dependencies = [
  "semver",
  "thiserror",
  "tracing",
-]
-
-[[package]]
-name = "olpc-cjson"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083"
-dependencies = [
- "serde",
- "serde_json",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -1301,15 +1289,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,6 +686,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "hex",
+ "http",
  "olpc-cjson",
  "reqwest",
  "serde",

--- a/crates/ocync-distribution/Cargo.toml
+++ b/crates/ocync-distribution/Cargo.toml
@@ -17,7 +17,6 @@ bytes = { version = "1", default-features = false }
 futures-util = { version = "0.3", default-features = false }
 http = { version = "1", default-features = false }
 hex.workspace = true
-olpc-cjson = { version = "0.1", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/ocync-distribution/Cargo.toml
+++ b/crates/ocync-distribution/Cargo.toml
@@ -15,6 +15,7 @@ aws-lc-rs.workspace = true
 base64 = { version = "0.22", default-features = false, features = ["alloc"] }
 bytes = { version = "1", default-features = false }
 futures-util = { version = "0.3", default-features = false }
+http = { version = "1", default-features = false }
 hex.workspace = true
 olpc-cjson = { version = "0.1", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }

--- a/crates/ocync-distribution/Cargo.toml
+++ b/crates/ocync-distribution/Cargo.toml
@@ -13,7 +13,10 @@ workspace = true
 [dependencies]
 aws-lc-rs.workspace = true
 base64 = { version = "0.22", default-features = false, features = ["alloc"] }
+bytes = { version = "1", default-features = false }
+futures-util = { version = "0.3", default-features = false }
 hex.workspace = true
+olpc-cjson = { version = "0.1", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/ocync-distribution/src/blob.rs
+++ b/crates/ocync-distribution/src/blob.rs
@@ -1,0 +1,310 @@
+use bytes::Bytes;
+use futures_util::Stream;
+use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, LOCATION};
+
+use crate::auth::Scope;
+use crate::client::{RegistryClient, build_url};
+use crate::digest::Digest;
+use crate::error::Error;
+use crate::sha256::Sha256;
+
+/// Result of a HEAD request to check blob existence.
+#[derive(Debug)]
+pub enum BlobExistsResult {
+    /// The blob exists with the given size in bytes.
+    Exists { size: u64 },
+    /// The blob was not found.
+    NotFound,
+}
+
+/// Result of a cross-repository blob mount attempt.
+#[derive(Debug)]
+pub enum MountResult {
+    /// The blob was successfully mounted.
+    Mounted,
+    /// The registry did not support mounting; use the returned upload URL instead.
+    FallbackUpload { upload_url: String },
+}
+
+/// Build the path segment for a blob: `/blobs/{digest}`.
+pub fn blob_path(digest: &Digest) -> String {
+    format!("blobs/{digest}")
+}
+
+/// Build the path segment for blob uploads: `/blobs/uploads/`.
+pub fn uploads_path() -> String {
+    "blobs/uploads/".to_owned()
+}
+
+impl RegistryClient {
+    /// Check whether a blob exists in the given repository.
+    ///
+    /// Issues a HEAD request to `/v2/{repository}/blobs/{digest}`.
+    pub async fn blob_exists(
+        &self,
+        repository: &str,
+        digest: &Digest,
+    ) -> Result<BlobExistsResult, Error> {
+        let path = blob_path(digest);
+        match self.head(repository, &path).await {
+            Ok(resp) => {
+                let size = resp
+                    .headers()
+                    .get(CONTENT_LENGTH)
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(|v| v.parse::<u64>().ok())
+                    .unwrap_or(0);
+                Ok(BlobExistsResult::Exists { size })
+            }
+            Err(Error::NotFound(_)) => Ok(BlobExistsResult::NotFound),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Pull a blob as a streaming response.
+    ///
+    /// Issues a GET request to `/v2/{repository}/blobs/{digest}` and returns
+    /// a byte stream for the response body.
+    pub async fn blob_pull(
+        &self,
+        repository: &str,
+        digest: &Digest,
+    ) -> Result<impl Stream<Item = Result<Bytes, reqwest::Error>>, Error> {
+        let path = blob_path(digest);
+        let resp = self.get(repository, &path, None).await?;
+        Ok(resp.bytes_stream())
+    }
+
+    /// Attempt a cross-repository blob mount.
+    ///
+    /// Issues a POST to `/v2/{repository}/blobs/uploads/?mount={digest}&from={from_repo}`.
+    /// If the registry supports it, returns `Mounted`. Otherwise, falls back to
+    /// a regular upload URL.
+    pub async fn blob_mount(
+        &self,
+        repository: &str,
+        digest: &Digest,
+        from_repo: &str,
+    ) -> Result<MountResult, Error> {
+        let url = build_url(&self.base_url, repository, &uploads_path())?;
+        let _permit = self.semaphore.acquire().await.expect("semaphore closed");
+
+        let scopes = [Scope::pull_push(repository), Scope::pull(from_repo)];
+        let headers = self.auth_headers(&scopes).await?;
+
+        let resp = self
+            .http
+            .post(url.clone())
+            .headers(headers.clone())
+            .query(&[
+                ("mount", digest.to_string()),
+                ("from", from_repo.to_owned()),
+            ])
+            .send()
+            .await?;
+
+        let status = resp.status().as_u16();
+
+        // 401 — refresh token and retry once.
+        if status == 401 {
+            tracing::debug!(url = %url, "got 401 on blob mount, refreshing auth token");
+            let headers = self.auth_headers(&scopes).await?;
+            let resp = self
+                .http
+                .post(url)
+                .headers(headers)
+                .query(&[
+                    ("mount", digest.to_string()),
+                    ("from", from_repo.to_owned()),
+                ])
+                .send()
+                .await?;
+
+            return self.classify_mount_response(resp).await;
+        }
+
+        self.classify_mount_response(resp).await
+    }
+
+    /// Classify a mount response into `Mounted` or `FallbackUpload`.
+    async fn classify_mount_response(
+        &self,
+        resp: reqwest::Response,
+    ) -> Result<MountResult, Error> {
+        let status = resp.status().as_u16();
+
+        match status {
+            // 201 Created — blob was successfully mounted.
+            201 => Ok(MountResult::Mounted),
+            // 202 Accepted — mount not supported; registry gave us an upload URL.
+            202 => {
+                let upload_url = resp
+                    .headers()
+                    .get(LOCATION)
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or_default()
+                    .to_owned();
+                Ok(MountResult::FallbackUpload { upload_url })
+            }
+            _ => {
+                let message = resp.text().await.unwrap_or_default();
+                Err(Error::RegistryError { status, message })
+            }
+        }
+    }
+
+    /// Push a blob to the given repository using a monolithic upload.
+    ///
+    /// 1. POST `/v2/{repository}/blobs/uploads/` to initiate the upload.
+    /// 2. PUT the entire data with the computed digest.
+    ///
+    /// Returns the digest of the uploaded blob.
+    pub async fn blob_push(
+        &self,
+        repository: &str,
+        data: Vec<u8>,
+    ) -> Result<Digest, Error> {
+        // Compute digest of the data.
+        let hash = Sha256::digest(&data);
+        let digest = Digest::from_sha256(hash);
+        let data_len = data.len();
+
+        let url = build_url(&self.base_url, repository, &uploads_path())?;
+        let _permit = self.semaphore.acquire().await.expect("semaphore closed");
+
+        let scopes = [Scope::pull_push(repository)];
+        let headers = self.auth_headers(&scopes).await?;
+
+        // Step 1: Initiate upload with POST.
+        let resp = self
+            .http
+            .post(url.clone())
+            .headers(headers.clone())
+            .send()
+            .await?;
+
+        let status = resp.status().as_u16();
+
+        // Handle 401 retry for initiation.
+        let resp = if status == 401 {
+            tracing::debug!(url = %url, "got 401 on blob push initiate, refreshing auth token");
+            let headers = self.auth_headers(&scopes).await?;
+            self.http.post(url).headers(headers).send().await?
+        } else {
+            resp
+        };
+
+        let status = resp.status().as_u16();
+        if status != 202 {
+            let message = resp.text().await.unwrap_or_default();
+            return Err(Error::RegistryError { status, message });
+        }
+
+        // Extract the upload URL from the Location header.
+        let upload_url = resp
+            .headers()
+            .get(LOCATION)
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| {
+                Error::Other("missing Location header in upload response".into())
+            })?
+            .to_owned();
+
+        // Resolve relative Location URLs against the base URL.
+        let put_url = if upload_url.starts_with("http://") || upload_url.starts_with("https://") {
+            upload_url.clone()
+        } else {
+            self.base_url
+                .join(&upload_url)
+                .map_err(|e| {
+                    Error::Other(format!("failed to resolve upload URL: {e}"))
+                })?
+                .to_string()
+        };
+
+        // Step 2: PUT the data with digest query param.
+        let headers = self.auth_headers(&scopes).await?;
+        let resp = self
+            .http
+            .put(&put_url)
+            .headers(headers)
+            .query(&[("digest", digest.to_string())])
+            .header(CONTENT_LENGTH, data_len.to_string())
+            .header(
+                CONTENT_TYPE,
+                HeaderValue::from_static("application/octet-stream"),
+            )
+            .body(data)
+            .send()
+            .await?;
+
+        let status = resp.status().as_u16();
+        if status != 201 {
+            let message = resp.text().await.unwrap_or_default();
+            return Err(Error::RegistryError { status, message });
+        }
+
+        Ok(digest)
+    }
+
+    /// Delete an in-progress blob upload.
+    ///
+    /// Issues a DELETE to the given upload URL.
+    pub async fn blob_upload_delete(&self, upload_url: &str) -> Result<(), Error> {
+        let _permit = self.semaphore.acquire().await.expect("semaphore closed");
+
+        // Upload URLs don't belong to a specific repo scope, but we still need auth.
+        // Use an empty scope list — the token from a previous request should still work.
+        let headers = self.auth_headers(&[]).await?;
+
+        let resp = self.http.delete(upload_url).headers(headers).send().await?;
+
+        let status = resp.status().as_u16();
+
+        // 401 — retry once.
+        if status == 401 {
+            tracing::debug!(
+                url = upload_url,
+                "got 401 on upload delete, refreshing auth token"
+            );
+            let headers = self.auth_headers(&[]).await?;
+            let resp = self.http.delete(upload_url).headers(headers).send().await?;
+
+            let status = resp.status().as_u16();
+            if status != 204 && status != 202 {
+                let message = resp.text().await.unwrap_or_default();
+                return Err(Error::RegistryError { status, message });
+            }
+            return Ok(());
+        }
+
+        if status != 204 && status != 202 {
+            let message = resp.text().await.unwrap_or_default();
+            return Err(Error::RegistryError { status, message });
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blob_path_format() {
+        let digest: Digest =
+            "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                .parse()
+                .unwrap();
+        assert_eq!(
+            blob_path(&digest),
+            "blobs/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn uploads_path_format() {
+        assert_eq!(uploads_path(), "blobs/uploads/");
+    }
+}

--- a/crates/ocync-distribution/src/blob.rs
+++ b/crates/ocync-distribution/src/blob.rs
@@ -2,6 +2,7 @@
 
 use bytes::Bytes;
 use futures_util::Stream;
+use http::StatusCode;
 use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, LOCATION};
 
 use crate::auth::Scope;
@@ -80,39 +81,18 @@ impl RegistryClient {
     ) -> Result<MountResult, Error> {
         let url = build_url(&self.base_url, repository, "blobs/uploads/")?;
         let _permit = self.semaphore.acquire().await.expect("semaphore closed");
-
         let scopes = [Scope::pull_push(repository), Scope::pull(from_repo)];
-        let headers = self.auth_headers(&scopes).await?;
+        let digest_str = digest.to_string();
+        let from = from_repo.to_owned();
 
         let resp = self
-            .http
-            .post(url.clone())
-            .headers(headers)
-            .query(&[
-                ("mount", digest.to_string()),
-                ("from", from_repo.to_owned()),
-            ])
-            .send()
+            .send_with_retry(&scopes, "blob mount", |headers| {
+                self.http
+                    .post(url.clone())
+                    .headers(headers)
+                    .query(&[("mount", &digest_str), ("from", &from)])
+            })
             .await?;
-
-        // 401 — invalidate token and retry once.
-        if resp.status().as_u16() == 401 {
-            tracing::debug!(url = %url, "got 401 on blob mount, refreshing auth token");
-            self.invalidate_auth().await;
-            let headers = self.auth_headers(&scopes).await?;
-            let resp = self
-                .http
-                .post(url)
-                .headers(headers)
-                .query(&[
-                    ("mount", digest.to_string()),
-                    ("from", from_repo.to_owned()),
-                ])
-                .send()
-                .await?;
-
-            return classify_mount_response(resp).await;
-        }
 
         classify_mount_response(resp).await
     }
@@ -129,25 +109,17 @@ impl RegistryClient {
 
         let url = build_url(&self.base_url, repository, "blobs/uploads/")?;
         let _permit = self.semaphore.acquire().await.expect("semaphore closed");
-
         let scopes = [Scope::pull_push(repository)];
-        let headers = self.auth_headers(&scopes).await?;
 
         // Step 1: Initiate upload with POST.
-        let resp = self.http.post(url.clone()).headers(headers).send().await?;
+        let resp = self
+            .send_with_retry(&scopes, "blob push initiate", |headers| {
+                self.http.post(url.clone()).headers(headers)
+            })
+            .await?;
 
-        // Handle 401 retry for initiation.
-        let resp = if resp.status().as_u16() == 401 {
-            tracing::debug!(url = %url, "got 401 on blob push initiate, refreshing auth token");
-            self.invalidate_auth().await;
-            let headers = self.auth_headers(&scopes).await?;
-            self.http.post(url).headers(headers).send().await?
-        } else {
-            resp
-        };
-
-        let status = resp.status().as_u16();
-        if status != 202 {
+        let status = resp.status();
+        if status != StatusCode::ACCEPTED {
             let message = resp.text().await.unwrap_or_default();
             return Err(Error::RegistryError { status, message });
         }
@@ -171,23 +143,24 @@ impl RegistryClient {
         };
 
         // Step 2: PUT the data with digest query param.
-        let headers = self.auth_headers(&scopes).await?;
+        let digest_str = digest.to_string();
         let resp = self
-            .http
-            .put(&put_url)
-            .headers(headers)
-            .query(&[("digest", digest.to_string())])
-            .header(CONTENT_LENGTH, data.len().to_string())
-            .header(
-                CONTENT_TYPE,
-                HeaderValue::from_static("application/octet-stream"),
-            )
-            .body(data.to_vec())
-            .send()
+            .send_with_retry(&scopes, "blob push upload", |headers| {
+                self.http
+                    .put(&put_url)
+                    .headers(headers)
+                    .query(&[("digest", &digest_str)])
+                    .header(CONTENT_LENGTH, data.len().to_string())
+                    .header(
+                        CONTENT_TYPE,
+                        HeaderValue::from_static("application/octet-stream"),
+                    )
+                    .body(data.to_vec())
+            })
             .await?;
 
-        let status = resp.status().as_u16();
-        if status != 201 {
+        let status = resp.status();
+        if status != StatusCode::CREATED {
             let message = resp.text().await.unwrap_or_default();
             return Err(Error::RegistryError { status, message });
         }
@@ -201,30 +174,14 @@ impl RegistryClient {
     pub async fn blob_upload_delete(&self, upload_url: &str) -> Result<(), Error> {
         let _permit = self.semaphore.acquire().await.expect("semaphore closed");
 
-        let headers = self.auth_headers(&[]).await?;
-        let resp = self.http.delete(upload_url).headers(headers).send().await?;
+        let resp = self
+            .send_with_retry(&[], "upload delete", |headers| {
+                self.http.delete(upload_url).headers(headers)
+            })
+            .await?;
 
-        let status = resp.status().as_u16();
-
-        // 401 — invalidate and retry once.
-        if status == 401 {
-            tracing::debug!(
-                url = upload_url,
-                "got 401 on upload delete, refreshing auth token"
-            );
-            self.invalidate_auth().await;
-            let headers = self.auth_headers(&[]).await?;
-            let resp = self.http.delete(upload_url).headers(headers).send().await?;
-
-            let status = resp.status().as_u16();
-            if status != 204 && status != 202 {
-                let message = resp.text().await.unwrap_or_default();
-                return Err(Error::RegistryError { status, message });
-            }
-            return Ok(());
-        }
-
-        if status != 204 && status != 202 {
+        let status = resp.status();
+        if status != StatusCode::NO_CONTENT && status != StatusCode::ACCEPTED {
             let message = resp.text().await.unwrap_or_default();
             return Err(Error::RegistryError { status, message });
         }
@@ -235,13 +192,11 @@ impl RegistryClient {
 
 /// Classify a mount response into [`MountResult`].
 async fn classify_mount_response(resp: reqwest::Response) -> Result<MountResult, Error> {
-    let status = resp.status().as_u16();
+    let status = resp.status();
 
     match status {
-        // 201 Created — blob was successfully mounted.
-        201 => Ok(MountResult::Mounted),
-        // 202 Accepted — mount not supported; registry gave us an upload URL.
-        202 => {
+        StatusCode::CREATED => Ok(MountResult::Mounted),
+        StatusCode::ACCEPTED => {
             let upload_url = resp
                 .headers()
                 .get(LOCATION)

--- a/crates/ocync-distribution/src/blob.rs
+++ b/crates/ocync-distribution/src/blob.rs
@@ -12,7 +12,10 @@ use crate::sha256::Sha256;
 #[derive(Debug)]
 pub enum BlobExistsResult {
     /// The blob exists with the given size in bytes.
-    Exists { size: u64 },
+    Exists {
+        /// Content length reported by the registry.
+        size: u64,
+    },
     /// The blob was not found.
     NotFound,
 }
@@ -23,7 +26,10 @@ pub enum MountResult {
     /// The blob was successfully mounted.
     Mounted,
     /// The registry did not support mounting; use the returned upload URL instead.
-    FallbackUpload { upload_url: String },
+    FallbackUpload {
+        /// The URL to use for a chunked upload.
+        upload_url: String,
+    },
 }
 
 /// Build the path segment for a blob: `/blobs/{digest}`.
@@ -127,10 +133,7 @@ impl RegistryClient {
     }
 
     /// Classify a mount response into `Mounted` or `FallbackUpload`.
-    async fn classify_mount_response(
-        &self,
-        resp: reqwest::Response,
-    ) -> Result<MountResult, Error> {
+    async fn classify_mount_response(&self, resp: reqwest::Response) -> Result<MountResult, Error> {
         let status = resp.status().as_u16();
 
         match status {
@@ -159,11 +162,7 @@ impl RegistryClient {
     /// 2. PUT the entire data with the computed digest.
     ///
     /// Returns the digest of the uploaded blob.
-    pub async fn blob_push(
-        &self,
-        repository: &str,
-        data: Vec<u8>,
-    ) -> Result<Digest, Error> {
+    pub async fn blob_push(&self, repository: &str, data: Vec<u8>) -> Result<Digest, Error> {
         // Compute digest of the data.
         let hash = Sha256::digest(&data);
         let digest = Digest::from_sha256(hash);
@@ -205,9 +204,7 @@ impl RegistryClient {
             .headers()
             .get(LOCATION)
             .and_then(|v| v.to_str().ok())
-            .ok_or_else(|| {
-                Error::Other("missing Location header in upload response".into())
-            })?
+            .ok_or_else(|| Error::Other("missing Location header in upload response".into()))?
             .to_owned();
 
         // Resolve relative Location URLs against the base URL.
@@ -216,9 +213,7 @@ impl RegistryClient {
         } else {
             self.base_url
                 .join(&upload_url)
-                .map_err(|e| {
-                    Error::Other(format!("failed to resolve upload URL: {e}"))
-                })?
+                .map_err(|e| Error::Other(format!("failed to resolve upload URL: {e}")))?
                 .to_string()
         };
 

--- a/crates/ocync-distribution/src/blob.rs
+++ b/crates/ocync-distribution/src/blob.rs
@@ -1,3 +1,5 @@
+//! Blob operations — existence checks, pull, push, mount, and upload management.
+
 use bytes::Bytes;
 use futures_util::Stream;
 use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, LOCATION};
@@ -7,18 +9,6 @@ use crate::client::{RegistryClient, build_url};
 use crate::digest::Digest;
 use crate::error::Error;
 use crate::sha256::Sha256;
-
-/// Result of a HEAD request to check blob existence.
-#[derive(Debug)]
-pub enum BlobExistsResult {
-    /// The blob exists with the given size in bytes.
-    Exists {
-        /// Content length reported by the registry.
-        size: u64,
-    },
-    /// The blob was not found.
-    NotFound,
-}
 
 /// Result of a cross-repository blob mount attempt.
 #[derive(Debug)]
@@ -33,24 +23,20 @@ pub enum MountResult {
 }
 
 /// Build the path segment for a blob: `/blobs/{digest}`.
-pub fn blob_path(digest: &Digest) -> String {
+fn blob_path(digest: &Digest) -> String {
     format!("blobs/{digest}")
-}
-
-/// Build the path segment for blob uploads: `/blobs/uploads/`.
-pub fn uploads_path() -> String {
-    "blobs/uploads/".to_owned()
 }
 
 impl RegistryClient {
     /// Check whether a blob exists in the given repository.
     ///
     /// Issues a HEAD request to `/v2/{repository}/blobs/{digest}`.
+    /// Returns `Some(size)` if the blob exists, `None` if not found.
     pub async fn blob_exists(
         &self,
         repository: &str,
         digest: &Digest,
-    ) -> Result<BlobExistsResult, Error> {
+    ) -> Result<Option<u64>, Error> {
         let path = blob_path(digest);
         match self.head(repository, &path).await {
             Ok(resp) => {
@@ -60,9 +46,9 @@ impl RegistryClient {
                     .and_then(|v| v.to_str().ok())
                     .and_then(|v| v.parse::<u64>().ok())
                     .unwrap_or(0);
-                Ok(BlobExistsResult::Exists { size })
+                Ok(Some(size))
             }
-            Err(Error::NotFound(_)) => Ok(BlobExistsResult::NotFound),
+            Err(Error::NotFound(_)) => Ok(None),
             Err(e) => Err(e),
         }
     }
@@ -84,15 +70,15 @@ impl RegistryClient {
     /// Attempt a cross-repository blob mount.
     ///
     /// Issues a POST to `/v2/{repository}/blobs/uploads/?mount={digest}&from={from_repo}`.
-    /// If the registry supports it, returns `Mounted`. Otherwise, falls back to
-    /// a regular upload URL.
+    /// If the registry supports it, returns [`MountResult::Mounted`]. Otherwise,
+    /// falls back to a regular upload URL.
     pub async fn blob_mount(
         &self,
         repository: &str,
         digest: &Digest,
         from_repo: &str,
     ) -> Result<MountResult, Error> {
-        let url = build_url(&self.base_url, repository, &uploads_path())?;
+        let url = build_url(&self.base_url, repository, "blobs/uploads/")?;
         let _permit = self.semaphore.acquire().await.expect("semaphore closed");
 
         let scopes = [Scope::pull_push(repository), Scope::pull(from_repo)];
@@ -101,7 +87,7 @@ impl RegistryClient {
         let resp = self
             .http
             .post(url.clone())
-            .headers(headers.clone())
+            .headers(headers)
             .query(&[
                 ("mount", digest.to_string()),
                 ("from", from_repo.to_owned()),
@@ -109,11 +95,10 @@ impl RegistryClient {
             .send()
             .await?;
 
-        let status = resp.status().as_u16();
-
-        // 401 — refresh token and retry once.
-        if status == 401 {
+        // 401 — invalidate token and retry once.
+        if resp.status().as_u16() == 401 {
             tracing::debug!(url = %url, "got 401 on blob mount, refreshing auth token");
+            self.invalidate_auth().await;
             let headers = self.auth_headers(&scopes).await?;
             let resp = self
                 .http
@@ -126,34 +111,10 @@ impl RegistryClient {
                 .send()
                 .await?;
 
-            return self.classify_mount_response(resp).await;
+            return classify_mount_response(resp).await;
         }
 
-        self.classify_mount_response(resp).await
-    }
-
-    /// Classify a mount response into `Mounted` or `FallbackUpload`.
-    async fn classify_mount_response(&self, resp: reqwest::Response) -> Result<MountResult, Error> {
-        let status = resp.status().as_u16();
-
-        match status {
-            // 201 Created — blob was successfully mounted.
-            201 => Ok(MountResult::Mounted),
-            // 202 Accepted — mount not supported; registry gave us an upload URL.
-            202 => {
-                let upload_url = resp
-                    .headers()
-                    .get(LOCATION)
-                    .and_then(|v| v.to_str().ok())
-                    .unwrap_or_default()
-                    .to_owned();
-                Ok(MountResult::FallbackUpload { upload_url })
-            }
-            _ => {
-                let message = resp.text().await.unwrap_or_default();
-                Err(Error::RegistryError { status, message })
-            }
-        }
+        classify_mount_response(resp).await
     }
 
     /// Push a blob to the given repository using a monolithic upload.
@@ -162,31 +123,23 @@ impl RegistryClient {
     /// 2. PUT the entire data with the computed digest.
     ///
     /// Returns the digest of the uploaded blob.
-    pub async fn blob_push(&self, repository: &str, data: Vec<u8>) -> Result<Digest, Error> {
-        // Compute digest of the data.
-        let hash = Sha256::digest(&data);
+    pub async fn blob_push(&self, repository: &str, data: &[u8]) -> Result<Digest, Error> {
+        let hash = Sha256::digest(data);
         let digest = Digest::from_sha256(hash);
-        let data_len = data.len();
 
-        let url = build_url(&self.base_url, repository, &uploads_path())?;
+        let url = build_url(&self.base_url, repository, "blobs/uploads/")?;
         let _permit = self.semaphore.acquire().await.expect("semaphore closed");
 
         let scopes = [Scope::pull_push(repository)];
         let headers = self.auth_headers(&scopes).await?;
 
         // Step 1: Initiate upload with POST.
-        let resp = self
-            .http
-            .post(url.clone())
-            .headers(headers.clone())
-            .send()
-            .await?;
-
-        let status = resp.status().as_u16();
+        let resp = self.http.post(url.clone()).headers(headers).send().await?;
 
         // Handle 401 retry for initiation.
-        let resp = if status == 401 {
+        let resp = if resp.status().as_u16() == 401 {
             tracing::debug!(url = %url, "got 401 on blob push initiate, refreshing auth token");
+            self.invalidate_auth().await;
             let headers = self.auth_headers(&scopes).await?;
             self.http.post(url).headers(headers).send().await?
         } else {
@@ -209,7 +162,7 @@ impl RegistryClient {
 
         // Resolve relative Location URLs against the base URL.
         let put_url = if upload_url.starts_with("http://") || upload_url.starts_with("https://") {
-            upload_url.clone()
+            upload_url
         } else {
             self.base_url
                 .join(&upload_url)
@@ -224,12 +177,12 @@ impl RegistryClient {
             .put(&put_url)
             .headers(headers)
             .query(&[("digest", digest.to_string())])
-            .header(CONTENT_LENGTH, data_len.to_string())
+            .header(CONTENT_LENGTH, data.len().to_string())
             .header(
                 CONTENT_TYPE,
                 HeaderValue::from_static("application/octet-stream"),
             )
-            .body(data)
+            .body(data.to_vec())
             .send()
             .await?;
 
@@ -248,20 +201,18 @@ impl RegistryClient {
     pub async fn blob_upload_delete(&self, upload_url: &str) -> Result<(), Error> {
         let _permit = self.semaphore.acquire().await.expect("semaphore closed");
 
-        // Upload URLs don't belong to a specific repo scope, but we still need auth.
-        // Use an empty scope list — the token from a previous request should still work.
         let headers = self.auth_headers(&[]).await?;
-
         let resp = self.http.delete(upload_url).headers(headers).send().await?;
 
         let status = resp.status().as_u16();
 
-        // 401 — retry once.
+        // 401 — invalidate and retry once.
         if status == 401 {
             tracing::debug!(
                 url = upload_url,
                 "got 401 on upload delete, refreshing auth token"
             );
+            self.invalidate_auth().await;
             let headers = self.auth_headers(&[]).await?;
             let resp = self.http.delete(upload_url).headers(headers).send().await?;
 
@@ -282,6 +233,30 @@ impl RegistryClient {
     }
 }
 
+/// Classify a mount response into [`MountResult`].
+async fn classify_mount_response(resp: reqwest::Response) -> Result<MountResult, Error> {
+    let status = resp.status().as_u16();
+
+    match status {
+        // 201 Created — blob was successfully mounted.
+        201 => Ok(MountResult::Mounted),
+        // 202 Accepted — mount not supported; registry gave us an upload URL.
+        202 => {
+            let upload_url = resp
+                .headers()
+                .get(LOCATION)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or_default()
+                .to_owned();
+            Ok(MountResult::FallbackUpload { upload_url })
+        }
+        _ => {
+            let message = resp.text().await.unwrap_or_default();
+            Err(Error::RegistryError { status, message })
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -296,10 +271,5 @@ mod tests {
             blob_path(&digest),
             "blobs/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         );
-    }
-
-    #[test]
-    fn uploads_path_format() {
-        assert_eq!(uploads_path(), "blobs/uploads/");
     }
 }

--- a/crates/ocync-distribution/src/catalog.rs
+++ b/crates/ocync-distribution/src/catalog.rs
@@ -1,0 +1,108 @@
+use reqwest::header::HeaderValue;
+use serde::Deserialize;
+
+use crate::client::RegistryClient;
+use crate::error::Error;
+use crate::tags::parse_next_link;
+
+/// Response body from the catalog API.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CatalogResponse {
+    pub repositories: Vec<String>,
+}
+
+impl RegistryClient {
+    /// List all repositories in the registry, automatically following pagination.
+    ///
+    /// Issues GET requests to `/v2/_catalog` and follows `Link: rel="next"`
+    /// headers until all repositories are collected.
+    pub async fn catalog(&self) -> Result<Vec<String>, Error> {
+        let mut all_repos = Vec::new();
+
+        let base_url = self
+            .base_url
+            .join("/v2/_catalog")
+            .map_err(|e| Error::Other(format!("failed to build catalog URL: {e}")))?;
+
+        let mut url = base_url.clone();
+        let _permit = self.semaphore.acquire().await.expect("semaphore closed");
+
+        loop {
+            let headers = self.auth_headers(&[]).await?;
+
+            let resp = self.http.get(url.clone()).headers(headers).send().await?;
+
+            let status = resp.status().as_u16();
+
+            // 401 — refresh and retry once.
+            let resp = if status == 401 {
+                tracing::debug!(url = %url, "got 401 on catalog, refreshing auth token");
+                let headers = self.auth_headers(&[]).await?;
+                self.http.get(url.clone()).headers(headers).send().await?
+            } else {
+                resp
+            };
+
+            let status = resp.status().as_u16();
+            if !reqwest::StatusCode::from_u16(status)
+                .map(|s| s.is_success())
+                .unwrap_or(false)
+            {
+                let message = resp.text().await.unwrap_or_default();
+                return Err(Error::RegistryError { status, message });
+            }
+
+            // Check for Link header before consuming the body.
+            let next_url = resp
+                .headers()
+                .get("link")
+                .and_then(|v: &HeaderValue| v.to_str().ok())
+                .and_then(parse_next_link);
+
+            let catalog: CatalogResponse = resp.json().await?;
+            all_repos.extend(catalog.repositories);
+
+            match next_url {
+                Some(next) => {
+                    // Resolve relative or absolute URL.
+                    if next.starts_with("http://") || next.starts_with("https://") {
+                        url = next.parse().map_err(|e| {
+                            Error::Other(format!("invalid catalog pagination URL: {e}"))
+                        })?;
+                    } else {
+                        url = self.base_url.join(&next).map_err(|e| {
+                            Error::Other(format!(
+                                "failed to resolve catalog pagination URL: {e}"
+                            ))
+                        })?;
+                    }
+                }
+                None => break,
+            }
+        }
+
+        Ok(all_repos)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_catalog_response() {
+        let json = r#"{"repositories": ["library/nginx", "library/alpine", "myuser/myapp"]}"#;
+        let resp: CatalogResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.repositories.len(), 3);
+        assert_eq!(resp.repositories[0], "library/nginx");
+        assert_eq!(resp.repositories[1], "library/alpine");
+        assert_eq!(resp.repositories[2], "myuser/myapp");
+    }
+
+    #[test]
+    fn parse_catalog_response_empty() {
+        let json = r#"{"repositories": []}"#;
+        let resp: CatalogResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.repositories.is_empty());
+    }
+}

--- a/crates/ocync-distribution/src/catalog.rs
+++ b/crates/ocync-distribution/src/catalog.rs
@@ -40,26 +40,16 @@ impl RegistryClient {
         let mut url = base_url.clone();
 
         loop {
-            // Acquire a permit per page, not for the entire loop.
             let _permit = self.semaphore.acquire().await.expect("semaphore closed");
 
-            let headers = self.auth_headers(&[]).await?;
-            let resp = self.http.get(url.clone()).headers(headers).send().await?;
+            let resp = self
+                .send_with_retry(&[], "catalog", |headers| {
+                    self.http.get(url.clone()).headers(headers)
+                })
+                .await?;
 
-            let status = resp.status().as_u16();
-
-            // 401 — invalidate token and retry once.
-            let resp = if status == 401 {
-                tracing::debug!(url = %url, "got 401 on catalog, refreshing auth token");
-                self.invalidate_auth().await;
-                let headers = self.auth_headers(&[]).await?;
-                self.http.get(url.clone()).headers(headers).send().await?
-            } else {
-                resp
-            };
-
-            let status = resp.status().as_u16();
-            if !(200..300).contains(&status) {
+            let status = resp.status();
+            if !status.is_success() {
                 let message = resp.text().await.unwrap_or_default();
                 return Err(Error::RegistryError { status, message });
             }
@@ -76,7 +66,6 @@ impl RegistryClient {
 
             match next_url {
                 Some(next) => {
-                    // Resolve relative or absolute URL.
                     if next.starts_with("http://") || next.starts_with("https://") {
                         url = next.parse().map_err(|e| {
                             Error::Other(format!("invalid catalog pagination URL: {e}"))

--- a/crates/ocync-distribution/src/catalog.rs
+++ b/crates/ocync-distribution/src/catalog.rs
@@ -1,3 +1,5 @@
+//! Catalog listing with pagination for OCI registries.
+
 use reqwest::header::HeaderValue;
 use serde::Deserialize;
 
@@ -7,9 +9,19 @@ use crate::tags::parse_next_link;
 
 /// Response body from the catalog API.
 #[derive(Debug, Clone, Deserialize)]
-pub struct CatalogResponse {
-    /// The list of repository names.
-    pub repositories: Vec<String>,
+pub(crate) struct CatalogResponse {
+    /// The list of repository names, or empty if none exist.
+    #[serde(default, deserialize_with = "deserialize_null_as_empty")]
+    pub(crate) repositories: Vec<String>,
+}
+
+/// Deserialize a `Vec<String>` that may be `null` or missing as an empty vec.
+fn deserialize_null_as_empty<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let opt: Option<Vec<String>> = Option::deserialize(deserializer)?;
+    Ok(opt.unwrap_or_default())
 }
 
 impl RegistryClient {
@@ -26,18 +38,20 @@ impl RegistryClient {
             .map_err(|e| Error::Other(format!("failed to build catalog URL: {e}")))?;
 
         let mut url = base_url.clone();
-        let _permit = self.semaphore.acquire().await.expect("semaphore closed");
 
         loop {
-            let headers = self.auth_headers(&[]).await?;
+            // Acquire a permit per page, not for the entire loop.
+            let _permit = self.semaphore.acquire().await.expect("semaphore closed");
 
+            let headers = self.auth_headers(&[]).await?;
             let resp = self.http.get(url.clone()).headers(headers).send().await?;
 
             let status = resp.status().as_u16();
 
-            // 401 — refresh and retry once.
+            // 401 — invalidate token and retry once.
             let resp = if status == 401 {
                 tracing::debug!(url = %url, "got 401 on catalog, refreshing auth token");
+                self.invalidate_auth().await;
                 let headers = self.auth_headers(&[]).await?;
                 self.http.get(url.clone()).headers(headers).send().await?
             } else {
@@ -45,10 +59,7 @@ impl RegistryClient {
             };
 
             let status = resp.status().as_u16();
-            if !reqwest::StatusCode::from_u16(status)
-                .map(|s| s.is_success())
-                .unwrap_or(false)
-            {
+            if !(200..300).contains(&status) {
                 let message = resp.text().await.unwrap_or_default();
                 return Err(Error::RegistryError { status, message });
             }
@@ -101,6 +112,20 @@ mod tests {
     #[test]
     fn parse_catalog_response_empty() {
         let json = r#"{"repositories": []}"#;
+        let resp: CatalogResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.repositories.is_empty());
+    }
+
+    #[test]
+    fn parse_catalog_response_null_repositories() {
+        let json = r#"{"repositories": null}"#;
+        let resp: CatalogResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.repositories.is_empty());
+    }
+
+    #[test]
+    fn parse_catalog_response_missing_repositories() {
+        let json = r#"{}"#;
         let resp: CatalogResponse = serde_json::from_str(json).unwrap();
         assert!(resp.repositories.is_empty());
     }

--- a/crates/ocync-distribution/src/catalog.rs
+++ b/crates/ocync-distribution/src/catalog.rs
@@ -8,6 +8,7 @@ use crate::tags::parse_next_link;
 /// Response body from the catalog API.
 #[derive(Debug, Clone, Deserialize)]
 pub struct CatalogResponse {
+    /// The list of repository names.
     pub repositories: Vec<String>,
 }
 
@@ -71,9 +72,7 @@ impl RegistryClient {
                         })?;
                     } else {
                         url = self.base_url.join(&next).map_err(|e| {
-                            Error::Other(format!(
-                                "failed to resolve catalog pagination URL: {e}"
-                            ))
+                            Error::Other(format!("failed to resolve catalog pagination URL: {e}"))
                         })?;
                     }
                 }

--- a/crates/ocync-distribution/src/client.rs
+++ b/crates/ocync-distribution/src/client.rs
@@ -217,6 +217,16 @@ impl RegistryClient {
         Ok(self.http.head(url.clone()).headers(headers).send().await?)
     }
 
+    /// Invalidate the cached auth token.
+    ///
+    /// Call this before retrying a request after a 401 response so the auth
+    /// provider fetches a fresh token instead of returning the stale one.
+    pub(crate) async fn invalidate_auth(&self) {
+        if let Some(ref auth) = self.auth {
+            auth.invalidate().await;
+        }
+    }
+
     /// Build auth headers for a request.
     pub(crate) async fn auth_headers(&self, scopes: &[Scope]) -> Result<HeaderMap, Error> {
         let mut headers = HeaderMap::new();

--- a/crates/ocync-distribution/src/client.rs
+++ b/crates/ocync-distribution/src/client.rs
@@ -89,11 +89,11 @@ impl RegistryClientBuilder {
 /// Each `RegistryClient` targets one registry host and owns its auth provider
 /// and concurrency semaphore. Construct via [`RegistryClientBuilder`].
 pub struct RegistryClient {
-    base_url: Url,
-    http: reqwest::Client,
-    auth: Option<Box<dyn AuthProvider>>,
-    semaphore: Arc<Semaphore>,
-    chunk_size: usize,
+    pub(crate) base_url: Url,
+    pub(crate) http: reqwest::Client,
+    pub(crate) auth: Option<Box<dyn AuthProvider>>,
+    pub(crate) semaphore: Arc<Semaphore>,
+    pub(crate) chunk_size: usize,
 }
 
 impl std::fmt::Debug for RegistryClient {
@@ -218,7 +218,7 @@ impl RegistryClient {
     }
 
     /// Build auth headers for a request.
-    async fn auth_headers(&self, scopes: &[Scope]) -> Result<HeaderMap, Error> {
+    pub(crate) async fn auth_headers(&self, scopes: &[Scope]) -> Result<HeaderMap, Error> {
         let mut headers = HeaderMap::new();
 
         if let Some(ref auth) = self.auth {

--- a/crates/ocync-distribution/src/client.rs
+++ b/crates/ocync-distribution/src/client.rs
@@ -1,7 +1,6 @@
 //! HTTP client for a single OCI registry endpoint.
 
-use std::sync::Arc;
-
+use http::StatusCode;
 use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue};
 use tokio::sync::Semaphore;
 use url::Url;
@@ -78,7 +77,7 @@ impl RegistryClientBuilder {
             base_url: self.url,
             http,
             auth: self.auth,
-            semaphore: Arc::new(Semaphore::new(self.max_concurrent)),
+            semaphore: Semaphore::new(self.max_concurrent),
             chunk_size: self.chunk_size,
         })
     }
@@ -92,7 +91,7 @@ pub struct RegistryClient {
     pub(crate) base_url: Url,
     pub(crate) http: reqwest::Client,
     pub(crate) auth: Option<Box<dyn AuthProvider>>,
-    pub(crate) semaphore: Arc<Semaphore>,
+    pub(crate) semaphore: Semaphore,
     pub(crate) chunk_size: usize,
 }
 
@@ -130,14 +129,11 @@ impl RegistryClient {
         let resp = self.http.get(url).send().await?;
         let status = resp.status();
 
-        if status.is_success() || status.as_u16() == 401 {
+        if status.is_success() || status == StatusCode::UNAUTHORIZED {
             Ok(())
         } else {
             let message = resp.text().await.unwrap_or_default();
-            Err(Error::RegistryError {
-                status: status.as_u16(),
-                message,
-            })
+            Err(Error::RegistryError { status, message })
         }
     }
 
@@ -153,21 +149,19 @@ impl RegistryClient {
     ) -> Result<reqwest::Response, Error> {
         let url = build_url(&self.base_url, repository, path)?;
         let _permit = self.semaphore.acquire().await.expect("semaphore closed");
-
         let scopes = [Scope::pull(repository)];
 
-        // First attempt.
-        let resp = self.send_get(&url, &scopes, accept).await?;
-        if resp.status().as_u16() != 401 {
-            return classify_response(resp, &self.base_url, repository).await;
-        }
+        let resp = self
+            .send_with_retry(&scopes, "GET", |mut headers| {
+                if let Some(accept) = accept {
+                    if let Ok(val) = HeaderValue::from_str(accept) {
+                        headers.insert(ACCEPT, val);
+                    }
+                }
+                self.http.get(url.clone()).headers(headers)
+            })
+            .await?;
 
-        // 401 — invalidate cached token and retry once.
-        tracing::debug!(url = %url, "got 401, invalidating token and retrying");
-        if let Some(ref auth) = self.auth {
-            auth.invalidate().await;
-        }
-        let resp = self.send_get(&url, &scopes, accept).await?;
         classify_response(resp, &self.base_url, repository).await
     }
 
@@ -177,44 +171,40 @@ impl RegistryClient {
     pub async fn head(&self, repository: &str, path: &str) -> Result<reqwest::Response, Error> {
         let url = build_url(&self.base_url, repository, path)?;
         let _permit = self.semaphore.acquire().await.expect("semaphore closed");
-
         let scopes = [Scope::pull(repository)];
 
-        let resp = self.send_head(&url, &scopes).await?;
-        if resp.status().as_u16() != 401 {
-            return classify_response(resp, &self.base_url, repository).await;
-        }
+        let resp = self
+            .send_with_retry(&scopes, "HEAD", |headers| {
+                self.http.head(url.clone()).headers(headers)
+            })
+            .await?;
 
-        // 401 — invalidate cached token and retry once.
-        tracing::debug!(url = %url, "got 401, invalidating token and retrying");
-        if let Some(ref auth) = self.auth {
-            auth.invalidate().await;
-        }
-        let resp = self.send_head(&url, &scopes).await?;
         classify_response(resp, &self.base_url, repository).await
     }
 
-    /// Internal: send a GET with auth headers.
-    async fn send_get(
+    /// Send a request with 401 retry and token invalidation.
+    ///
+    /// Builds the request via `build_request` (called with fresh auth headers),
+    /// sends it, and if a 401 is returned, invalidates the cached token and
+    /// retries once. Does NOT acquire a semaphore permit — callers manage their
+    /// own permits.
+    pub(crate) async fn send_with_retry(
         &self,
-        url: &Url,
         scopes: &[Scope],
-        accept: Option<&str>,
+        context: &str,
+        build_request: impl Fn(HeaderMap) -> reqwest::RequestBuilder,
     ) -> Result<reqwest::Response, Error> {
-        let mut headers = self.auth_headers(scopes).await?;
-        if let Some(accept) = accept {
-            if let Ok(val) = HeaderValue::from_str(accept) {
-                headers.insert(ACCEPT, val);
-            }
+        let headers = self.auth_headers(scopes).await?;
+        let resp = build_request(headers).send().await?;
+
+        if resp.status() != StatusCode::UNAUTHORIZED {
+            return Ok(resp);
         }
 
-        Ok(self.http.get(url.clone()).headers(headers).send().await?)
-    }
-
-    /// Internal: send a HEAD with auth headers.
-    async fn send_head(&self, url: &Url, scopes: &[Scope]) -> Result<reqwest::Response, Error> {
+        tracing::debug!(context, "got 401, invalidating token and retrying");
+        self.invalidate_auth().await;
         let headers = self.auth_headers(scopes).await?;
-        Ok(self.http.head(url.clone()).headers(headers).send().await?)
+        Ok(build_request(headers).send().await?)
     }
 
     /// Invalidate the cached auth token.
@@ -259,22 +249,19 @@ async fn classify_response(
 
     let registry = base_url.host_str().unwrap_or("unknown").to_owned();
 
-    match status.as_u16() {
-        401 => Err(Error::Unauthorized { registry }),
-        403 => Err(Error::Forbidden {
+    match status {
+        StatusCode::UNAUTHORIZED => Err(Error::Unauthorized { registry }),
+        StatusCode::FORBIDDEN => Err(Error::Forbidden {
             registry,
             repository: repository.to_owned(),
         }),
-        404 => {
+        StatusCode::NOT_FOUND => {
             let message = resp.text().await.unwrap_or_default();
             Err(Error::NotFound(message))
         }
         _ => {
             let message = resp.text().await.unwrap_or_default();
-            Err(Error::RegistryError {
-                status: status.as_u16(),
-                message,
-            })
+            Err(Error::RegistryError { status, message })
         }
     }
 }

--- a/crates/ocync-distribution/src/error.rs
+++ b/crates/ocync-distribution/src/error.rs
@@ -85,7 +85,7 @@ pub enum Error {
     #[error("registry returned {status}: {message}")]
     RegistryError {
         /// The HTTP status code.
-        status: u16,
+        status: http::StatusCode,
         /// The response body.
         message: String,
     },

--- a/crates/ocync-distribution/src/lib.rs
+++ b/crates/ocync-distribution/src/lib.rs
@@ -12,6 +12,7 @@ pub mod manifest;
 pub mod reference;
 pub mod sha256;
 pub mod spec;
+pub mod tags;
 
 pub use client::RegistryClient;
 pub use digest::Digest;

--- a/crates/ocync-distribution/src/lib.rs
+++ b/crates/ocync-distribution/src/lib.rs
@@ -29,4 +29,4 @@ pub use digest::Digest;
 pub use error::Error;
 pub use manifest::{ManifestHead, ManifestPull};
 pub use reference::Reference;
-pub use spec::{Descriptor, ImageIndex, ImageManifest, ManifestKind, Platform};
+pub use spec::{Descriptor, ImageIndex, ImageManifest, ManifestKind, MediaType, Platform};

--- a/crates/ocync-distribution/src/lib.rs
+++ b/crates/ocync-distribution/src/lib.rs
@@ -2,6 +2,8 @@
 
 /// Authentication providers and token management.
 pub mod auth;
+/// Blob operations (upload, download, existence checks).
+pub mod blob;
 /// OCI registry HTTP client.
 pub mod client;
 pub mod digest;

--- a/crates/ocync-distribution/src/lib.rs
+++ b/crates/ocync-distribution/src/lib.rs
@@ -2,22 +2,28 @@
 
 /// Authentication providers and token management.
 pub mod auth;
-/// Blob operations (upload, download, existence checks).
+/// Blob operations (upload, download, existence checks, mounting).
 pub mod blob;
 /// Catalog listing with pagination.
 pub mod catalog;
 /// OCI registry HTTP client.
 pub mod client;
+/// OCI content-addressable digest type.
 pub mod digest;
+/// Error types for OCI distribution operations.
 pub mod error;
-/// Manifest operations (pull, push, head).
+/// Manifest operations (pull, push, head, referrers).
 pub mod manifest;
+/// OCI image reference parser.
 pub mod reference;
+/// SHA-256 wrapper backed by aws-lc-rs.
 pub mod sha256;
+/// OCI image spec types — manifests, descriptors, and platforms.
 pub mod spec;
 /// Tag listing with pagination.
 pub mod tags;
 
+pub use blob::MountResult;
 pub use client::RegistryClient;
 pub use digest::Digest;
 pub use error::Error;

--- a/crates/ocync-distribution/src/lib.rs
+++ b/crates/ocync-distribution/src/lib.rs
@@ -8,6 +8,7 @@ pub mod blob;
 pub mod client;
 pub mod digest;
 pub mod error;
+pub mod manifest;
 pub mod reference;
 pub mod sha256;
 pub mod spec;

--- a/crates/ocync-distribution/src/lib.rs
+++ b/crates/ocync-distribution/src/lib.rs
@@ -4,18 +4,23 @@
 pub mod auth;
 /// Blob operations (upload, download, existence checks).
 pub mod blob;
+/// Catalog listing with pagination.
+pub mod catalog;
 /// OCI registry HTTP client.
 pub mod client;
 pub mod digest;
 pub mod error;
+/// Manifest operations (pull, push, head).
 pub mod manifest;
 pub mod reference;
 pub mod sha256;
 pub mod spec;
+/// Tag listing with pagination.
 pub mod tags;
 
 pub use client::RegistryClient;
 pub use digest::Digest;
 pub use error::Error;
+pub use manifest::{ManifestHead, ManifestPull};
 pub use reference::Reference;
 pub use spec::{Descriptor, ImageIndex, ImageManifest, ManifestKind, Platform};

--- a/crates/ocync-distribution/src/manifest.rs
+++ b/crates/ocync-distribution/src/manifest.rs
@@ -1,5 +1,6 @@
 //! Manifest operations — pull, push, head checks, and referrers queries.
 
+use http::StatusCode;
 use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE, HeaderValue};
 
 use crate::auth::Scope;
@@ -7,7 +8,7 @@ use crate::client::{RegistryClient, build_url};
 use crate::digest::Digest;
 use crate::error::Error;
 use crate::sha256::Sha256;
-use crate::spec::{ImageIndex, ManifestKind, media_types};
+use crate::spec::{ImageIndex, ManifestKind, MediaType};
 
 /// Result of a manifest HEAD request.
 #[derive(Debug, Clone)]
@@ -15,7 +16,7 @@ pub struct ManifestHead {
     /// The digest of the manifest.
     pub digest: Digest,
     /// The media type reported by the registry.
-    pub media_type: String,
+    pub media_type: MediaType,
     /// The size in bytes.
     pub size: u64,
 }
@@ -28,20 +29,18 @@ pub struct ManifestPull {
     /// The raw bytes as received from the registry (preserved verbatim for push).
     pub raw_bytes: Vec<u8>,
     /// The media type reported by the registry.
-    pub media_type: String,
+    pub media_type: MediaType,
     /// The digest computed from the raw bytes.
     pub digest: Digest,
 }
 
 /// Build the Accept header value for manifest requests.
-///
-/// Includes all four supported manifest media types.
 fn manifest_accept_header() -> String {
     [
-        media_types::OCI_IMAGE_MANIFEST,
-        media_types::OCI_IMAGE_INDEX,
-        media_types::DOCKER_MANIFEST_V2,
-        media_types::DOCKER_MANIFEST_LIST,
+        MediaType::OciManifest.as_str(),
+        MediaType::OciIndex.as_str(),
+        MediaType::DockerManifestV2.as_str(),
+        MediaType::DockerManifestList.as_str(),
     ]
     .join(", ")
 }
@@ -80,11 +79,11 @@ impl RegistryClient {
                     ))
                 })?;
 
-                let media_type = headers
+                let media_type: MediaType = headers
                     .get(CONTENT_TYPE)
                     .and_then(|v| v.to_str().ok())
                     .unwrap_or_default()
-                    .to_owned();
+                    .into();
 
                 let size = headers
                     .get(CONTENT_LENGTH)
@@ -116,12 +115,12 @@ impl RegistryClient {
         let accept = manifest_accept_header();
         let resp = self.get(repository, &path, Some(&accept)).await?;
 
-        let media_type = resp
+        let media_type: MediaType = resp
             .headers()
             .get(CONTENT_TYPE)
             .and_then(|v| v.to_str().ok())
-            .unwrap_or(media_types::OCI_IMAGE_MANIFEST)
-            .to_owned();
+            .unwrap_or(MediaType::OciManifest.as_str())
+            .into();
 
         let raw_bytes = resp.bytes().await?.to_vec();
 
@@ -146,7 +145,7 @@ impl RegistryClient {
         &self,
         repository: &str,
         reference: &str,
-        media_type: &str,
+        media_type: &MediaType,
         raw_bytes: &[u8],
     ) -> Result<Digest, Error> {
         let hash = Sha256::digest(raw_bytes);
@@ -154,49 +153,24 @@ impl RegistryClient {
 
         let url = build_url(&self.base_url, repository, &manifest_path(reference))?;
         let _permit = self.semaphore.acquire().await.expect("semaphore closed");
-
         let scopes = [Scope::pull_push(repository)];
-        let headers = self.auth_headers(&scopes).await?;
 
-        let content_type = HeaderValue::from_str(media_type)
+        let content_type = HeaderValue::from_str(media_type.as_str())
             .map_err(|e| Error::Other(format!("invalid media type header value: {e}")))?;
 
         let resp = self
-            .http
-            .put(url.clone())
-            .headers(headers)
-            .header(CONTENT_TYPE, content_type.clone())
-            .header(CONTENT_LENGTH, raw_bytes.len().to_string())
-            .body(raw_bytes.to_vec())
-            .send()
+            .send_with_retry(&scopes, "manifest push", |headers| {
+                self.http
+                    .put(url.clone())
+                    .headers(headers)
+                    .header(CONTENT_TYPE, content_type.clone())
+                    .header(CONTENT_LENGTH, raw_bytes.len().to_string())
+                    .body(raw_bytes.to_vec())
+            })
             .await?;
 
-        let status = resp.status().as_u16();
-
-        // 401 — invalidate token and retry once.
-        if status == 401 {
-            tracing::debug!(url = %url, "got 401 on manifest push, refreshing auth token");
-            self.invalidate_auth().await;
-            let headers = self.auth_headers(&scopes).await?;
-            let resp = self
-                .http
-                .put(url)
-                .headers(headers)
-                .header(CONTENT_TYPE, content_type)
-                .header(CONTENT_LENGTH, raw_bytes.len().to_string())
-                .body(raw_bytes.to_vec())
-                .send()
-                .await?;
-
-            let status = resp.status().as_u16();
-            if status != 201 && status != 200 {
-                let message = resp.text().await.unwrap_or_default();
-                return Err(Error::RegistryError { status, message });
-            }
-            return Ok(digest);
-        }
-
-        if status != 201 && status != 200 {
+        let status = resp.status();
+        if !status.is_success() {
             let message = resp.text().await.unwrap_or_default();
             return Err(Error::RegistryError { status, message });
         }
@@ -207,7 +181,8 @@ impl RegistryClient {
     /// Query the referrers API for a given digest.
     ///
     /// Returns `None` if the registry does not support the referrers API (404).
-    /// Optionally filters by `artifact_type`.
+    /// Optionally filters by `artifact_type` (an OCI artifact MIME type string,
+    /// e.g. `application/vnd.dev.cosign.simplesigning.v1+json`).
     pub async fn referrers(
         &self,
         repository: &str,
@@ -215,7 +190,7 @@ impl RegistryClient {
         artifact_type: Option<&str>,
     ) -> Result<Option<ImageIndex>, Error> {
         let path = referrers_path(digest);
-        let accept = media_types::OCI_IMAGE_INDEX;
+        let accept = MediaType::OciIndex.as_str();
 
         // Build URL with optional artifactType filter.
         let mut url = build_url(&self.base_url, repository, &path)?;
@@ -225,36 +200,15 @@ impl RegistryClient {
 
         let _permit = self.semaphore.acquire().await.expect("semaphore closed");
         let scopes = [Scope::pull(repository)];
-        let headers = self.auth_headers(&scopes).await?;
-
-        let mut req_headers = headers;
-        if let Ok(val) = HeaderValue::from_str(accept) {
-            req_headers.insert(reqwest::header::ACCEPT, val);
-        }
 
         let resp = self
-            .http
-            .get(url.clone())
-            .headers(req_headers)
-            .send()
+            .send_with_retry(&scopes, "referrers", |mut headers| {
+                if let Ok(val) = HeaderValue::from_str(accept) {
+                    headers.insert(reqwest::header::ACCEPT, val);
+                }
+                self.http.get(url.clone()).headers(headers)
+            })
             .await?;
-
-        let status = resp.status().as_u16();
-
-        // 401 — invalidate and retry.
-        if status == 401 {
-            tracing::debug!(url = %url, "got 401 on referrers, refreshing auth token");
-            self.invalidate_auth().await;
-            let headers = self.auth_headers(&scopes).await?;
-            let mut req_headers = headers;
-            if let Ok(val) = HeaderValue::from_str(accept) {
-                req_headers.insert(reqwest::header::ACCEPT, val);
-            }
-
-            let resp = self.http.get(url).headers(req_headers).send().await?;
-
-            return classify_referrers_response(resp).await;
-        }
 
         classify_referrers_response(resp).await
     }
@@ -262,14 +216,14 @@ impl RegistryClient {
 
 /// Classify a referrers response.
 async fn classify_referrers_response(resp: reqwest::Response) -> Result<Option<ImageIndex>, Error> {
-    let status = resp.status().as_u16();
+    let status = resp.status();
 
     match status {
-        200 => {
+        StatusCode::OK => {
             let index: ImageIndex = resp.json().await?;
             Ok(Some(index))
         }
-        404 => Ok(None),
+        StatusCode::NOT_FOUND => Ok(None),
         _ => {
             let message = resp.text().await.unwrap_or_default();
             Err(Error::RegistryError { status, message })
@@ -300,11 +254,11 @@ mod tests {
     }
 
     #[test]
-    fn accept_header_contains_all_types() {
+    fn accept_header_contains_all_manifest_types() {
         let accept = manifest_accept_header();
-        assert!(accept.contains(media_types::OCI_IMAGE_MANIFEST));
-        assert!(accept.contains(media_types::OCI_IMAGE_INDEX));
-        assert!(accept.contains(media_types::DOCKER_MANIFEST_V2));
-        assert!(accept.contains(media_types::DOCKER_MANIFEST_LIST));
+        assert!(accept.contains(MediaType::OciManifest.as_str()));
+        assert!(accept.contains(MediaType::OciIndex.as_str()));
+        assert!(accept.contains(MediaType::DockerManifestV2.as_str()));
+        assert!(accept.contains(MediaType::DockerManifestList.as_str()));
     }
 }

--- a/crates/ocync-distribution/src/manifest.rs
+++ b/crates/ocync-distribution/src/manifest.rs
@@ -158,9 +158,8 @@ impl RegistryClient {
         let scopes = [Scope::pull_push(repository)];
         let headers = self.auth_headers(&scopes).await?;
 
-        let content_type = HeaderValue::from_str(media_type).map_err(|e| {
-            Error::Other(format!("invalid media type header value: {e}"))
-        })?;
+        let content_type = HeaderValue::from_str(media_type)
+            .map_err(|e| Error::Other(format!("invalid media type header value: {e}")))?;
 
         let resp = self
             .http

--- a/crates/ocync-distribution/src/manifest.rs
+++ b/crates/ocync-distribution/src/manifest.rs
@@ -3,9 +3,9 @@ use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE, HeaderValue};
 use crate::auth::Scope;
 use crate::client::{RegistryClient, build_url};
 use crate::digest::Digest;
-use crate::error::DistributionError;
+use crate::error::Error;
 use crate::sha256::Sha256;
-use crate::spec::{ImageIndex, Manifest, media_types};
+use crate::spec::{ImageIndex, ManifestKind, media_types};
 
 /// Result of a manifest HEAD request.
 #[derive(Debug, Clone)]
@@ -22,7 +22,7 @@ pub struct ManifestHead {
 #[derive(Debug, Clone)]
 pub struct ManifestPull {
     /// The parsed manifest.
-    pub manifest: Manifest,
+    pub manifest: ManifestKind,
     /// The raw bytes as received from the registry (preserved verbatim for push).
     pub raw_bytes: Vec<u8>,
     /// The media type reported by the registry.
@@ -62,7 +62,7 @@ impl RegistryClient {
         &self,
         repository: &str,
         reference: &str,
-    ) -> Result<Option<ManifestHead>, DistributionError> {
+    ) -> Result<Option<ManifestHead>, Error> {
         let path = manifest_path(reference);
         match self.head(repository, &path).await {
             Ok(resp) => {
@@ -73,7 +73,7 @@ impl RegistryClient {
                     .and_then(|v| v.to_str().ok())
                     .unwrap_or_default();
                 let digest: Digest = digest_str.parse().map_err(|_| {
-                    DistributionError::Other(format!(
+                    Error::Other(format!(
                         "invalid digest in Docker-Content-Digest header: {digest_str}"
                     ))
                 })?;
@@ -96,7 +96,7 @@ impl RegistryClient {
                     size,
                 }))
             }
-            Err(DistributionError::NotFound(_)) => Ok(None),
+            Err(Error::NotFound(_)) => Ok(None),
             Err(e) => Err(e),
         }
     }
@@ -109,7 +109,7 @@ impl RegistryClient {
         &self,
         repository: &str,
         reference: &str,
-    ) -> Result<ManifestPull, DistributionError> {
+    ) -> Result<ManifestPull, Error> {
         let path = manifest_path(reference);
         let accept = manifest_accept_header();
         let resp = self.get(repository, &path, Some(&accept)).await?;
@@ -127,7 +127,7 @@ impl RegistryClient {
         let hash = Sha256::digest(&raw_bytes);
         let digest = Digest::from_sha256(hash);
 
-        let manifest = Manifest::from_json(&media_type, &raw_bytes)?;
+        let manifest = ManifestKind::from_json(&media_type, &raw_bytes)?;
 
         Ok(ManifestPull {
             manifest,
@@ -147,7 +147,7 @@ impl RegistryClient {
         reference: &str,
         media_type: &str,
         raw_bytes: Vec<u8>,
-    ) -> Result<Digest, DistributionError> {
+    ) -> Result<Digest, Error> {
         let hash = Sha256::digest(&raw_bytes);
         let digest = Digest::from_sha256(hash);
         let data_len = raw_bytes.len();
@@ -159,7 +159,7 @@ impl RegistryClient {
         let headers = self.auth_headers(&scopes).await?;
 
         let content_type = HeaderValue::from_str(media_type).map_err(|e| {
-            DistributionError::Other(format!("invalid media type header value: {e}"))
+            Error::Other(format!("invalid media type header value: {e}"))
         })?;
 
         let resp = self
@@ -191,14 +191,14 @@ impl RegistryClient {
             let status = resp.status().as_u16();
             if status != 201 && status != 200 {
                 let message = resp.text().await.unwrap_or_default();
-                return Err(DistributionError::RegistryError { status, message });
+                return Err(Error::RegistryError { status, message });
             }
             return Ok(digest);
         }
 
         if status != 201 && status != 200 {
             let message = resp.text().await.unwrap_or_default();
-            return Err(DistributionError::RegistryError { status, message });
+            return Err(Error::RegistryError { status, message });
         }
 
         Ok(digest)
@@ -213,7 +213,7 @@ impl RegistryClient {
         repository: &str,
         digest: &Digest,
         artifact_type: Option<&str>,
-    ) -> Result<Option<ImageIndex>, DistributionError> {
+    ) -> Result<Option<ImageIndex>, Error> {
         let path = referrers_path(digest);
         let accept = media_types::OCI_IMAGE_INDEX;
 
@@ -262,7 +262,7 @@ impl RegistryClient {
     async fn classify_referrers_response(
         &self,
         resp: reqwest::Response,
-    ) -> Result<Option<ImageIndex>, DistributionError> {
+    ) -> Result<Option<ImageIndex>, Error> {
         let status = resp.status().as_u16();
 
         match status {
@@ -273,7 +273,7 @@ impl RegistryClient {
             404 => Ok(None),
             _ => {
                 let message = resp.text().await.unwrap_or_default();
-                Err(DistributionError::RegistryError { status, message })
+                Err(Error::RegistryError { status, message })
             }
         }
     }

--- a/crates/ocync-distribution/src/manifest.rs
+++ b/crates/ocync-distribution/src/manifest.rs
@@ -1,0 +1,312 @@
+use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE, HeaderValue};
+
+use crate::auth::Scope;
+use crate::client::{RegistryClient, build_url};
+use crate::digest::Digest;
+use crate::error::DistributionError;
+use crate::sha256::Sha256;
+use crate::spec::{ImageIndex, Manifest, media_types};
+
+/// Result of a manifest HEAD request.
+#[derive(Debug, Clone)]
+pub struct ManifestHead {
+    /// The digest of the manifest.
+    pub digest: Digest,
+    /// The media type reported by the registry.
+    pub media_type: String,
+    /// The size in bytes.
+    pub size: u64,
+}
+
+/// Result of a manifest pull (GET) request.
+#[derive(Debug, Clone)]
+pub struct ManifestPull {
+    /// The parsed manifest.
+    pub manifest: Manifest,
+    /// The raw bytes as received from the registry (preserved verbatim for push).
+    pub raw_bytes: Vec<u8>,
+    /// The media type reported by the registry.
+    pub media_type: String,
+    /// The digest computed from the raw bytes.
+    pub digest: Digest,
+}
+
+/// Build the Accept header value for manifest requests.
+///
+/// Includes all four supported manifest media types.
+pub fn manifest_accept_header() -> String {
+    [
+        media_types::OCI_IMAGE_MANIFEST,
+        media_types::OCI_IMAGE_INDEX,
+        media_types::DOCKER_MANIFEST_V2,
+        media_types::DOCKER_MANIFEST_LIST,
+    ]
+    .join(", ")
+}
+
+/// Build the path segment for a manifest: `/manifests/{reference}`.
+pub fn manifest_path(reference: &str) -> String {
+    format!("manifests/{reference}")
+}
+
+/// Build the path segment for the referrers API: `/referrers/{digest}`.
+pub fn referrers_path(digest: &Digest) -> String {
+    format!("referrers/{digest}")
+}
+
+impl RegistryClient {
+    /// Check whether a manifest exists and retrieve its metadata.
+    ///
+    /// Returns `None` if the manifest is not found (404).
+    pub async fn manifest_head(
+        &self,
+        repository: &str,
+        reference: &str,
+    ) -> Result<Option<ManifestHead>, DistributionError> {
+        let path = manifest_path(reference);
+        match self.head(repository, &path).await {
+            Ok(resp) => {
+                let headers = resp.headers();
+
+                let digest_str = headers
+                    .get("docker-content-digest")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or_default();
+                let digest: Digest = digest_str.parse().map_err(|_| {
+                    DistributionError::Other(format!(
+                        "invalid digest in Docker-Content-Digest header: {digest_str}"
+                    ))
+                })?;
+
+                let media_type = headers
+                    .get(CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or_default()
+                    .to_owned();
+
+                let size = headers
+                    .get(CONTENT_LENGTH)
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(|v| v.parse::<u64>().ok())
+                    .unwrap_or(0);
+
+                Ok(Some(ManifestHead {
+                    digest,
+                    media_type,
+                    size,
+                }))
+            }
+            Err(DistributionError::NotFound(_)) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Pull a manifest from the registry.
+    ///
+    /// Issues a GET with all supported media types in the Accept header, parses
+    /// the manifest, and computes the digest from the raw bytes.
+    pub async fn manifest_pull(
+        &self,
+        repository: &str,
+        reference: &str,
+    ) -> Result<ManifestPull, DistributionError> {
+        let path = manifest_path(reference);
+        let accept = manifest_accept_header();
+        let resp = self.get(repository, &path, Some(&accept)).await?;
+
+        let media_type = resp
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or(media_types::OCI_IMAGE_MANIFEST)
+            .to_owned();
+
+        let raw_bytes = resp.bytes().await?.to_vec();
+
+        // Compute digest from the raw bytes.
+        let hash = Sha256::digest(&raw_bytes);
+        let digest = Digest::from_sha256(hash);
+
+        let manifest = Manifest::from_json(&media_type, &raw_bytes)?;
+
+        Ok(ManifestPull {
+            manifest,
+            raw_bytes,
+            media_type,
+            digest,
+        })
+    }
+
+    /// Push a manifest to the registry.
+    ///
+    /// Issues a PUT to `/v2/{repository}/manifests/{reference}` with the raw bytes
+    /// exactly as provided. Returns the digest computed from those bytes.
+    pub async fn manifest_push(
+        &self,
+        repository: &str,
+        reference: &str,
+        media_type: &str,
+        raw_bytes: Vec<u8>,
+    ) -> Result<Digest, DistributionError> {
+        let hash = Sha256::digest(&raw_bytes);
+        let digest = Digest::from_sha256(hash);
+        let data_len = raw_bytes.len();
+
+        let url = build_url(&self.base_url, repository, &manifest_path(reference))?;
+        let _permit = self.semaphore.acquire().await.expect("semaphore closed");
+
+        let scopes = [Scope::pull_push(repository)];
+        let headers = self.auth_headers(&scopes).await?;
+
+        let content_type = HeaderValue::from_str(media_type).map_err(|e| {
+            DistributionError::Other(format!("invalid media type header value: {e}"))
+        })?;
+
+        let resp = self
+            .http
+            .put(url.clone())
+            .headers(headers)
+            .header(CONTENT_TYPE, content_type.clone())
+            .header(CONTENT_LENGTH, data_len.to_string())
+            .body(raw_bytes.clone())
+            .send()
+            .await?;
+
+        let status = resp.status().as_u16();
+
+        // 401 — refresh token and retry once.
+        if status == 401 {
+            tracing::debug!(url = %url, "got 401 on manifest push, refreshing auth token");
+            let headers = self.auth_headers(&scopes).await?;
+            let resp = self
+                .http
+                .put(url)
+                .headers(headers)
+                .header(CONTENT_TYPE, content_type)
+                .header(CONTENT_LENGTH, data_len.to_string())
+                .body(raw_bytes)
+                .send()
+                .await?;
+
+            let status = resp.status().as_u16();
+            if status != 201 && status != 200 {
+                let message = resp.text().await.unwrap_or_default();
+                return Err(DistributionError::RegistryError { status, message });
+            }
+            return Ok(digest);
+        }
+
+        if status != 201 && status != 200 {
+            let message = resp.text().await.unwrap_or_default();
+            return Err(DistributionError::RegistryError { status, message });
+        }
+
+        Ok(digest)
+    }
+
+    /// Query the referrers API for a given digest.
+    ///
+    /// Returns `None` if the registry does not support the referrers API (404).
+    /// Optionally filters by `artifact_type`.
+    pub async fn referrers(
+        &self,
+        repository: &str,
+        digest: &Digest,
+        artifact_type: Option<&str>,
+    ) -> Result<Option<ImageIndex>, DistributionError> {
+        let path = referrers_path(digest);
+        let accept = media_types::OCI_IMAGE_INDEX;
+
+        // Build URL with optional artifactType filter.
+        let mut url = build_url(&self.base_url, repository, &path)?;
+        if let Some(at) = artifact_type {
+            url.query_pairs_mut().append_pair("artifactType", at);
+        }
+
+        let _permit = self.semaphore.acquire().await.expect("semaphore closed");
+        let scopes = [Scope::pull(repository)];
+        let headers = self.auth_headers(&scopes).await?;
+
+        let mut req_headers = headers.clone();
+        if let Ok(val) = HeaderValue::from_str(accept) {
+            req_headers.insert(reqwest::header::ACCEPT, val);
+        }
+
+        let resp = self
+            .http
+            .get(url.clone())
+            .headers(req_headers)
+            .send()
+            .await?;
+
+        let status = resp.status().as_u16();
+
+        // 401 — refresh and retry.
+        if status == 401 {
+            tracing::debug!(url = %url, "got 401 on referrers, refreshing auth token");
+            let headers = self.auth_headers(&scopes).await?;
+            let mut req_headers = headers;
+            if let Ok(val) = HeaderValue::from_str(accept) {
+                req_headers.insert(reqwest::header::ACCEPT, val);
+            }
+
+            let resp = self.http.get(url).headers(req_headers).send().await?;
+
+            return self.classify_referrers_response(resp).await;
+        }
+
+        self.classify_referrers_response(resp).await
+    }
+
+    /// Classify a referrers response.
+    async fn classify_referrers_response(
+        &self,
+        resp: reqwest::Response,
+    ) -> Result<Option<ImageIndex>, DistributionError> {
+        let status = resp.status().as_u16();
+
+        match status {
+            200 => {
+                let index: ImageIndex = resp.json().await?;
+                Ok(Some(index))
+            }
+            404 => Ok(None),
+            _ => {
+                let message = resp.text().await.unwrap_or_default();
+                Err(DistributionError::RegistryError { status, message })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_path_format() {
+        assert_eq!(manifest_path("latest"), "manifests/latest");
+        assert_eq!(manifest_path("v1.0"), "manifests/v1.0");
+    }
+
+    #[test]
+    fn referrers_path_format() {
+        let digest: Digest =
+            "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                .parse()
+                .unwrap();
+        assert_eq!(
+            referrers_path(&digest),
+            "referrers/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn accept_header_contains_all_types() {
+        let accept = manifest_accept_header();
+        assert!(accept.contains(media_types::OCI_IMAGE_MANIFEST));
+        assert!(accept.contains(media_types::OCI_IMAGE_INDEX));
+        assert!(accept.contains(media_types::DOCKER_MANIFEST_V2));
+        assert!(accept.contains(media_types::DOCKER_MANIFEST_LIST));
+    }
+}

--- a/crates/ocync-distribution/src/manifest.rs
+++ b/crates/ocync-distribution/src/manifest.rs
@@ -1,3 +1,5 @@
+//! Manifest operations — pull, push, head checks, and referrers queries.
+
 use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE, HeaderValue};
 
 use crate::auth::Scope;
@@ -34,7 +36,7 @@ pub struct ManifestPull {
 /// Build the Accept header value for manifest requests.
 ///
 /// Includes all four supported manifest media types.
-pub fn manifest_accept_header() -> String {
+fn manifest_accept_header() -> String {
     [
         media_types::OCI_IMAGE_MANIFEST,
         media_types::OCI_IMAGE_INDEX,
@@ -45,12 +47,12 @@ pub fn manifest_accept_header() -> String {
 }
 
 /// Build the path segment for a manifest: `/manifests/{reference}`.
-pub fn manifest_path(reference: &str) -> String {
+fn manifest_path(reference: &str) -> String {
     format!("manifests/{reference}")
 }
 
 /// Build the path segment for the referrers API: `/referrers/{digest}`.
-pub fn referrers_path(digest: &Digest) -> String {
+fn referrers_path(digest: &Digest) -> String {
     format!("referrers/{digest}")
 }
 
@@ -123,7 +125,6 @@ impl RegistryClient {
 
         let raw_bytes = resp.bytes().await?.to_vec();
 
-        // Compute digest from the raw bytes.
         let hash = Sha256::digest(&raw_bytes);
         let digest = Digest::from_sha256(hash);
 
@@ -146,11 +147,10 @@ impl RegistryClient {
         repository: &str,
         reference: &str,
         media_type: &str,
-        raw_bytes: Vec<u8>,
+        raw_bytes: &[u8],
     ) -> Result<Digest, Error> {
-        let hash = Sha256::digest(&raw_bytes);
+        let hash = Sha256::digest(raw_bytes);
         let digest = Digest::from_sha256(hash);
-        let data_len = raw_bytes.len();
 
         let url = build_url(&self.base_url, repository, &manifest_path(reference))?;
         let _permit = self.semaphore.acquire().await.expect("semaphore closed");
@@ -166,24 +166,25 @@ impl RegistryClient {
             .put(url.clone())
             .headers(headers)
             .header(CONTENT_TYPE, content_type.clone())
-            .header(CONTENT_LENGTH, data_len.to_string())
-            .body(raw_bytes.clone())
+            .header(CONTENT_LENGTH, raw_bytes.len().to_string())
+            .body(raw_bytes.to_vec())
             .send()
             .await?;
 
         let status = resp.status().as_u16();
 
-        // 401 — refresh token and retry once.
+        // 401 — invalidate token and retry once.
         if status == 401 {
             tracing::debug!(url = %url, "got 401 on manifest push, refreshing auth token");
+            self.invalidate_auth().await;
             let headers = self.auth_headers(&scopes).await?;
             let resp = self
                 .http
                 .put(url)
                 .headers(headers)
                 .header(CONTENT_TYPE, content_type)
-                .header(CONTENT_LENGTH, data_len.to_string())
-                .body(raw_bytes)
+                .header(CONTENT_LENGTH, raw_bytes.len().to_string())
+                .body(raw_bytes.to_vec())
                 .send()
                 .await?;
 
@@ -226,7 +227,7 @@ impl RegistryClient {
         let scopes = [Scope::pull(repository)];
         let headers = self.auth_headers(&scopes).await?;
 
-        let mut req_headers = headers.clone();
+        let mut req_headers = headers;
         if let Ok(val) = HeaderValue::from_str(accept) {
             req_headers.insert(reqwest::header::ACCEPT, val);
         }
@@ -240,9 +241,10 @@ impl RegistryClient {
 
         let status = resp.status().as_u16();
 
-        // 401 — refresh and retry.
+        // 401 — invalidate and retry.
         if status == 401 {
             tracing::debug!(url = %url, "got 401 on referrers, refreshing auth token");
+            self.invalidate_auth().await;
             let headers = self.auth_headers(&scopes).await?;
             let mut req_headers = headers;
             if let Ok(val) = HeaderValue::from_str(accept) {
@@ -251,29 +253,26 @@ impl RegistryClient {
 
             let resp = self.http.get(url).headers(req_headers).send().await?;
 
-            return self.classify_referrers_response(resp).await;
+            return classify_referrers_response(resp).await;
         }
 
-        self.classify_referrers_response(resp).await
+        classify_referrers_response(resp).await
     }
+}
 
-    /// Classify a referrers response.
-    async fn classify_referrers_response(
-        &self,
-        resp: reqwest::Response,
-    ) -> Result<Option<ImageIndex>, Error> {
-        let status = resp.status().as_u16();
+/// Classify a referrers response.
+async fn classify_referrers_response(resp: reqwest::Response) -> Result<Option<ImageIndex>, Error> {
+    let status = resp.status().as_u16();
 
-        match status {
-            200 => {
-                let index: ImageIndex = resp.json().await?;
-                Ok(Some(index))
-            }
-            404 => Ok(None),
-            _ => {
-                let message = resp.text().await.unwrap_or_default();
-                Err(Error::RegistryError { status, message })
-            }
+    match status {
+        200 => {
+            let index: ImageIndex = resp.json().await?;
+            Ok(Some(index))
+        }
+        404 => Ok(None),
+        _ => {
+            let message = resp.text().await.unwrap_or_default();
+            Err(Error::RegistryError { status, message })
         }
     }
 }

--- a/crates/ocync-distribution/src/spec.rs
+++ b/crates/ocync-distribution/src/spec.rs
@@ -8,31 +8,114 @@ use serde::{Deserialize, Serialize};
 use crate::digest::Digest;
 use crate::error::Error;
 
-/// OCI and Docker media type constants.
-pub mod media_types {
-    /// OCI image manifest.
-    pub const OCI_IMAGE_MANIFEST: &str = "application/vnd.oci.image.manifest.v1+json";
-    /// OCI image index (multi-platform manifest list).
-    pub const OCI_IMAGE_INDEX: &str = "application/vnd.oci.image.index.v1+json";
-    /// OCI image configuration.
-    pub const OCI_IMAGE_CONFIG: &str = "application/vnd.oci.image.config.v1+json";
-    /// OCI image layer compressed with gzip.
-    pub const OCI_IMAGE_LAYER_GZIP: &str = "application/vnd.oci.image.layer.v1.tar+gzip";
-    /// OCI image layer compressed with zstd.
-    pub const OCI_IMAGE_LAYER_ZSTD: &str = "application/vnd.oci.image.layer.v1.tar+zstd";
-    /// OCI non-distributable image layer compressed with gzip.
-    pub const OCI_IMAGE_LAYER_NONDISTRIBUTABLE_GZIP: &str =
-        "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip";
+/// OCI and Docker media type.
+///
+/// Known types have dedicated variants for type-safe matching.
+/// Unknown or future types are represented by [`Other`](Self::Other).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum MediaType {
+    /// `application/vnd.oci.image.manifest.v1+json`
+    OciManifest,
+    /// `application/vnd.oci.image.index.v1+json`
+    OciIndex,
+    /// `application/vnd.oci.image.config.v1+json`
+    OciConfig,
+    /// `application/vnd.oci.image.layer.v1.tar+gzip`
+    OciLayerGzip,
+    /// `application/vnd.oci.image.layer.v1.tar+zstd`
+    OciLayerZstd,
+    /// `application/vnd.oci.image.layer.nondistributable.v1.tar+gzip`
+    OciLayerNondistributableGzip,
+    /// `application/vnd.docker.distribution.manifest.v2+json`
+    DockerManifestV2,
+    /// `application/vnd.docker.distribution.manifest.list.v2+json`
+    DockerManifestList,
+    /// `application/vnd.docker.container.image.v1+json`
+    DockerConfig,
+    /// `application/vnd.docker.image.rootfs.diff.tar.gzip`
+    DockerLayerGzip,
+    /// An unrecognized media type.
+    Other(String),
+}
 
-    /// Docker v2 image manifest.
-    pub const DOCKER_MANIFEST_V2: &str = "application/vnd.docker.distribution.manifest.v2+json";
-    /// Docker v2 manifest list.
-    pub const DOCKER_MANIFEST_LIST: &str =
-        "application/vnd.docker.distribution.manifest.list.v2+json";
-    /// Docker v2 image configuration.
-    pub const DOCKER_IMAGE_CONFIG: &str = "application/vnd.docker.container.image.v1+json";
-    /// Docker v2 image layer compressed with gzip.
-    pub const DOCKER_IMAGE_LAYER_GZIP: &str = "application/vnd.docker.image.rootfs.diff.tar.gzip";
+impl MediaType {
+    /// The wire-format MIME type string.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::OciManifest => "application/vnd.oci.image.manifest.v1+json",
+            Self::OciIndex => "application/vnd.oci.image.index.v1+json",
+            Self::OciConfig => "application/vnd.oci.image.config.v1+json",
+            Self::OciLayerGzip => "application/vnd.oci.image.layer.v1.tar+gzip",
+            Self::OciLayerZstd => "application/vnd.oci.image.layer.v1.tar+zstd",
+            Self::OciLayerNondistributableGzip => {
+                "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip"
+            }
+            Self::DockerManifestV2 => "application/vnd.docker.distribution.manifest.v2+json",
+            Self::DockerManifestList => "application/vnd.docker.distribution.manifest.list.v2+json",
+            Self::DockerConfig => "application/vnd.docker.container.image.v1+json",
+            Self::DockerLayerGzip => "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            Self::Other(s) => s,
+        }
+    }
+}
+
+impl fmt::Display for MediaType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<&str> for MediaType {
+    fn from(s: &str) -> Self {
+        match s {
+            "application/vnd.oci.image.manifest.v1+json" => Self::OciManifest,
+            "application/vnd.oci.image.index.v1+json" => Self::OciIndex,
+            "application/vnd.oci.image.config.v1+json" => Self::OciConfig,
+            "application/vnd.oci.image.layer.v1.tar+gzip" => Self::OciLayerGzip,
+            "application/vnd.oci.image.layer.v1.tar+zstd" => Self::OciLayerZstd,
+            "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip" => {
+                Self::OciLayerNondistributableGzip
+            }
+            "application/vnd.docker.distribution.manifest.v2+json" => Self::DockerManifestV2,
+            "application/vnd.docker.distribution.manifest.list.v2+json" => Self::DockerManifestList,
+            "application/vnd.docker.container.image.v1+json" => Self::DockerConfig,
+            "application/vnd.docker.image.rootfs.diff.tar.gzip" => Self::DockerLayerGzip,
+            other => Self::Other(other.to_owned()),
+        }
+    }
+}
+
+impl From<String> for MediaType {
+    fn from(s: String) -> Self {
+        match s.as_str() {
+            "application/vnd.oci.image.manifest.v1+json" => Self::OciManifest,
+            "application/vnd.oci.image.index.v1+json" => Self::OciIndex,
+            "application/vnd.oci.image.config.v1+json" => Self::OciConfig,
+            "application/vnd.oci.image.layer.v1.tar+gzip" => Self::OciLayerGzip,
+            "application/vnd.oci.image.layer.v1.tar+zstd" => Self::OciLayerZstd,
+            "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip" => {
+                Self::OciLayerNondistributableGzip
+            }
+            "application/vnd.docker.distribution.manifest.v2+json" => Self::DockerManifestV2,
+            "application/vnd.docker.distribution.manifest.list.v2+json" => Self::DockerManifestList,
+            "application/vnd.docker.container.image.v1+json" => Self::DockerConfig,
+            "application/vnd.docker.image.rootfs.diff.tar.gzip" => Self::DockerLayerGzip,
+            _ => Self::Other(s),
+        }
+    }
+}
+
+impl Serialize for MediaType {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for MediaType {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(MediaType::from(s))
+    }
 }
 
 /// OCI content descriptor.
@@ -40,7 +123,7 @@ pub mod media_types {
 #[serde(rename_all = "camelCase")]
 pub struct Descriptor {
     /// MIME type of the referenced content.
-    pub media_type: String,
+    pub media_type: MediaType,
     /// Content-addressable digest of the referenced content.
     pub digest: Digest,
     /// Size of the referenced content in bytes.
@@ -98,7 +181,7 @@ pub struct ImageManifest {
     /// Must be `2` for OCI image manifests.
     pub schema_version: u32,
     /// Media type of this manifest.
-    pub media_type: Option<String>,
+    pub media_type: Option<MediaType>,
     /// Image configuration descriptor.
     pub config: Descriptor,
     /// Ordered list of layer descriptors.
@@ -124,7 +207,7 @@ pub struct ImageIndex {
     /// Must be `2` for OCI image indexes.
     pub schema_version: u32,
     /// Media type of this index.
-    pub media_type: Option<String>,
+    pub media_type: Option<MediaType>,
     /// List of platform-specific manifest descriptors.
     pub manifests: Vec<Descriptor>,
 
@@ -152,18 +235,18 @@ pub enum ManifestKind {
 
 impl ManifestKind {
     /// Deserialize a manifest from JSON bytes, using the media type to discriminate.
-    pub fn from_json(media_type: &str, bytes: &[u8]) -> Result<Self, Error> {
+    pub fn from_json(media_type: &MediaType, bytes: &[u8]) -> Result<Self, Error> {
         match media_type {
-            media_types::OCI_IMAGE_MANIFEST | media_types::DOCKER_MANIFEST_V2 => {
+            MediaType::OciManifest | MediaType::DockerManifestV2 => {
                 let m: ImageManifest = serde_json::from_slice(bytes)?;
                 Ok(Self::Image(Box::new(m)))
             }
-            media_types::OCI_IMAGE_INDEX | media_types::DOCKER_MANIFEST_LIST => {
+            MediaType::OciIndex | MediaType::DockerManifestList => {
                 let m: ImageIndex = serde_json::from_slice(bytes)?;
                 Ok(Self::Index(Box::new(m)))
             }
             _ => Err(Error::UnsupportedMediaType {
-                media_type: media_type.to_owned(),
+                media_type: media_type.to_string(),
             }),
         }
     }
@@ -207,10 +290,61 @@ mod tests {
         })
     }
 
+    // -- MediaType tests --
+
+    #[test]
+    fn media_type_from_known_string() {
+        assert_eq!(
+            MediaType::from("application/vnd.oci.image.manifest.v1+json"),
+            MediaType::OciManifest
+        );
+        assert_eq!(
+            MediaType::from("application/vnd.docker.distribution.manifest.v2+json"),
+            MediaType::DockerManifestV2
+        );
+    }
+
+    #[test]
+    fn media_type_from_unknown_string() {
+        let mt = MediaType::from("text/plain");
+        assert_eq!(mt, MediaType::Other("text/plain".to_owned()));
+        assert_eq!(mt.as_str(), "text/plain");
+    }
+
+    #[test]
+    fn media_type_display() {
+        assert_eq!(
+            MediaType::OciManifest.to_string(),
+            "application/vnd.oci.image.manifest.v1+json"
+        );
+        assert_eq!(
+            MediaType::Other("custom/type".into()).to_string(),
+            "custom/type"
+        );
+    }
+
+    #[test]
+    fn media_type_serde_roundtrip() {
+        let mt = MediaType::OciManifest;
+        let json = serde_json::to_string(&mt).unwrap();
+        assert_eq!(json, r#""application/vnd.oci.image.manifest.v1+json""#);
+        let parsed: MediaType = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, mt);
+    }
+
+    #[test]
+    fn media_type_serde_unknown() {
+        let json = r#""application/x-custom""#;
+        let mt: MediaType = serde_json::from_str(json).unwrap();
+        assert_eq!(mt, MediaType::Other("application/x-custom".into()));
+    }
+
+    // -- Descriptor tests --
+
     #[test]
     fn deserialize_descriptor() {
         let d: Descriptor = serde_json::from_value(test_descriptor()).unwrap();
-        assert_eq!(d.media_type, media_types::OCI_IMAGE_CONFIG);
+        assert_eq!(d.media_type, MediaType::OciConfig);
         assert_eq!(d.digest.to_string(), TEST_DIGEST);
         assert_eq!(d.size, 1234);
         assert!(d.platform.is_none());
@@ -255,13 +389,13 @@ mod tests {
     fn deserialize_image_manifest() {
         let json = serde_json::json!({
             "schemaVersion": 2,
-            "mediaType": media_types::OCI_IMAGE_MANIFEST,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
             "config": test_descriptor(),
             "layers": [test_layer_descriptor()]
         });
         let m: ImageManifest = serde_json::from_value(json).unwrap();
         assert_eq!(m.schema_version, 2);
-        assert_eq!(m.config.media_type, media_types::OCI_IMAGE_CONFIG);
+        assert_eq!(m.config.media_type, MediaType::OciConfig);
         assert_eq!(m.layers.len(), 1);
     }
 
@@ -269,9 +403,9 @@ mod tests {
     fn deserialize_image_index() {
         let json = serde_json::json!({
             "schemaVersion": 2,
-            "mediaType": media_types::OCI_IMAGE_INDEX,
+            "mediaType": "application/vnd.oci.image.index.v1+json",
             "manifests": [{
-                "mediaType": media_types::OCI_IMAGE_MANIFEST,
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
                 "digest": TEST_DIGEST,
                 "size": 1000,
                 "platform": {
@@ -294,7 +428,7 @@ mod tests {
             "layers": [test_layer_descriptor()]
         });
         let bytes = serde_json::to_vec(&json).unwrap();
-        let m = ManifestKind::from_json(media_types::OCI_IMAGE_MANIFEST, &bytes).unwrap();
+        let m = ManifestKind::from_json(&MediaType::OciManifest, &bytes).unwrap();
         assert!(matches!(m, ManifestKind::Image(_)));
     }
 
@@ -306,7 +440,7 @@ mod tests {
             "layers": [test_layer_descriptor()]
         });
         let bytes = serde_json::to_vec(&json).unwrap();
-        let m = ManifestKind::from_json(media_types::DOCKER_MANIFEST_V2, &bytes).unwrap();
+        let m = ManifestKind::from_json(&MediaType::DockerManifestV2, &bytes).unwrap();
         assert!(matches!(m, ManifestKind::Image(_)));
     }
 
@@ -315,19 +449,19 @@ mod tests {
         let json = serde_json::json!({
             "schemaVersion": 2,
             "manifests": [{
-                "mediaType": media_types::OCI_IMAGE_MANIFEST,
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
                 "digest": TEST_DIGEST,
                 "size": 1000
             }]
         });
         let bytes = serde_json::to_vec(&json).unwrap();
-        let m = ManifestKind::from_json(media_types::OCI_IMAGE_INDEX, &bytes).unwrap();
+        let m = ManifestKind::from_json(&MediaType::OciIndex, &bytes).unwrap();
         assert!(matches!(m, ManifestKind::Index(_)));
     }
 
     #[test]
     fn manifest_from_json_unsupported() {
-        let r = ManifestKind::from_json("text/plain", b"{}");
+        let r = ManifestKind::from_json(&MediaType::Other("text/plain".into()), b"{}");
         assert!(r.is_err());
     }
 
@@ -339,7 +473,7 @@ mod tests {
             "layers": [test_layer_descriptor()]
         });
         let bytes = serde_json::to_vec(&json).unwrap();
-        let m = ManifestKind::from_json(media_types::OCI_IMAGE_MANIFEST, &bytes).unwrap();
+        let m = ManifestKind::from_json(&MediaType::OciManifest, &bytes).unwrap();
         let digests = m.referenced_digests();
         assert_eq!(digests.len(), 2); // config + 1 layer
     }
@@ -350,19 +484,19 @@ mod tests {
             "schemaVersion": 2,
             "manifests": [
                 {
-                    "mediaType": media_types::OCI_IMAGE_MANIFEST,
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
                     "digest": TEST_DIGEST,
                     "size": 1000
                 },
                 {
-                    "mediaType": media_types::OCI_IMAGE_MANIFEST,
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
                     "digest": TEST_DIGEST,
                     "size": 2000
                 }
             ]
         });
         let bytes = serde_json::to_vec(&json).unwrap();
-        let m = ManifestKind::from_json(media_types::OCI_IMAGE_INDEX, &bytes).unwrap();
+        let m = ManifestKind::from_json(&MediaType::OciIndex, &bytes).unwrap();
         let digests = m.referenced_digests();
         assert_eq!(digests.len(), 2);
     }
@@ -383,10 +517,23 @@ mod tests {
     }
 
     #[test]
-    fn media_type_constants() {
-        assert!(media_types::OCI_IMAGE_MANIFEST.contains("oci"));
-        assert!(media_types::DOCKER_MANIFEST_V2.contains("docker"));
-        assert!(media_types::OCI_IMAGE_INDEX.contains("index"));
-        assert!(media_types::DOCKER_MANIFEST_LIST.contains("list"));
+    fn media_type_all_known_variants_roundtrip() {
+        let known = [
+            MediaType::OciManifest,
+            MediaType::OciIndex,
+            MediaType::OciConfig,
+            MediaType::OciLayerGzip,
+            MediaType::OciLayerZstd,
+            MediaType::OciLayerNondistributableGzip,
+            MediaType::DockerManifestV2,
+            MediaType::DockerManifestList,
+            MediaType::DockerConfig,
+            MediaType::DockerLayerGzip,
+        ];
+        for mt in &known {
+            let s = mt.as_str();
+            let parsed = MediaType::from(s);
+            assert_eq!(&parsed, mt, "roundtrip failed for {s}");
+        }
     }
 }

--- a/crates/ocync-distribution/src/tags.rs
+++ b/crates/ocync-distribution/src/tags.rs
@@ -1,0 +1,177 @@
+use serde::Deserialize;
+
+use crate::client::RegistryClient;
+use crate::error::DistributionError;
+
+/// Response body from the tag listing API.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TagListResponse {
+    pub name: String,
+    #[serde(default, deserialize_with = "deserialize_null_as_empty")]
+    pub tags: Vec<String>,
+}
+
+/// Deserialize a `Vec<String>` that may be `null` or missing as an empty vec.
+fn deserialize_null_as_empty<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let opt: Option<Vec<String>> = Option::deserialize(deserializer)?;
+    Ok(opt.unwrap_or_default())
+}
+
+/// Parse a `Link` header to extract the URL for the `rel="next"` page.
+///
+/// The OCI Distribution spec uses RFC 5988 Link headers for pagination:
+/// `<url>; rel="next"`.
+pub fn parse_next_link(link_header: &str) -> Option<String> {
+    for part in link_header.split(',') {
+        let part = part.trim();
+        // Check if this link relation contains rel="next".
+        if !part.contains("rel=\"next\"") {
+            continue;
+        }
+        // Extract URL from angle brackets.
+        if let Some(start) = part.find('<') {
+            if let Some(end) = part.find('>') {
+                if start < end {
+                    return Some(part[start + 1..end].to_owned());
+                }
+            }
+        }
+    }
+    None
+}
+
+impl RegistryClient {
+    /// List all tags in a repository, automatically following pagination.
+    ///
+    /// Returns a complete list of tags by following `Link: rel="next"` headers.
+    pub async fn list_tags(&self, repository: &str) -> Result<Vec<String>, DistributionError> {
+        let mut all_tags = Vec::new();
+        let mut path = "tags/list".to_owned();
+
+        loop {
+            let resp = self.get(repository, &path, None).await?;
+
+            // Check for Link header before consuming the body.
+            let next_url = resp
+                .headers()
+                .get("link")
+                .and_then(|v| v.to_str().ok())
+                .and_then(parse_next_link);
+
+            let tag_list: TagListResponse = resp.json().await?;
+            all_tags.extend(tag_list.tags);
+
+            match next_url {
+                Some(url) => {
+                    // The Link header may be an absolute URL or a relative path.
+                    // We need to extract just the path+query portion for build_url
+                    // since the client's get() method builds a full URL.
+                    //
+                    // For relative URLs like `/v2/repo/tags/list?n=100&last=tag`,
+                    // strip the `/v2/{repository}/` prefix.
+                    let prefix = format!("/v2/{repository}/");
+                    if let Some(stripped) = url.strip_prefix(&prefix) {
+                        path = stripped.to_owned();
+                    } else if url.starts_with("http://") || url.starts_with("https://") {
+                        // Absolute URL — extract path+query after the /v2/{repo}/ prefix.
+                        if let Ok(parsed) = url::Url::parse(&url) {
+                            let full_path = parsed.path();
+                            if let Some(stripped) = full_path.strip_prefix(&prefix) {
+                                path = match parsed.query() {
+                                    Some(q) => format!("{stripped}?{q}"),
+                                    None => stripped.to_owned(),
+                                };
+                            } else {
+                                // Fallback: use the full path as-is.
+                                path = match parsed.query() {
+                                    Some(q) => format!("{}?{q}", &full_path[1..]),
+                                    None => full_path[1..].to_owned(),
+                                };
+                            }
+                        } else {
+                            break;
+                        }
+                    } else {
+                        // Plain relative path.
+                        path = url;
+                    }
+                }
+                None => break,
+            }
+        }
+
+        Ok(all_tags)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_tag_list_response() {
+        let json = r#"{"name": "library/nginx", "tags": ["latest", "1.25", "1.24"]}"#;
+        let resp: TagListResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.name, "library/nginx");
+        assert_eq!(resp.tags, vec!["latest", "1.25", "1.24"]);
+    }
+
+    #[test]
+    fn parse_tag_list_response_empty_tags() {
+        let json = r#"{"name": "library/nginx", "tags": []}"#;
+        let resp: TagListResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.name, "library/nginx");
+        assert!(resp.tags.is_empty());
+    }
+
+    #[test]
+    fn parse_tag_list_response_null_tags() {
+        // Some registries return null instead of an empty array.
+        let json = r#"{"name": "library/nginx", "tags": null}"#;
+        let resp: TagListResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.name, "library/nginx");
+        assert!(resp.tags.is_empty());
+    }
+
+    #[test]
+    fn parse_tag_list_response_missing_tags() {
+        // serde(default) handles missing field.
+        let json = r#"{"name": "library/nginx"}"#;
+        let resp: TagListResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.name, "library/nginx");
+        assert!(resp.tags.is_empty());
+    }
+
+    #[test]
+    fn parse_next_link_with_next() {
+        let header = r#"</v2/repo/tags/list?n=100&last=tag99>; rel="next""#;
+        let result = parse_next_link(header);
+        assert_eq!(
+            result,
+            Some("/v2/repo/tags/list?n=100&last=tag99".to_owned())
+        );
+    }
+
+    #[test]
+    fn parse_next_link_without_next() {
+        let header = r#"</v2/repo/tags/list?n=100>; rel="previous""#;
+        let result = parse_next_link(header);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn parse_next_link_empty() {
+        let result = parse_next_link("");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn parse_next_link_multiple_rels() {
+        let header = r#"</v2/repo/tags/list?n=100&last=a>; rel="prev", </v2/repo/tags/list?n=100&last=z>; rel="next""#;
+        let result = parse_next_link(header);
+        assert_eq!(result, Some("/v2/repo/tags/list?n=100&last=z".to_owned()));
+    }
+}

--- a/crates/ocync-distribution/src/tags.rs
+++ b/crates/ocync-distribution/src/tags.rs
@@ -1,3 +1,5 @@
+//! Tag listing with pagination for OCI repositories.
+
 use serde::Deserialize;
 
 use crate::client::RegistryClient;
@@ -5,12 +7,13 @@ use crate::error::Error;
 
 /// Response body from the tag listing API.
 #[derive(Debug, Clone, Deserialize)]
-pub struct TagListResponse {
-    /// The repository name.
-    pub name: String,
+pub(crate) struct TagListResponse {
+    /// The repository name (required by the spec but unused after deserialization).
+    #[allow(dead_code)]
+    name: String,
     /// The list of tags, or empty if none exist.
     #[serde(default, deserialize_with = "deserialize_null_as_empty")]
-    pub tags: Vec<String>,
+    pub(crate) tags: Vec<String>,
 }
 
 /// Deserialize a `Vec<String>` that may be `null` or missing as an empty vec.
@@ -26,7 +29,7 @@ where
 ///
 /// The OCI Distribution spec uses RFC 5988 Link headers for pagination:
 /// `<url>; rel="next"`.
-pub fn parse_next_link(link_header: &str) -> Option<String> {
+pub(crate) fn parse_next_link(link_header: &str) -> Option<String> {
     for part in link_header.split(',') {
         let part = part.trim();
         // Check if this link relation contains rel="next".

--- a/crates/ocync-distribution/src/tags.rs
+++ b/crates/ocync-distribution/src/tags.rs
@@ -6,7 +6,9 @@ use crate::error::Error;
 /// Response body from the tag listing API.
 #[derive(Debug, Clone, Deserialize)]
 pub struct TagListResponse {
+    /// The repository name.
     pub name: String,
+    /// The list of tags, or empty if none exist.
     #[serde(default, deserialize_with = "deserialize_null_as_empty")]
     pub tags: Vec<String>,
 }

--- a/crates/ocync-distribution/src/tags.rs
+++ b/crates/ocync-distribution/src/tags.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 
 use crate::client::RegistryClient;
-use crate::error::DistributionError;
+use crate::error::Error;
 
 /// Response body from the tag listing API.
 #[derive(Debug, Clone, Deserialize)]
@@ -47,7 +47,7 @@ impl RegistryClient {
     /// List all tags in a repository, automatically following pagination.
     ///
     /// Returns a complete list of tags by following `Link: rel="next"` headers.
-    pub async fn list_tags(&self, repository: &str) -> Result<Vec<String>, DistributionError> {
+    pub async fn list_tags(&self, repository: &str) -> Result<Vec<String>, Error> {
         let mut all_tags = Vec::new();
         let mut path = "tags/list".to_owned();
 

--- a/crates/ocync-distribution/tests/client_integration.rs
+++ b/crates/ocync-distribution/tests/client_integration.rs
@@ -237,7 +237,7 @@ async fn get_500_returns_registry_error() {
     let result = client.get("repo", "manifests/latest", None).await;
     assert!(matches!(
         result,
-        Err(Error::RegistryError { status: 500, .. })
+        Err(Error::RegistryError { status, .. }) if status == http::StatusCode::INTERNAL_SERVER_ERROR
     ));
 }
 

--- a/docs/specs/2026-04-10-ocync-design.md
+++ b/docs/specs/2026-04-10-ocync-design.md
@@ -352,6 +352,62 @@ recompress_level: 3              # zstd compression level (1-22, default: 3)
 
 **Dependencies:** `flate2` (gzip), `zstd` crate (zstd compression/decompression).
 
+### Registry-Specific Optimizations
+
+The standard OCI Distribution API is single-resource per request — no batch endpoints exist in the spec. However, ECR exposes native AWS APIs that dramatically reduce round-trips during the planning phase. ocync uses these when available, falling back to standard OCI calls for other registries.
+
+#### ECR Batch APIs (feature-gated behind `ecr`)
+
+When the target or source is an ECR registry, ocync uses the AWS SDK instead of individual OCI HEAD/GET calls for discovery:
+
+| ECR API | Replaces | Max per batch | Savings |
+|---|---|---|---|
+| `BatchCheckLayerAvailability` | `HEAD /v2/{repo}/blobs/{digest}` (1 per layer) | 100 digests | 200 HEAD calls → 2 batch calls |
+| `BatchGetImage` | `GET /v2/{repo}/manifests/{ref}` (1 per image) | 100 image IDs | 50 GET calls → 1 batch call |
+| `DescribeImages` | `HEAD /v2/{repo}/manifests/{tag}` (1 per tag) | 100 image IDs | Bulk digest+size for all images |
+| `ListImages` | `GET /v2/{repo}/tags/list` + N HEADs | 1000 per page | Tag+digest pairs in one call |
+
+**Planning phase with ECR batch APIs:**
+
+```
+1. ListImages on destination repo → all tag+digest pairs (1 paginated call)
+2. Compare with source tag list → identify tags needing sync
+3. BatchGetImage on source → pull all needed manifests at once (1-2 calls)
+4. Collect all blob digests from manifests
+5. BatchCheckLayerAvailability on destination → find missing blobs (2-3 calls)
+6. Build transfer plan from results
+```
+
+For 50 images with 200 unique layers, this replaces ~300 individual OCI API calls with ~6 batch calls — **98% fewer round-trips in the planning phase**.
+
+**ECR-specific constraints:**
+
+- `PutImage` has **no batch equivalent** and is rate-limited to **10 TPS** (adjustable via Service Quotas). This is the bottleneck for manifest pushes — 50 images takes a minimum of 5 seconds.
+- `BatchGetImage` is **not available on ECR Public** (`public.ecr.aws`). ECR Public source registries fall back to standard OCI manifest GETs.
+- All batch APIs are **regional** — cross-region requires separate calls per region.
+- Cross-account batch calls require repository policies granting the caller's IAM principal the relevant `ecr:Batch*` actions.
+- `InitiateLayerUpload` (100 TPS) and `CompleteLayerUpload` (100 TPS) are the upload-phase bottlenecks. `UploadLayerPart` is 500 TPS.
+
+**Implementation:** The `RegistryClient` detects ECR endpoints by hostname pattern (`*.dkr.ecr.*.amazonaws.com`) and delegates discovery operations to the AWS SDK when the `ecr` feature is enabled. The sync orchestrator calls a `plan()` trait method that ECR implements with batch APIs and other registries implement with standard OCI calls.
+
+#### Registry Capability Matrix
+
+| Registry | Cross-repo blob mount | Batch discovery APIs | Chunked upload | HEAD-free rate limit |
+|---|---|---|---|---|
+| **ECR (private)** | Yes (same account/region, opt-in) | Yes (`BatchCheck`, `BatchGet`, `ListImages`) | Yes | N/A (no pull limits) |
+| **ECR Public** | Yes | Partial (`BatchCheck` only, no `BatchGet`) | Yes | N/A |
+| **Docker Hub** | Yes | No | Yes | HEAD requests are free (don't count toward pull limits) |
+| **GAR** | Likely unsupported | No | **Monolithic only** | N/A |
+| **GHCR** | Yes (implicit global dedup) | No | Monolithic in practice | N/A |
+| **ACR** | Yes | No | Yes | N/A |
+| **Harbor** | Yes | No | Yes | N/A |
+| **Quay.io** | Unconfirmed | No | Yes | N/A |
+| **Chainguard** | Unconfirmed | No | Unknown | No rate limits |
+
+**GAR monolithic upload constraint:** GAR does not support chunked (`PATCH`) uploads. The blob upload pipeline must detect GAR endpoints and use monolithic `POST`+`PUT` (buffer entire blob in memory). This increases memory usage for large layers but is unavoidable.
+
+**Docker Hub rate limit awareness:** Docker Hub returns `ratelimit-limit` and `ratelimit-remaining` headers on manifest responses. ocync parses these and exposes them in sync reports. HEAD requests do NOT count toward the pull limit — this validates the HEAD-first `skip_existing` design.
+
 ---
 
 ## Rate Limiting and Retry


### PR DESCRIPTION
## Summary

Adds the full OCI Distribution API surface to `RegistryClient` — blob, manifest, tag, and catalog operations — with strongly typed APIs and centralized auth retry.

- **Blob operations** — `blob_exists` (returns `Option<u64>`), `blob_pull` (streaming), `blob_push` (monolithic upload), `blob_mount` (cross-repo zero-transfer), `blob_upload_delete`
- **Manifest operations** — `manifest_head`, `manifest_pull`, `manifest_push`, `referrers` query with artifact type filtering
- **Tag listing** — automatic pagination with `Link: rel="next"` header following, null-safe deserialization
- **Catalog listing** — paginated repository enumeration with per-page semaphore acquisition

### Type safety

- **`MediaType` enum** — replaces stringly-typed media types with 10 known variants + `Other(String)` fallback. Used across `Descriptor`, `ManifestHead`, `ManifestPull`, `ImageManifest`, `ImageIndex`, and `manifest_push`. Eliminates the `media_types` constants module.
- **`http::StatusCode`** — replaces raw `u16` in `Error::RegistryError` and all response classification (`StatusCode::CREATED` vs magic `201`)
- **`send_with_retry()`** — centralized 401-retry-with-invalidation pattern. All operations use it, eliminating ~60 lines of duplicated retry logic. Properly calls `invalidate_auth()` before retry (the hand-rolled versions were missing this).
- **Bare `Semaphore`** — dropped unnecessary `Arc` wrapper since `RegistryClient` is never cloned

### Design spec update

Added "Registry-Specific Optimizations" section documenting ECR batch APIs (`BatchCheckLayerAvailability`, `BatchGetImage`, `ListImages`, `DescribeImages`) that reduce planning-phase round trips by ~98%. Includes registry capability matrix across ECR, GAR, GHCR, Docker Hub, ACR, Harbor, Quay, and Chainguard.

## Test plan

- [x] `cargo test --workspace` — 210 tests pass
- [x] `cargo clippy --workspace` — no warnings
- [x] `cargo fmt --check` — clean