### PR TITLE
chore: add CI push trigger for main and fix README wording

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,18 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/workflows/ci.yml"
+      - ".github/actions/setup-rust/**"
+      - "clippy.toml"
+      - "rustfmt.toml"
+      - "rust-toolchain.toml"
+      - "deny.toml"
   pull_request:
     paths:
       - "**/*.rs"
@@ -10,6 +22,7 @@ on:
       - ".github/actions/setup-rust/**"
       - "clippy.toml"
       - "rustfmt.toml"
+      - "rust-toolchain.toml"
       - "deny.toml"
 
 permissions:
@@ -56,6 +69,7 @@ jobs:
   test-arm64:
     name: Test (linux-arm64)
     runs-on: ubuntu-24.04-arm
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-rust

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ OCI registry sync tool — copies container images between registries.
 
 ## Features
 
-- **Library-first** — `ocync-distribution` is a standalone OCI Distribution client; `ocync-sync` will provide sync orchestration
+- **Library-first** — `ocync-distribution` is a standalone OCI Distribution client; `ocync-sync` provides sync orchestration
 - **Pure OCI Distribution API** — no skopeo, no Docker daemon, direct HTTPS
 - **Additive sync only** — never deletes; registries handle lifecycle
 - **ECR-first** with broad registry support (GCR, ACR, GHCR, Docker Hub, Chainguard)
-- **FIPS 140-3** by default via aws-lc-rs (NIST Certificate #4816)
+- **FIPS 140-3 ready** via aws-lc-rs (NIST Certificate #4816)
 - **Two-phase sync** — resolve all manifests, deduplicate blobs globally, then transfer
 - **Cross-repo blob mounting** — zero data transfer for shared layers
 - **Tag filtering** — glob, semver ranges, exclude patterns, sort + latest-N


### PR DESCRIPTION
## Summary

- Add `push` trigger on `main` branch to CI workflow so tests run post-merge (matching existing `pull_request` path filters)
- Add `rust-toolchain.toml` to CI path filters (was missing)
- Gate ARM64 test job to main-only (`if: github.ref == 'refs/heads/main'`) to save runner costs on PRs
- Fix README: "will provide" -> "provides", "FIPS 140-3" -> "FIPS 140-3 ready" (no feature flag)

## Test plan

- [x] `cargo test --workspace` — 381 tests pass
- [x] `cargo clippy --workspace` — clean
- [x] `cargo fmt --check` — clean
- [x] CI jobs triggered and running