### PR TITLE
feat(sync): implement sync engine with 1:N fan-out, CLI commands, and error consolidation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 OCI registry sync tool. Rust workspace with 3 crates: `ocync` (CLI binary), `ocync-distribution` (OCI registry client), `ocync-sync` (sync engine).
 
+## Design priorities
+
+1. **Performance and efficiency** — this is the most important property of the tool. Every design decision must prioritize throughput, minimal API calls, low memory overhead, and wall-clock speed. Concurrent transfers, global blob deduplication, HEAD-before-pull skip checks, cross-repo mounts, streaming (no local disk), and chunked uploads exist to minimize time and bandwidth. Never trade performance for convenience. Never add unnecessary allocations, clones, or API round-trips. Measure before assuming something is fast enough.
+2. **User experience** — a very close second. Clear error messages with actionable context, structured output for CI/CD, progress reporting (TTY-aware), dry-run validation, and sensible defaults. Users should never have to guess what went wrong or what the tool is doing. But UX features must not compromise transfer performance — e.g., progress reporting must be zero-cost when disabled, output formatting must not block the transfer pipeline.
+
+When these conflict, performance wins — but look hard for solutions that satisfy both before accepting the tradeoff.
+
 ## Scope discipline
 
 Every PR must be self-contained. Code in the diff must be called, tested, and integrated within that same diff.
@@ -11,7 +18,7 @@ Every PR must be self-contained. Code in the diff must be called, tested, and in
 - No error variants that are never constructed
 - No struct fields that are never read
 - No enum variants for "future use"
-- No feature flags — single binary, all registries, always
+- No Cargo feature flags anywhere — single binary, all registries, always; this is a CLI tool, not a library
 - If you can't write a test that exercises a code path in this PR, it doesn't belong in this PR
 
 ## Pre-commit audit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# ocync
+
+OCI registry sync tool. Rust workspace with 3 crates: `ocync` (CLI binary), `ocync-distribution` (OCI registry client), `ocync-sync` (sync engine).
+
+## Scope discipline
+
+Every PR must be self-contained. Code in the diff must be called, tested, and integrated within that same diff.
+
+- No forward declarations, placeholder types, or stub implementations
+- No `pub` items without a caller in the diff (or existing code)
+- No error variants that are never constructed
+- No struct fields that are never read
+- No enum variants for "future use"
+- No feature flags — single binary, all registries, always
+- If you can't write a test that exercises a code path in this PR, it doesn't belong in this PR
+
+## Pre-commit audit
+
+Before marking work complete, mechanically verify:
+
+1. **Dead code**: every `pub` item, error variant, struct field, and enum variant has a live caller/reader
+2. **Wiring**: trace data flows end-to-end, not just "does this type-check" — follow the value from entry to exit
+3. **Pattern breadth**: when fixing something, `grep` the full codebase for the same anti-pattern
+4. **Visibility**: default to private; `pub(crate)` only when needed within the crate; `pub` only when consumed by another crate in this diff
+5. **CI gates**: `cargo fmt --check && cargo clippy -- -D warnings && cargo test && cargo deny check` must pass locally before push
+
+## Code standards
+
+- **Naming**: stutter-free types (`Error` not `DistributionError`), spec terminology verbatim for OCI types, semantic field names
+- **Imports**: `use` statements, never inline paths; group std > external > crate; direct deps, not re-exports
+- **Docs**: every `.rs` file gets a `//!` module doc comment; all `pub` items get `///` doc comments
+- **Errors**: invalid user config must return `Result` errors, never silently degrade; users can't distinguish "nothing matched" from "config broken"
+- **Types**: prefer enums/newtypes over `String`/`u16` for domain concepts (media types, artifact types, status codes)
+- **Dependencies**: `default-features = false` on everything; justify every new dep; prefer hand-written code under ~100 lines over a crate; use `regex-lite` for ASCII patterns
+- **Security**: manual `Debug` impls use `&"[REDACTED]"` for secrets; tracing HTTP crate caps via `add_directive()` after `EnvFilter`, never in base filter string
+- **Auth**: expose both `get_token()` and `invalidate()`; never hand-roll 401 retry — use shared `invalidate_auth()` + retry helpers; use API-provided expiry over constants
+- **Process control**: return `ExitCode` via `Termination` trait, never call `process::exit()`
+- **Config parsing**: env var expansion on raw YAML before serde deserialization, not round-trip after
+- **Testing**: network code requires `wiremock` tests verifying actual HTTP request sequences, not just unit tests on types
+- **Classifiers**: response classifier functions that don't use `self` should be free functions
+
+## Review protocol
+
+Before claiming work is complete, dispatch independent review agents with specific questions:
+
+- "Find any `pub` items with no callers"
+- "Find any error variants never constructed"
+- "Trace [specific data flow] end-to-end — does it actually work?"
+- "Are there other instances of [the pattern just fixed] in the codebase?"
+
+Never trust the implementer's self-report alone.
+
+## Git workflow
+
+- One PR at a time, merge to main, then next — no stacked/chained PRs, ever
+- Never include `Co-Authored-By: Claude` or Anthropic attribution in commits or PRs
+- Run CI checks locally before pushing
+- Regenerate `Cargo.lock` during rebase conflicts (`git checkout --theirs Cargo.lock && cargo generate-lockfile`), never manually resolve
+- Clean stale worktrees before switching to branches from past sessions
+
+## Commands
+
+```bash
+# CI gate (run before every push)
+cargo fmt --check && cargo clippy -- -D warnings && cargo test && cargo deny check
+
+# Run all tests
+cargo test
+
+# Check formatting
+cargo fmt --check
+
+# Lint
+cargo clippy -- -D warnings
+
+# License/advisory check
+cargo deny check
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,11 @@ Never trust the implementer's self-report alone.
 - Regenerate `Cargo.lock` during rebase conflicts (`git checkout --theirs Cargo.lock && cargo generate-lockfile`), never manually resolve
 - Clean stale worktrees before switching to branches from past sessions
 
+## Plans and specs
+
+- **Design spec**: `docs/specs/2026-04-10-ocync-design.md` — full design document (1,752 lines)
+- **Implementation plans**: `docs/superpowers/plans/` (gitignored) — current v1 implementation plan is `2026-04-12-ocync-v1-implementation.md`
+
 ## Commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,17 @@ Before marking work complete, mechanically verify:
 4. **Visibility**: default to private; `pub(crate)` only when needed within the crate; `pub` only when consumed by another crate in this diff
 5. **CI gates**: `cargo fmt --check && cargo clippy -- -D warnings && cargo test && cargo deny check` must pass locally before push
 
+## Engine architecture
+
+The sync engine uses a **pull-once, fan-out** pattern for 1:N mappings:
+
+1. Pull source manifest once per tag (including child manifests for indexes)
+2. For each target: HEAD check, transfer blobs, push manifests
+
+Source-side work (manifest pulls) must NEVER be repeated per target. The loop structure must be `tag → pull_source → for target → push_to_target`, never `tag → for target → (pull + push)`. Blobs are inherently target-specific (dedup/mount decisions depend on target state) so blob pulls may repeat across targets, but manifest pulls are pure source-side work that is identical across all targets.
+
+OCI blobs are repo-scoped: a blob pushed to `registry/repo-a` is NOT accessible from `registry/repo-b` without a cross-repo mount or separate push. The blob dedup map must check `known_repos` for the current repo before skipping — never skip based on status alone.
+
 ## Code standards
 
 - **Naming**: stutter-free types (`Error` not `DistributionError`), spec terminology verbatim for OCI types, semantic field names

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,10 +1364,13 @@ dependencies = [
  "reqwest",
  "semver",
  "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "tracing",
+ "url",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,6 +1321,7 @@ dependencies = [
  "ocync-sync",
  "reqwest",
  "serde",
+ "serde_json",
  "serde_yaml_ng",
  "thiserror",
  "tokio",
@@ -1356,9 +1357,11 @@ dependencies = [
 name = "ocync-sync"
 version = "0.1.0"
 dependencies = [
+ "futures-util",
  "globset",
  "http 1.4.0",
  "ocync-distribution",
+ "reqwest",
  "semver",
  "serde",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ clap = { version = "4", default-features = false, features = ["derive", "std", "
 ocync-distribution.workspace = true
 ocync-sync.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 serde_yaml = { package = "serde_yaml_ng", version = "0.10", default-features = false }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }

--- a/crates/ocync-distribution/src/blob.rs
+++ b/crates/ocync-distribution/src/blob.rs
@@ -54,6 +54,22 @@ impl RegistryClient {
         }
     }
 
+    /// Pull a blob and return the complete bytes.
+    ///
+    /// Issues a GET request to `/v2/{repository}/blobs/{digest}` and returns
+    /// the full response body as a `Vec<u8>`. For large blobs, prefer
+    /// [`blob_pull`](Self::blob_pull) which returns a streaming response.
+    pub async fn blob_pull_all(
+        &self,
+        repository: &str,
+        digest: &Digest,
+    ) -> Result<Vec<u8>, Error> {
+        let path = blob_path(digest);
+        let resp = self.get(repository, &path, None).await?;
+        let bytes = resp.bytes().await?;
+        Ok(bytes.into())
+    }
+
     /// Pull a blob as a streaming response.
     ///
     /// Issues a GET request to `/v2/{repository}/blobs/{digest}` and returns

--- a/crates/ocync-distribution/src/blob.rs
+++ b/crates/ocync-distribution/src/blob.rs
@@ -49,7 +49,7 @@ impl RegistryClient {
                     .unwrap_or(0);
                 Ok(Some(size))
             }
-            Err(Error::NotFound(_)) => Ok(None),
+            Err(e) if e.is_not_found() => Ok(None),
             Err(e) => Err(e),
         }
     }

--- a/crates/ocync-distribution/src/blob.rs
+++ b/crates/ocync-distribution/src/blob.rs
@@ -59,11 +59,7 @@ impl RegistryClient {
     /// Issues a GET request to `/v2/{repository}/blobs/{digest}` and returns
     /// the full response body as a `Vec<u8>`. For large blobs, prefer
     /// [`blob_pull`](Self::blob_pull) which returns a streaming response.
-    pub async fn blob_pull_all(
-        &self,
-        repository: &str,
-        digest: &Digest,
-    ) -> Result<Vec<u8>, Error> {
+    pub async fn blob_pull_all(&self, repository: &str, digest: &Digest) -> Result<Vec<u8>, Error> {
         let path = blob_path(digest);
         let resp = self.get(repository, &path, None).await?;
         let bytes = resp.bytes().await?;

--- a/crates/ocync-distribution/src/client.rs
+++ b/crates/ocync-distribution/src/client.rs
@@ -247,23 +247,15 @@ async fn classify_response(
         return Ok(resp);
     }
 
-    let registry = base_url.host_str().unwrap_or("unknown").to_owned();
+    let registry = base_url.host_str().unwrap_or("unknown");
+    let body = resp.text().await.unwrap_or_default();
+    let message = if body.is_empty() {
+        format!("{registry}/{repository}")
+    } else {
+        format!("{registry}/{repository}: {body}")
+    };
 
-    match status {
-        StatusCode::UNAUTHORIZED => Err(Error::Unauthorized { registry }),
-        StatusCode::FORBIDDEN => Err(Error::Forbidden {
-            registry,
-            repository: repository.to_owned(),
-        }),
-        StatusCode::NOT_FOUND => {
-            let message = resp.text().await.unwrap_or_default();
-            Err(Error::NotFound(message))
-        }
-        _ => {
-            let message = resp.text().await.unwrap_or_default();
-            Err(Error::RegistryError { status, message })
-        }
-    }
+    Err(Error::RegistryError { status, message })
 }
 
 /// Construct a URL for the `/v2/` endpoint.

--- a/crates/ocync-distribution/src/error.rs
+++ b/crates/ocync-distribution/src/error.rs
@@ -106,6 +106,19 @@ pub enum Error {
     Other(String),
 }
 
+impl Error {
+    /// Extract the HTTP status code from this error, if applicable.
+    pub fn status_code(&self) -> Option<http::StatusCode> {
+        match self {
+            Self::Unauthorized { .. } => Some(http::StatusCode::UNAUTHORIZED),
+            Self::Forbidden { .. } => Some(http::StatusCode::FORBIDDEN),
+            Self::NotFound(_) => Some(http::StatusCode::NOT_FOUND),
+            Self::RegistryError { status, .. } => Some(*status),
+            _ => None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -159,5 +172,55 @@ mod tests {
     fn is_send_and_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<Error>();
+    }
+
+    #[test]
+    fn status_code_unauthorized() {
+        let err = Error::Unauthorized {
+            registry: "example.com".into(),
+        };
+        assert_eq!(err.status_code(), Some(http::StatusCode::UNAUTHORIZED));
+    }
+
+    #[test]
+    fn status_code_forbidden() {
+        let err = Error::Forbidden {
+            registry: "example.com".into(),
+            repository: "repo".into(),
+        };
+        assert_eq!(err.status_code(), Some(http::StatusCode::FORBIDDEN));
+    }
+
+    #[test]
+    fn status_code_not_found() {
+        let err = Error::NotFound("something".into());
+        assert_eq!(err.status_code(), Some(http::StatusCode::NOT_FOUND));
+    }
+
+    #[test]
+    fn status_code_registry_error() {
+        let err = Error::RegistryError {
+            status: http::StatusCode::TOO_MANY_REQUESTS,
+            message: "rate limited".into(),
+        };
+        assert_eq!(err.status_code(), Some(http::StatusCode::TOO_MANY_REQUESTS));
+    }
+
+    #[test]
+    fn status_code_none_for_other_variants() {
+        let err = Error::Other("something".into());
+        assert_eq!(err.status_code(), None);
+
+        let err = Error::InvalidReference {
+            input: "bad".into(),
+            reason: "reason".into(),
+        };
+        assert_eq!(err.status_code(), None);
+
+        let err = Error::AuthFailed {
+            registry: "example.com".into(),
+            reason: "bad creds".into(),
+        };
+        assert_eq!(err.status_code(), None);
     }
 }

--- a/crates/ocync-distribution/src/error.rs
+++ b/crates/ocync-distribution/src/error.rs
@@ -72,34 +72,14 @@ pub enum Error {
     #[error("HTTP request failed: {0}")]
     Http(#[from] reqwest::Error),
 
-    /// The registry returned an unexpected HTTP status.
+    /// The registry returned a non-success HTTP status.
     #[error("registry returned {status}: {message}")]
     RegistryError {
         /// The HTTP status code.
         status: http::StatusCode,
-        /// The response body.
+        /// Human-readable context (typically registry/repository and response body).
         message: String,
     },
-
-    /// The registry returned 401 Unauthorized.
-    #[error("registry returned 401 Unauthorized for {registry}")]
-    Unauthorized {
-        /// The registry hostname.
-        registry: String,
-    },
-
-    /// The registry returned 403 Forbidden.
-    #[error("registry returned 403 Forbidden for {registry}/{repository}")]
-    Forbidden {
-        /// The registry hostname.
-        registry: String,
-        /// The repository that was denied.
-        repository: String,
-    },
-
-    /// The requested resource was not found.
-    #[error("not found: {0}")]
-    NotFound(String),
 
     /// Catch-all for errors without a dedicated variant.
     #[error("{0}")]
@@ -110,12 +90,14 @@ impl Error {
     /// Extract the HTTP status code from this error, if applicable.
     pub fn status_code(&self) -> Option<http::StatusCode> {
         match self {
-            Self::Unauthorized { .. } => Some(http::StatusCode::UNAUTHORIZED),
-            Self::Forbidden { .. } => Some(http::StatusCode::FORBIDDEN),
-            Self::NotFound(_) => Some(http::StatusCode::NOT_FOUND),
             Self::RegistryError { status, .. } => Some(*status),
             _ => None,
         }
+    }
+
+    /// Whether this error represents a 404 Not Found response.
+    pub fn is_not_found(&self) -> bool {
+        self.status_code() == Some(http::StatusCode::NOT_FOUND)
     }
 }
 
@@ -175,30 +157,7 @@ mod tests {
     }
 
     #[test]
-    fn status_code_unauthorized() {
-        let err = Error::Unauthorized {
-            registry: "example.com".into(),
-        };
-        assert_eq!(err.status_code(), Some(http::StatusCode::UNAUTHORIZED));
-    }
-
-    #[test]
-    fn status_code_forbidden() {
-        let err = Error::Forbidden {
-            registry: "example.com".into(),
-            repository: "repo".into(),
-        };
-        assert_eq!(err.status_code(), Some(http::StatusCode::FORBIDDEN));
-    }
-
-    #[test]
-    fn status_code_not_found() {
-        let err = Error::NotFound("something".into());
-        assert_eq!(err.status_code(), Some(http::StatusCode::NOT_FOUND));
-    }
-
-    #[test]
-    fn status_code_registry_error() {
+    fn status_code_from_registry_error() {
         let err = Error::RegistryError {
             status: http::StatusCode::TOO_MANY_REQUESTS,
             message: "rate limited".into(),
@@ -207,7 +166,7 @@ mod tests {
     }
 
     #[test]
-    fn status_code_none_for_other_variants() {
+    fn status_code_none_for_non_registry_errors() {
         let err = Error::Other("something".into());
         assert_eq!(err.status_code(), None);
 
@@ -222,5 +181,23 @@ mod tests {
             reason: "bad creds".into(),
         };
         assert_eq!(err.status_code(), None);
+    }
+
+    #[test]
+    fn is_not_found() {
+        let err = Error::RegistryError {
+            status: http::StatusCode::NOT_FOUND,
+            message: "missing".into(),
+        };
+        assert!(err.is_not_found());
+
+        let err = Error::RegistryError {
+            status: http::StatusCode::UNAUTHORIZED,
+            message: "denied".into(),
+        };
+        assert!(!err.is_not_found());
+
+        let err = Error::Other("unrelated".into());
+        assert!(!err.is_not_found());
     }
 }

--- a/crates/ocync-distribution/src/manifest.rs
+++ b/crates/ocync-distribution/src/manifest.rs
@@ -97,7 +97,7 @@ impl RegistryClient {
                     size,
                 }))
             }
-            Err(Error::NotFound(_)) => Ok(None),
+            Err(e) if e.is_not_found() => Ok(None),
             Err(e) => Err(e),
         }
     }

--- a/crates/ocync-distribution/src/spec.rs
+++ b/crates/ocync-distribution/src/spec.rs
@@ -65,43 +65,36 @@ impl fmt::Display for MediaType {
     }
 }
 
+/// Look up a known media type from its wire-format string.
+fn known_media_type(s: &str) -> Option<MediaType> {
+    Some(match s {
+        "application/vnd.oci.image.manifest.v1+json" => MediaType::OciManifest,
+        "application/vnd.oci.image.index.v1+json" => MediaType::OciIndex,
+        "application/vnd.oci.image.config.v1+json" => MediaType::OciConfig,
+        "application/vnd.oci.image.layer.v1.tar+gzip" => MediaType::OciLayerGzip,
+        "application/vnd.oci.image.layer.v1.tar+zstd" => MediaType::OciLayerZstd,
+        "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip" => {
+            MediaType::OciLayerNondistributableGzip
+        }
+        "application/vnd.docker.distribution.manifest.v2+json" => MediaType::DockerManifestV2,
+        "application/vnd.docker.distribution.manifest.list.v2+json" => {
+            MediaType::DockerManifestList
+        }
+        "application/vnd.docker.container.image.v1+json" => MediaType::DockerConfig,
+        "application/vnd.docker.image.rootfs.diff.tar.gzip" => MediaType::DockerLayerGzip,
+        _ => return None,
+    })
+}
+
 impl From<&str> for MediaType {
     fn from(s: &str) -> Self {
-        match s {
-            "application/vnd.oci.image.manifest.v1+json" => Self::OciManifest,
-            "application/vnd.oci.image.index.v1+json" => Self::OciIndex,
-            "application/vnd.oci.image.config.v1+json" => Self::OciConfig,
-            "application/vnd.oci.image.layer.v1.tar+gzip" => Self::OciLayerGzip,
-            "application/vnd.oci.image.layer.v1.tar+zstd" => Self::OciLayerZstd,
-            "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip" => {
-                Self::OciLayerNondistributableGzip
-            }
-            "application/vnd.docker.distribution.manifest.v2+json" => Self::DockerManifestV2,
-            "application/vnd.docker.distribution.manifest.list.v2+json" => Self::DockerManifestList,
-            "application/vnd.docker.container.image.v1+json" => Self::DockerConfig,
-            "application/vnd.docker.image.rootfs.diff.tar.gzip" => Self::DockerLayerGzip,
-            other => Self::Other(other.to_owned()),
-        }
+        known_media_type(s).unwrap_or_else(|| Self::Other(s.to_owned()))
     }
 }
 
 impl From<String> for MediaType {
     fn from(s: String) -> Self {
-        match s.as_str() {
-            "application/vnd.oci.image.manifest.v1+json" => Self::OciManifest,
-            "application/vnd.oci.image.index.v1+json" => Self::OciIndex,
-            "application/vnd.oci.image.config.v1+json" => Self::OciConfig,
-            "application/vnd.oci.image.layer.v1.tar+gzip" => Self::OciLayerGzip,
-            "application/vnd.oci.image.layer.v1.tar+zstd" => Self::OciLayerZstd,
-            "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip" => {
-                Self::OciLayerNondistributableGzip
-            }
-            "application/vnd.docker.distribution.manifest.v2+json" => Self::DockerManifestV2,
-            "application/vnd.docker.distribution.manifest.list.v2+json" => Self::DockerManifestList,
-            "application/vnd.docker.container.image.v1+json" => Self::DockerConfig,
-            "application/vnd.docker.image.rootfs.diff.tar.gzip" => Self::DockerLayerGzip,
-            _ => Self::Other(s),
-        }
+        known_media_type(&s).unwrap_or(Self::Other(s))
     }
 }
 

--- a/crates/ocync-distribution/tests/client_integration.rs
+++ b/crates/ocync-distribution/tests/client_integration.rs
@@ -4,6 +4,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU32, Ordering};
 
+use http::StatusCode;
 use ocync_distribution::Error;
 use ocync_distribution::auth::{AuthProvider, Scope, Token};
 use ocync_distribution::client::RegistryClientBuilder;
@@ -153,7 +154,8 @@ async fn get_double_401_returns_unauthorized() {
         .unwrap();
 
     let result = client.get("repo", "manifests/latest", None).await;
-    assert!(matches!(result, Err(Error::Unauthorized { .. })));
+    let err = result.unwrap_err();
+    assert_eq!(err.status_code(), Some(StatusCode::UNAUTHORIZED));
 }
 
 #[tokio::test]
@@ -195,7 +197,8 @@ async fn get_403_returns_forbidden() {
         .unwrap();
 
     let result = client.get("private/repo", "manifests/latest", None).await;
-    assert!(matches!(result, Err(Error::Forbidden { .. })));
+    let err = result.unwrap_err();
+    assert_eq!(err.status_code(), Some(StatusCode::FORBIDDEN));
 }
 
 #[tokio::test]
@@ -215,7 +218,7 @@ async fn get_404_returns_not_found() {
         .unwrap();
 
     let result = client.get("repo", "manifests/nonexistent", None).await;
-    assert!(matches!(result, Err(Error::NotFound(_))));
+    assert!(result.unwrap_err().is_not_found());
 }
 
 #[tokio::test]
@@ -235,10 +238,8 @@ async fn get_500_returns_registry_error() {
         .unwrap();
 
     let result = client.get("repo", "manifests/latest", None).await;
-    assert!(matches!(
-        result,
-        Err(Error::RegistryError { status, .. }) if status == http::StatusCode::INTERNAL_SERVER_ERROR
-    ));
+    let err = result.unwrap_err();
+    assert_eq!(err.status_code(), Some(StatusCode::INTERNAL_SERVER_ERROR));
 }
 
 #[tokio::test]
@@ -355,5 +356,6 @@ async fn head_double_401_returns_unauthorized() {
         .unwrap();
 
     let result = client.head("repo", "manifests/latest").await;
-    assert!(matches!(result, Err(Error::Unauthorized { .. })));
+    let err = result.unwrap_err();
+    assert_eq!(err.status_code(), Some(StatusCode::UNAUTHORIZED));
 }

--- a/crates/ocync-sync/Cargo.toml
+++ b/crates/ocync-sync/Cargo.toml
@@ -17,7 +17,9 @@ ocync-distribution.workspace = true
 semver = { version = "1", default-features = false, features = ["std"] }
 serde.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["sync"] }
+futures-util = { version = "0.3", default-features = false }
+reqwest.workspace = true
+tokio = { workspace = true, features = ["sync", "time"] }
 tracing.workspace = true
 uuid = { version = "1", default-features = false, features = ["v7", "serde"] }
 

--- a/crates/ocync-sync/Cargo.toml
+++ b/crates/ocync-sync/Cargo.toml
@@ -24,4 +24,7 @@ tracing.workspace = true
 uuid = { version = "1", default-features = false, features = ["v7", "serde"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt"] }
+serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+url.workspace = true
+wiremock = "0.6"

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -1,0 +1,113 @@
+//! Sync engine — two-phase orchestrator for image transfers.
+
+use std::sync::Arc;
+
+use ocync_distribution::spec::ImageManifest;
+use ocync_distribution::{Digest, RegistryClient};
+
+/// A fully resolved mapping ready for the sync engine.
+///
+/// All config resolution (registry lookup, tag filtering) is done
+/// before constructing this type. The engine operates purely on
+/// resolved values.
+#[derive(Debug)]
+pub struct ResolvedMapping {
+    /// Client for the source registry.
+    pub source_client: Arc<RegistryClient>,
+    /// Repository path at the source (e.g. `library/nginx`).
+    pub source_repo: String,
+    /// Repository path at the target (e.g. `mirror/nginx`).
+    pub target_repo: String,
+    /// Target registries to sync to.
+    pub targets: Vec<TargetEntry>,
+    /// Tags to sync (already filtered).
+    pub tags: Vec<String>,
+}
+
+/// A single target registry entry.
+#[derive(Debug)]
+pub struct TargetEntry {
+    /// Human-readable name from config (e.g. `us-ecr`).
+    pub name: String,
+    /// Client for this target registry.
+    pub client: Arc<RegistryClient>,
+}
+
+/// Collect all blob digests from an image manifest (config + layers).
+fn collect_image_blobs(manifest: &ImageManifest) -> Vec<Digest> {
+    let mut digests = Vec::with_capacity(1 + manifest.layers.len());
+    digests.push(manifest.config.digest.clone());
+    for layer in &manifest.layers {
+        digests.push(layer.digest.clone());
+    }
+    digests
+}
+
+#[cfg(test)]
+mod tests {
+    use ocync_distribution::spec::{Descriptor, MediaType};
+
+    use super::*;
+
+    /// Build a valid sha256 digest from a short suffix, zero-padded to 64 hex chars.
+    fn test_digest(suffix: &str) -> Digest {
+        format!("sha256:{suffix:0>64}").parse().unwrap()
+    }
+
+    /// Build a minimal descriptor with the given digest.
+    fn test_descriptor(digest: Digest, media_type: MediaType) -> Descriptor {
+        Descriptor {
+            media_type,
+            digest,
+            size: 0,
+            platform: None,
+            artifact_type: None,
+            annotations: None,
+        }
+    }
+
+    #[test]
+    fn collect_blobs_config_and_layers() {
+        let config_digest = test_digest("c0");
+        let layer1_digest = test_digest("a1");
+        let layer2_digest = test_digest("b2");
+
+        let manifest = ImageManifest {
+            schema_version: 2,
+            media_type: None,
+            config: test_descriptor(config_digest.clone(), MediaType::OciConfig),
+            layers: vec![
+                test_descriptor(layer1_digest.clone(), MediaType::OciLayerGzip),
+                test_descriptor(layer2_digest.clone(), MediaType::OciLayerGzip),
+            ],
+            subject: None,
+            artifact_type: None,
+            annotations: None,
+        };
+
+        let blobs = collect_image_blobs(&manifest);
+        assert_eq!(blobs.len(), 3);
+        assert_eq!(blobs[0], config_digest);
+        assert_eq!(blobs[1], layer1_digest);
+        assert_eq!(blobs[2], layer2_digest);
+    }
+
+    #[test]
+    fn collect_blobs_no_layers() {
+        let config_digest = test_digest("cc");
+
+        let manifest = ImageManifest {
+            schema_version: 2,
+            media_type: None,
+            config: test_descriptor(config_digest.clone(), MediaType::OciConfig),
+            layers: vec![],
+            subject: None,
+            artifact_type: None,
+            annotations: None,
+        };
+
+        let blobs = collect_image_blobs(&manifest);
+        assert_eq!(blobs.len(), 1);
+        assert_eq!(blobs[0], config_digest);
+    }
+}

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -1,9 +1,18 @@
 //! Sync engine — two-phase orchestrator for image transfers.
 
+use std::fmt;
 use std::sync::Arc;
+use std::time::Instant;
 
-use ocync_distribution::spec::ImageManifest;
+use ocync_distribution::blob::MountResult;
+use ocync_distribution::spec::{ImageManifest, ManifestKind};
 use ocync_distribution::{Digest, RegistryClient};
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+use crate::plan::BlobDedupMap;
+use crate::retry::{self, RetryConfig};
+use crate::{ImageResult, ImageStatus, SkipReason};
 
 /// A fully resolved mapping ready for the sync engine.
 ///
@@ -34,6 +43,7 @@ pub struct TargetEntry {
 }
 
 /// Collect all blob digests from an image manifest (config + layers).
+#[allow(dead_code)] // Called by sync_image_inner; public entry point `run()` added next.
 fn collect_image_blobs(manifest: &ImageManifest) -> Vec<Digest> {
     let mut digests = Vec::with_capacity(1 + manifest.layers.len());
     digests.push(manifest.config.digest.clone());
@@ -41,6 +51,379 @@ fn collect_image_blobs(manifest: &ImageManifest) -> Vec<Digest> {
         digests.push(layer.digest.clone());
     }
     digests
+}
+
+/// Sync engine — orchestrates image transfers across registries.
+///
+/// Processes [`ResolvedMapping`]s sequentially, syncing each tag from source
+/// to every target. Blob deduplication is tracked globally so that layers
+/// shared across images or repositories are transferred at most once per
+/// target registry.
+pub struct SyncEngine {
+    retry: RetryConfig,
+    #[allow(dead_code)] // Used by transfer_blobs; public entry point `run()` added next.
+    dedup: std::sync::Mutex<BlobDedupMap>,
+}
+
+impl fmt::Debug for SyncEngine {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SyncEngine")
+            .field("retry", &self.retry)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SyncEngine {
+    /// Create a new sync engine with the given retry configuration.
+    pub fn new(retry: RetryConfig) -> Self {
+        Self {
+            retry,
+            dedup: std::sync::Mutex::new(BlobDedupMap::new()),
+        }
+    }
+
+    /// Sync a single image (one tag) from source to one target.
+    ///
+    /// Returns an [`ImageResult`] — never panics. All errors are captured
+    /// as [`ImageStatus::Failed`].
+    #[allow(dead_code)] // Public entry point `run()` added next.
+    async fn sync_image(
+        &self,
+        source: &RegistryClient,
+        source_repo: &str,
+        target: &RegistryClient,
+        target_name: &str,
+        target_repo: &str,
+        tag: &str,
+    ) -> ImageResult {
+        let image_start = Instant::now();
+        let image_id = Uuid::now_v7();
+        let source_ref = format!("{source_repo}:{tag}");
+        let target_ref = format!("{target_repo}:{tag}");
+
+        let result = self
+            .sync_image_inner(source, source_repo, target, target_name, target_repo, tag)
+            .await;
+
+        let duration = image_start.elapsed();
+
+        match result {
+            Ok((status, bytes_transferred)) => ImageResult {
+                image_id,
+                source: source_ref,
+                target: target_ref,
+                status,
+                bytes_transferred,
+                duration,
+            },
+            Err(err) => {
+                warn!(source = %source_ref, target = %target_ref, error = %err, "image sync failed");
+                ImageResult {
+                    image_id,
+                    source: source_ref,
+                    target: target_ref,
+                    status: ImageStatus::Failed {
+                        error: err,
+                        retries: self.retry.max_retries,
+                    },
+                    bytes_transferred: 0,
+                    duration,
+                }
+            }
+        }
+    }
+
+    /// Inner implementation of image sync that returns Result for ergonomic error handling.
+    async fn sync_image_inner(
+        &self,
+        source: &RegistryClient,
+        source_repo: &str,
+        target: &RegistryClient,
+        target_name: &str,
+        target_repo: &str,
+        tag: &str,
+    ) -> Result<(ImageStatus, u64), String> {
+        // Step 1: Pull source manifest.
+        let pull = source
+            .manifest_pull(source_repo, tag)
+            .await
+            .map_err(|e| format!("failed to pull source manifest: {e}"))?;
+
+        // Step 2: HEAD target manifest — skip if digest matches.
+        match target.manifest_head(target_repo, tag).await {
+            Ok(Some(head)) if head.digest == pull.digest => {
+                info!(
+                    source_repo,
+                    target_repo,
+                    tag,
+                    digest = %pull.digest,
+                    "skipping — digest matches at target"
+                );
+                return Ok((
+                    ImageStatus::Skipped {
+                        reason: SkipReason::DigestMatch,
+                    },
+                    0,
+                ));
+            }
+            Ok(_) => {} // manifest missing or digest differs — proceed
+            Err(e) => {
+                debug!(
+                    target_repo,
+                    tag,
+                    error = %e,
+                    "target manifest HEAD failed, proceeding with sync"
+                );
+            }
+        }
+
+        // Step 3/4: Handle based on manifest kind.
+        let bytes_transferred = match &pull.manifest {
+            ManifestKind::Image(image_manifest) => {
+                let blobs = collect_image_blobs(image_manifest);
+                let bytes = self
+                    .transfer_blobs(
+                        source,
+                        source_repo,
+                        target,
+                        target_name,
+                        target_repo,
+                        &blobs,
+                    )
+                    .await?;
+
+                // Push manifest by tag.
+                target
+                    .manifest_push(target_repo, tag, &pull.media_type, &pull.raw_bytes)
+                    .await
+                    .map_err(|e| format!("failed to push manifest: {e}"))?;
+
+                bytes
+            }
+            ManifestKind::Index(index) => {
+                let mut total_bytes = 0u64;
+
+                // For each child descriptor, pull child manifest, transfer blobs, push child.
+                for child_desc in &index.manifests {
+                    let child_digest_str = child_desc.digest.to_string();
+                    let child_pull = source
+                        .manifest_pull(source_repo, &child_digest_str)
+                        .await
+                        .map_err(|e| {
+                            format!("failed to pull child manifest {}: {e}", child_desc.digest)
+                        })?;
+
+                    if let ManifestKind::Image(child_image) = &child_pull.manifest {
+                        let blobs = collect_image_blobs(child_image);
+                        let bytes = self
+                            .transfer_blobs(
+                                source,
+                                source_repo,
+                                target,
+                                target_name,
+                                target_repo,
+                                &blobs,
+                            )
+                            .await?;
+                        total_bytes = total_bytes.saturating_add(bytes);
+                    }
+
+                    // Push child manifest to target by digest.
+                    target
+                        .manifest_push(
+                            target_repo,
+                            &child_digest_str,
+                            &child_pull.media_type,
+                            &child_pull.raw_bytes,
+                        )
+                        .await
+                        .map_err(|e| {
+                            format!("failed to push child manifest {}: {e}", child_desc.digest)
+                        })?;
+                }
+
+                // Push the index by tag.
+                target
+                    .manifest_push(target_repo, tag, &pull.media_type, &pull.raw_bytes)
+                    .await
+                    .map_err(|e| format!("failed to push index manifest: {e}"))?;
+
+                total_bytes
+            }
+        };
+
+        info!(
+            source_repo,
+            target_repo, tag, bytes_transferred, "image synced"
+        );
+
+        Ok((ImageStatus::Synced, bytes_transferred))
+    }
+
+    /// Transfer blobs from source to target, using dedup and cross-repo mount.
+    ///
+    /// For each digest: checks the dedup map, does a HEAD check at the target,
+    /// attempts a cross-repo mount, and falls back to pull+push. Returns the
+    /// total bytes transferred.
+    async fn transfer_blobs(
+        &self,
+        source: &RegistryClient,
+        source_repo: &str,
+        target: &RegistryClient,
+        target_name: &str,
+        target_repo: &str,
+        digests: &[Digest],
+    ) -> Result<u64, String> {
+        let mut total_bytes = 0u64;
+
+        for digest in digests {
+            // Check dedup map — skip if already handled.
+            {
+                let dedup = self.dedup.lock().expect("dedup lock poisoned");
+                if let Some(status) = dedup.status(target_name, digest) {
+                    use crate::plan::BlobStatus;
+                    match status {
+                        BlobStatus::ExistsAtTarget
+                        | BlobStatus::Completed
+                        | BlobStatus::InProgress => {
+                            debug!(%digest, status = ?status, "blob already handled, skipping");
+                            continue;
+                        }
+                        BlobStatus::Unknown | BlobStatus::Failed(_) => {}
+                    }
+                }
+            }
+
+            // HEAD check at target — if exists, mark in dedup map and skip.
+            match target.blob_exists(target_repo, digest).await {
+                Ok(Some(_size)) => {
+                    debug!(%digest, "blob exists at target, skipping");
+                    let mut dedup = self.dedup.lock().expect("dedup lock poisoned");
+                    dedup.set_exists(target_name, digest, target_repo);
+                    continue;
+                }
+                Ok(None) => {} // not found, need to transfer
+                Err(e) => {
+                    debug!(%digest, error = %e, "blob HEAD check failed, will attempt transfer");
+                }
+            }
+
+            // Mark in-progress.
+            {
+                let mut dedup = self.dedup.lock().expect("dedup lock poisoned");
+                dedup.set_in_progress(target_name, digest);
+            }
+
+            // Try cross-repo mount.
+            let mount_source = {
+                let dedup = self.dedup.lock().expect("dedup lock poisoned");
+                dedup
+                    .mount_source(target_name, digest, target_repo)
+                    .map(|s| s.to_owned())
+            };
+
+            if let Some(from_repo) = mount_source {
+                debug!(%digest, from_repo, "attempting cross-repo mount");
+                match target.blob_mount(target_repo, digest, &from_repo).await {
+                    Ok(MountResult::Mounted) => {
+                        debug!(%digest, "blob mounted from {from_repo}");
+                        let mut dedup = self.dedup.lock().expect("dedup lock poisoned");
+                        dedup.set_completed(target_name, digest, target_repo);
+                        continue;
+                    }
+                    Ok(MountResult::FallbackUpload { .. }) => {
+                        debug!(%digest, "mount fallback, proceeding with pull+push");
+                    }
+                    Err(e) => {
+                        debug!(%digest, error = %e, "mount failed, proceeding with pull+push");
+                    }
+                }
+            }
+
+            // Pull from source with retry.
+            let data = self
+                .pull_blob_with_retry(source, source_repo, digest)
+                .await?;
+            let blob_size = data.len() as u64;
+
+            // Push to target with retry.
+            self.push_blob_with_retry(target, target_repo, &data)
+                .await?;
+
+            total_bytes = total_bytes.saturating_add(blob_size);
+
+            // Mark completed.
+            let mut dedup = self.dedup.lock().expect("dedup lock poisoned");
+            dedup.set_completed(target_name, digest, target_repo);
+        }
+
+        Ok(total_bytes)
+    }
+
+    /// Pull a blob with retry logic for transient errors.
+    async fn pull_blob_with_retry(
+        &self,
+        source: &RegistryClient,
+        source_repo: &str,
+        digest: &Digest,
+    ) -> Result<Vec<u8>, String> {
+        let mut attempt = 0;
+        loop {
+            match source.blob_pull_all(source_repo, digest).await {
+                Ok(data) => return Ok(data),
+                Err(e) => {
+                    if let Some(status) = e.status_code() {
+                        if retry::should_retry(status, attempt, self.retry.max_retries) {
+                            let backoff = self.retry.backoff_for(attempt);
+                            warn!(
+                                %digest,
+                                attempt,
+                                status = %status,
+                                backoff_ms = backoff.as_millis(),
+                                "retrying blob pull"
+                            );
+                            tokio::time::sleep(backoff).await;
+                            attempt += 1;
+                            continue;
+                        }
+                    }
+                    return Err(format!("failed to pull blob {digest}: {e}"));
+                }
+            }
+        }
+    }
+
+    /// Push a blob with retry logic for transient errors.
+    async fn push_blob_with_retry(
+        &self,
+        target: &RegistryClient,
+        target_repo: &str,
+        data: &[u8],
+    ) -> Result<Digest, String> {
+        let mut attempt = 0;
+        loop {
+            match target.blob_push(target_repo, data).await {
+                Ok(digest) => return Ok(digest),
+                Err(e) => {
+                    if let Some(status) = e.status_code() {
+                        if retry::should_retry(status, attempt, self.retry.max_retries) {
+                            let backoff = self.retry.backoff_for(attempt);
+                            warn!(
+                                attempt,
+                                status = %status,
+                                backoff_ms = backoff.as_millis(),
+                                "retrying blob push"
+                            );
+                            tokio::time::sleep(backoff).await;
+                            attempt += 1;
+                            continue;
+                        }
+                    }
+                    return Err(format!("failed to push blob: {e}"));
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -4,7 +4,10 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Instant;
 
+use std::time::Duration;
+
 use ocync_distribution::blob::MountResult;
+use ocync_distribution::manifest::ManifestPull;
 use ocync_distribution::spec::{ImageManifest, ManifestKind};
 use ocync_distribution::{Digest, RegistryClient};
 use tracing::{debug, info, warn};
@@ -101,12 +104,39 @@ fn collect_image_blobs(manifest: &ImageManifest) -> Vec<Digest> {
     digests
 }
 
+/// Source manifest data pre-pulled once per tag.
+///
+/// Separating the source pull from the target push ensures manifests
+/// are fetched once regardless of target count (1:N fan-out).
+struct SourceData {
+    /// The top-level manifest (image or index).
+    pull: ManifestPull,
+    /// For index manifests: pre-pulled child image manifests with their blob lists.
+    /// Empty for single-image manifests (blobs are derived from `pull.manifest`).
+    children: Vec<ChildData>,
+}
+
+/// A pre-pulled child manifest within an index.
+struct ChildData {
+    pull: ManifestPull,
+    blobs: Vec<Digest>,
+}
+
+/// Per-target result of a fan-out blob transfer phase.
+#[derive(Default)]
+struct BlobTransferResult {
+    bytes_transferred: u64,
+    stats: BlobTransferStats,
+    /// `Some` if a target-specific push failed. Other targets are unaffected.
+    error: Option<crate::Error>,
+}
+
 /// Sync engine — orchestrates image transfers across registries.
 ///
-/// Processes [`ResolvedMapping`]s sequentially, syncing each tag from source
-/// to every target. Blob deduplication is tracked globally so that layers
-/// shared across images or repositories are transferred at most once per
-/// target registry.
+/// For each tag, the engine pulls from the source once and fans out to all
+/// targets. Blob deduplication is tracked globally so that layers shared
+/// across images or repositories are transferred at most once per target
+/// registry.
 #[derive(Debug)]
 pub struct SyncEngine {
     retry: RetryConfig,
@@ -124,10 +154,9 @@ impl SyncEngine {
 
     /// Run the sync engine across all resolved mappings.
     ///
-    /// Processes mappings sequentially. For each mapping, iterates over every
-    /// tag and every target, calling [`sync_image`](Self::sync_image) for each
-    /// combination. Progress callbacks are invoked before and after each image.
-    /// Returns a [`SyncReport`] with per-image results and aggregate statistics.
+    /// For each mapping and tag: pulls from source once, HEAD-checks all
+    /// targets, fans out blob transfers (each blob pulled once from source,
+    /// pushed to all targets that need it), then pushes manifests.
     pub async fn run(
         &mut self,
         mappings: Vec<ResolvedMapping>,
@@ -145,24 +174,8 @@ impl SyncEngine {
             };
 
             for tag_pair in &mapping.tags {
-                for target_entry in &mapping.targets {
-                    let target = Endpoint {
-                        client: &target_entry.client,
-                        repo: &mapping.target_repo,
-                        name: &target_entry.name,
-                    };
-
-                    let source_display =
-                        format!("{}:{} -> {}", source.repo, tag_pair.source, target.name);
-                    let target_display = format!("{}:{}", target.repo, tag_pair.target);
-
-                    progress.image_started(&source_display, &target_display);
-
-                    let result = self.sync_image(&source, &target, tag_pair).await;
-
-                    progress.image_completed(&result);
-                    images.push(result);
-                }
+                self.sync_tag(&source, mapping, tag_pair, progress, &mut images)
+                    .await;
             }
         }
 
@@ -180,63 +193,234 @@ impl SyncEngine {
         report
     }
 
-    /// Sync a single image (one tag) from source to one target.
+    /// Sync one tag across all targets in a mapping.
     ///
-    /// Returns an [`ImageResult`] — never panics. All errors are captured
-    /// as [`ImageStatus::Failed`].
-    async fn sync_image(
+    /// Three phases:
+    /// 1. Pull source manifest + children once
+    /// 2. HEAD-check each target, fan-out blob transfer (pull each blob once)
+    /// 3. Push manifests to each target that succeeded
+    async fn sync_tag(
         &mut self,
         source: &Endpoint<'_>,
-        target: &Endpoint<'_>,
+        mapping: &ResolvedMapping,
         tag_pair: &TagPair,
-    ) -> ImageResult {
-        let image_start = Instant::now();
-        let image_id = Uuid::now_v7();
-        let source_display = format!("{}:{}", source.repo, tag_pair.source);
-        let target_display = format!("{}:{}", target.repo, tag_pair.target);
+        progress: &dyn crate::progress::ProgressReporter,
+        images: &mut Vec<ImageResult>,
+    ) {
+        let source_tag = &tag_pair.source;
+        let target_tag = &tag_pair.target;
 
-        let result = self.try_sync_image(source, target, tag_pair).await;
-
-        let duration = image_start.elapsed();
-
-        match result {
-            Ok((status, bytes_transferred, blob_stats)) => ImageResult {
-                image_id,
-                source: source_display,
-                target: target_display,
-                status,
-                bytes_transferred,
-                blob_stats,
-                duration,
-            },
+        // Phase 0: Pull source manifest once.
+        let source_data = match self.pull_source(source, source_tag).await {
+            Ok(data) => data,
             Err(err) => {
-                warn!(source = %source_display, target = %target_display, error = %err, "image sync failed");
-                ImageResult {
-                    image_id,
-                    source: source_display,
-                    target: target_display,
+                let error_str = err.to_string();
+                warn!(
+                    source_repo = source.repo,
+                    tag = %source_tag,
+                    error = %error_str,
+                    "source pull failed, skipping all targets"
+                );
+                for te in &mapping.targets {
+                    let result = ImageResult {
+                        image_id: Uuid::now_v7(),
+                        source: format!("{}:{source_tag}", source.repo),
+                        target: format!("{}:{target_tag}", mapping.target_repo),
+                        status: ImageStatus::Failed {
+                            error: error_str.clone(),
+                            retries: self.retry.max_retries,
+                        },
+                        bytes_transferred: 0,
+                        blob_stats: BlobTransferStats::default(),
+                        duration: Duration::ZERO,
+                    };
+                    progress.image_completed(&result);
+                    images.push(result);
+                    let _ = te; // all targets get the same failure
+                }
+                return;
+            }
+        };
+
+        // Build target endpoints.
+        let targets: Vec<Endpoint<'_>> = mapping
+            .targets
+            .iter()
+            .map(|te| Endpoint {
+                client: &te.client,
+                repo: &mapping.target_repo,
+                name: &te.name,
+            })
+            .collect();
+
+        // Phase 1: HEAD-check each target — partition into active/skipped.
+        let mut active: Vec<(usize, Instant)> = Vec::new(); // (index, start_time)
+
+        for (i, target) in targets.iter().enumerate() {
+            let source_display = format!("{}:{source_tag} -> {}", source.repo, target.name);
+            let target_display = format!("{}:{target_tag}", target.repo);
+            progress.image_started(&source_display, &target_display);
+
+            match target.client.manifest_head(target.repo, target_tag).await {
+                Ok(Some(head)) if head.digest == source_data.pull.digest => {
+                    info!(
+                        source_repo = source.repo,
+                        target_repo = target.repo,
+                        tag = source_tag,
+                        digest = %source_data.pull.digest,
+                        "skipping — digest matches at target"
+                    );
+                    let result = ImageResult {
+                        image_id: Uuid::now_v7(),
+                        source: format!("{}:{source_tag}", source.repo),
+                        target: target_display,
+                        status: ImageStatus::Skipped {
+                            reason: SkipReason::DigestMatch,
+                        },
+                        bytes_transferred: 0,
+                        blob_stats: BlobTransferStats::default(),
+                        duration: Duration::ZERO,
+                    };
+                    progress.image_completed(&result);
+                    images.push(result);
+                }
+                Ok(_) => active.push((i, Instant::now())),
+                Err(e) => {
+                    warn!(
+                        target_repo = target.repo,
+                        target_tag,
+                        error = %e,
+                        "target manifest HEAD failed, proceeding with sync"
+                    );
+                    active.push((i, Instant::now()));
+                }
+            }
+        }
+
+        if active.is_empty() {
+            return;
+        }
+
+        // Collect all blob digests from the source data.
+        let owned_blobs;
+        let all_blobs: Vec<&Digest> = match &source_data.pull.manifest {
+            ManifestKind::Image(m) => {
+                owned_blobs = collect_image_blobs(m);
+                owned_blobs.iter().collect()
+            }
+            ManifestKind::Index(_) => source_data.children.iter().flat_map(|c| &c.blobs).collect(),
+        };
+
+        // Phase 2: Fan-out blob transfer — pull each blob once, push to all active targets.
+        let active_targets: Vec<&Endpoint<'_>> = active.iter().map(|&(i, _)| &targets[i]).collect();
+
+        let blob_results = match self
+            .transfer_blobs_fanout(source, &active_targets, &all_blobs)
+            .await
+        {
+            Ok(results) => results,
+            Err(err) => {
+                // Source blob pull failed — all active targets fail.
+                let error_str = err.to_string();
+                for &(i, start) in &active {
+                    let target = &targets[i];
+                    let result = ImageResult {
+                        image_id: Uuid::now_v7(),
+                        source: format!("{}:{source_tag}", source.repo),
+                        target: format!("{}:{target_tag}", target.repo),
+                        status: ImageStatus::Failed {
+                            error: error_str.clone(),
+                            retries: self.retry.max_retries,
+                        },
+                        bytes_transferred: 0,
+                        blob_stats: BlobTransferStats::default(),
+                        duration: start.elapsed(),
+                    };
+                    progress.image_completed(&result);
+                    images.push(result);
+                }
+                return;
+            }
+        };
+
+        // Phase 3: Push manifests to targets whose blobs all succeeded.
+        for (br, &(i, start)) in blob_results.into_iter().zip(active.iter()) {
+            let target = &targets[i];
+            let source_str = format!("{}:{source_tag}", source.repo);
+            let target_str = format!("{}:{target_tag}", target.repo);
+
+            if let Some(err) = br.error {
+                warn!(target_name = target.name, error = %err, "blob transfer failed");
+                let result = ImageResult {
+                    image_id: Uuid::now_v7(),
+                    source: source_str,
+                    target: target_str,
                     status: ImageStatus::Failed {
                         error: err.to_string(),
                         retries: self.retry.max_retries,
                     },
-                    bytes_transferred: 0,
-                    blob_stats: BlobTransferStats::default(),
-                    duration,
+                    bytes_transferred: br.bytes_transferred,
+                    blob_stats: br.stats,
+                    duration: start.elapsed(),
+                };
+                progress.image_completed(&result);
+                images.push(result);
+                continue;
+            }
+
+            // Push manifests.
+            match self.push_manifests(target, target_tag, &source_data).await {
+                Ok(()) => {
+                    info!(
+                        source_repo = source.repo,
+                        target_repo = target.repo,
+                        source_tag,
+                        target_tag,
+                        bytes = br.bytes_transferred,
+                        "image synced"
+                    );
+                    let result = ImageResult {
+                        image_id: Uuid::now_v7(),
+                        source: source_str,
+                        target: target_str,
+                        status: ImageStatus::Synced,
+                        bytes_transferred: br.bytes_transferred,
+                        blob_stats: br.stats,
+                        duration: start.elapsed(),
+                    };
+                    progress.image_completed(&result);
+                    images.push(result);
+                }
+                Err(err) => {
+                    warn!(target_name = target.name, error = %err, "manifest push failed");
+                    let result = ImageResult {
+                        image_id: Uuid::now_v7(),
+                        source: source_str,
+                        target: target_str,
+                        status: ImageStatus::Failed {
+                            error: err.to_string(),
+                            retries: self.retry.max_retries,
+                        },
+                        bytes_transferred: br.bytes_transferred,
+                        blob_stats: br.stats,
+                        duration: start.elapsed(),
+                    };
+                    progress.image_completed(&result);
+                    images.push(result);
                 }
             }
         }
     }
 
-    /// Attempt to sync a single image, returning `Result` for ergonomic `?` usage.
-    async fn try_sync_image(
-        &mut self,
+    /// Pull all source manifest data for a single tag.
+    ///
+    /// For image manifests, returns just the manifest. For index manifests,
+    /// also pulls all child manifests and computes their blob lists.
+    async fn pull_source(
+        &self,
         source: &Endpoint<'_>,
-        target: &Endpoint<'_>,
-        tag_pair: &TagPair,
-    ) -> Result<(ImageStatus, u64, BlobTransferStats), crate::Error> {
-        let source_tag = &tag_pair.source;
-        let target_tag = &tag_pair.target;
-        // Step 1: Pull source manifest.
+        source_tag: &str,
+    ) -> Result<SourceData, crate::Error> {
         let pull = with_retry(&self.retry, "manifest pull", || {
             source.client.manifest_pull(source.repo, source_tag)
         })
@@ -246,66 +430,10 @@ impl SyncEngine {
             source: e,
         })?;
 
-        // Step 2: HEAD target manifest — skip if digest matches.
-        match target.client.manifest_head(target.repo, target_tag).await {
-            Ok(Some(head)) if head.digest == pull.digest => {
-                info!(
-                    source_repo = source.repo,
-                    target_repo = target.repo,
-                    source_tag,
-                    target_tag,
-                    digest = %pull.digest,
-                    "skipping — digest matches at target"
-                );
-                return Ok((
-                    ImageStatus::Skipped {
-                        reason: SkipReason::DigestMatch,
-                    },
-                    0,
-                    BlobTransferStats::default(),
-                ));
-            }
-            Ok(_) => {} // manifest missing or digest differs — proceed
-            Err(e) => {
-                warn!(
-                    target_repo = target.repo,
-                    target_tag,
-                    error = %e,
-                    "target manifest HEAD failed, proceeding with sync"
-                );
-            }
-        }
-
-        // Step 3/4: Handle based on manifest kind.
-        let mut blob_stats = BlobTransferStats::default();
-
-        let bytes_transferred = match &pull.manifest {
-            ManifestKind::Image(image_manifest) => {
-                let blobs = collect_image_blobs(image_manifest);
-                let (bytes, stats) = self.transfer_blobs(source, target, &blobs).await?;
-                blob_stats = stats;
-
-                // Push manifest by tag.
-                with_retry(&self.retry, "manifest push", || {
-                    target.client.manifest_push(
-                        target.repo,
-                        target_tag,
-                        &pull.media_type,
-                        &pull.raw_bytes,
-                    )
-                })
-                .await
-                .map_err(|e| crate::Error::Manifest {
-                    reference: target_tag.to_owned(),
-                    source: e,
-                })?;
-
-                bytes
-            }
+        let children = match &pull.manifest {
+            ManifestKind::Image(_) => Vec::new(),
             ManifestKind::Index(index) => {
-                let mut total_bytes = 0u64;
-
-                // For each child descriptor, pull child manifest, transfer blobs, push child.
+                let mut children = Vec::with_capacity(index.manifests.len());
                 for child_desc in &index.manifests {
                     let child_digest_str = child_desc.digest.to_string();
                     let child_pull = with_retry(&self.retry, "manifest pull", || {
@@ -320,12 +448,10 @@ impl SyncEngine {
                     match &child_pull.manifest {
                         ManifestKind::Image(child_image) => {
                             let blobs = collect_image_blobs(child_image);
-                            let (bytes, child_stats) =
-                                self.transfer_blobs(source, target, &blobs).await?;
-                            total_bytes = total_bytes.saturating_add(bytes);
-                            blob_stats.transferred += child_stats.transferred;
-                            blob_stats.skipped += child_stats.skipped;
-                            blob_stats.mounted += child_stats.mounted;
+                            children.push(ChildData {
+                                pull: child_pull,
+                                blobs,
+                            });
                         }
                         ManifestKind::Index(_) => {
                             return Err(crate::Error::Manifest {
@@ -336,177 +462,173 @@ impl SyncEngine {
                             });
                         }
                     }
-
-                    // Push child manifest to target by digest.
-                    with_retry(&self.retry, "manifest push", || {
-                        target.client.manifest_push(
-                            target.repo,
-                            &child_digest_str,
-                            &child_pull.media_type,
-                            &child_pull.raw_bytes,
-                        )
-                    })
-                    .await
-                    .map_err(|e| crate::Error::Manifest {
-                        reference: child_digest_str.clone(),
-                        source: e,
-                    })?;
                 }
-
-                // Push the index by tag.
-                with_retry(&self.retry, "manifest push", || {
-                    target.client.manifest_push(
-                        target.repo,
-                        target_tag,
-                        &pull.media_type,
-                        &pull.raw_bytes,
-                    )
-                })
-                .await
-                .map_err(|e| crate::Error::Manifest {
-                    reference: target_tag.to_owned(),
-                    source: e,
-                })?;
-
-                total_bytes
+                children
             }
         };
 
-        info!(
-            source_repo = source.repo,
-            target_repo = target.repo,
-            source_tag,
-            target_tag,
-            bytes_transferred,
-            "image synced"
-        );
-
-        Ok((ImageStatus::Synced, bytes_transferred, blob_stats))
+        Ok(SourceData { pull, children })
     }
 
-    /// Transfer blobs from source to target, using dedup and cross-repo mount.
+    /// Push all manifests (children for indexes, then top-level) to one target.
+    async fn push_manifests(
+        &self,
+        target: &Endpoint<'_>,
+        target_tag: &str,
+        source_data: &SourceData,
+    ) -> Result<(), crate::Error> {
+        // For index manifests, push each child by digest first.
+        for child in &source_data.children {
+            let child_digest_str = child.pull.digest.to_string();
+            with_retry(&self.retry, "manifest push", || {
+                target.client.manifest_push(
+                    target.repo,
+                    &child_digest_str,
+                    &child.pull.media_type,
+                    &child.pull.raw_bytes,
+                )
+            })
+            .await
+            .map_err(|e| crate::Error::Manifest {
+                reference: child_digest_str.clone(),
+                source: e,
+            })?;
+        }
+
+        // Push top-level manifest by tag.
+        with_retry(&self.retry, "manifest push", || {
+            target.client.manifest_push(
+                target.repo,
+                target_tag,
+                &source_data.pull.media_type,
+                &source_data.pull.raw_bytes,
+            )
+        })
+        .await
+        .map_err(|e| crate::Error::Manifest {
+            reference: target_tag.to_owned(),
+            source: e,
+        })?;
+
+        Ok(())
+    }
+
+    /// Fan-out blob transfer: pull each blob once from source, push to all targets.
     ///
-    /// For each digest: checks the dedup map, does a HEAD check at the target,
-    /// attempts a cross-repo mount, and falls back to pull+push. Returns the
-    /// total bytes transferred and per-call blob statistics.
-    async fn transfer_blobs(
+    /// For each digest, checks dedup/HEAD/mount per target. If any target
+    /// needs a pull, pulls from source once and pushes to all targets that need it.
+    /// Source pull failure is fatal (returns `Err`). Target push failures are
+    /// per-target (recorded in the returned results, other targets continue).
+    async fn transfer_blobs_fanout(
         &mut self,
         source: &Endpoint<'_>,
-        target: &Endpoint<'_>,
-        digests: &[Digest],
-    ) -> Result<(u64, BlobTransferStats), crate::Error> {
-        let mut total_bytes = 0u64;
-        let mut stats = BlobTransferStats::default();
+        targets: &[&Endpoint<'_>],
+        digests: &[&Digest],
+    ) -> Result<Vec<BlobTransferResult>, crate::Error> {
+        let mut results: Vec<BlobTransferResult> = targets
+            .iter()
+            .map(|_| BlobTransferResult::default())
+            .collect();
 
-        for digest in digests {
-            // Check dedup map — skip only if this repo already has the blob.
-            // OCI blobs are repo-scoped: a blob in repo-a is NOT accessible
-            // from repo-b at the same registry without a mount or push.
-            let current_repo_has_blob = self
-                .dedup
-                .known_repos(target.name, digest)
-                .is_some_and(|repos| repos.contains(target.repo));
+        for &digest in digests {
+            // Determine which targets need this blob pulled+pushed.
+            let mut needs_pull: Vec<usize> = Vec::new();
 
-            if current_repo_has_blob {
-                debug!(%digest, repo = target.repo, "blob already in target repo, skipping");
-                stats.skipped += 1;
-                continue;
-            }
+            for (i, target) in targets.iter().enumerate() {
+                if results[i].error.is_some() {
+                    continue; // already failed, skip
+                }
 
-            // Check if we should skip other status checks (in-progress elsewhere).
-            if let Some(crate::plan::BlobStatus::InProgress) =
-                self.dedup.status(target.name, digest)
-            {
-                debug!(%digest, "blob transfer in progress, skipping");
-                stats.skipped += 1;
-                continue;
-            }
-
-            // HEAD check at target — if exists, mark in dedup map and skip.
-            match target.client.blob_exists(target.repo, digest).await {
-                Ok(Some(_size)) => {
-                    debug!(%digest, "blob exists at target, skipping");
-                    self.dedup.set_exists(target.name, digest, target.repo);
-                    stats.skipped += 1;
+                // Dedup: skip if this repo already has it.
+                let has_blob = self
+                    .dedup
+                    .known_repos(target.name, digest)
+                    .is_some_and(|repos| repos.contains(target.repo));
+                if has_blob {
+                    results[i].stats.skipped += 1;
                     continue;
                 }
-                Ok(None) => {} // not found, need to transfer
-                Err(e) => {
-                    debug!(%digest, error = %e, "blob HEAD check failed, will attempt transfer");
-                }
-            }
 
-            // Try cross-repo mount if another repo at this target has the blob.
-            let mount_source = self
-                .dedup
-                .mount_source(target.name, digest, target.repo)
-                .map(|s| s.to_owned());
-
-            if let Some(from_repo) = mount_source {
-                debug!(%digest, %from_repo, "attempting cross-repo mount");
-                match target
-                    .client
-                    .blob_mount(target.repo, digest, &from_repo)
-                    .await
-                {
-                    Ok(MountResult::Mounted) => {
-                        debug!(%digest, %from_repo, "blob mounted");
-                        self.dedup.set_completed(target.name, digest, target.repo);
-                        stats.mounted += 1;
+                // HEAD check at target.
+                match target.client.blob_exists(target.repo, digest).await {
+                    Ok(Some(_)) => {
+                        self.dedup.set_exists(target.name, digest, target.repo);
+                        results[i].stats.skipped += 1;
                         continue;
                     }
-                    Ok(MountResult::FallbackUpload { .. }) => {
-                        debug!(%digest, "mount fallback, proceeding with pull+push");
-                    }
+                    Ok(None) => {}
                     Err(e) => {
-                        debug!(%digest, error = %e, "mount failed, proceeding with pull+push");
+                        debug!(%digest, target = target.name, error = %e, "blob HEAD failed");
                     }
                 }
+
+                // Try cross-repo mount.
+                if let Some(from_repo) = self
+                    .dedup
+                    .mount_source(target.name, digest, target.repo)
+                    .map(|s| s.to_owned())
+                {
+                    debug!(%digest, %from_repo, target = target.name, "attempting mount");
+                    match target
+                        .client
+                        .blob_mount(target.repo, digest, &from_repo)
+                        .await
+                    {
+                        Ok(MountResult::Mounted) => {
+                            self.dedup.set_completed(target.name, digest, target.repo);
+                            results[i].stats.mounted += 1;
+                            continue;
+                        }
+                        Ok(MountResult::FallbackUpload { .. }) | Err(_) => {
+                            debug!(%digest, target = target.name, "mount failed, needs pull");
+                        }
+                    }
+                }
+
+                needs_pull.push(i);
             }
 
-            // Mark in-progress before pull+push.
-            self.dedup.set_in_progress(target.name, digest);
+            if needs_pull.is_empty() {
+                continue;
+            }
 
-            // Pull from source with retry.
-            let data = match with_retry(&self.retry, "blob pull", || {
+            // Pull from source ONCE.
+            let data = with_retry(&self.retry, "blob pull", || {
                 source.client.blob_pull_all(source.repo, digest)
             })
             .await
-            {
-                Ok(data) => data,
-                Err(e) => {
-                    let err = crate::Error::BlobPull {
+            .map_err(|e| crate::Error::BlobPull {
+                digest: digest.to_string(),
+                source: e,
+            })?;
+            let blob_size = data.len() as u64;
+
+            // Push to each target that needs it.
+            for &i in &needs_pull {
+                let target = targets[i];
+                self.dedup.set_in_progress(target.name, digest);
+
+                if let Err(e) = with_retry(&self.retry, "blob push", || {
+                    target.client.blob_push(target.repo, &data)
+                })
+                .await
+                {
+                    let err = crate::Error::BlobPush {
                         digest: digest.to_string(),
                         source: e,
                     };
                     self.dedup.set_failed(target.name, digest, err.to_string());
-                    return Err(err);
+                    results[i].error = Some(err);
+                    continue; // other targets may still succeed
                 }
-            };
-            let blob_size = data.len() as u64;
 
-            // Push to target with retry.
-            if let Err(e) = with_retry(&self.retry, "blob push", || {
-                target.client.blob_push(target.repo, &data)
-            })
-            .await
-            {
-                let err = crate::Error::BlobPush {
-                    digest: digest.to_string(),
-                    source: e,
-                };
-                self.dedup.set_failed(target.name, digest, err.to_string());
-                return Err(err);
+                results[i].bytes_transferred += blob_size;
+                results[i].stats.transferred += 1;
+                self.dedup.set_completed(target.name, digest, target.repo);
             }
-
-            total_bytes = total_bytes.saturating_add(blob_size);
-            stats.transferred += 1;
-
-            // Mark completed.
-            self.dedup.set_completed(target.name, digest, target.repo);
         }
 
-        Ok((total_bytes, stats))
+        Ok(results)
     }
 }
 
@@ -649,7 +771,7 @@ mod tests {
             status,
             bytes_transferred: bytes,
             blob_stats: BlobTransferStats::default(),
-            duration: std::time::Duration::from_millis(100),
+            duration: Duration::from_millis(100),
         }
     }
 

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 
 use crate::plan::BlobDedupMap;
 use crate::retry::{self, RetryConfig};
-use crate::{ImageResult, ImageStatus, SkipReason};
+use crate::{ImageResult, ImageStatus, SkipReason, SyncReport, SyncStats};
 
 /// A fully resolved mapping ready for the sync engine.
 ///
@@ -43,7 +43,6 @@ pub struct TargetEntry {
 }
 
 /// Collect all blob digests from an image manifest (config + layers).
-#[allow(dead_code)] // Called by sync_image_inner; public entry point `run()` added next.
 fn collect_image_blobs(manifest: &ImageManifest) -> Vec<Digest> {
     let mut digests = Vec::with_capacity(1 + manifest.layers.len());
     digests.push(manifest.config.digest.clone());
@@ -61,7 +60,6 @@ fn collect_image_blobs(manifest: &ImageManifest) -> Vec<Digest> {
 /// target registry.
 pub struct SyncEngine {
     retry: RetryConfig,
-    #[allow(dead_code)] // Used by transfer_blobs; public entry point `run()` added next.
     dedup: std::sync::Mutex<BlobDedupMap>,
 }
 
@@ -82,11 +80,64 @@ impl SyncEngine {
         }
     }
 
+    /// Run the sync engine across all resolved mappings.
+    ///
+    /// Processes mappings sequentially. For each mapping, iterates over every
+    /// tag and every target, calling [`sync_image`](Self::sync_image) for each
+    /// combination. Progress callbacks are invoked before and after each image.
+    /// Returns a [`SyncReport`] with per-image results and aggregate statistics.
+    pub async fn run(
+        &self,
+        mappings: Vec<ResolvedMapping>,
+        progress: &dyn crate::progress::ProgressReporter,
+    ) -> SyncReport {
+        let run_start = Instant::now();
+        let run_id = Uuid::now_v7();
+        let mut images = Vec::new();
+
+        for mapping in &mappings {
+            for tag in &mapping.tags {
+                for target in &mapping.targets {
+                    let source_ref = format!("{}:{}@{}", mapping.source_repo, tag, target.name);
+                    let target_ref = format!("{}:{}", mapping.target_repo, tag);
+
+                    progress.image_started(&source_ref, &target_ref);
+
+                    let result = self
+                        .sync_image(
+                            &mapping.source_client,
+                            &mapping.source_repo,
+                            &target.client,
+                            &target.name,
+                            &mapping.target_repo,
+                            tag,
+                        )
+                        .await;
+
+                    progress.image_completed(&result);
+                    images.push(result);
+                }
+            }
+        }
+
+        let stats = compute_stats(&images);
+        let duration = run_start.elapsed();
+
+        let report = SyncReport {
+            run_id,
+            images,
+            stats,
+            duration,
+        };
+
+        progress.run_completed(&report);
+        report
+    }
+
     /// Sync a single image (one tag) from source to one target.
     ///
     /// Returns an [`ImageResult`] — never panics. All errors are captured
     /// as [`ImageStatus::Failed`].
-    #[allow(dead_code)] // Public entry point `run()` added next.
     async fn sync_image(
         &self,
         source: &RegistryClient,
@@ -426,6 +477,26 @@ impl SyncEngine {
     }
 }
 
+/// Compute aggregate statistics from a list of image results.
+fn compute_stats(images: &[ImageResult]) -> SyncStats {
+    let mut stats = SyncStats::default();
+    for image in images {
+        match &image.status {
+            ImageStatus::Synced => {
+                stats.images_synced += 1;
+                stats.bytes_transferred += image.bytes_transferred;
+            }
+            ImageStatus::Skipped { .. } => {
+                stats.images_skipped += 1;
+            }
+            ImageStatus::Failed { .. } => {
+                stats.images_failed += 1;
+            }
+        }
+    }
+    stats
+}
+
 #[cfg(test)]
 mod tests {
     use ocync_distribution::spec::{Descriptor, MediaType};
@@ -492,5 +563,51 @@ mod tests {
         let blobs = collect_image_blobs(&manifest);
         assert_eq!(blobs.len(), 1);
         assert_eq!(blobs[0], config_digest);
+    }
+
+    fn make_image_result(status: ImageStatus, bytes: u64) -> ImageResult {
+        ImageResult {
+            image_id: Uuid::now_v7(),
+            source: "source/repo:tag".into(),
+            target: "target/repo:tag".into(),
+            status,
+            bytes_transferred: bytes,
+            duration: std::time::Duration::from_millis(100),
+        }
+    }
+
+    #[test]
+    fn compute_stats_mixed_results() {
+        let images = vec![
+            make_image_result(ImageStatus::Synced, 1024),
+            make_image_result(
+                ImageStatus::Skipped {
+                    reason: SkipReason::DigestMatch,
+                },
+                0,
+            ),
+            make_image_result(
+                ImageStatus::Failed {
+                    error: "timeout".into(),
+                    retries: 3,
+                },
+                0,
+            ),
+        ];
+
+        let stats = compute_stats(&images);
+        assert_eq!(stats.images_synced, 1);
+        assert_eq!(stats.images_skipped, 1);
+        assert_eq!(stats.images_failed, 1);
+        assert_eq!(stats.bytes_transferred, 1024);
+    }
+
+    #[test]
+    fn compute_stats_empty() {
+        let stats = compute_stats(&[]);
+        assert_eq!(stats.images_synced, 0);
+        assert_eq!(stats.images_skipped, 0);
+        assert_eq!(stats.images_failed, 0);
+        assert_eq!(stats.bytes_transferred, 0);
     }
 }

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -1,6 +1,6 @@
 //! Sync engine — two-phase orchestrator for image transfers.
 
-use std::fmt;
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -12,7 +12,7 @@ use uuid::Uuid;
 
 use crate::plan::BlobDedupMap;
 use crate::retry::{self, RetryConfig};
-use crate::{ImageResult, ImageStatus, SkipReason, SyncReport, SyncStats};
+use crate::{BlobTransferStats, ImageResult, ImageStatus, SkipReason, SyncReport, SyncStats};
 
 /// A fully resolved mapping ready for the sync engine.
 ///
@@ -89,17 +89,10 @@ fn collect_image_blobs(manifest: &ImageManifest) -> Vec<Digest> {
 /// to every target. Blob deduplication is tracked globally so that layers
 /// shared across images or repositories are transferred at most once per
 /// target registry.
+#[derive(Debug)]
 pub struct SyncEngine {
     retry: RetryConfig,
-    dedup: std::sync::Mutex<BlobDedupMap>,
-}
-
-impl fmt::Debug for SyncEngine {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SyncEngine")
-            .field("retry", &self.retry)
-            .finish_non_exhaustive()
-    }
+    dedup: BlobDedupMap,
 }
 
 impl SyncEngine {
@@ -107,7 +100,7 @@ impl SyncEngine {
     pub fn new(retry: RetryConfig) -> Self {
         Self {
             retry,
-            dedup: std::sync::Mutex::new(BlobDedupMap::new()),
+            dedup: BlobDedupMap::new(),
         }
     }
 
@@ -118,7 +111,7 @@ impl SyncEngine {
     /// combination. Progress callbacks are invoked before and after each image.
     /// Returns a [`SyncReport`] with per-image results and aggregate statistics.
     pub async fn run(
-        &self,
+        &mut self,
         mappings: Vec<ResolvedMapping>,
         progress: &dyn crate::progress::ProgressReporter,
     ) -> SyncReport {
@@ -130,7 +123,7 @@ impl SyncEngine {
             for tag_pair in &mapping.tags {
                 for target in &mapping.targets {
                     let source_ref = format!(
-                        "{}:{}@{}",
+                        "{}:{} -> {}",
                         mapping.source_repo, tag_pair.source, target.name
                     );
                     let target_ref = format!("{}:{}", mapping.target_repo, tag_pair.target);
@@ -175,7 +168,7 @@ impl SyncEngine {
     /// as [`ImageStatus::Failed`].
     #[allow(clippy::too_many_arguments)]
     async fn sync_image(
-        &self,
+        &mut self,
         source: &RegistryClient,
         source_repo: &str,
         target: &RegistryClient,
@@ -204,12 +197,13 @@ impl SyncEngine {
         let duration = image_start.elapsed();
 
         match result {
-            Ok((status, bytes_transferred)) => ImageResult {
+            Ok((status, bytes_transferred, blob_stats)) => ImageResult {
                 image_id,
                 source: source_ref,
                 target: target_ref,
                 status,
                 bytes_transferred,
+                blob_stats,
                 duration,
             },
             Err(err) => {
@@ -219,10 +213,11 @@ impl SyncEngine {
                     source: source_ref,
                     target: target_ref,
                     status: ImageStatus::Failed {
-                        error: err,
+                        error: err.to_string(),
                         retries: self.retry.max_retries,
                     },
                     bytes_transferred: 0,
+                    blob_stats: BlobTransferStats::default(),
                     duration,
                 }
             }
@@ -232,7 +227,7 @@ impl SyncEngine {
     /// Inner implementation of image sync that returns Result for ergonomic error handling.
     #[allow(clippy::too_many_arguments)]
     async fn sync_image_inner(
-        &self,
+        &mut self,
         source: &RegistryClient,
         source_repo: &str,
         target: &RegistryClient,
@@ -240,11 +235,16 @@ impl SyncEngine {
         target_repo: &str,
         source_tag: &str,
         target_tag: &str,
-    ) -> Result<(ImageStatus, u64), String> {
+    ) -> Result<(ImageStatus, u64, BlobTransferStats), crate::Error> {
         // Step 1: Pull source manifest.
-        let pull = self
-            .manifest_pull_with_retry(source, source_repo, source_tag)
-            .await?;
+        let pull = with_retry(&self.retry, "manifest pull", || {
+            source.manifest_pull(source_repo, source_tag)
+        })
+        .await
+        .map_err(|e| crate::Error::Manifest {
+            reference: source_tag.to_owned(),
+            source: e,
+        })?;
 
         // Step 2: HEAD target manifest — skip if digest matches.
         match target.manifest_head(target_repo, target_tag).await {
@@ -262,6 +262,7 @@ impl SyncEngine {
                         reason: SkipReason::DigestMatch,
                     },
                     0,
+                    BlobTransferStats::default(),
                 ));
             }
             Ok(_) => {} // manifest missing or digest differs — proceed
@@ -276,10 +277,12 @@ impl SyncEngine {
         }
 
         // Step 3/4: Handle based on manifest kind.
+        let mut blob_stats = BlobTransferStats::default();
+
         let bytes_transferred = match &pull.manifest {
             ManifestKind::Image(image_manifest) => {
                 let blobs = collect_image_blobs(image_manifest);
-                let bytes = self
+                let (bytes, stats) = self
                     .transfer_blobs(
                         source,
                         source_repo,
@@ -289,16 +292,17 @@ impl SyncEngine {
                         &blobs,
                     )
                     .await?;
+                blob_stats = stats;
 
                 // Push manifest by tag.
-                self.manifest_push_with_retry(
-                    target,
-                    target_repo,
-                    target_tag,
-                    &pull.media_type,
-                    &pull.raw_bytes,
-                )
-                .await?;
+                with_retry(&self.retry, "manifest push", || {
+                    target.manifest_push(target_repo, target_tag, &pull.media_type, &pull.raw_bytes)
+                })
+                .await
+                .map_err(|e| crate::Error::Manifest {
+                    reference: target_tag.to_owned(),
+                    source: e,
+                })?;
 
                 bytes
             }
@@ -308,13 +312,18 @@ impl SyncEngine {
                 // For each child descriptor, pull child manifest, transfer blobs, push child.
                 for child_desc in &index.manifests {
                     let child_digest_str = child_desc.digest.to_string();
-                    let child_pull = self
-                        .manifest_pull_with_retry(source, source_repo, &child_digest_str)
-                        .await?;
+                    let child_pull = with_retry(&self.retry, "manifest pull", || {
+                        source.manifest_pull(source_repo, &child_digest_str)
+                    })
+                    .await
+                    .map_err(|e| crate::Error::Manifest {
+                        reference: child_digest_str.clone(),
+                        source: e,
+                    })?;
 
                     if let ManifestKind::Image(child_image) = &child_pull.manifest {
                         let blobs = collect_image_blobs(child_image);
-                        let bytes = self
+                        let (bytes, child_stats) = self
                             .transfer_blobs(
                                 source,
                                 source_repo,
@@ -325,28 +334,36 @@ impl SyncEngine {
                             )
                             .await?;
                         total_bytes = total_bytes.saturating_add(bytes);
+                        blob_stats.transferred += child_stats.transferred;
+                        blob_stats.skipped += child_stats.skipped;
+                        blob_stats.mounted += child_stats.mounted;
                     }
 
                     // Push child manifest to target by digest.
-                    self.manifest_push_with_retry(
-                        target,
-                        target_repo,
-                        &child_digest_str,
-                        &child_pull.media_type,
-                        &child_pull.raw_bytes,
-                    )
-                    .await?;
+                    with_retry(&self.retry, "manifest push", || {
+                        target.manifest_push(
+                            target_repo,
+                            &child_digest_str,
+                            &child_pull.media_type,
+                            &child_pull.raw_bytes,
+                        )
+                    })
+                    .await
+                    .map_err(|e| crate::Error::Manifest {
+                        reference: child_digest_str.clone(),
+                        source: e,
+                    })?;
                 }
 
                 // Push the index by tag.
-                self.manifest_push_with_retry(
-                    target,
-                    target_repo,
-                    target_tag,
-                    &pull.media_type,
-                    &pull.raw_bytes,
-                )
-                .await?;
+                with_retry(&self.retry, "manifest push", || {
+                    target.manifest_push(target_repo, target_tag, &pull.media_type, &pull.raw_bytes)
+                })
+                .await
+                .map_err(|e| crate::Error::Manifest {
+                    reference: target_tag.to_owned(),
+                    source: e,
+                })?;
 
                 total_bytes
             }
@@ -357,40 +374,37 @@ impl SyncEngine {
             target_repo, source_tag, target_tag, bytes_transferred, "image synced"
         );
 
-        Ok((ImageStatus::Synced, bytes_transferred))
+        Ok((ImageStatus::Synced, bytes_transferred, blob_stats))
     }
 
     /// Transfer blobs from source to target, using dedup and cross-repo mount.
     ///
     /// For each digest: checks the dedup map, does a HEAD check at the target,
     /// attempts a cross-repo mount, and falls back to pull+push. Returns the
-    /// total bytes transferred.
+    /// total bytes transferred and per-call blob statistics.
     async fn transfer_blobs(
-        &self,
+        &mut self,
         source: &RegistryClient,
         source_repo: &str,
         target: &RegistryClient,
         target_name: &str,
         target_repo: &str,
         digests: &[Digest],
-    ) -> Result<u64, String> {
+    ) -> Result<(u64, BlobTransferStats), crate::Error> {
         let mut total_bytes = 0u64;
+        let mut stats = BlobTransferStats::default();
 
         for digest in digests {
             // Check dedup map — skip if already handled.
-            {
-                let dedup = self.dedup.lock().expect("dedup lock poisoned");
-                if let Some(status) = dedup.status(target_name, digest) {
-                    use crate::plan::BlobStatus;
-                    match status {
-                        BlobStatus::ExistsAtTarget
-                        | BlobStatus::Completed
-                        | BlobStatus::InProgress => {
-                            debug!(%digest, status = ?status, "blob already handled, skipping");
-                            continue;
-                        }
-                        BlobStatus::Unknown | BlobStatus::Failed(_) => {}
+            if let Some(status) = self.dedup.status(target_name, digest) {
+                use crate::plan::BlobStatus;
+                match status {
+                    BlobStatus::ExistsAtTarget | BlobStatus::Completed | BlobStatus::InProgress => {
+                        debug!(%digest, status = ?status, "blob already handled, skipping");
+                        stats.skipped += 1;
+                        continue;
                     }
+                    BlobStatus::Unknown | BlobStatus::Failed(_) => {}
                 }
             }
 
@@ -398,8 +412,8 @@ impl SyncEngine {
             match target.blob_exists(target_repo, digest).await {
                 Ok(Some(_size)) => {
                     debug!(%digest, "blob exists at target, skipping");
-                    let mut dedup = self.dedup.lock().expect("dedup lock poisoned");
-                    dedup.set_exists(target_name, digest, target_repo);
+                    self.dedup.set_exists(target_name, digest, target_repo);
+                    stats.skipped += 1;
                     continue;
                 }
                 Ok(None) => {} // not found, need to transfer
@@ -409,26 +423,21 @@ impl SyncEngine {
             }
 
             // Mark in-progress.
-            {
-                let mut dedup = self.dedup.lock().expect("dedup lock poisoned");
-                dedup.set_in_progress(target_name, digest);
-            }
+            self.dedup.set_in_progress(target_name, digest);
 
             // Try cross-repo mount.
-            let mount_source = {
-                let dedup = self.dedup.lock().expect("dedup lock poisoned");
-                dedup
-                    .mount_source(target_name, digest, target_repo)
-                    .map(|s| s.to_owned())
-            };
+            let mount_source = self
+                .dedup
+                .mount_source(target_name, digest, target_repo)
+                .map(|s| s.to_owned());
 
             if let Some(from_repo) = mount_source {
-                debug!(%digest, from_repo, "attempting cross-repo mount");
+                debug!(%digest, %from_repo, "attempting cross-repo mount");
                 match target.blob_mount(target_repo, digest, &from_repo).await {
                     Ok(MountResult::Mounted) => {
-                        debug!(%digest, "blob mounted from {from_repo}");
-                        let mut dedup = self.dedup.lock().expect("dedup lock poisoned");
-                        dedup.set_completed(target_name, digest, target_repo);
+                        debug!(%digest, %from_repo, "blob mounted");
+                        self.dedup.set_completed(target_name, digest, target_repo);
+                        stats.mounted += 1;
                         continue;
                     }
                     Ok(MountResult::FallbackUpload { .. }) => {
@@ -441,165 +450,83 @@ impl SyncEngine {
             }
 
             // Pull from source with retry.
-            let data = match self.pull_blob_with_retry(source, source_repo, digest).await {
+            let data = match with_retry(&self.retry, "blob pull", || {
+                source.blob_pull_all(source_repo, digest)
+            })
+            .await
+            {
                 Ok(data) => data,
                 Err(e) => {
-                    let mut dedup = self.dedup.lock().expect("dedup lock poisoned");
-                    dedup.set_failed(target_name, digest, e.clone());
-                    return Err(e);
+                    let err = crate::Error::BlobPull {
+                        digest: digest.to_string(),
+                        source: e,
+                    };
+                    self.dedup.set_failed(target_name, digest, err.to_string());
+                    return Err(err);
                 }
             };
             let blob_size = data.len() as u64;
 
             // Push to target with retry.
-            if let Err(e) = self.push_blob_with_retry(target, target_repo, &data).await {
-                let mut dedup = self.dedup.lock().expect("dedup lock poisoned");
-                dedup.set_failed(target_name, digest, e.clone());
-                return Err(e);
+            if let Err(e) = with_retry(&self.retry, "blob push", || {
+                target.blob_push(target_repo, &data)
+            })
+            .await
+            {
+                let err = crate::Error::BlobPush {
+                    digest: digest.to_string(),
+                    source: e,
+                };
+                self.dedup.set_failed(target_name, digest, err.to_string());
+                return Err(err);
             }
 
             total_bytes = total_bytes.saturating_add(blob_size);
+            stats.transferred += 1;
 
             // Mark completed.
-            let mut dedup = self.dedup.lock().expect("dedup lock poisoned");
-            dedup.set_completed(target_name, digest, target_repo);
+            self.dedup.set_completed(target_name, digest, target_repo);
         }
 
-        Ok(total_bytes)
+        Ok((total_bytes, stats))
     }
+}
 
-    /// Pull a blob with retry logic for transient errors.
-    async fn pull_blob_with_retry(
-        &self,
-        source: &RegistryClient,
-        source_repo: &str,
-        digest: &Digest,
-    ) -> Result<Vec<u8>, String> {
-        let mut attempt = 0;
-        loop {
-            match source.blob_pull_all(source_repo, digest).await {
-                Ok(data) => return Ok(data),
-                Err(e) => {
-                    if let Some(status) = e.status_code() {
-                        if retry::should_retry(status, attempt, self.retry.max_retries) {
-                            let backoff = self.retry.backoff_for(attempt);
-                            warn!(
-                                %digest,
-                                attempt,
-                                status = %status,
-                                backoff_ms = backoff.as_millis(),
-                                "retrying blob pull"
-                            );
-                            tokio::time::sleep(backoff).await;
-                            attempt += 1;
-                            continue;
-                        }
+/// Retry an async operation with exponential backoff on transient HTTP errors.
+///
+/// Calls `f()` in a loop. If the result is `Err` with a retryable HTTP status
+/// (408, 429, 5xx), waits with exponential backoff and tries again up to
+/// `config.max_retries` times. Returns the first `Ok` or the final `Err`.
+async fn with_retry<T, F, Fut>(
+    config: &RetryConfig,
+    operation: &str,
+    f: F,
+) -> Result<T, ocync_distribution::Error>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, ocync_distribution::Error>>,
+{
+    let mut attempt = 0;
+    loop {
+        match f().await {
+            Ok(val) => return Ok(val),
+            Err(e) => {
+                if let Some(status) = e.status_code() {
+                    if retry::should_retry(status, attempt, config.max_retries) {
+                        let backoff = config.backoff_for(attempt);
+                        warn!(
+                            operation,
+                            attempt,
+                            status = %status,
+                            backoff_ms = backoff.as_millis(),
+                            "retrying"
+                        );
+                        tokio::time::sleep(backoff).await;
+                        attempt += 1;
+                        continue;
                     }
-                    return Err(format!("failed to pull blob {digest}: {e}"));
                 }
-            }
-        }
-    }
-
-    /// Push a blob with retry logic for transient errors.
-    async fn push_blob_with_retry(
-        &self,
-        target: &RegistryClient,
-        target_repo: &str,
-        data: &[u8],
-    ) -> Result<Digest, String> {
-        let mut attempt = 0;
-        loop {
-            match target.blob_push(target_repo, data).await {
-                Ok(digest) => return Ok(digest),
-                Err(e) => {
-                    if let Some(status) = e.status_code() {
-                        if retry::should_retry(status, attempt, self.retry.max_retries) {
-                            let backoff = self.retry.backoff_for(attempt);
-                            warn!(
-                                attempt,
-                                status = %status,
-                                backoff_ms = backoff.as_millis(),
-                                "retrying blob push"
-                            );
-                            tokio::time::sleep(backoff).await;
-                            attempt += 1;
-                            continue;
-                        }
-                    }
-                    return Err(format!("failed to push blob: {e}"));
-                }
-            }
-        }
-    }
-
-    /// Pull a manifest with retry logic for transient errors.
-    async fn manifest_pull_with_retry(
-        &self,
-        client: &RegistryClient,
-        repo: &str,
-        reference: &str,
-    ) -> Result<ocync_distribution::ManifestPull, String> {
-        let mut attempt = 0;
-        loop {
-            match client.manifest_pull(repo, reference).await {
-                Ok(pull) => return Ok(pull),
-                Err(e) => {
-                    if let Some(status) = e.status_code() {
-                        if retry::should_retry(status, attempt, self.retry.max_retries) {
-                            let backoff = self.retry.backoff_for(attempt);
-                            warn!(
-                                reference,
-                                attempt,
-                                status = %status,
-                                backoff_ms = backoff.as_millis(),
-                                "retrying manifest pull"
-                            );
-                            tokio::time::sleep(backoff).await;
-                            attempt += 1;
-                            continue;
-                        }
-                    }
-                    return Err(format!("failed to pull manifest {reference}: {e}"));
-                }
-            }
-        }
-    }
-
-    /// Push a manifest with retry logic for transient errors.
-    async fn manifest_push_with_retry(
-        &self,
-        client: &RegistryClient,
-        repo: &str,
-        reference: &str,
-        media_type: &ocync_distribution::MediaType,
-        raw_bytes: &[u8],
-    ) -> Result<Digest, String> {
-        let mut attempt = 0;
-        loop {
-            match client
-                .manifest_push(repo, reference, media_type, raw_bytes)
-                .await
-            {
-                Ok(digest) => return Ok(digest),
-                Err(e) => {
-                    if let Some(status) = e.status_code() {
-                        if retry::should_retry(status, attempt, self.retry.max_retries) {
-                            let backoff = self.retry.backoff_for(attempt);
-                            warn!(
-                                reference,
-                                attempt,
-                                status = %status,
-                                backoff_ms = backoff.as_millis(),
-                                "retrying manifest push"
-                            );
-                            tokio::time::sleep(backoff).await;
-                            attempt += 1;
-                            continue;
-                        }
-                    }
-                    return Err(format!("failed to push manifest {reference}: {e}"));
-                }
+                return Err(e);
             }
         }
     }
@@ -621,6 +548,9 @@ fn compute_stats(images: &[ImageResult]) -> SyncStats {
                 stats.images_failed += 1;
             }
         }
+        stats.blobs_transferred += image.blob_stats.transferred;
+        stats.blobs_skipped += image.blob_stats.skipped;
+        stats.blobs_mounted += image.blob_stats.mounted;
     }
     stats
 }
@@ -700,6 +630,7 @@ mod tests {
             target: "target/repo:tag".into(),
             status,
             bytes_transferred: bytes,
+            blob_stats: BlobTransferStats::default(),
             duration: std::time::Duration::from_millis(100),
         }
     }

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -34,9 +34,16 @@ pub struct ResolvedMapping {
 }
 
 /// A single target registry entry.
+///
+/// `name` must be unique across targets within a [`ResolvedMapping`] — it is
+/// used as the key in the blob deduplication map to track which blobs have
+/// already been transferred to each target.
 #[derive(Debug)]
 pub struct TargetEntry {
-    /// Human-readable name from config (e.g. `us-ecr`).
+    /// Registry identifier used as the blob dedup key.
+    ///
+    /// Must be unique per mapping. Typically the config-defined registry name
+    /// (e.g. `us-ecr`) or the bare hostname for ad-hoc commands.
     pub name: String,
     /// Client for this target registry.
     pub client: Arc<RegistryClient>,
@@ -71,6 +78,17 @@ impl TagPair {
             target: target.into(),
         }
     }
+}
+
+/// A registry endpoint bundling client, repo, and identity for sync operations.
+///
+/// Used internally to pass source/target pairs through the engine without
+/// threading 4+ loose parameters.
+struct Endpoint<'a> {
+    client: &'a RegistryClient,
+    repo: &'a str,
+    /// Identity key — used as the blob dedup map key for targets.
+    name: &'a str,
 }
 
 /// Collect all blob digests from an image manifest (config + layers).
@@ -120,27 +138,27 @@ impl SyncEngine {
         let mut images = Vec::new();
 
         for mapping in &mappings {
+            let source = Endpoint {
+                client: &mapping.source_client,
+                repo: &mapping.source_repo,
+                name: &mapping.source_repo,
+            };
+
             for tag_pair in &mapping.tags {
-                for target in &mapping.targets {
-                    let source_ref = format!(
-                        "{}:{} -> {}",
-                        mapping.source_repo, tag_pair.source, target.name
-                    );
-                    let target_ref = format!("{}:{}", mapping.target_repo, tag_pair.target);
+                for target_entry in &mapping.targets {
+                    let target = Endpoint {
+                        client: &target_entry.client,
+                        repo: &mapping.target_repo,
+                        name: &target_entry.name,
+                    };
 
-                    progress.image_started(&source_ref, &target_ref);
+                    let source_display =
+                        format!("{}:{} -> {}", source.repo, tag_pair.source, target.name);
+                    let target_display = format!("{}:{}", target.repo, tag_pair.target);
 
-                    let result = self
-                        .sync_image(
-                            &mapping.source_client,
-                            &mapping.source_repo,
-                            &target.client,
-                            &target.name,
-                            &mapping.target_repo,
-                            &tag_pair.source,
-                            &tag_pair.target,
-                        )
-                        .await;
+                    progress.image_started(&source_display, &target_display);
+
+                    let result = self.sync_image(&source, &target, tag_pair).await;
 
                     progress.image_completed(&result);
                     images.push(result);
@@ -166,52 +184,37 @@ impl SyncEngine {
     ///
     /// Returns an [`ImageResult`] — never panics. All errors are captured
     /// as [`ImageStatus::Failed`].
-    #[allow(clippy::too_many_arguments)]
     async fn sync_image(
         &mut self,
-        source: &RegistryClient,
-        source_repo: &str,
-        target: &RegistryClient,
-        target_name: &str,
-        target_repo: &str,
-        source_tag: &str,
-        target_tag: &str,
+        source: &Endpoint<'_>,
+        target: &Endpoint<'_>,
+        tag_pair: &TagPair,
     ) -> ImageResult {
         let image_start = Instant::now();
         let image_id = Uuid::now_v7();
-        let source_ref = format!("{source_repo}:{source_tag}");
-        let target_ref = format!("{target_repo}:{target_tag}");
+        let source_display = format!("{}:{}", source.repo, tag_pair.source);
+        let target_display = format!("{}:{}", target.repo, tag_pair.target);
 
-        let result = self
-            .sync_image_inner(
-                source,
-                source_repo,
-                target,
-                target_name,
-                target_repo,
-                source_tag,
-                target_tag,
-            )
-            .await;
+        let result = self.try_sync_image(source, target, tag_pair).await;
 
         let duration = image_start.elapsed();
 
         match result {
             Ok((status, bytes_transferred, blob_stats)) => ImageResult {
                 image_id,
-                source: source_ref,
-                target: target_ref,
+                source: source_display,
+                target: target_display,
                 status,
                 bytes_transferred,
                 blob_stats,
                 duration,
             },
             Err(err) => {
-                warn!(source = %source_ref, target = %target_ref, error = %err, "image sync failed");
+                warn!(source = %source_display, target = %target_display, error = %err, "image sync failed");
                 ImageResult {
                     image_id,
-                    source: source_ref,
-                    target: target_ref,
+                    source: source_display,
+                    target: target_display,
                     status: ImageStatus::Failed {
                         error: err.to_string(),
                         retries: self.retry.max_retries,
@@ -224,21 +227,18 @@ impl SyncEngine {
         }
     }
 
-    /// Inner implementation of image sync that returns Result for ergonomic error handling.
-    #[allow(clippy::too_many_arguments)]
-    async fn sync_image_inner(
+    /// Attempt to sync a single image, returning `Result` for ergonomic `?` usage.
+    async fn try_sync_image(
         &mut self,
-        source: &RegistryClient,
-        source_repo: &str,
-        target: &RegistryClient,
-        target_name: &str,
-        target_repo: &str,
-        source_tag: &str,
-        target_tag: &str,
+        source: &Endpoint<'_>,
+        target: &Endpoint<'_>,
+        tag_pair: &TagPair,
     ) -> Result<(ImageStatus, u64, BlobTransferStats), crate::Error> {
+        let source_tag = &tag_pair.source;
+        let target_tag = &tag_pair.target;
         // Step 1: Pull source manifest.
         let pull = with_retry(&self.retry, "manifest pull", || {
-            source.manifest_pull(source_repo, source_tag)
+            source.client.manifest_pull(source.repo, source_tag)
         })
         .await
         .map_err(|e| crate::Error::Manifest {
@@ -247,11 +247,11 @@ impl SyncEngine {
         })?;
 
         // Step 2: HEAD target manifest — skip if digest matches.
-        match target.manifest_head(target_repo, target_tag).await {
+        match target.client.manifest_head(target.repo, target_tag).await {
             Ok(Some(head)) if head.digest == pull.digest => {
                 info!(
-                    source_repo,
-                    target_repo,
+                    source_repo = source.repo,
+                    target_repo = target.repo,
                     source_tag,
                     target_tag,
                     digest = %pull.digest,
@@ -267,8 +267,8 @@ impl SyncEngine {
             }
             Ok(_) => {} // manifest missing or digest differs — proceed
             Err(e) => {
-                debug!(
-                    target_repo,
+                warn!(
+                    target_repo = target.repo,
                     target_tag,
                     error = %e,
                     "target manifest HEAD failed, proceeding with sync"
@@ -282,21 +282,17 @@ impl SyncEngine {
         let bytes_transferred = match &pull.manifest {
             ManifestKind::Image(image_manifest) => {
                 let blobs = collect_image_blobs(image_manifest);
-                let (bytes, stats) = self
-                    .transfer_blobs(
-                        source,
-                        source_repo,
-                        target,
-                        target_name,
-                        target_repo,
-                        &blobs,
-                    )
-                    .await?;
+                let (bytes, stats) = self.transfer_blobs(source, target, &blobs).await?;
                 blob_stats = stats;
 
                 // Push manifest by tag.
                 with_retry(&self.retry, "manifest push", || {
-                    target.manifest_push(target_repo, target_tag, &pull.media_type, &pull.raw_bytes)
+                    target.client.manifest_push(
+                        target.repo,
+                        target_tag,
+                        &pull.media_type,
+                        &pull.raw_bytes,
+                    )
                 })
                 .await
                 .map_err(|e| crate::Error::Manifest {
@@ -313,7 +309,7 @@ impl SyncEngine {
                 for child_desc in &index.manifests {
                     let child_digest_str = child_desc.digest.to_string();
                     let child_pull = with_retry(&self.retry, "manifest pull", || {
-                        source.manifest_pull(source_repo, &child_digest_str)
+                        source.client.manifest_pull(source.repo, &child_digest_str)
                     })
                     .await
                     .map_err(|e| crate::Error::Manifest {
@@ -321,28 +317,30 @@ impl SyncEngine {
                         source: e,
                     })?;
 
-                    if let ManifestKind::Image(child_image) = &child_pull.manifest {
-                        let blobs = collect_image_blobs(child_image);
-                        let (bytes, child_stats) = self
-                            .transfer_blobs(
-                                source,
-                                source_repo,
-                                target,
-                                target_name,
-                                target_repo,
-                                &blobs,
-                            )
-                            .await?;
-                        total_bytes = total_bytes.saturating_add(bytes);
-                        blob_stats.transferred += child_stats.transferred;
-                        blob_stats.skipped += child_stats.skipped;
-                        blob_stats.mounted += child_stats.mounted;
+                    match &child_pull.manifest {
+                        ManifestKind::Image(child_image) => {
+                            let blobs = collect_image_blobs(child_image);
+                            let (bytes, child_stats) =
+                                self.transfer_blobs(source, target, &blobs).await?;
+                            total_bytes = total_bytes.saturating_add(bytes);
+                            blob_stats.transferred += child_stats.transferred;
+                            blob_stats.skipped += child_stats.skipped;
+                            blob_stats.mounted += child_stats.mounted;
+                        }
+                        ManifestKind::Index(_) => {
+                            return Err(crate::Error::Manifest {
+                                reference: child_digest_str,
+                                source: ocync_distribution::Error::Other(
+                                    "nested index manifests are not supported".into(),
+                                ),
+                            });
+                        }
                     }
 
                     // Push child manifest to target by digest.
                     with_retry(&self.retry, "manifest push", || {
-                        target.manifest_push(
-                            target_repo,
+                        target.client.manifest_push(
+                            target.repo,
                             &child_digest_str,
                             &child_pull.media_type,
                             &child_pull.raw_bytes,
@@ -357,7 +355,12 @@ impl SyncEngine {
 
                 // Push the index by tag.
                 with_retry(&self.retry, "manifest push", || {
-                    target.manifest_push(target_repo, target_tag, &pull.media_type, &pull.raw_bytes)
+                    target.client.manifest_push(
+                        target.repo,
+                        target_tag,
+                        &pull.media_type,
+                        &pull.raw_bytes,
+                    )
                 })
                 .await
                 .map_err(|e| crate::Error::Manifest {
@@ -370,8 +373,12 @@ impl SyncEngine {
         };
 
         info!(
-            source_repo,
-            target_repo, source_tag, target_tag, bytes_transferred, "image synced"
+            source_repo = source.repo,
+            target_repo = target.repo,
+            source_tag,
+            target_tag,
+            bytes_transferred,
+            "image synced"
         );
 
         Ok((ImageStatus::Synced, bytes_transferred, blob_stats))
@@ -384,35 +391,42 @@ impl SyncEngine {
     /// total bytes transferred and per-call blob statistics.
     async fn transfer_blobs(
         &mut self,
-        source: &RegistryClient,
-        source_repo: &str,
-        target: &RegistryClient,
-        target_name: &str,
-        target_repo: &str,
+        source: &Endpoint<'_>,
+        target: &Endpoint<'_>,
         digests: &[Digest],
     ) -> Result<(u64, BlobTransferStats), crate::Error> {
         let mut total_bytes = 0u64;
         let mut stats = BlobTransferStats::default();
 
         for digest in digests {
-            // Check dedup map — skip if already handled.
-            if let Some(status) = self.dedup.status(target_name, digest) {
-                use crate::plan::BlobStatus;
-                match status {
-                    BlobStatus::ExistsAtTarget | BlobStatus::Completed | BlobStatus::InProgress => {
-                        debug!(%digest, status = ?status, "blob already handled, skipping");
-                        stats.skipped += 1;
-                        continue;
-                    }
-                    BlobStatus::Unknown | BlobStatus::Failed(_) => {}
-                }
+            // Check dedup map — skip only if this repo already has the blob.
+            // OCI blobs are repo-scoped: a blob in repo-a is NOT accessible
+            // from repo-b at the same registry without a mount or push.
+            let current_repo_has_blob = self
+                .dedup
+                .known_repos(target.name, digest)
+                .is_some_and(|repos| repos.contains(target.repo));
+
+            if current_repo_has_blob {
+                debug!(%digest, repo = target.repo, "blob already in target repo, skipping");
+                stats.skipped += 1;
+                continue;
+            }
+
+            // Check if we should skip other status checks (in-progress elsewhere).
+            if let Some(crate::plan::BlobStatus::InProgress) =
+                self.dedup.status(target.name, digest)
+            {
+                debug!(%digest, "blob transfer in progress, skipping");
+                stats.skipped += 1;
+                continue;
             }
 
             // HEAD check at target — if exists, mark in dedup map and skip.
-            match target.blob_exists(target_repo, digest).await {
+            match target.client.blob_exists(target.repo, digest).await {
                 Ok(Some(_size)) => {
                     debug!(%digest, "blob exists at target, skipping");
-                    self.dedup.set_exists(target_name, digest, target_repo);
+                    self.dedup.set_exists(target.name, digest, target.repo);
                     stats.skipped += 1;
                     continue;
                 }
@@ -422,21 +436,22 @@ impl SyncEngine {
                 }
             }
 
-            // Mark in-progress.
-            self.dedup.set_in_progress(target_name, digest);
-
-            // Try cross-repo mount.
+            // Try cross-repo mount if another repo at this target has the blob.
             let mount_source = self
                 .dedup
-                .mount_source(target_name, digest, target_repo)
+                .mount_source(target.name, digest, target.repo)
                 .map(|s| s.to_owned());
 
             if let Some(from_repo) = mount_source {
                 debug!(%digest, %from_repo, "attempting cross-repo mount");
-                match target.blob_mount(target_repo, digest, &from_repo).await {
+                match target
+                    .client
+                    .blob_mount(target.repo, digest, &from_repo)
+                    .await
+                {
                     Ok(MountResult::Mounted) => {
                         debug!(%digest, %from_repo, "blob mounted");
-                        self.dedup.set_completed(target_name, digest, target_repo);
+                        self.dedup.set_completed(target.name, digest, target.repo);
                         stats.mounted += 1;
                         continue;
                     }
@@ -449,9 +464,12 @@ impl SyncEngine {
                 }
             }
 
+            // Mark in-progress before pull+push.
+            self.dedup.set_in_progress(target.name, digest);
+
             // Pull from source with retry.
             let data = match with_retry(&self.retry, "blob pull", || {
-                source.blob_pull_all(source_repo, digest)
+                source.client.blob_pull_all(source.repo, digest)
             })
             .await
             {
@@ -461,7 +479,7 @@ impl SyncEngine {
                         digest: digest.to_string(),
                         source: e,
                     };
-                    self.dedup.set_failed(target_name, digest, err.to_string());
+                    self.dedup.set_failed(target.name, digest, err.to_string());
                     return Err(err);
                 }
             };
@@ -469,7 +487,7 @@ impl SyncEngine {
 
             // Push to target with retry.
             if let Err(e) = with_retry(&self.retry, "blob push", || {
-                target.blob_push(target_repo, &data)
+                target.client.blob_push(target.repo, &data)
             })
             .await
             {
@@ -477,7 +495,7 @@ impl SyncEngine {
                     digest: digest.to_string(),
                     source: e,
                 };
-                self.dedup.set_failed(target_name, digest, err.to_string());
+                self.dedup.set_failed(target.name, digest, err.to_string());
                 return Err(err);
             }
 
@@ -485,7 +503,7 @@ impl SyncEngine {
             stats.transferred += 1;
 
             // Mark completed.
-            self.dedup.set_completed(target_name, digest, target_repo);
+            self.dedup.set_completed(target.name, digest, target.repo);
         }
 
         Ok((total_bytes, stats))

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -29,8 +29,8 @@ pub struct ResolvedMapping {
     pub target_repo: String,
     /// Target registries to sync to.
     pub targets: Vec<TargetEntry>,
-    /// Tags to sync (already filtered).
-    pub tags: Vec<String>,
+    /// Tag pairs to sync (already filtered).
+    pub tags: Vec<TagPair>,
 }
 
 /// A single target registry entry.
@@ -40,6 +40,37 @@ pub struct TargetEntry {
     pub name: String,
     /// Client for this target registry.
     pub client: Arc<RegistryClient>,
+}
+
+/// A source/target tag pair for syncing.
+///
+/// For most sync operations the source and target tags are identical.
+/// For `copy` with retagging they may differ.
+#[derive(Debug, Clone)]
+pub struct TagPair {
+    /// Tag name at the source registry.
+    pub source: String,
+    /// Tag name at the target registry.
+    pub target: String,
+}
+
+impl TagPair {
+    /// Create a pair where source and target tags are the same.
+    pub fn same(tag: impl Into<String>) -> Self {
+        let t = tag.into();
+        Self {
+            source: t.clone(),
+            target: t,
+        }
+    }
+
+    /// Create a pair with different source and target tags.
+    pub fn retag(source: impl Into<String>, target: impl Into<String>) -> Self {
+        Self {
+            source: source.into(),
+            target: target.into(),
+        }
+    }
 }
 
 /// Collect all blob digests from an image manifest (config + layers).
@@ -96,10 +127,13 @@ impl SyncEngine {
         let mut images = Vec::new();
 
         for mapping in &mappings {
-            for tag in &mapping.tags {
+            for tag_pair in &mapping.tags {
                 for target in &mapping.targets {
-                    let source_ref = format!("{}:{}@{}", mapping.source_repo, tag, target.name);
-                    let target_ref = format!("{}:{}", mapping.target_repo, tag);
+                    let source_ref = format!(
+                        "{}:{}@{}",
+                        mapping.source_repo, tag_pair.source, target.name
+                    );
+                    let target_ref = format!("{}:{}", mapping.target_repo, tag_pair.target);
 
                     progress.image_started(&source_ref, &target_ref);
 
@@ -110,7 +144,8 @@ impl SyncEngine {
                             &target.client,
                             &target.name,
                             &mapping.target_repo,
-                            tag,
+                            &tag_pair.source,
+                            &tag_pair.target,
                         )
                         .await;
 
@@ -138,6 +173,7 @@ impl SyncEngine {
     ///
     /// Returns an [`ImageResult`] — never panics. All errors are captured
     /// as [`ImageStatus::Failed`].
+    #[allow(clippy::too_many_arguments)]
     async fn sync_image(
         &self,
         source: &RegistryClient,
@@ -145,15 +181,24 @@ impl SyncEngine {
         target: &RegistryClient,
         target_name: &str,
         target_repo: &str,
-        tag: &str,
+        source_tag: &str,
+        target_tag: &str,
     ) -> ImageResult {
         let image_start = Instant::now();
         let image_id = Uuid::now_v7();
-        let source_ref = format!("{source_repo}:{tag}");
-        let target_ref = format!("{target_repo}:{tag}");
+        let source_ref = format!("{source_repo}:{source_tag}");
+        let target_ref = format!("{target_repo}:{target_tag}");
 
         let result = self
-            .sync_image_inner(source, source_repo, target, target_name, target_repo, tag)
+            .sync_image_inner(
+                source,
+                source_repo,
+                target,
+                target_name,
+                target_repo,
+                source_tag,
+                target_tag,
+            )
             .await;
 
         let duration = image_start.elapsed();
@@ -185,6 +230,7 @@ impl SyncEngine {
     }
 
     /// Inner implementation of image sync that returns Result for ergonomic error handling.
+    #[allow(clippy::too_many_arguments)]
     async fn sync_image_inner(
         &self,
         source: &RegistryClient,
@@ -192,21 +238,22 @@ impl SyncEngine {
         target: &RegistryClient,
         target_name: &str,
         target_repo: &str,
-        tag: &str,
+        source_tag: &str,
+        target_tag: &str,
     ) -> Result<(ImageStatus, u64), String> {
         // Step 1: Pull source manifest.
-        let pull = source
-            .manifest_pull(source_repo, tag)
-            .await
-            .map_err(|e| format!("failed to pull source manifest: {e}"))?;
+        let pull = self
+            .manifest_pull_with_retry(source, source_repo, source_tag)
+            .await?;
 
         // Step 2: HEAD target manifest — skip if digest matches.
-        match target.manifest_head(target_repo, tag).await {
+        match target.manifest_head(target_repo, target_tag).await {
             Ok(Some(head)) if head.digest == pull.digest => {
                 info!(
                     source_repo,
                     target_repo,
-                    tag,
+                    source_tag,
+                    target_tag,
                     digest = %pull.digest,
                     "skipping — digest matches at target"
                 );
@@ -221,7 +268,7 @@ impl SyncEngine {
             Err(e) => {
                 debug!(
                     target_repo,
-                    tag,
+                    target_tag,
                     error = %e,
                     "target manifest HEAD failed, proceeding with sync"
                 );
@@ -244,10 +291,14 @@ impl SyncEngine {
                     .await?;
 
                 // Push manifest by tag.
-                target
-                    .manifest_push(target_repo, tag, &pull.media_type, &pull.raw_bytes)
-                    .await
-                    .map_err(|e| format!("failed to push manifest: {e}"))?;
+                self.manifest_push_with_retry(
+                    target,
+                    target_repo,
+                    target_tag,
+                    &pull.media_type,
+                    &pull.raw_bytes,
+                )
+                .await?;
 
                 bytes
             }
@@ -257,12 +308,9 @@ impl SyncEngine {
                 // For each child descriptor, pull child manifest, transfer blobs, push child.
                 for child_desc in &index.manifests {
                     let child_digest_str = child_desc.digest.to_string();
-                    let child_pull = source
-                        .manifest_pull(source_repo, &child_digest_str)
-                        .await
-                        .map_err(|e| {
-                            format!("failed to pull child manifest {}: {e}", child_desc.digest)
-                        })?;
+                    let child_pull = self
+                        .manifest_pull_with_retry(source, source_repo, &child_digest_str)
+                        .await?;
 
                     if let ManifestKind::Image(child_image) = &child_pull.manifest {
                         let blobs = collect_image_blobs(child_image);
@@ -280,24 +328,25 @@ impl SyncEngine {
                     }
 
                     // Push child manifest to target by digest.
-                    target
-                        .manifest_push(
-                            target_repo,
-                            &child_digest_str,
-                            &child_pull.media_type,
-                            &child_pull.raw_bytes,
-                        )
-                        .await
-                        .map_err(|e| {
-                            format!("failed to push child manifest {}: {e}", child_desc.digest)
-                        })?;
+                    self.manifest_push_with_retry(
+                        target,
+                        target_repo,
+                        &child_digest_str,
+                        &child_pull.media_type,
+                        &child_pull.raw_bytes,
+                    )
+                    .await?;
                 }
 
                 // Push the index by tag.
-                target
-                    .manifest_push(target_repo, tag, &pull.media_type, &pull.raw_bytes)
-                    .await
-                    .map_err(|e| format!("failed to push index manifest: {e}"))?;
+                self.manifest_push_with_retry(
+                    target,
+                    target_repo,
+                    target_tag,
+                    &pull.media_type,
+                    &pull.raw_bytes,
+                )
+                .await?;
 
                 total_bytes
             }
@@ -305,7 +354,7 @@ impl SyncEngine {
 
         info!(
             source_repo,
-            target_repo, tag, bytes_transferred, "image synced"
+            target_repo, source_tag, target_tag, bytes_transferred, "image synced"
         );
 
         Ok((ImageStatus::Synced, bytes_transferred))
@@ -392,14 +441,22 @@ impl SyncEngine {
             }
 
             // Pull from source with retry.
-            let data = self
-                .pull_blob_with_retry(source, source_repo, digest)
-                .await?;
+            let data = match self.pull_blob_with_retry(source, source_repo, digest).await {
+                Ok(data) => data,
+                Err(e) => {
+                    let mut dedup = self.dedup.lock().expect("dedup lock poisoned");
+                    dedup.set_failed(target_name, digest, e.clone());
+                    return Err(e);
+                }
+            };
             let blob_size = data.len() as u64;
 
             // Push to target with retry.
-            self.push_blob_with_retry(target, target_repo, &data)
-                .await?;
+            if let Err(e) = self.push_blob_with_retry(target, target_repo, &data).await {
+                let mut dedup = self.dedup.lock().expect("dedup lock poisoned");
+                dedup.set_failed(target_name, digest, e.clone());
+                return Err(e);
+            }
 
             total_bytes = total_bytes.saturating_add(blob_size);
 
@@ -471,6 +528,77 @@ impl SyncEngine {
                         }
                     }
                     return Err(format!("failed to push blob: {e}"));
+                }
+            }
+        }
+    }
+
+    /// Pull a manifest with retry logic for transient errors.
+    async fn manifest_pull_with_retry(
+        &self,
+        client: &RegistryClient,
+        repo: &str,
+        reference: &str,
+    ) -> Result<ocync_distribution::ManifestPull, String> {
+        let mut attempt = 0;
+        loop {
+            match client.manifest_pull(repo, reference).await {
+                Ok(pull) => return Ok(pull),
+                Err(e) => {
+                    if let Some(status) = e.status_code() {
+                        if retry::should_retry(status, attempt, self.retry.max_retries) {
+                            let backoff = self.retry.backoff_for(attempt);
+                            warn!(
+                                reference,
+                                attempt,
+                                status = %status,
+                                backoff_ms = backoff.as_millis(),
+                                "retrying manifest pull"
+                            );
+                            tokio::time::sleep(backoff).await;
+                            attempt += 1;
+                            continue;
+                        }
+                    }
+                    return Err(format!("failed to pull manifest {reference}: {e}"));
+                }
+            }
+        }
+    }
+
+    /// Push a manifest with retry logic for transient errors.
+    async fn manifest_push_with_retry(
+        &self,
+        client: &RegistryClient,
+        repo: &str,
+        reference: &str,
+        media_type: &ocync_distribution::MediaType,
+        raw_bytes: &[u8],
+    ) -> Result<Digest, String> {
+        let mut attempt = 0;
+        loop {
+            match client
+                .manifest_push(repo, reference, media_type, raw_bytes)
+                .await
+            {
+                Ok(digest) => return Ok(digest),
+                Err(e) => {
+                    if let Some(status) = e.status_code() {
+                        if retry::should_retry(status, attempt, self.retry.max_retries) {
+                            let backoff = self.retry.backoff_for(attempt);
+                            warn!(
+                                reference,
+                                attempt,
+                                status = %status,
+                                backoff_ms = backoff.as_millis(),
+                                "retrying manifest push"
+                            );
+                            tokio::time::sleep(backoff).await;
+                            attempt += 1;
+                            continue;
+                        }
+                    }
+                    return Err(format!("failed to push manifest {reference}: {e}"));
                 }
             }
         }

--- a/crates/ocync-sync/src/error.rs
+++ b/crates/ocync-sync/src/error.rs
@@ -130,7 +130,10 @@ mod tests {
     fn display_manifest_error() {
         let err = Error::Manifest {
             reference: "latest".into(),
-            source: ocync_distribution::Error::NotFound("not found".into()),
+            source: ocync_distribution::Error::RegistryError {
+                status: http::StatusCode::NOT_FOUND,
+                message: "not found".into(),
+            },
         };
         let msg = err.to_string();
         assert!(msg.contains("latest"));
@@ -141,7 +144,10 @@ mod tests {
     fn display_blob_pull_error() {
         let err = Error::BlobPull {
             digest: "sha256:abc".into(),
-            source: ocync_distribution::Error::NotFound("missing".into()),
+            source: ocync_distribution::Error::RegistryError {
+                status: http::StatusCode::NOT_FOUND,
+                message: "missing".into(),
+            },
         };
         let msg = err.to_string();
         assert!(msg.contains("sha256:abc"));

--- a/crates/ocync-sync/src/error.rs
+++ b/crates/ocync-sync/src/error.rs
@@ -35,6 +35,45 @@ pub enum Error {
         /// The configured minimum.
         minimum: usize,
     },
+
+    /// A manifest pull or push failed during sync.
+    #[error("manifest operation failed for {reference}: {source}")]
+    Manifest {
+        /// The manifest reference (tag or digest) involved.
+        reference: String,
+        /// The underlying distribution error.
+        source: ocync_distribution::Error,
+    },
+
+    /// A blob pull failed during sync.
+    #[error("blob pull failed for {digest}: {source}")]
+    BlobPull {
+        /// The digest of the blob that could not be pulled.
+        digest: String,
+        /// The underlying distribution error.
+        source: ocync_distribution::Error,
+    },
+
+    /// A blob push failed during sync.
+    #[error("blob push failed for {digest}: {source}")]
+    BlobPush {
+        /// The digest of the blob that could not be pushed.
+        digest: String,
+        /// The underlying distribution error.
+        source: ocync_distribution::Error,
+    },
+}
+
+impl Error {
+    /// Extract the HTTP status code from the underlying distribution error, if any.
+    pub fn status_code(&self) -> Option<http::StatusCode> {
+        match self {
+            Self::Manifest { source, .. }
+            | Self::BlobPull { source, .. }
+            | Self::BlobPush { source, .. } => source.status_code(),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -85,5 +124,56 @@ mod tests {
     fn is_send_and_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<Error>();
+    }
+
+    #[test]
+    fn display_manifest_error() {
+        let err = Error::Manifest {
+            reference: "latest".into(),
+            source: ocync_distribution::Error::NotFound("not found".into()),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("latest"));
+        assert!(msg.contains("manifest"));
+    }
+
+    #[test]
+    fn display_blob_pull_error() {
+        let err = Error::BlobPull {
+            digest: "sha256:abc".into(),
+            source: ocync_distribution::Error::NotFound("missing".into()),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("sha256:abc"));
+        assert!(msg.contains("blob pull"));
+    }
+
+    #[test]
+    fn display_blob_push_error() {
+        let err = Error::BlobPush {
+            digest: "sha256:def".into(),
+            source: ocync_distribution::Error::Other("timeout".into()),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("blob push"));
+        assert!(msg.contains("sha256:def"));
+    }
+
+    #[test]
+    fn status_code_from_manifest_error() {
+        let err = Error::Manifest {
+            reference: "v1".into(),
+            source: ocync_distribution::Error::RegistryError {
+                status: http::StatusCode::TOO_MANY_REQUESTS,
+                message: "rate limited".into(),
+            },
+        };
+        assert_eq!(err.status_code(), Some(http::StatusCode::TOO_MANY_REQUESTS));
+    }
+
+    #[test]
+    fn status_code_none_for_filter_errors() {
+        let err = Error::LatestWithoutSort;
+        assert_eq!(err.status_code(), None);
     }
 }

--- a/crates/ocync-sync/src/lib.rs
+++ b/crates/ocync-sync/src/lib.rs
@@ -12,6 +12,9 @@ pub mod progress;
 /// Retry configuration and backoff logic.
 pub mod retry;
 
+/// Sync engine — two-phase orchestration of image transfers.
+pub mod engine;
+
 use std::time::Duration;
 
 pub use error::Error;

--- a/crates/ocync-sync/src/lib.rs
+++ b/crates/ocync-sync/src/lib.rs
@@ -66,8 +66,21 @@ pub struct ImageResult {
     pub status: ImageStatus,
     /// Total bytes transferred for this image.
     pub bytes_transferred: u64,
+    /// Per-image blob transfer statistics.
+    pub blob_stats: BlobTransferStats,
     /// Wall-clock duration of this image transfer.
     pub duration: Duration,
+}
+
+/// Per-image blob transfer statistics.
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct BlobTransferStats {
+    /// Blobs transferred over the network (pull+push).
+    pub transferred: u64,
+    /// Blobs skipped because they already existed at the target (dedup or HEAD).
+    pub skipped: u64,
+    /// Blobs satisfied via cross-repo mount.
+    pub mounted: u64,
 }
 
 /// Outcome status for a single image transfer.
@@ -102,6 +115,16 @@ pub enum SkipReason {
     ImmutableTag,
 }
 
+impl std::fmt::Display for SkipReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DigestMatch => f.write_str("digest match"),
+            Self::SkipExisting => f.write_str("skip existing"),
+            Self::ImmutableTag => f.write_str("immutable tag"),
+        }
+    }
+}
+
 /// Aggregate statistics for a sync run.
 #[derive(Debug, Default, Serialize)]
 pub struct SyncStats {
@@ -111,16 +134,14 @@ pub struct SyncStats {
     pub images_skipped: u64,
     /// Number of images that failed.
     pub images_failed: u64,
-    /// Total layers transferred across all images.
-    pub layers_transferred: u64,
-    /// Unique layer references (before dedup).
-    pub layers_unique_refs: u64,
-    /// Layers satisfied via cross-repo mount.
-    pub layers_mounted: u64,
+    /// Total blobs transferred over the network (pull+push).
+    pub blobs_transferred: u64,
+    /// Blobs skipped because they already existed at the target.
+    pub blobs_skipped: u64,
+    /// Blobs satisfied via cross-repo mount.
+    pub blobs_mounted: u64,
     /// Total bytes transferred over the network.
     pub bytes_transferred: u64,
-    /// Total logical size of all images (before dedup/skip).
-    pub bytes_total: u64,
 }
 
 #[cfg(test)]
@@ -138,6 +159,7 @@ mod tests {
                     target: "tgt".into(),
                     status,
                     bytes_transferred: 0,
+                    blob_stats: BlobTransferStats::default(),
                     duration: Duration::ZERO,
                 })
                 .collect(),
@@ -204,10 +226,24 @@ mod tests {
         assert_eq!(stats.images_synced, 0);
         assert_eq!(stats.images_skipped, 0);
         assert_eq!(stats.images_failed, 0);
-        assert_eq!(stats.layers_transferred, 0);
-        assert_eq!(stats.layers_unique_refs, 0);
-        assert_eq!(stats.layers_mounted, 0);
+        assert_eq!(stats.blobs_transferred, 0);
+        assert_eq!(stats.blobs_skipped, 0);
+        assert_eq!(stats.blobs_mounted, 0);
         assert_eq!(stats.bytes_transferred, 0);
-        assert_eq!(stats.bytes_total, 0);
+    }
+
+    #[test]
+    fn skip_reason_display() {
+        assert_eq!(SkipReason::DigestMatch.to_string(), "digest match");
+        assert_eq!(SkipReason::SkipExisting.to_string(), "skip existing");
+        assert_eq!(SkipReason::ImmutableTag.to_string(), "immutable tag");
+    }
+
+    #[test]
+    fn blob_transfer_stats_default_is_zeroed() {
+        let stats = BlobTransferStats::default();
+        assert_eq!(stats.transferred, 0);
+        assert_eq!(stats.skipped, 0);
+        assert_eq!(stats.mounted, 0);
     }
 }

--- a/crates/ocync-sync/src/plan.rs
+++ b/crates/ocync-sync/src/plan.rs
@@ -87,9 +87,13 @@ impl BlobDedupMap {
     }
 
     /// Mark a blob as in-progress at the target.
+    ///
+    /// `Completed → InProgress` is expected when re-processing a blob for a
+    /// different repo at the same target (cross-repo mount fallback). Only
+    /// `Failed → InProgress` is warned since it may indicate a logic error.
     pub fn set_in_progress(&mut self, target: &str, digest: &Digest) {
         let entry = self.entry_mut(target, digest);
-        if matches!(entry.status, BlobStatus::Completed | BlobStatus::Failed(_)) {
+        if matches!(entry.status, BlobStatus::Failed(_)) {
             warn!(
                 target,
                 %digest,

--- a/crates/ocync-sync/src/plan.rs
+++ b/crates/ocync-sync/src/plan.rs
@@ -32,20 +32,8 @@ pub(crate) struct BlobInfo {
     pub repos: BTreeSet<String>,
 }
 
-/// Result of attempting to claim a blob for transfer.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ClaimResult {
-    /// Successfully claimed — caller should proceed with transfer.
-    Claimed,
-    /// Claim denied — the blob is already in the given state.
-    Occupied(BlobStatus),
-}
-
 /// Per-registry index of tracked blobs.
 type BlobIndex = HashMap<Digest, BlobInfo>;
-
-// TODO: Replace outer `String` key with a `RegistryHost` newtype when the sync
-// engine is built — prevents confusing hostnames with repository names or refs.
 
 /// Process-global deduplication map keyed by target registry, then by digest.
 ///
@@ -80,22 +68,6 @@ impl BlobDedupMap {
     /// Get the current status for a blob at the given target.
     pub fn status(&self, target: &str, digest: &Digest) -> Option<&BlobStatus> {
         self.inner.get(target)?.get(digest).map(|info| &info.status)
-    }
-
-    /// Atomically check blob status and claim it for transfer if unclaimed.
-    ///
-    /// Returns [`ClaimResult::Claimed`] and sets status to [`BlobStatus::InProgress`]
-    /// only if the blob was previously [`BlobStatus::Unknown`]. All other states
-    /// return a descriptive result without modifying the map.
-    pub fn try_claim(&mut self, target: &str, digest: &Digest) -> ClaimResult {
-        let entry = self.entry_mut(target, digest);
-        match &entry.status {
-            BlobStatus::Unknown => {
-                entry.status = BlobStatus::InProgress;
-                ClaimResult::Claimed
-            }
-            other => ClaimResult::Occupied(other.clone()),
-        }
     }
 
     /// Mark a blob as existing at the target in the given repo.
@@ -192,23 +164,6 @@ impl Default for BlobDedupMap {
     }
 }
 
-/// Transfer dependency ordering — variants are declared in transfer order.
-///
-/// `Ord` uses declaration order: blobs first (manifests reference them),
-/// then platform manifests, then multi-platform indexes, then referrers
-/// (which point back at the artifact they annotate).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum TransferKind {
-    /// Layer / config blob.
-    Blob,
-    /// Platform-specific manifest.
-    PlatformManifest,
-    /// Multi-platform index / manifest list.
-    Index,
-    /// OCI referrer (signatures, SBOMs, attestations).
-    Referrer,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -298,13 +253,6 @@ mod tests {
     }
 
     #[test]
-    fn transfer_kind_ordering() {
-        assert!(TransferKind::Blob < TransferKind::PlatformManifest);
-        assert!(TransferKind::PlatformManifest < TransferKind::Index);
-        assert!(TransferKind::Index < TransferKind::Referrer);
-    }
-
-    #[test]
     fn status_transitions() {
         let mut map = BlobDedupMap::new();
         let d = test_digest();
@@ -325,65 +273,6 @@ mod tests {
         assert_eq!(
             map.status("reg.io", &d),
             Some(&BlobStatus::Failed("connection refused".into()))
-        );
-    }
-
-    // -- try_claim tests --
-
-    #[test]
-    fn try_claim_unknown_becomes_in_progress() {
-        let mut map = BlobDedupMap::new();
-        let d = test_digest();
-
-        assert_eq!(map.try_claim("reg.io", &d), ClaimResult::Claimed);
-        assert_eq!(map.status("reg.io", &d), Some(&BlobStatus::InProgress));
-    }
-
-    #[test]
-    fn try_claim_in_progress() {
-        let mut map = BlobDedupMap::new();
-        let d = test_digest();
-
-        map.set_in_progress("reg.io", &d);
-        assert_eq!(
-            map.try_claim("reg.io", &d),
-            ClaimResult::Occupied(BlobStatus::InProgress)
-        );
-    }
-
-    #[test]
-    fn try_claim_completed() {
-        let mut map = BlobDedupMap::new();
-        let d = test_digest();
-
-        map.set_completed("reg.io", &d, "library/alpine");
-        assert_eq!(
-            map.try_claim("reg.io", &d),
-            ClaimResult::Occupied(BlobStatus::Completed)
-        );
-    }
-
-    #[test]
-    fn try_claim_exists_at_target() {
-        let mut map = BlobDedupMap::new();
-        let d = test_digest();
-
-        map.set_exists("reg.io", &d, "library/alpine");
-        assert_eq!(
-            map.try_claim("reg.io", &d),
-            ClaimResult::Occupied(BlobStatus::ExistsAtTarget)
-        );
-    }
-
-    #[test]
-    fn try_claim_failed() {
-        let mut map = BlobDedupMap::new();
-        let d = test_digest();
-
-        map.set_failed("reg.io", &d, "connection refused".into());
-        assert_eq!(
-            map.try_claim("reg.io", &d),
-            ClaimResult::Occupied(BlobStatus::Failed("connection refused".into()))
         );
     }
 }

--- a/crates/ocync-sync/src/progress.rs
+++ b/crates/ocync-sync/src/progress.rs
@@ -6,8 +6,6 @@ use crate::{ImageResult, SyncReport};
 pub trait ProgressReporter: Send + Sync {
     /// Called when an image transfer begins.
     fn image_started(&self, source: &str, target: &str);
-    /// Called periodically with blob transfer progress.
-    fn blob_progress(&self, source: &str, bytes_transferred: u64, total_bytes: u64);
     /// Called when an individual image transfer completes.
     fn image_completed(&self, result: &ImageResult);
     /// Called when the entire sync run completes.
@@ -20,7 +18,6 @@ pub struct NullProgress;
 
 impl ProgressReporter for NullProgress {
     fn image_started(&self, _: &str, _: &str) {}
-    fn blob_progress(&self, _: &str, _: u64, _: u64) {}
     fn image_completed(&self, _: &ImageResult) {}
     fn run_completed(&self, _: &SyncReport) {}
 }
@@ -45,7 +42,6 @@ mod tests {
     fn null_progress_methods_do_not_panic() {
         let p = NullProgress;
         p.image_started("source/repo:tag", "target/repo:tag");
-        p.blob_progress("source/repo:tag", 512, 1024);
 
         let result = ImageResult {
             image_id: Uuid::now_v7(),
@@ -53,6 +49,7 @@ mod tests {
             target: "tgt".into(),
             status: ImageStatus::Synced,
             bytes_transferred: 1024,
+            blob_stats: crate::BlobTransferStats::default(),
             duration: Duration::from_secs(1),
         };
         p.image_completed(&result);

--- a/crates/ocync-sync/tests/engine_integration.rs
+++ b/crates/ocync-sync/tests/engine_integration.rs
@@ -1,0 +1,739 @@
+//! Integration tests for `SyncEngine` using mock HTTP servers.
+
+use std::sync::Arc;
+
+use ocync_distribution::spec::{Descriptor, ImageManifest, MediaType};
+use ocync_distribution::{Digest, RegistryClientBuilder};
+use ocync_sync::engine::{ResolvedMapping, SyncEngine, TagPair, TargetEntry};
+use ocync_sync::progress::NullProgress;
+use ocync_sync::retry::RetryConfig;
+use ocync_sync::{ImageStatus, SkipReason};
+use url::Url;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build a valid sha256 digest from a short suffix, zero-padded to 64 hex chars.
+fn test_digest(suffix: &str) -> Digest {
+    format!("sha256:{suffix:0>64}").parse().unwrap()
+}
+
+fn mock_url(server: &MockServer) -> Url {
+    Url::parse(&server.uri()).unwrap()
+}
+
+fn mock_client(server: &MockServer) -> Arc<ocync_distribution::RegistryClient> {
+    Arc::new(
+        RegistryClientBuilder::new(mock_url(server))
+            .build()
+            .unwrap(),
+    )
+}
+
+fn fast_retry() -> RetryConfig {
+    RetryConfig {
+        max_retries: 2,
+        initial_backoff: std::time::Duration::from_millis(1),
+        max_backoff: std::time::Duration::from_millis(10),
+        backoff_multiplier: 2,
+    }
+}
+
+/// Serialize an `ImageManifest` to JSON bytes and compute its digest.
+fn serialize_manifest(manifest: &ImageManifest) -> (Vec<u8>, Digest) {
+    let bytes = serde_json::to_vec(manifest).unwrap();
+    let hash = ocync_distribution::sha256::Sha256::digest(&bytes);
+    let digest = Digest::from_sha256(hash);
+    (bytes, digest)
+}
+
+fn test_descriptor(digest: Digest, media_type: MediaType) -> Descriptor {
+    Descriptor {
+        media_type,
+        digest,
+        size: 100,
+        platform: None,
+        artifact_type: None,
+        annotations: None,
+    }
+}
+
+fn simple_image_manifest(config_digest: &Digest, layer_digest: &Digest) -> ImageManifest {
+    ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: test_descriptor(config_digest.clone(), MediaType::OciConfig),
+        layers: vec![test_descriptor(
+            layer_digest.clone(),
+            MediaType::OciLayerGzip,
+        )],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    }
+}
+
+/// Mount mock endpoints for a full image sync on the source server:
+/// - GET manifest (returns the given JSON bytes with media type header)
+async fn mount_source_manifest(server: &MockServer, repo: &str, tag: &str, bytes: &[u8]) {
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/{repo}/manifests/{tag}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(bytes.to_vec())
+                .insert_header("content-type", MediaType::OciManifest.as_str()),
+        )
+        .mount(server)
+        .await;
+}
+
+/// Mount mock for blob pull (GET).
+async fn mount_blob_pull(server: &MockServer, repo: &str, digest: &Digest, data: &[u8]) {
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/{repo}/blobs/{digest}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(data.to_vec())
+                .insert_header("content-length", data.len().to_string()),
+        )
+        .mount(server)
+        .await;
+}
+
+/// Mount mock for blob HEAD (exists check) returning 404 (not found).
+async fn mount_blob_not_found(server: &MockServer, repo: &str, digest: &Digest) {
+    Mock::given(method("HEAD"))
+        .and(path(format!("/v2/{repo}/blobs/{digest}")))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(server)
+        .await;
+}
+
+/// Mount mock for blob HEAD (exists check) returning 200 (exists).
+async fn mount_blob_exists(server: &MockServer, repo: &str, digest: &Digest) {
+    Mock::given(method("HEAD"))
+        .and(path(format!("/v2/{repo}/blobs/{digest}")))
+        .respond_with(ResponseTemplate::new(200).insert_header("content-length", "100"))
+        .mount(server)
+        .await;
+}
+
+/// Mount mock for blob push: POST initiate + PUT upload.
+async fn mount_blob_push(server: &MockServer, repo: &str) {
+    // POST initiate upload — return 202 with Location.
+    Mock::given(method("POST"))
+        .and(path(format!("/v2/{repo}/blobs/uploads/")))
+        .respond_with(
+            ResponseTemplate::new(202)
+                .insert_header("location", format!("/v2/{repo}/blobs/uploads/upload-id")),
+        )
+        .mount(server)
+        .await;
+
+    // PUT the blob data — return 201 Created.
+    Mock::given(method("PUT"))
+        .and(path(format!("/v2/{repo}/blobs/uploads/upload-id")))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(server)
+        .await;
+}
+
+/// Mount mock for manifest HEAD returning 404.
+async fn mount_manifest_head_not_found(server: &MockServer, repo: &str, tag: &str) {
+    Mock::given(method("HEAD"))
+        .and(path(format!("/v2/{repo}/manifests/{tag}")))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(server)
+        .await;
+}
+
+/// Mount mock for manifest HEAD returning matching digest.
+async fn mount_manifest_head_matching(server: &MockServer, repo: &str, tag: &str, digest: &Digest) {
+    Mock::given(method("HEAD"))
+        .and(path(format!("/v2/{repo}/manifests/{tag}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("docker-content-digest", digest.to_string())
+                .insert_header("content-type", MediaType::OciManifest.as_str())
+                .insert_header("content-length", "100"),
+        )
+        .mount(server)
+        .await;
+}
+
+/// Mount mock for manifest push (PUT) returning 201.
+async fn mount_manifest_push(server: &MockServer, repo: &str, reference: &str) {
+    Mock::given(method("PUT"))
+        .and(path(format!("/v2/{repo}/manifests/{reference}")))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(server)
+        .await;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sync_image_happy_path() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_digest = test_digest("c0c0");
+    let layer_digest = test_digest("1a1a");
+    let manifest = simple_image_manifest(&config_digest, &layer_digest);
+    let (manifest_bytes, _manifest_digest) = serialize_manifest(&manifest);
+
+    // Source: serve manifest and blobs.
+    mount_source_manifest(&source_server, "library/nginx", "latest", &manifest_bytes).await;
+    mount_blob_pull(
+        &source_server,
+        "library/nginx",
+        &config_digest,
+        b"config-data",
+    )
+    .await;
+    mount_blob_pull(
+        &source_server,
+        "library/nginx",
+        &layer_digest,
+        b"layer-data",
+    )
+    .await;
+
+    // Target: manifest HEAD 404, blobs not found, push endpoints.
+    mount_manifest_head_not_found(&target_server, "mirror/nginx", "latest").await;
+    mount_blob_not_found(&target_server, "mirror/nginx", &config_digest).await;
+    mount_blob_not_found(&target_server, "mirror/nginx", &layer_digest).await;
+    mount_blob_push(&target_server, "mirror/nginx").await;
+    mount_manifest_push(&target_server, "mirror/nginx", "latest").await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping = ResolvedMapping {
+        source_client,
+        source_repo: "library/nginx".into(),
+        target_repo: "mirror/nginx".into(),
+        targets: vec![TargetEntry {
+            name: "target-reg".into(),
+            client: target_client,
+        }],
+        tags: vec![TagPair::same("latest")],
+    };
+
+    let mut engine = SyncEngine::new(fast_retry());
+    let report = engine.run(vec![mapping], &NullProgress).await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(matches!(report.images[0].status, ImageStatus::Synced));
+    assert!(report.images[0].bytes_transferred > 0);
+    assert_eq!(report.stats.images_synced, 1);
+    assert_eq!(report.stats.images_failed, 0);
+    assert_eq!(report.stats.blobs_transferred, 2);
+    assert_eq!(report.stats.blobs_skipped, 0);
+    assert_eq!(report.exit_code(), 0);
+}
+
+#[tokio::test]
+async fn sync_image_skip_on_digest_match() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_digest = test_digest("cc");
+    let layer_digest = test_digest("11");
+    let manifest = simple_image_manifest(&config_digest, &layer_digest);
+    let (manifest_bytes, manifest_digest) = serialize_manifest(&manifest);
+
+    // Source: serve manifest.
+    mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
+
+    // Target: manifest HEAD returns matching digest → should skip.
+    mount_manifest_head_matching(&target_server, "repo", "v1", &manifest_digest).await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping = ResolvedMapping {
+        source_client,
+        source_repo: "repo".into(),
+        target_repo: "repo".into(),
+        targets: vec![TargetEntry {
+            name: "target".into(),
+            client: target_client,
+        }],
+        tags: vec![TagPair::same("v1")],
+    };
+
+    let mut engine = SyncEngine::new(fast_retry());
+    let report = engine.run(vec![mapping], &NullProgress).await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(matches!(
+        report.images[0].status,
+        ImageStatus::Skipped {
+            reason: SkipReason::DigestMatch,
+        }
+    ));
+    assert_eq!(report.images[0].bytes_transferred, 0);
+    assert_eq!(report.stats.images_skipped, 1);
+    assert_eq!(report.stats.images_synced, 0);
+    assert_eq!(report.exit_code(), 0);
+}
+
+#[tokio::test]
+async fn sync_image_blob_exists_at_target_skips_transfer() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_digest = test_digest("c1");
+    let layer_digest = test_digest("b1");
+    let manifest = simple_image_manifest(&config_digest, &layer_digest);
+    let (manifest_bytes, _) = serialize_manifest(&manifest);
+
+    // Source: serve manifest (blobs NOT served — they shouldn't be pulled).
+    mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
+
+    // Target: manifest HEAD 404, but both blobs already exist.
+    mount_manifest_head_not_found(&target_server, "repo", "v1").await;
+    mount_blob_exists(&target_server, "repo", &config_digest).await;
+    mount_blob_exists(&target_server, "repo", &layer_digest).await;
+    mount_manifest_push(&target_server, "repo", "v1").await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping = ResolvedMapping {
+        source_client,
+        source_repo: "repo".into(),
+        target_repo: "repo".into(),
+        targets: vec![TargetEntry {
+            name: "target".into(),
+            client: target_client,
+        }],
+        tags: vec![TagPair::same("v1")],
+    };
+
+    let mut engine = SyncEngine::new(fast_retry());
+    let report = engine.run(vec![mapping], &NullProgress).await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(matches!(report.images[0].status, ImageStatus::Synced));
+    // No bytes transferred — blobs existed at target.
+    assert_eq!(report.images[0].bytes_transferred, 0);
+    assert_eq!(report.images[0].blob_stats.skipped, 2);
+    assert_eq!(report.images[0].blob_stats.transferred, 0);
+    assert_eq!(report.stats.blobs_skipped, 2);
+}
+
+#[tokio::test]
+async fn sync_image_manifest_pull_failure() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    // Source: 403 on manifest pull (non-retryable).
+    Mock::given(method("GET"))
+        .and(path("/v2/repo/manifests/v1"))
+        .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+        .mount(&source_server)
+        .await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping = ResolvedMapping {
+        source_client,
+        source_repo: "repo".into(),
+        target_repo: "repo".into(),
+        targets: vec![TargetEntry {
+            name: "target".into(),
+            client: target_client,
+        }],
+        tags: vec![TagPair::same("v1")],
+    };
+
+    let mut engine = SyncEngine::new(fast_retry());
+    let report = engine.run(vec![mapping], &NullProgress).await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(matches!(
+        report.images[0].status,
+        ImageStatus::Failed { .. }
+    ));
+    assert_eq!(report.stats.images_failed, 1);
+    assert_eq!(report.exit_code(), 2);
+}
+
+#[tokio::test]
+async fn sync_image_blob_pull_retries_on_500() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_digest = test_digest("c2");
+    let layer_digest = test_digest("b2");
+    let manifest = simple_image_manifest(&config_digest, &layer_digest);
+    let (manifest_bytes, _) = serialize_manifest(&manifest);
+
+    // Source: manifest succeeds, config blob succeeds.
+    mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_digest, b"config").await;
+
+    // Layer blob: first attempt 500, second attempt succeeds.
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/blobs/{layer_digest}")))
+        .respond_with(ResponseTemplate::new(500))
+        .up_to_n_times(1)
+        .mount(&source_server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/blobs/{layer_digest}")))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(b"layer-data".to_vec()))
+        .mount(&source_server)
+        .await;
+
+    // Target: standard setup.
+    mount_manifest_head_not_found(&target_server, "repo", "v1").await;
+    mount_blob_not_found(&target_server, "repo", &config_digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_digest).await;
+    mount_blob_push(&target_server, "repo").await;
+    mount_manifest_push(&target_server, "repo", "v1").await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping = ResolvedMapping {
+        source_client,
+        source_repo: "repo".into(),
+        target_repo: "repo".into(),
+        targets: vec![TargetEntry {
+            name: "target".into(),
+            client: target_client,
+        }],
+        tags: vec![TagPair::same("v1")],
+    };
+
+    let mut engine = SyncEngine::new(fast_retry());
+    let report = engine.run(vec![mapping], &NullProgress).await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(matches!(report.images[0].status, ImageStatus::Synced));
+    assert_eq!(report.stats.blobs_transferred, 2);
+}
+
+#[tokio::test]
+async fn sync_dedup_across_tags() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    // Two tags share the same blobs.
+    let config_digest = test_digest("aa00");
+    let layer_digest = test_digest("bb00");
+    let manifest = simple_image_manifest(&config_digest, &layer_digest);
+    let (manifest_bytes, _) = serialize_manifest(&manifest);
+
+    // Source: both tags serve the same manifest.
+    mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
+    mount_source_manifest(&source_server, "repo", "v2", &manifest_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_digest, b"config").await;
+    mount_blob_pull(&source_server, "repo", &layer_digest, b"layer").await;
+
+    // Target: manifest HEAD 404 for both, blobs not found initially.
+    mount_manifest_head_not_found(&target_server, "repo", "v1").await;
+    mount_manifest_head_not_found(&target_server, "repo", "v2").await;
+    mount_blob_not_found(&target_server, "repo", &config_digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_digest).await;
+    mount_blob_push(&target_server, "repo").await;
+    mount_manifest_push(&target_server, "repo", "v1").await;
+    mount_manifest_push(&target_server, "repo", "v2").await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping = ResolvedMapping {
+        source_client,
+        source_repo: "repo".into(),
+        target_repo: "repo".into(),
+        targets: vec![TargetEntry {
+            name: "target".into(),
+            client: target_client,
+        }],
+        tags: vec![TagPair::same("v1"), TagPair::same("v2")],
+    };
+
+    let mut engine = SyncEngine::new(fast_retry());
+    let report = engine.run(vec![mapping], &NullProgress).await;
+
+    assert_eq!(report.images.len(), 2);
+    assert!(matches!(report.images[0].status, ImageStatus::Synced));
+    assert!(matches!(report.images[1].status, ImageStatus::Synced));
+
+    // First tag transfers blobs; second tag skips them (dedup).
+    assert_eq!(report.images[0].blob_stats.transferred, 2);
+    assert_eq!(report.images[1].blob_stats.skipped, 2);
+    assert_eq!(report.stats.blobs_transferred, 2);
+    assert_eq!(report.stats.blobs_skipped, 2);
+}
+
+#[tokio::test]
+async fn sync_multiple_targets() {
+    let source_server = MockServer::start().await;
+    let target_a = MockServer::start().await;
+    let target_b = MockServer::start().await;
+
+    let config_digest = test_digest("c3");
+    let layer_digest = test_digest("b3");
+    let manifest = simple_image_manifest(&config_digest, &layer_digest);
+    let (manifest_bytes, _) = serialize_manifest(&manifest);
+
+    mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_digest, b"config").await;
+    mount_blob_pull(&source_server, "repo", &layer_digest, b"layer").await;
+
+    // Both targets: no manifest, no blobs, accept pushes.
+    for target in [&target_a, &target_b] {
+        mount_manifest_head_not_found(target, "repo", "v1").await;
+        mount_blob_not_found(target, "repo", &config_digest).await;
+        mount_blob_not_found(target, "repo", &layer_digest).await;
+        mount_blob_push(target, "repo").await;
+        mount_manifest_push(target, "repo", "v1").await;
+    }
+
+    let source_client = mock_client(&source_server);
+
+    let mapping = ResolvedMapping {
+        source_client,
+        source_repo: "repo".into(),
+        target_repo: "repo".into(),
+        targets: vec![
+            TargetEntry {
+                name: "target-a".into(),
+                client: mock_client(&target_a),
+            },
+            TargetEntry {
+                name: "target-b".into(),
+                client: mock_client(&target_b),
+            },
+        ],
+        tags: vec![TagPair::same("v1")],
+    };
+
+    let mut engine = SyncEngine::new(fast_retry());
+    let report = engine.run(vec![mapping], &NullProgress).await;
+
+    assert_eq!(report.images.len(), 2);
+    assert_eq!(report.stats.images_synced, 2);
+    assert_eq!(report.exit_code(), 0);
+}
+
+#[tokio::test]
+async fn sync_retag() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_digest = test_digest("c4");
+    let layer_digest = test_digest("b4");
+    let manifest = simple_image_manifest(&config_digest, &layer_digest);
+    let (manifest_bytes, _) = serialize_manifest(&manifest);
+
+    // Source: serve manifest at source tag.
+    mount_source_manifest(&source_server, "repo", "latest", &manifest_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_digest, b"config").await;
+    mount_blob_pull(&source_server, "repo", &layer_digest, b"layer").await;
+
+    // Target: HEAD for target tag, blobs missing, push at target tag.
+    mount_manifest_head_not_found(&target_server, "repo", "stable").await;
+    mount_blob_not_found(&target_server, "repo", &config_digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_digest).await;
+    mount_blob_push(&target_server, "repo").await;
+    mount_manifest_push(&target_server, "repo", "stable").await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping = ResolvedMapping {
+        source_client,
+        source_repo: "repo".into(),
+        target_repo: "repo".into(),
+        targets: vec![TargetEntry {
+            name: "target".into(),
+            client: target_client,
+        }],
+        tags: vec![TagPair::retag("latest", "stable")],
+    };
+
+    let mut engine = SyncEngine::new(fast_retry());
+    let report = engine.run(vec![mapping], &NullProgress).await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(matches!(report.images[0].status, ImageStatus::Synced));
+}
+
+#[tokio::test]
+async fn sync_empty_mappings() {
+    let mut engine = SyncEngine::new(fast_retry());
+    let report = engine.run(vec![], &NullProgress).await;
+
+    assert!(report.images.is_empty());
+    assert_eq!(report.stats.images_synced, 0);
+    assert_eq!(report.exit_code(), 0);
+}
+
+#[tokio::test]
+async fn sync_blob_push_failure() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_digest = test_digest("c5");
+    let layer_digest = test_digest("b5");
+    let manifest = simple_image_manifest(&config_digest, &layer_digest);
+    let (manifest_bytes, _) = serialize_manifest(&manifest);
+
+    mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_digest, b"config").await;
+
+    // Target: manifest HEAD 404, config blob not found.
+    mount_manifest_head_not_found(&target_server, "repo", "v1").await;
+    mount_blob_not_found(&target_server, "repo", &config_digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_digest).await;
+
+    // Blob push: POST initiate returns 403 (non-retryable).
+    Mock::given(method("POST"))
+        .and(path("/v2/repo/blobs/uploads/"))
+        .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+        .mount(&target_server)
+        .await;
+
+    let mapping = ResolvedMapping {
+        source_client: mock_client(&source_server),
+        source_repo: "repo".into(),
+        target_repo: "repo".into(),
+        targets: vec![TargetEntry {
+            name: "target".into(),
+            client: mock_client(&target_server),
+        }],
+        tags: vec![TagPair::same("v1")],
+    };
+
+    let mut engine = SyncEngine::new(fast_retry());
+    let report = engine.run(vec![mapping], &NullProgress).await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(matches!(
+        report.images[0].status,
+        ImageStatus::Failed { .. }
+    ));
+    if let ImageStatus::Failed { error, .. } = &report.images[0].status {
+        assert!(error.contains("blob push"));
+    }
+    assert_eq!(report.stats.images_failed, 1);
+    assert_eq!(report.exit_code(), 2);
+}
+
+#[tokio::test]
+async fn sync_index_manifest_multi_platform() {
+    use ocync_distribution::spec::ImageIndex;
+
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    // Build two child image manifests (simulating amd64 and arm64).
+    let amd64_config = test_digest("a0");
+    let amd64_layer = test_digest("a1");
+    let amd64_manifest = simple_image_manifest(&amd64_config, &amd64_layer);
+    let (amd64_bytes, amd64_digest) = serialize_manifest(&amd64_manifest);
+
+    let arm64_config = test_digest("b0");
+    let arm64_layer = test_digest("b1");
+    let arm64_manifest = simple_image_manifest(&arm64_config, &arm64_layer);
+    let (arm64_bytes, arm64_digest) = serialize_manifest(&arm64_manifest);
+
+    // Build the index manifest referencing both children.
+    let index = ImageIndex {
+        schema_version: 2,
+        media_type: None,
+        manifests: vec![
+            test_descriptor(amd64_digest.clone(), MediaType::OciManifest),
+            test_descriptor(arm64_digest.clone(), MediaType::OciManifest),
+        ],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let index_bytes = serde_json::to_vec(&index).unwrap();
+
+    // Source: serve the index by tag and children by digest.
+    Mock::given(method("GET"))
+        .and(path("/v2/repo/manifests/latest"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(index_bytes.clone())
+                .insert_header("content-type", MediaType::OciIndex.as_str()),
+        )
+        .mount(&source_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/manifests/{amd64_digest}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(amd64_bytes)
+                .insert_header("content-type", MediaType::OciManifest.as_str()),
+        )
+        .mount(&source_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/manifests/{arm64_digest}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(arm64_bytes)
+                .insert_header("content-type", MediaType::OciManifest.as_str()),
+        )
+        .mount(&source_server)
+        .await;
+
+    // Source: blobs.
+    mount_blob_pull(&source_server, "repo", &amd64_config, b"amd64-config").await;
+    mount_blob_pull(&source_server, "repo", &amd64_layer, b"amd64-layer").await;
+    mount_blob_pull(&source_server, "repo", &arm64_config, b"arm64-config").await;
+    mount_blob_pull(&source_server, "repo", &arm64_layer, b"arm64-layer").await;
+
+    // Target: no manifest, no blobs, accept all pushes.
+    mount_manifest_head_not_found(&target_server, "repo", "latest").await;
+    mount_blob_not_found(&target_server, "repo", &amd64_config).await;
+    mount_blob_not_found(&target_server, "repo", &amd64_layer).await;
+    mount_blob_not_found(&target_server, "repo", &arm64_config).await;
+    mount_blob_not_found(&target_server, "repo", &arm64_layer).await;
+    mount_blob_push(&target_server, "repo").await;
+
+    // Accept child manifest pushes (by digest) and index push (by tag).
+    mount_manifest_push(&target_server, "repo", &amd64_digest.to_string()).await;
+    mount_manifest_push(&target_server, "repo", &arm64_digest.to_string()).await;
+    mount_manifest_push(&target_server, "repo", "latest").await;
+
+    let mapping = ResolvedMapping {
+        source_client: mock_client(&source_server),
+        source_repo: "repo".into(),
+        target_repo: "repo".into(),
+        targets: vec![TargetEntry {
+            name: "target".into(),
+            client: mock_client(&target_server),
+        }],
+        tags: vec![TagPair::same("latest")],
+    };
+
+    let mut engine = SyncEngine::new(fast_retry());
+    let report = engine.run(vec![mapping], &NullProgress).await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(matches!(report.images[0].status, ImageStatus::Synced));
+    // 4 blobs: 2 configs + 2 layers across two platforms.
+    assert_eq!(report.images[0].blob_stats.transferred, 4);
+    assert_eq!(report.images[0].blob_stats.skipped, 0);
+    assert!(report.images[0].bytes_transferred > 0);
+    assert_eq!(report.stats.images_synced, 1);
+    assert_eq!(report.stats.blobs_transferred, 4);
+}

--- a/crates/ocync-sync/tests/engine_integration.rs
+++ b/crates/ocync-sync/tests/engine_integration.rs
@@ -737,3 +737,432 @@ async fn sync_index_manifest_multi_platform() {
     assert_eq!(report.stats.images_synced, 1);
     assert_eq!(report.stats.blobs_transferred, 4);
 }
+
+#[tokio::test]
+async fn sync_head_different_digest_proceeds_with_sync() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_digest = test_digest("d0");
+    let layer_digest = test_digest("d1");
+    let manifest = simple_image_manifest(&config_digest, &layer_digest);
+    let (manifest_bytes, _manifest_digest) = serialize_manifest(&manifest);
+
+    // Source: serve manifest and blobs.
+    mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_digest, b"config").await;
+    mount_blob_pull(&source_server, "repo", &layer_digest, b"layer").await;
+
+    // Target: manifest HEAD returns a DIFFERENT digest → should proceed.
+    let stale_digest = test_digest("5ca1e");
+    mount_manifest_head_matching(&target_server, "repo", "v1", &stale_digest).await;
+    mount_blob_not_found(&target_server, "repo", &config_digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_digest).await;
+    mount_blob_push(&target_server, "repo").await;
+    mount_manifest_push(&target_server, "repo", "v1").await;
+
+    let mapping = ResolvedMapping {
+        source_client: mock_client(&source_server),
+        source_repo: "repo".into(),
+        target_repo: "repo".into(),
+        targets: vec![TargetEntry {
+            name: "target".into(),
+            client: mock_client(&target_server),
+        }],
+        tags: vec![TagPair::same("v1")],
+    };
+
+    let mut engine = SyncEngine::new(fast_retry());
+    let report = engine.run(vec![mapping], &NullProgress).await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(matches!(report.images[0].status, ImageStatus::Synced));
+    assert_eq!(report.stats.images_synced, 1);
+    assert_eq!(report.stats.blobs_transferred, 2);
+}
+
+#[tokio::test]
+async fn sync_empty_tags_produces_no_images() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let mapping = ResolvedMapping {
+        source_client: mock_client(&source_server),
+        source_repo: "repo".into(),
+        target_repo: "repo".into(),
+        targets: vec![TargetEntry {
+            name: "target".into(),
+            client: mock_client(&target_server),
+        }],
+        tags: vec![],
+    };
+
+    let mut engine = SyncEngine::new(fast_retry());
+    let report = engine.run(vec![mapping], &NullProgress).await;
+
+    assert!(report.images.is_empty());
+    assert_eq!(report.stats.images_synced, 0);
+    assert_eq!(report.exit_code(), 0);
+}
+
+#[tokio::test]
+async fn sync_manifest_push_failure() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_digest = test_digest("c6");
+    let layer_digest = test_digest("b6");
+    let manifest = simple_image_manifest(&config_digest, &layer_digest);
+    let (manifest_bytes, _) = serialize_manifest(&manifest);
+
+    // Source: serve everything normally.
+    mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_digest, b"config").await;
+    mount_blob_pull(&source_server, "repo", &layer_digest, b"layer").await;
+
+    // Target: blobs succeed, but manifest PUT fails with 403.
+    mount_manifest_head_not_found(&target_server, "repo", "v1").await;
+    mount_blob_not_found(&target_server, "repo", &config_digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_digest).await;
+    mount_blob_push(&target_server, "repo").await;
+
+    Mock::given(method("PUT"))
+        .and(path("/v2/repo/manifests/v1"))
+        .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+        .mount(&target_server)
+        .await;
+
+    let mapping = ResolvedMapping {
+        source_client: mock_client(&source_server),
+        source_repo: "repo".into(),
+        target_repo: "repo".into(),
+        targets: vec![TargetEntry {
+            name: "target".into(),
+            client: mock_client(&target_server),
+        }],
+        tags: vec![TagPair::same("v1")],
+    };
+
+    let mut engine = SyncEngine::new(fast_retry());
+    let report = engine.run(vec![mapping], &NullProgress).await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(matches!(
+        report.images[0].status,
+        ImageStatus::Failed { .. }
+    ));
+    if let ImageStatus::Failed { error, .. } = &report.images[0].status {
+        assert!(
+            error.contains("manifest"),
+            "error should mention manifest: {error}"
+        );
+    }
+    assert_eq!(report.stats.images_failed, 1);
+}
+
+#[tokio::test]
+async fn sync_retry_exhaustion_returns_final_error() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_digest = test_digest("c7");
+    let layer_digest = test_digest("b7");
+    let manifest = simple_image_manifest(&config_digest, &layer_digest);
+    let (manifest_bytes, _) = serialize_manifest(&manifest);
+
+    mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_digest, b"config").await;
+
+    // Layer blob: always returns 429 (retryable) — should exhaust retries.
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/blobs/{layer_digest}")))
+        .respond_with(ResponseTemplate::new(429).set_body_string("rate limited"))
+        .mount(&source_server)
+        .await;
+
+    mount_manifest_head_not_found(&target_server, "repo", "v1").await;
+    mount_blob_not_found(&target_server, "repo", &config_digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_digest).await;
+    mount_blob_push(&target_server, "repo").await;
+
+    let mapping = ResolvedMapping {
+        source_client: mock_client(&source_server),
+        source_repo: "repo".into(),
+        target_repo: "repo".into(),
+        targets: vec![TargetEntry {
+            name: "target".into(),
+            client: mock_client(&target_server),
+        }],
+        tags: vec![TagPair::same("v1")],
+    };
+
+    let mut engine = SyncEngine::new(fast_retry());
+    let report = engine.run(vec![mapping], &NullProgress).await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(matches!(
+        report.images[0].status,
+        ImageStatus::Failed { .. }
+    ));
+    if let ImageStatus::Failed { error, retries } = &report.images[0].status {
+        assert!(
+            error.contains("blob pull"),
+            "error should mention blob pull: {error}"
+        );
+        assert_eq!(*retries, 2); // max_retries from fast_retry()
+    }
+    assert_eq!(report.stats.images_failed, 1);
+}
+
+#[tokio::test]
+async fn sync_cross_repo_mount_success() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    // Shared blobs across two different source repos.
+    let config_digest = test_digest("ac00");
+    let layer_digest = test_digest("ac01");
+
+    let manifest_a = simple_image_manifest(&config_digest, &layer_digest);
+    let (manifest_a_bytes, _) = serialize_manifest(&manifest_a);
+    let manifest_b = simple_image_manifest(&config_digest, &layer_digest);
+    let (manifest_b_bytes, _) = serialize_manifest(&manifest_b);
+
+    // Source: two repos with the same blobs.
+    mount_source_manifest(&source_server, "repo-a", "v1", &manifest_a_bytes).await;
+    mount_source_manifest(&source_server, "repo-b", "v1", &manifest_b_bytes).await;
+    mount_blob_pull(&source_server, "repo-a", &config_digest, b"config").await;
+    mount_blob_pull(&source_server, "repo-a", &layer_digest, b"layer").await;
+
+    // Target for repo-a: no manifest, no blobs, push succeeds.
+    mount_manifest_head_not_found(&target_server, "repo-a", "v1").await;
+    mount_blob_not_found(&target_server, "repo-a", &config_digest).await;
+    mount_blob_not_found(&target_server, "repo-a", &layer_digest).await;
+    mount_blob_push(&target_server, "repo-a").await;
+    mount_manifest_push(&target_server, "repo-a", "v1").await;
+
+    // Target for repo-b: no manifest, blobs not found, mount succeeds (201 Created).
+    mount_manifest_head_not_found(&target_server, "repo-b", "v1").await;
+    mount_blob_not_found(&target_server, "repo-b", &config_digest).await;
+    mount_blob_not_found(&target_server, "repo-b", &layer_digest).await;
+    Mock::given(method("POST"))
+        .and(path("/v2/repo-b/blobs/uploads/"))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(&target_server)
+        .await;
+    mount_manifest_push(&target_server, "repo-b", "v1").await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    // First mapping: repo-a syncs normally (pull+push).
+    let mapping_a = ResolvedMapping {
+        source_client: source_client.clone(),
+        source_repo: "repo-a".into(),
+        target_repo: "repo-a".into(),
+        targets: vec![TargetEntry {
+            name: "target".into(),
+            client: target_client.clone(),
+        }],
+        tags: vec![TagPair::same("v1")],
+    };
+
+    // Second mapping: repo-b should mount from repo-a.
+    let mapping_b = ResolvedMapping {
+        source_client,
+        source_repo: "repo-b".into(),
+        target_repo: "repo-b".into(),
+        targets: vec![TargetEntry {
+            name: "target".into(),
+            client: target_client,
+        }],
+        tags: vec![TagPair::same("v1")],
+    };
+
+    let mut engine = SyncEngine::new(fast_retry());
+    let report = engine.run(vec![mapping_a, mapping_b], &NullProgress).await;
+
+    assert_eq!(report.images.len(), 2);
+    assert!(matches!(report.images[0].status, ImageStatus::Synced));
+    assert!(matches!(report.images[1].status, ImageStatus::Synced));
+    // First mapping: 2 blobs transferred.
+    assert_eq!(report.images[0].blob_stats.transferred, 2);
+    // Second mapping: 2 blobs mounted (not transferred).
+    assert_eq!(report.images[1].blob_stats.mounted, 2);
+    assert_eq!(report.images[1].blob_stats.transferred, 0);
+    assert_eq!(report.stats.blobs_mounted, 2);
+}
+
+#[tokio::test]
+async fn sync_cross_repo_mount_fallback_to_pull_push() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_digest = test_digest("f0");
+    let layer_digest = test_digest("f1");
+
+    let manifest_a = simple_image_manifest(&config_digest, &layer_digest);
+    let (manifest_a_bytes, _) = serialize_manifest(&manifest_a);
+    let manifest_b = simple_image_manifest(&config_digest, &layer_digest);
+    let (manifest_b_bytes, _) = serialize_manifest(&manifest_b);
+
+    // Source: two repos.
+    mount_source_manifest(&source_server, "repo-a", "v1", &manifest_a_bytes).await;
+    mount_source_manifest(&source_server, "repo-b", "v1", &manifest_b_bytes).await;
+    mount_blob_pull(&source_server, "repo-a", &config_digest, b"config").await;
+    mount_blob_pull(&source_server, "repo-a", &layer_digest, b"layer").await;
+    // repo-b blob pulls needed for fallback.
+    mount_blob_pull(&source_server, "repo-b", &config_digest, b"config").await;
+    mount_blob_pull(&source_server, "repo-b", &layer_digest, b"layer").await;
+
+    // Target for repo-a: normal sync.
+    mount_manifest_head_not_found(&target_server, "repo-a", "v1").await;
+    mount_blob_not_found(&target_server, "repo-a", &config_digest).await;
+    mount_blob_not_found(&target_server, "repo-a", &layer_digest).await;
+    mount_blob_push(&target_server, "repo-a").await;
+    mount_manifest_push(&target_server, "repo-a", "v1").await;
+
+    // Target for repo-b: mount returns 202 Accepted (fallback).
+    mount_manifest_head_not_found(&target_server, "repo-b", "v1").await;
+    mount_blob_not_found(&target_server, "repo-b", &config_digest).await;
+    mount_blob_not_found(&target_server, "repo-b", &layer_digest).await;
+    Mock::given(method("POST"))
+        .and(path("/v2/repo-b/blobs/uploads/"))
+        .respond_with(
+            ResponseTemplate::new(202)
+                .insert_header("location", "/v2/repo-b/blobs/uploads/fallback-id"),
+        )
+        .mount(&target_server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path("/v2/repo-b/blobs/uploads/fallback-id"))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(&target_server)
+        .await;
+    mount_manifest_push(&target_server, "repo-b", "v1").await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping_a = ResolvedMapping {
+        source_client: source_client.clone(),
+        source_repo: "repo-a".into(),
+        target_repo: "repo-a".into(),
+        targets: vec![TargetEntry {
+            name: "target".into(),
+            client: target_client.clone(),
+        }],
+        tags: vec![TagPair::same("v1")],
+    };
+
+    let mapping_b = ResolvedMapping {
+        source_client,
+        source_repo: "repo-b".into(),
+        target_repo: "repo-b".into(),
+        targets: vec![TargetEntry {
+            name: "target".into(),
+            client: target_client,
+        }],
+        tags: vec![TagPair::same("v1")],
+    };
+
+    let mut engine = SyncEngine::new(fast_retry());
+    let report = engine.run(vec![mapping_a, mapping_b], &NullProgress).await;
+
+    assert_eq!(report.images.len(), 2);
+    assert!(matches!(report.images[0].status, ImageStatus::Synced));
+    assert!(matches!(report.images[1].status, ImageStatus::Synced));
+    // Second mapping: mount fallback → pull+push, so transferred not mounted.
+    assert_eq!(report.images[1].blob_stats.mounted, 0);
+    assert_eq!(report.images[1].blob_stats.transferred, 2);
+}
+
+#[tokio::test]
+async fn sync_cross_repo_mount_failure_falls_back() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_digest = test_digest("e0");
+    let layer_digest = test_digest("e1");
+
+    let manifest_a = simple_image_manifest(&config_digest, &layer_digest);
+    let (manifest_a_bytes, _) = serialize_manifest(&manifest_a);
+    let manifest_b = simple_image_manifest(&config_digest, &layer_digest);
+    let (manifest_b_bytes, _) = serialize_manifest(&manifest_b);
+
+    // Source: two repos.
+    mount_source_manifest(&source_server, "repo-a", "v1", &manifest_a_bytes).await;
+    mount_source_manifest(&source_server, "repo-b", "v1", &manifest_b_bytes).await;
+    mount_blob_pull(&source_server, "repo-a", &config_digest, b"config").await;
+    mount_blob_pull(&source_server, "repo-a", &layer_digest, b"layer").await;
+    mount_blob_pull(&source_server, "repo-b", &config_digest, b"config").await;
+    mount_blob_pull(&source_server, "repo-b", &layer_digest, b"layer").await;
+
+    // Target for repo-a: normal sync.
+    mount_manifest_head_not_found(&target_server, "repo-a", "v1").await;
+    mount_blob_not_found(&target_server, "repo-a", &config_digest).await;
+    mount_blob_not_found(&target_server, "repo-a", &layer_digest).await;
+    mount_blob_push(&target_server, "repo-a").await;
+    mount_manifest_push(&target_server, "repo-a", "v1").await;
+
+    // Target for repo-b: mount returns 500 (error), falls back to pull+push.
+    mount_manifest_head_not_found(&target_server, "repo-b", "v1").await;
+    mount_blob_not_found(&target_server, "repo-b", &config_digest).await;
+    mount_blob_not_found(&target_server, "repo-b", &layer_digest).await;
+    Mock::given(method("POST"))
+        .and(path("/v2/repo-b/blobs/uploads/"))
+        .respond_with(ResponseTemplate::new(500))
+        .up_to_n_times(2) // First two POSTs are mount attempts that fail.
+        .mount(&target_server)
+        .await;
+    // Subsequent POSTs succeed (fallback upload initiation).
+    Mock::given(method("POST"))
+        .and(path("/v2/repo-b/blobs/uploads/"))
+        .respond_with(
+            ResponseTemplate::new(202)
+                .insert_header("location", "/v2/repo-b/blobs/uploads/retry-id"),
+        )
+        .mount(&target_server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path("/v2/repo-b/blobs/uploads/retry-id"))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(&target_server)
+        .await;
+    mount_manifest_push(&target_server, "repo-b", "v1").await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping_a = ResolvedMapping {
+        source_client: source_client.clone(),
+        source_repo: "repo-a".into(),
+        target_repo: "repo-a".into(),
+        targets: vec![TargetEntry {
+            name: "target".into(),
+            client: target_client.clone(),
+        }],
+        tags: vec![TagPair::same("v1")],
+    };
+
+    let mapping_b = ResolvedMapping {
+        source_client,
+        source_repo: "repo-b".into(),
+        target_repo: "repo-b".into(),
+        targets: vec![TargetEntry {
+            name: "target".into(),
+            client: target_client,
+        }],
+        tags: vec![TagPair::same("v1")],
+    };
+
+    let mut engine = SyncEngine::new(fast_retry());
+    let report = engine.run(vec![mapping_a, mapping_b], &NullProgress).await;
+
+    assert_eq!(report.images.len(), 2);
+    assert!(matches!(report.images[0].status, ImageStatus::Synced));
+    assert!(matches!(report.images[1].status, ImageStatus::Synced));
+    // Mount failed → fell back to pull+push.
+    assert_eq!(report.images[1].blob_stats.mounted, 0);
+    assert_eq!(report.images[1].blob_stats.transferred, 2);
+}

--- a/src/cli/commands/copy.rs
+++ b/src/cli/commands/copy.rs
@@ -1,10 +1,95 @@
 //! The `copy` subcommand — copies a single image between registries.
 
-use crate::CopyArgs;
-use crate::cli::{CliError, ExitCode};
+use std::sync::Arc;
 
-pub(crate) async fn run(_args: &CopyArgs) -> Result<ExitCode, CliError> {
-    Err(CliError::Input(
-        "copy command not yet implemented".to_string(),
-    ))
+use ocync_sync::engine::{ResolvedMapping, SyncEngine, TargetEntry};
+use ocync_sync::progress::NullProgress;
+use ocync_sync::retry::RetryConfig;
+use ocync_sync::{ImageStatus, SkipReason};
+
+use crate::CopyArgs;
+use crate::cli::{CliError, ExitCode, build_registry_client};
+
+/// Run the copy command: transfer a single image from source to destination.
+pub(crate) async fn run(args: &CopyArgs) -> Result<ExitCode, CliError> {
+    let src_tag = args
+        .source
+        .tag()
+        .ok_or_else(|| CliError::Input(format!("source '{}' has no tag", args.source)))?;
+    let dst_tag = args
+        .destination
+        .tag()
+        .ok_or_else(|| CliError::Input(format!("destination '{}' has no tag", args.destination)))?;
+
+    // Tags must match — the engine syncs a single tag from source to target.
+    if src_tag != dst_tag {
+        return Err(CliError::Input(format!(
+            "source tag '{src_tag}' does not match destination tag '{dst_tag}'"
+        )));
+    }
+
+    let source_client = Arc::new(build_registry_client(args.source.registry(), None).await?);
+    let target_client = Arc::new(build_registry_client(args.destination.registry(), None).await?);
+
+    let mapping = ResolvedMapping {
+        source_client,
+        source_repo: args.source.repository().to_owned(),
+        target_repo: args.destination.repository().to_owned(),
+        targets: vec![TargetEntry {
+            name: args.destination.registry().to_owned(),
+            client: target_client,
+        }],
+        tags: vec![src_tag.to_owned()],
+    };
+
+    let engine = SyncEngine::new(RetryConfig::default());
+    let progress = NullProgress;
+    let report = engine.run(vec![mapping], &progress).await;
+
+    let src_display = format!(
+        "{}/{}:{}",
+        args.source.registry(),
+        args.source.repository(),
+        src_tag
+    );
+    let dst_display = format!(
+        "{}/{}:{}",
+        args.destination.registry(),
+        args.destination.repository(),
+        dst_tag
+    );
+
+    // Exactly one image result expected.
+    if let Some(result) = report.images.first() {
+        match &result.status {
+            ImageStatus::Synced => {
+                println!(
+                    "Copied {src_display} -> {dst_display} ({:.1}s)",
+                    result.duration.as_secs_f64()
+                );
+            }
+            ImageStatus::Skipped { reason } => {
+                let reason_str = skip_reason_label(reason);
+                println!("Skipped {src_display} -> {dst_display} (reason: {reason_str})");
+            }
+            ImageStatus::Failed { error, retries } => {
+                eprintln!("Failed {src_display} -> {dst_display}: {error} (retries: {retries})");
+            }
+        }
+    }
+
+    match report.exit_code() {
+        0 => Ok(ExitCode::Success),
+        1 => Ok(ExitCode::Failure),
+        _ => Ok(ExitCode::Error),
+    }
+}
+
+/// Human-readable label for a skip reason.
+fn skip_reason_label(reason: &SkipReason) -> &'static str {
+    match reason {
+        SkipReason::DigestMatch => "DigestMatch",
+        SkipReason::SkipExisting => "SkipExisting",
+        SkipReason::ImmutableTag => "ImmutableTag",
+    }
 }

--- a/src/cli/commands/copy.rs
+++ b/src/cli/commands/copy.rs
@@ -2,10 +2,10 @@
 
 use std::sync::Arc;
 
+use ocync_sync::ImageStatus;
 use ocync_sync::engine::{ResolvedMapping, SyncEngine, TagPair, TargetEntry};
 use ocync_sync::progress::NullProgress;
 use ocync_sync::retry::RetryConfig;
-use ocync_sync::{ImageStatus, SkipReason};
 
 use crate::CopyArgs;
 use crate::cli::{CliError, ExitCode, build_registry_client};
@@ -32,7 +32,7 @@ pub(crate) async fn run(args: &CopyArgs) -> Result<ExitCode, CliError> {
         tags: vec![TagPair::retag(src_tag.to_owned(), dst_tag.to_owned())],
     };
 
-    let engine = SyncEngine::new(RetryConfig::default());
+    let mut engine = SyncEngine::new(RetryConfig::default());
     let progress = NullProgress;
     let report = engine.run(vec![mapping], &progress).await;
 
@@ -59,8 +59,7 @@ pub(crate) async fn run(args: &CopyArgs) -> Result<ExitCode, CliError> {
                 );
             }
             ImageStatus::Skipped { reason } => {
-                let reason_str = skip_reason_label(reason);
-                println!("Skipped {src_display} -> {dst_display} (reason: {reason_str})");
+                println!("Skipped {src_display} -> {dst_display} (reason: {reason})");
             }
             ImageStatus::Failed { error, retries } => {
                 eprintln!("Failed {src_display} -> {dst_display}: {error} (retries: {retries})");
@@ -72,14 +71,5 @@ pub(crate) async fn run(args: &CopyArgs) -> Result<ExitCode, CliError> {
         0 => Ok(ExitCode::Success),
         1 => Ok(ExitCode::Failure),
         _ => Ok(ExitCode::Error),
-    }
-}
-
-/// Human-readable label for a skip reason.
-fn skip_reason_label(reason: &SkipReason) -> &'static str {
-    match reason {
-        SkipReason::DigestMatch => "DigestMatch",
-        SkipReason::SkipExisting => "SkipExisting",
-        SkipReason::ImmutableTag => "ImmutableTag",
     }
 }

--- a/src/cli/commands/copy.rs
+++ b/src/cli/commands/copy.rs
@@ -8,7 +8,7 @@ use ocync_sync::progress::NullProgress;
 use ocync_sync::retry::RetryConfig;
 
 use crate::CopyArgs;
-use crate::cli::{CliError, ExitCode, build_registry_client};
+use crate::cli::{CliError, ExitCode, bare_hostname, build_registry_client};
 
 /// Run the copy command: transfer a single image from source to destination.
 pub(crate) async fn run(args: &CopyArgs) -> Result<ExitCode, CliError> {
@@ -18,15 +18,17 @@ pub(crate) async fn run(args: &CopyArgs) -> Result<ExitCode, CliError> {
         .ok_or_else(|| CliError::Input(format!("source '{}' has no tag", args.source)))?;
     let dst_tag = args.destination.tag().unwrap_or(src_tag);
 
-    let source_client = Arc::new(build_registry_client(args.source.registry(), None).await?);
-    let target_client = Arc::new(build_registry_client(args.destination.registry(), None).await?);
+    let source_client =
+        Arc::new(build_registry_client(bare_hostname(args.source.registry()), None).await?);
+    let target_client =
+        Arc::new(build_registry_client(bare_hostname(args.destination.registry()), None).await?);
 
     let mapping = ResolvedMapping {
         source_client,
         source_repo: args.source.repository().to_owned(),
         target_repo: args.destination.repository().to_owned(),
         targets: vec![TargetEntry {
-            name: args.destination.registry().to_owned(),
+            name: bare_hostname(args.destination.registry()).to_owned(),
             client: target_client,
         }],
         tags: vec![TagPair::retag(src_tag.to_owned(), dst_tag.to_owned())],

--- a/src/cli/commands/copy.rs
+++ b/src/cli/commands/copy.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use ocync_sync::engine::{ResolvedMapping, SyncEngine, TargetEntry};
+use ocync_sync::engine::{ResolvedMapping, SyncEngine, TagPair, TargetEntry};
 use ocync_sync::progress::NullProgress;
 use ocync_sync::retry::RetryConfig;
 use ocync_sync::{ImageStatus, SkipReason};
@@ -16,17 +16,7 @@ pub(crate) async fn run(args: &CopyArgs) -> Result<ExitCode, CliError> {
         .source
         .tag()
         .ok_or_else(|| CliError::Input(format!("source '{}' has no tag", args.source)))?;
-    let dst_tag = args
-        .destination
-        .tag()
-        .ok_or_else(|| CliError::Input(format!("destination '{}' has no tag", args.destination)))?;
-
-    // Tags must match — the engine syncs a single tag from source to target.
-    if src_tag != dst_tag {
-        return Err(CliError::Input(format!(
-            "source tag '{src_tag}' does not match destination tag '{dst_tag}'"
-        )));
-    }
+    let dst_tag = args.destination.tag().unwrap_or(src_tag);
 
     let source_client = Arc::new(build_registry_client(args.source.registry(), None).await?);
     let target_client = Arc::new(build_registry_client(args.destination.registry(), None).await?);
@@ -39,7 +29,7 @@ pub(crate) async fn run(args: &CopyArgs) -> Result<ExitCode, CliError> {
             name: args.destination.registry().to_owned(),
             client: target_client,
         }],
-        tags: vec![src_tag.to_owned()],
+        tags: vec![TagPair::retag(src_tag.to_owned(), dst_tag.to_owned())],
     };
 
     let engine = SyncEngine::new(RetryConfig::default());

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -1,10 +1,380 @@
-//! The `sync` subcommand — runs all mappings from config.
+//! The `sync` subcommand -- runs all mappings from config.
 
-use crate::SyncArgs;
-use crate::cli::{CliError, ExitCode};
+use std::collections::HashMap;
+use std::sync::Arc;
 
-pub(crate) async fn run(_args: &SyncArgs) -> Result<ExitCode, CliError> {
-    Err(CliError::Input(
-        "sync command not yet implemented".to_string(),
-    ))
+use ocync_distribution::RegistryClient;
+use ocync_sync::SyncReport;
+use ocync_sync::engine::{ResolvedMapping, SyncEngine, TargetEntry};
+use ocync_sync::filter::FilterConfig;
+use ocync_sync::progress::NullProgress;
+use ocync_sync::retry::RetryConfig;
+
+use crate::cli::config::{
+    Config, GlobOrList, MappingConfig, TagsConfig, load_config, resolve_target_names,
+};
+use crate::cli::{CliError, ExitCode, bare_hostname, build_registry_client};
+use crate::{OutputFormat, SyncArgs};
+
+/// Run the sync command: load config, resolve mappings, and execute.
+pub(crate) async fn run(args: &SyncArgs) -> Result<ExitCode, CliError> {
+    let config = load_config(&args.config[0])?;
+
+    let clients = build_clients(&config).await?;
+
+    let mut mappings = Vec::new();
+    for mapping in &config.mappings {
+        match resolve_mapping(mapping, &config, &clients).await {
+            Ok(Some(resolved)) => mappings.push(resolved),
+            Ok(None) => {} // no tags after filtering, logged inside
+            Err(err) => return Err(err),
+        }
+    }
+
+    if args.dry_run {
+        print_dry_run(&mappings);
+        return Ok(ExitCode::Success);
+    }
+
+    let engine = SyncEngine::new(RetryConfig::default());
+    let progress = NullProgress;
+    let report = engine.run(mappings, &progress).await;
+
+    write_output(args, &report)?;
+
+    match report.exit_code() {
+        0 => Ok(ExitCode::Success),
+        1 => Ok(ExitCode::Failure),
+        _ => Ok(ExitCode::Error),
+    }
+}
+
+/// Build a `RegistryClient` for each named registry in config, keyed by name.
+async fn build_clients(config: &Config) -> Result<HashMap<String, Arc<RegistryClient>>, CliError> {
+    let mut clients = HashMap::with_capacity(config.registries.len());
+    for (name, reg) in &config.registries {
+        let hostname = bare_hostname(&reg.url);
+        let client = build_registry_client(hostname, reg.auth_type.as_ref()).await?;
+        clients.insert(name.clone(), Arc::new(client));
+    }
+    Ok(clients)
+}
+
+/// Resolve a single mapping config into a `ResolvedMapping`, or `None` if no
+/// tags survive filtering.
+///
+/// Falls back to `defaults.source`, `defaults.targets`, and `defaults.tags`
+/// when the mapping does not specify its own values.
+async fn resolve_mapping(
+    mapping: &MappingConfig,
+    config: &Config,
+    clients: &HashMap<String, Arc<RegistryClient>>,
+) -> Result<Option<ResolvedMapping>, CliError> {
+    // --- Source registry ---
+    let source_name = mapping
+        .source
+        .as_deref()
+        .or(config.defaults.as_ref().and_then(|d| d.source.as_deref()))
+        .ok_or_else(|| {
+            CliError::Input(format!(
+                "mapping '{}': no source registry (set mapping.source or defaults.source)",
+                mapping.from,
+            ))
+        })?;
+
+    let source_client = clients.get(source_name).cloned().ok_or_else(|| {
+        CliError::Input(format!(
+            "mapping '{}': source registry '{}' not found in clients",
+            mapping.from, source_name,
+        ))
+    })?;
+
+    // --- Target registries ---
+    let targets_value = mapping
+        .targets
+        .as_ref()
+        .or(config.defaults.as_ref().and_then(|d| d.targets.as_ref()))
+        .ok_or_else(|| {
+            CliError::Input(format!(
+                "mapping '{}': no target registries (set mapping.targets or defaults.targets)",
+                mapping.from,
+            ))
+        })?;
+
+    let known: std::collections::HashSet<&str> =
+        config.registries.keys().map(String::as_str).collect();
+    let context = format!("mapping '{}'", mapping.from);
+    let target_names =
+        resolve_target_names(targets_value, config, &known, &context).map_err(CliError::Config)?;
+
+    let targets: Vec<TargetEntry> = target_names
+        .into_iter()
+        .map(|name| {
+            let client = clients.get(&name).cloned().ok_or_else(|| {
+                CliError::Input(format!(
+                    "mapping '{}': target registry '{}' not found in clients",
+                    mapping.from, name,
+                ))
+            })?;
+            Ok(TargetEntry { name, client })
+        })
+        .collect::<Result<Vec<_>, CliError>>()?;
+
+    // --- Fetch and filter tags ---
+    let all_tags = source_client.list_tags(&mapping.from).await?;
+
+    let tags_config = mapping
+        .tags
+        .as_ref()
+        .or(config.defaults.as_ref().and_then(|d| d.tags.as_ref()));
+
+    let filter = build_filter(tags_config);
+    let tag_refs: Vec<&str> = all_tags.iter().map(String::as_str).collect();
+    let filtered = filter.apply(&tag_refs)?;
+
+    if filtered.is_empty() {
+        tracing::warn!(
+            from = %mapping.from,
+            "no tags matched after filtering, skipping mapping"
+        );
+        return Ok(None);
+    }
+
+    // --- Target repo ---
+    let target_repo = mapping.to.as_deref().unwrap_or(&mapping.from).to_owned();
+
+    Ok(Some(ResolvedMapping {
+        source_client,
+        source_repo: mapping.from.clone(),
+        target_repo,
+        targets,
+        tags: filtered,
+    }))
+}
+
+/// Build a `FilterConfig` from a `TagsConfig`, falling back to defaults.
+fn build_filter(tags: Option<&TagsConfig>) -> FilterConfig {
+    let Some(tags) = tags else {
+        return FilterConfig::default();
+    };
+
+    FilterConfig {
+        glob: glob_or_list_to_vec(tags.glob.as_ref()),
+        semver: tags.semver.clone(),
+        semver_prerelease: tags.semver_prerelease,
+        exclude: glob_or_list_to_vec(tags.exclude.as_ref()),
+        sort: tags.sort,
+        latest: tags.latest,
+        min_tags: tags.min_tags,
+    }
+}
+
+/// Flatten a `GlobOrList` into a `Vec<String>`.
+fn glob_or_list_to_vec(g: Option<&GlobOrList>) -> Vec<String> {
+    match g {
+        Some(GlobOrList::Single(s)) => vec![s.clone()],
+        Some(GlobOrList::List(v)) => v.clone(),
+        None => Vec::new(),
+    }
+}
+
+/// Print dry-run output showing what would be synced.
+fn print_dry_run(mappings: &[ResolvedMapping]) {
+    if mappings.is_empty() {
+        println!("dry-run: no mappings to sync");
+        return;
+    }
+
+    for mapping in mappings {
+        let target_names: Vec<&str> = mapping.targets.iter().map(|t| t.name.as_str()).collect();
+        println!(
+            "dry-run: {} -> {} ({} tag(s)) => [{}]",
+            mapping.source_repo,
+            mapping.target_repo,
+            mapping.tags.len(),
+            target_names.join(", "),
+        );
+        for tag in &mapping.tags {
+            println!("  {tag}");
+        }
+    }
+}
+
+/// Write sync output in the requested format.
+fn write_output(args: &SyncArgs, report: &SyncReport) -> Result<(), CliError> {
+    let is_json = matches!(args.output_format, Some(OutputFormat::Json));
+
+    if is_json {
+        let json = serde_json::to_string_pretty(report)
+            .map_err(|e| CliError::Input(format!("failed to serialize report: {e}")))?;
+
+        if let Some(ref path) = args.output {
+            std::fs::write(path, &json).map_err(|e| {
+                CliError::Input(format!(
+                    "failed to write output to '{}': {e}",
+                    path.display()
+                ))
+            })?;
+        } else {
+            println!("{json}");
+        }
+    } else {
+        print_summary(report);
+
+        if let Some(ref path) = args.output {
+            let json = serde_json::to_string_pretty(report)
+                .map_err(|e| CliError::Input(format!("failed to serialize report: {e}")))?;
+            std::fs::write(path, &json).map_err(|e| {
+                CliError::Input(format!(
+                    "failed to write output to '{}': {e}",
+                    path.display()
+                ))
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Print a human-readable summary of the sync report.
+fn print_summary(report: &SyncReport) {
+    let s = &report.stats;
+    println!(
+        "sync complete: {} synced, {} skipped, {} failed ({}, {:.1}s)",
+        s.images_synced,
+        s.images_skipped,
+        s.images_failed,
+        format_bytes(s.bytes_transferred),
+        report.duration.as_secs_f64(),
+    );
+}
+
+/// Format a byte count as a human-readable string.
+fn format_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = 1024 * KB;
+    const GB: u64 = 1024 * MB;
+
+    if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.1} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_bytes_zero() {
+        assert_eq!(format_bytes(0), "0 B");
+    }
+
+    #[test]
+    fn format_bytes_bytes() {
+        assert_eq!(format_bytes(512), "512 B");
+    }
+
+    #[test]
+    fn format_bytes_kb() {
+        assert_eq!(format_bytes(1024), "1.0 KB");
+        assert_eq!(format_bytes(1536), "1.5 KB");
+    }
+
+    #[test]
+    fn format_bytes_mb() {
+        assert_eq!(format_bytes(1024 * 1024), "1.0 MB");
+        assert_eq!(format_bytes(5 * 1024 * 1024 + 512 * 1024), "5.5 MB");
+    }
+
+    #[test]
+    fn format_bytes_gb() {
+        assert_eq!(format_bytes(1024 * 1024 * 1024), "1.0 GB");
+    }
+
+    #[test]
+    fn build_filter_none_returns_default() {
+        let filter = build_filter(None);
+        assert!(filter.glob.is_empty());
+        assert!(filter.semver.is_none());
+        assert!(filter.exclude.is_empty());
+        assert!(filter.sort.is_none());
+        assert!(filter.latest.is_none());
+        assert!(filter.min_tags.is_none());
+    }
+
+    #[test]
+    fn build_filter_single_glob() {
+        let tags = TagsConfig {
+            glob: Some(GlobOrList::Single("v1.*".into())),
+            ..Default::default()
+        };
+        let filter = build_filter(Some(&tags));
+        assert_eq!(filter.glob, vec!["v1.*"]);
+    }
+
+    #[test]
+    fn build_filter_glob_list() {
+        let tags = TagsConfig {
+            glob: Some(GlobOrList::List(vec!["v1.*".into(), "v2.*".into()])),
+            ..Default::default()
+        };
+        let filter = build_filter(Some(&tags));
+        assert_eq!(filter.glob, vec!["v1.*", "v2.*"]);
+    }
+
+    #[test]
+    fn build_filter_exclude_patterns() {
+        let tags = TagsConfig {
+            exclude: Some(GlobOrList::List(vec!["*-rc*".into(), "*-beta*".into()])),
+            ..Default::default()
+        };
+        let filter = build_filter(Some(&tags));
+        assert_eq!(filter.exclude, vec!["*-rc*", "*-beta*"]);
+    }
+
+    #[test]
+    fn build_filter_full() {
+        use ocync_sync::filter::{SemverPrerelease, SortOrder};
+
+        let tags = TagsConfig {
+            glob: Some(GlobOrList::Single("*".into())),
+            semver: Some(">=1.0.0".into()),
+            semver_prerelease: Some(SemverPrerelease::Exclude),
+            exclude: Some(GlobOrList::Single("*-alpine".into())),
+            sort: Some(SortOrder::Semver),
+            latest: Some(5),
+            min_tags: Some(1),
+        };
+        let filter = build_filter(Some(&tags));
+        assert_eq!(filter.glob, vec!["*"]);
+        assert_eq!(filter.semver.as_deref(), Some(">=1.0.0"));
+        assert_eq!(filter.semver_prerelease, Some(SemverPrerelease::Exclude));
+        assert_eq!(filter.exclude, vec!["*-alpine"]);
+        assert_eq!(filter.sort, Some(SortOrder::Semver));
+        assert_eq!(filter.latest, Some(5));
+        assert_eq!(filter.min_tags, Some(1));
+    }
+
+    #[test]
+    fn glob_or_list_to_vec_none() {
+        assert!(glob_or_list_to_vec(None).is_empty());
+    }
+
+    #[test]
+    fn glob_or_list_to_vec_single() {
+        let g = GlobOrList::Single("pattern".into());
+        assert_eq!(glob_or_list_to_vec(Some(&g)), vec!["pattern"]);
+    }
+
+    #[test]
+    fn glob_or_list_to_vec_list() {
+        let g = GlobOrList::List(vec!["a".into(), "b".into()]);
+        assert_eq!(glob_or_list_to_vec(Some(&g)), vec!["a", "b"]);
+    }
 }

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use ocync_distribution::RegistryClient;
 use ocync_sync::SyncReport;
-use ocync_sync::engine::{ResolvedMapping, SyncEngine, TargetEntry};
+use ocync_sync::engine::{ResolvedMapping, SyncEngine, TagPair, TargetEntry};
 use ocync_sync::filter::FilterConfig;
 use ocync_sync::progress::NullProgress;
 use ocync_sync::retry::RetryConfig;
@@ -148,7 +148,7 @@ async fn resolve_mapping(
         source_repo: mapping.from.clone(),
         target_repo,
         targets,
-        tags: filtered,
+        tags: filtered.into_iter().map(TagPair::same).collect(),
     }))
 }
 
@@ -194,8 +194,12 @@ fn print_dry_run(mappings: &[ResolvedMapping]) {
             mapping.tags.len(),
             target_names.join(", "),
         );
-        for tag in &mapping.tags {
-            println!("  {tag}");
+        for tag_pair in &mapping.tags {
+            if tag_pair.source == tag_pair.target {
+                println!("  {}", tag_pair.source);
+            } else {
+                println!("  {} -> {}", tag_pair.source, tag_pair.target);
+            }
         }
     }
 }

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -18,7 +18,7 @@ use crate::{OutputFormat, SyncArgs};
 
 /// Run the sync command: load config, resolve mappings, and execute.
 pub(crate) async fn run(args: &SyncArgs) -> Result<ExitCode, CliError> {
-    let config = load_config(&args.config[0])?;
+    let config = load_config(&args.config)?;
 
     let clients = build_clients(&config).await?;
 
@@ -36,7 +36,7 @@ pub(crate) async fn run(args: &SyncArgs) -> Result<ExitCode, CliError> {
         return Ok(ExitCode::Success);
     }
 
-    let engine = SyncEngine::new(RetryConfig::default());
+    let mut engine = SyncEngine::new(RetryConfig::default());
     let progress = NullProgress;
     let report = engine.run(mappings, &progress).await;
 
@@ -244,10 +244,13 @@ fn write_output(args: &SyncArgs, report: &SyncReport) -> Result<(), CliError> {
 fn print_summary(report: &SyncReport) {
     let s = &report.stats;
     println!(
-        "sync complete: {} synced, {} skipped, {} failed ({}, {:.1}s)",
+        "sync complete: {} synced, {} skipped, {} failed | blobs: {} transferred, {} skipped, {} mounted | {} in {:.1}s",
         s.images_synced,
         s.images_skipped,
         s.images_failed,
+        s.blobs_transferred,
+        s.blobs_skipped,
+        s.blobs_mounted,
         format_bytes(s.bytes_transferred),
         report.duration.as_secs_f64(),
     );

--- a/src/cli/commands/watch.rs
+++ b/src/cli/commands/watch.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use crate::cli::commands::synchronize;
 use crate::cli::shutdown::ShutdownSignal;
 use crate::cli::{CliError, ExitCode};
-use crate::{OutputFormat, SyncArgs, WatchArgs};
+use crate::{SyncArgs, WatchArgs};
 
 /// Run the watch command: loop forever, running sync then waiting for the
 /// configured interval or a shutdown signal.
@@ -18,7 +18,7 @@ pub(crate) async fn run(args: &WatchArgs, shutdown: ShutdownSignal) -> Result<Ex
             config: args.config.clone(),
             dry_run: false,
             output: None,
-            output_format: Some(OutputFormat::Text),
+            output_format: None,
         };
 
         match synchronize::run(&sync_args).await {
@@ -30,28 +30,13 @@ pub(crate) async fn run(args: &WatchArgs, shutdown: ShutdownSignal) -> Result<Ex
             }
         }
 
-        if wait_or_shutdown(interval, &shutdown).await {
-            tracing::info!("shutdown signal received, exiting watch mode");
-            return Ok(ExitCode::Success);
+        // Wait for the interval to elapse, or return early on shutdown.
+        tokio::select! {
+            () = tokio::time::sleep(interval) => {}
+            () = shutdown.notified() => {
+                tracing::info!("shutdown signal received, exiting watch mode");
+                return Ok(ExitCode::Success);
+            }
         }
     }
-}
-
-/// Wait for the given duration, polling the shutdown signal every 500ms.
-///
-/// Returns `true` if shutdown was triggered before the duration elapsed,
-/// `false` if the full duration elapsed without a shutdown signal.
-async fn wait_or_shutdown(duration: Duration, shutdown: &ShutdownSignal) -> bool {
-    let poll_interval = Duration::from_millis(500);
-    let mut elapsed = Duration::ZERO;
-
-    while elapsed < duration {
-        if shutdown.is_triggered() {
-            return true;
-        }
-        tokio::time::sleep(poll_interval).await;
-        elapsed += poll_interval;
-    }
-
-    shutdown.is_triggered()
 }

--- a/src/cli/commands/watch.rs
+++ b/src/cli/commands/watch.rs
@@ -1,10 +1,57 @@
-//! The `watch` subcommand — daemon mode for continuous sync.
+//! The `watch` subcommand -- daemon mode for periodic sync with graceful shutdown.
 
-use crate::WatchArgs;
+use std::time::Duration;
+
+use crate::cli::commands::synchronize;
+use crate::cli::shutdown::ShutdownSignal;
 use crate::cli::{CliError, ExitCode};
+use crate::{OutputFormat, SyncArgs, WatchArgs};
 
-pub(crate) async fn run(_args: &WatchArgs) -> Result<ExitCode, CliError> {
-    Err(CliError::Input(
-        "watch command not yet implemented".to_string(),
-    ))
+/// Run the watch command: loop forever, running sync then waiting for the
+/// configured interval or a shutdown signal.
+pub(crate) async fn run(args: &WatchArgs, shutdown: ShutdownSignal) -> Result<ExitCode, CliError> {
+    let interval = Duration::from_secs(args.interval);
+    tracing::info!(interval_secs = args.interval, "starting watch mode");
+
+    loop {
+        let sync_args = SyncArgs {
+            config: args.config.clone(),
+            dry_run: false,
+            output: None,
+            output_format: Some(OutputFormat::Text),
+        };
+
+        match synchronize::run(&sync_args).await {
+            Ok(code) => {
+                tracing::info!(exit_code = ?code, "sync cycle complete");
+            }
+            Err(err) => {
+                tracing::error!(error = %err, "sync cycle failed");
+            }
+        }
+
+        if wait_or_shutdown(interval, &shutdown).await {
+            tracing::info!("shutdown signal received, exiting watch mode");
+            return Ok(ExitCode::Success);
+        }
+    }
+}
+
+/// Wait for the given duration, polling the shutdown signal every 500ms.
+///
+/// Returns `true` if shutdown was triggered before the duration elapsed,
+/// `false` if the full duration elapsed without a shutdown signal.
+async fn wait_or_shutdown(duration: Duration, shutdown: &ShutdownSignal) -> bool {
+    let poll_interval = Duration::from_millis(500);
+    let mut elapsed = Duration::ZERO;
+
+    while elapsed < duration {
+        if shutdown.is_triggered() {
+            return true;
+        }
+        tokio::time::sleep(poll_interval).await;
+        elapsed += poll_interval;
+    }
+
+    shutdown.is_triggered()
 }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -25,9 +25,15 @@ pub(crate) fn load_config(path: &Path) -> Result<Config, ConfigError> {
         .map_err(|e| ConfigError::Parse(format!("failed to parse {}: {e}", path.display())))?;
 
     // Structural validation.
+    let has_default_tags = config.defaults.as_ref().is_some_and(|d| d.tags.is_some());
     for mapping in &config.mappings {
-        validate_mapping(mapping)?;
+        validate_mapping(mapping, has_default_tags)?;
         if let Some(ref tags) = mapping.tags {
+            validate_tags(tags)?;
+        }
+    }
+    if let Some(ref defaults) = config.defaults {
+        if let Some(ref tags) = defaults.tags {
             validate_tags(tags)?;
         }
     }
@@ -331,12 +337,17 @@ pub(crate) fn validate_tags(tags: &TagsConfig) -> Result<(), ConfigError> {
     Ok(())
 }
 
-// TODO(defaults): When defaults merging is implemented, allow mappings to omit
-// `tags` and inherit from `defaults.tags`. This validation must become context-aware.
-pub(crate) fn validate_mapping(mapping: &MappingConfig) -> Result<(), ConfigError> {
-    if mapping.tags.is_none() {
+/// Validate a mapping's tags block, falling back to defaults when present.
+///
+/// A mapping must have its own `tags` block OR inherit from `defaults.tags`.
+/// If neither is present, this returns a validation error.
+pub(crate) fn validate_mapping(
+    mapping: &MappingConfig,
+    has_default_tags: bool,
+) -> Result<(), ConfigError> {
+    if mapping.tags.is_none() && !has_default_tags {
         return Err(ConfigError::Validation(format!(
-            "mapping '{}' is missing a tags block",
+            "mapping '{}' is missing a tags block (and no defaults.tags is set)",
             mapping.from,
         )));
     }
@@ -345,7 +356,7 @@ pub(crate) fn validate_mapping(mapping: &MappingConfig) -> Result<(), ConfigErro
 
 /// Resolve a `TargetsValue` into a list of registry names, producing clear
 /// errors that distinguish unknown groups from unknown registries.
-fn resolve_target_names(
+pub(crate) fn resolve_target_names(
     targets: &TargetsValue,
     config: &Config,
     known: &std::collections::HashSet<&str>,
@@ -706,7 +717,7 @@ mappings:
     }
 
     #[test]
-    fn missing_tags_block() {
+    fn missing_tags_block_no_defaults() {
         let mapping = MappingConfig {
             from: "nginx".to_string(),
             to: None,
@@ -714,8 +725,20 @@ mappings:
             targets: None,
             tags: None,
         };
-        let err = validate_mapping(&mapping).unwrap_err();
+        let err = validate_mapping(&mapping, false).unwrap_err();
         assert!(matches!(err, ConfigError::Validation(_)));
+    }
+
+    #[test]
+    fn missing_tags_block_with_defaults() {
+        let mapping = MappingConfig {
+            from: "nginx".to_string(),
+            to: None,
+            source: None,
+            targets: None,
+            tags: None,
+        };
+        validate_mapping(&mapping, true).unwrap();
     }
 
     #[test]

--- a/src/cli/shutdown.rs
+++ b/src/cli/shutdown.rs
@@ -4,12 +4,14 @@ use std::fmt;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-/// Cooperative shutdown signal using an atomic flag.
+/// Cooperative shutdown signal using an atomic flag and async notification.
 ///
-/// Components check `is_triggered()` at safe points to exit gracefully.
+/// Components can poll `is_triggered()` at safe points, or `await`
+/// [`notified()`](Self::notified) for instant notification without polling.
 #[derive(Clone)]
 pub(crate) struct ShutdownSignal {
     triggered: Arc<AtomicBool>,
+    notify: Arc<tokio::sync::Notify>,
 }
 
 impl ShutdownSignal {
@@ -17,17 +19,31 @@ impl ShutdownSignal {
     pub(crate) fn new() -> Self {
         Self {
             triggered: Arc::new(AtomicBool::new(false)),
+            notify: Arc::new(tokio::sync::Notify::new()),
         }
     }
 
-    /// Set the shutdown flag. All clones will observe the change.
+    /// Set the shutdown flag and wake all waiters. All clones will observe the change.
     pub(crate) fn trigger(&self) {
         self.triggered.store(true, Ordering::Release);
+        self.notify.notify_waiters();
     }
 
     /// Check whether shutdown has been requested.
     pub(crate) fn is_triggered(&self) -> bool {
         self.triggered.load(Ordering::Acquire)
+    }
+
+    /// Wait until shutdown is triggered. Returns immediately if already triggered.
+    ///
+    /// Registers the `Notify` listener before checking the flag to avoid a
+    /// TOCTOU race where `trigger()` fires between the check and the await.
+    pub(crate) async fn notified(&self) {
+        let future = self.notify.notified();
+        if self.is_triggered() {
+            return;
+        }
+        future.await;
     }
 }
 
@@ -134,5 +150,35 @@ mod tests {
         signal.trigger();
         let debug = format!("{signal:?}");
         assert!(debug.contains("triggered: true"));
+    }
+
+    #[tokio::test]
+    async fn notified_returns_immediately_when_already_triggered() {
+        let signal = ShutdownSignal::new();
+        signal.trigger();
+        // Should return immediately, not hang.
+        signal.notified().await;
+        assert!(signal.is_triggered());
+    }
+
+    #[tokio::test]
+    async fn notified_wakes_on_trigger() {
+        let signal = ShutdownSignal::new();
+        let signal_clone = signal.clone();
+
+        let handle = tokio::spawn(async move {
+            signal_clone.notified().await;
+            true
+        });
+
+        // Small delay to let the spawned task start waiting.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        signal.trigger();
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(1), handle)
+            .await
+            .expect("timed out waiting for notified()")
+            .expect("task panicked");
+        assert!(result);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,9 +65,9 @@ pub(crate) enum Commands {
 /// Arguments for the `sync` subcommand.
 #[derive(Debug, clap::Args)]
 pub(crate) struct SyncArgs {
-    /// Config file path(s).
-    #[arg(short, long, required = true)]
-    pub(crate) config: Vec<PathBuf>,
+    /// Config file path.
+    #[arg(short, long)]
+    pub(crate) config: PathBuf,
     /// Perform a dry run without making changes.
     #[arg(long)]
     pub(crate) dry_run: bool,
@@ -174,11 +174,11 @@ pub(crate) struct ExpandArgs {
 /// Arguments for the `watch` subcommand.
 #[derive(Debug, clap::Args)]
 pub(crate) struct WatchArgs {
-    /// Config file path(s).
-    #[arg(short, long, required = true)]
-    pub(crate) config: Vec<PathBuf>,
-    /// Sync interval in seconds.
-    #[arg(long, default_value = "300")]
+    /// Config file path.
+    #[arg(short, long)]
+    pub(crate) config: PathBuf,
+    /// Sync interval in seconds (minimum 1).
+    #[arg(long, default_value = "300", value_parser = clap::value_parser!(u64).range(1..))]
     pub(crate) interval: u64,
 }
 
@@ -234,14 +234,6 @@ mod tests {
         let cli = Cli::parse_from(["ocync", "sync", "--config", "c.yaml", "--dry-run"]);
         if let Commands::Sync(args) = cli.command {
             assert!(args.dry_run);
-        }
-    }
-
-    #[test]
-    fn parse_sync_multiple_configs() {
-        let cli = Cli::parse_from(["ocync", "sync", "--config", "a.yaml", "--config", "b.yaml"]);
-        if let Commands::Sync(args) = cli.command {
-            assert_eq!(args.config.len(), 2);
         }
     }
 
@@ -352,5 +344,12 @@ mod tests {
         } else {
             panic!("expected Watch command");
         }
+    }
+
+    #[test]
+    fn watch_interval_zero_rejected() {
+        let result =
+            Cli::try_parse_from(["ocync", "watch", "--config", "c.yaml", "--interval", "0"]);
+        assert!(result.is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,6 +177,9 @@ pub(crate) struct WatchArgs {
     /// Config file path(s).
     #[arg(short, long, required = true)]
     pub(crate) config: Vec<PathBuf>,
+    /// Sync interval in seconds.
+    #[arg(long, default_value = "300")]
+    pub(crate) interval: u64,
 }
 
 #[tokio::main]
@@ -184,11 +187,9 @@ async fn main() -> std::process::ExitCode {
     let cli = Cli::parse();
     cli::setup_logging(&cli);
 
-    // Install signal handlers for graceful shutdown logging. The signal is not
-    // yet propagated to commands — sync/watch will need a clone passed down
-    // once they are implemented.
+    // Install signal handlers for graceful shutdown.
     let shutdown = cli::shutdown::ShutdownSignal::new();
-    cli::shutdown::install_signal_handlers(shutdown);
+    cli::shutdown::install_signal_handlers(shutdown.clone());
 
     let result = match cli.command {
         Commands::Sync(args) => cli::commands::synchronize::run(&args).await,
@@ -199,7 +200,7 @@ async fn main() -> std::process::ExitCode {
         },
         Commands::Validate(args) => cli::commands::validate::run(&args),
         Commands::Expand(args) => cli::commands::expand::run(&args),
-        Commands::Watch(args) => cli::commands::watch::run(&args).await,
+        Commands::Watch(args) => cli::commands::watch::run(&args, shutdown.clone()).await,
         Commands::Version => Ok(cli::commands::version::run()),
     };
 
@@ -331,5 +332,25 @@ mod tests {
             "c.yaml",
         ]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_watch() {
+        let cli = Cli::parse_from(["ocync", "watch", "--config", "c.yaml"]);
+        if let Commands::Watch(args) = cli.command {
+            assert_eq!(args.interval, 300);
+        } else {
+            panic!("expected Watch command");
+        }
+    }
+
+    #[test]
+    fn parse_watch_custom_interval() {
+        let cli = Cli::parse_from(["ocync", "watch", "--config", "c.yaml", "--interval", "60"]);
+        if let Commands::Watch(args) = cli.command {
+            assert_eq!(args.interval, 60);
+        } else {
+            panic!("expected Watch command");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Implement the sync engine with pull-once/fan-out architecture: source manifests and blobs are pulled once per tag, then pushed to all N targets. Each blob is pulled from source exactly once regardless of target count.
- Add CLI commands: `sync` (config-driven multi-mapping), `copy` (single-image transfer with retag), `watch` (daemon mode with periodic sync and graceful shutdown)
- Consolidate `Unauthorized`/`Forbidden`/`NotFound` error variants into `RegistryError` with `status_code()` and `is_not_found()` helpers. Deduplicate `MediaType` conversion via shared `known_media_type()` lookup.
- Fix cross-repo blob dedup bug: OCI blobs are repo-scoped, so the dedup map now checks `known_repos` for the current repo before skipping — enabling cross-repo mounts (previously unreachable dead code)

### Engine architecture

Three-phase execution per tag:
1. **Pull source** — manifest + children pulled once (`pull_source`)
2. **Fan-out blob transfer** — HEAD-check all targets, cross-repo mount where possible, pull each blob once from source and push to all targets that need it (`transfer_blobs_fanout`)
3. **Push manifests** — child manifests (for indexes) then top-level manifest per target (`push_manifests`)

Source pull failure propagates to all targets. Target push failure is isolated — other targets continue.

### New integration tests (18 total)

- Happy path, digest-match skip, blob-exists-at-target skip
- Manifest pull failure (403), blob pull retry on 500, retry exhaustion (429)
- Blob push failure, manifest push failure
- Cross-repo mount success, mount fallback (202), mount failure (500)
- Dedup across tags, multiple targets, retag
- HEAD with different digest, empty tags, empty mappings
- Multi-platform index manifest

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --workspace` — 425 tests pass across 8 suites
- [x] `cargo deny check` — no errors (warnings only for duplicate transitive deps)
- [ ] Manual test against real registries (ECR, GHCR, Docker Hub)