### PR TITLE
feat(cli): colorized help, improved descriptions, and UX cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "anyhow"
@@ -528,6 +572,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
 ]
@@ -558,6 +603,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "core-foundation"
@@ -1189,6 +1240,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,6 +1373,7 @@ dependencies = [
 name = "ocync"
 version = "0.1.0"
 dependencies = [
+ "anstyle",
  "clap",
  "ocync-distribution",
  "ocync-sync",
@@ -1378,6 +1436,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
@@ -2239,6 +2303,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,8 @@ description = "OCI registry sync tool"
 workspace = true
 
 [dependencies]
-clap = { version = "4", default-features = false, features = ["derive", "std", "help", "usage", "error-context"] }
+anstyle = { version = "1", default-features = false }
+clap = { version = "4", default-features = false, features = ["derive", "std", "help", "usage", "error-context", "color"] }
 ocync-distribution.workspace = true
 ocync-sync.workspace = true
 serde.workspace = true

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -10,11 +10,11 @@ use ocync_sync::filter::FilterConfig;
 use ocync_sync::progress::NullProgress;
 use ocync_sync::retry::RetryConfig;
 
+use crate::SyncArgs;
 use crate::cli::config::{
     Config, GlobOrList, MappingConfig, TagsConfig, load_config, resolve_target_names,
 };
 use crate::cli::{CliError, ExitCode, bare_hostname, build_registry_client};
-use crate::{OutputFormat, SyncArgs};
 
 /// Run the sync command: load config, resolve mappings, and execute.
 pub(crate) async fn run(args: &SyncArgs) -> Result<ExitCode, CliError> {
@@ -40,7 +40,7 @@ pub(crate) async fn run(args: &SyncArgs) -> Result<ExitCode, CliError> {
     let progress = NullProgress;
     let report = engine.run(mappings, &progress).await;
 
-    write_output(args, &report)?;
+    write_output(&report, args.json)?;
 
     match report.exit_code() {
         0 => Ok(ExitCode::Success),
@@ -205,36 +205,13 @@ fn print_dry_run(mappings: &[ResolvedMapping]) {
 }
 
 /// Write sync output in the requested format.
-fn write_output(args: &SyncArgs, report: &SyncReport) -> Result<(), CliError> {
-    let is_json = matches!(args.output_format, Some(OutputFormat::Json));
-
-    if is_json {
+fn write_output(report: &SyncReport, json: bool) -> Result<(), CliError> {
+    if json {
         let json = serde_json::to_string_pretty(report)
             .map_err(|e| CliError::Input(format!("failed to serialize report: {e}")))?;
-
-        if let Some(ref path) = args.output {
-            std::fs::write(path, &json).map_err(|e| {
-                CliError::Input(format!(
-                    "failed to write output to '{}': {e}",
-                    path.display()
-                ))
-            })?;
-        } else {
-            println!("{json}");
-        }
+        println!("{json}");
     } else {
         print_summary(report);
-
-        if let Some(ref path) = args.output {
-            let json = serde_json::to_string_pretty(report)
-                .map_err(|e| CliError::Input(format!("failed to serialize report: {e}")))?;
-            std::fs::write(path, &json).map_err(|e| {
-                CliError::Input(format!(
-                    "failed to write output to '{}': {e}",
-                    path.display()
-                ))
-            })?;
-        }
     }
 
     Ok(())

--- a/src/cli/commands/watch.rs
+++ b/src/cli/commands/watch.rs
@@ -17,8 +17,7 @@ pub(crate) async fn run(args: &WatchArgs, shutdown: ShutdownSignal) -> Result<Ex
         let sync_args = SyncArgs {
             config: args.config.clone(),
             dry_run: false,
-            output: None,
-            output_format: None,
+            json: args.json,
         };
 
         match synchronize::run(&sync_args).await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,120 +4,211 @@ mod cli;
 
 use std::path::PathBuf;
 
+use anstyle::{Ansi256Color, Color, Style};
+use clap::builder::Styles;
 use clap::{Parser, Subcommand, ValueEnum};
 use ocync_distribution::Reference;
 
-/// OCI registry sync tool.
+const PINK: Option<Color> = Some(Color::Ansi256(Ansi256Color(213)));
+const PURPLE: Option<Color> = Some(Color::Ansi256(Ansi256Color(141)));
+const CYAN: Option<Color> = Some(Color::Ansi256(Ansi256Color(75)));
+
+/// CLI help color scheme: purple headers, cyan literals, pink placeholders.
+const STYLES: Styles = Styles::styled()
+    .header(Style::new().fg_color(PURPLE).bold())
+    .usage(Style::new().fg_color(PURPLE).bold())
+    .literal(Style::new().fg_color(CYAN).bold())
+    .placeholder(Style::new().fg_color(PINK))
+    .valid(Style::new().fg_color(CYAN))
+    .invalid(Style::new().fg_color(PINK).bold())
+    .error(Style::new().fg_color(PINK).bold());
+
+const MAIN_LONG_ABOUT: &str = "\
+Sync OCI container images across registries
+
+ocync copies container images between OCI-compliant registries with blob
+deduplication, cross-repo mounts, and streaming transfers — no local disk
+required.
+
+Examples:
+  ocync sync -c config.yaml
+  ocync sync -c config.yaml --dry-run
+  ocync copy docker.io/library/nginx:1.27 ghcr.io/myorg/nginx:1.27
+  ocync tags docker.io/library/nginx --semver '>=1.0' --latest 10";
+
+const SYNC_LONG_ABOUT: &str = "\
+Sync images across registries using a config file
+
+Reads a YAML config that defines source and target registry mappings, then syncs
+all matching images. Supports glob and semver tag filtering, dry-run previews,
+and structured output.
+
+Examples:
+  ocync sync -c config.yaml
+  ocync sync -c config.yaml --dry-run
+  ocync sync -c config.yaml --json > results.json";
+
+const COPY_LONG_ABOUT: &str = "\
+Copy a single image from one registry to another
+
+Copies a single tagged image between registries. Useful for one-off transfers
+without a config file.
+
+Examples:
+  ocync copy docker.io/library/nginx:1.27 ghcr.io/myorg/nginx:1.27
+  ocync copy 123456789.dkr.ecr.us-east-1.amazonaws.com/app:v2 ghcr.io/myorg/app:v2";
+
+const TAGS_LONG_ABOUT: &str = "\
+List, filter, and sort repository tags
+
+Query a registry for available tags and apply filters. Useful for discovering
+which tags exist before configuring a sync mapping.
+
+Examples:
+  ocync tags docker.io/library/nginx
+  ocync tags docker.io/library/nginx --semver '>=1.0, <2.0' --latest 5
+  ocync tags docker.io/library/nginx --glob 'alpine*' --exclude '*beta*' --sort semver";
+
+const WATCH_LONG_ABOUT: &str = "\
+Run sync continuously on a recurring schedule
+
+Runs the sync operation in a loop at the configured interval. Handles graceful
+shutdown on SIGINT/SIGTERM.
+
+Examples:
+  ocync watch -c config.yaml
+  ocync watch -c config.yaml --interval 60";
+
+/// Sync OCI container images across registries.
 #[derive(Debug, Parser)]
-#[command(name = "ocync", version, about = "OCI registry sync tool")]
+#[command(
+    name = "ocync",
+    version,
+    about = "Sync OCI container images across registries",
+    long_about = MAIN_LONG_ABOUT,
+    styles = STYLES,
+)]
 pub(crate) struct Cli {
     /// Subcommand to execute.
     #[command(subcommand)]
     pub(crate) command: Commands,
 
-    /// Increase verbosity (-v, -vv, -vvv).
-    #[arg(short, long, action = clap::ArgAction::Count, global = true, conflicts_with = "quiet")]
+    /// Increase log verbosity (-v, -vv, -vvv).
+    #[arg(short, long, action = clap::ArgAction::Count, global = true, conflicts_with = "quiet", help_heading = "Global options")]
     pub(crate) verbose: u8,
 
-    /// Quiet mode (errors only).
-    #[arg(short, long, global = true)]
+    /// Suppress all output except errors.
+    #[arg(short, long, global = true, help_heading = "Global options")]
     pub(crate) quiet: bool,
 
-    /// Override log format.
-    #[arg(long, global = true, value_enum)]
+    /// Set the log output format (auto-detected in Kubernetes).
+    #[arg(long, global = true, value_enum, help_heading = "Global options")]
     pub(crate) log_format: Option<LogFormat>,
 }
 
 /// Log output format.
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub(crate) enum LogFormat {
-    /// Human-readable text output.
+    /// Human-readable log lines.
     Text,
-    /// Structured JSON output.
+    /// Structured JSON log entries.
     Json,
 }
 
-/// Available CLI subcommands.
+/// Available commands.
 #[derive(Debug, Subcommand)]
 pub(crate) enum Commands {
-    /// Run all mappings from config.
+    /// Sync images across registries using a config file.
+    #[command(long_about = SYNC_LONG_ABOUT)]
     Sync(SyncArgs),
-    /// Copy a single image between registries.
+
+    /// Copy a single image from one registry to another.
+    #[command(long_about = COPY_LONG_ABOUT)]
     Copy(CopyArgs),
-    /// List and filter tags.
+
+    /// List, filter, and sort repository tags.
+    #[command(long_about = TAGS_LONG_ABOUT)]
     Tags(TagsArgs),
-    /// Validate credentials.
+
+    /// Manage registry authentication.
+    #[command(long_about = "\
+Manage registry authentication
+
+Verify that credentials are valid for all registries defined in a config file.")]
     Auth {
         /// Auth subcommand.
         #[command(subcommand)]
         action: AuthAction,
     },
-    /// Offline config validation.
+
+    /// Validate a config file without connecting to registries.
+    #[command(long_about = "\
+Validate a config file without connecting to registries
+
+Checks config syntax, structure, and references without making any network
+requests. Catches errors before attempting a sync.")]
     Validate(ValidateArgs),
-    /// Show resolved config.
+
+    /// Display config with all environment variables resolved.
+    #[command(long_about = "\
+Display config with all environment variables resolved
+
+Shows the fully expanded config after variable substitution. Secrets are
+redacted by default unless --show-secrets is passed.")]
     Expand(ExpandArgs),
-    /// Daemon mode.
+
+    /// Run sync continuously on a recurring schedule.
+    #[command(long_about = WATCH_LONG_ABOUT)]
     Watch(WatchArgs),
-    /// Show version information.
+
+    /// Print version and build information.
     Version,
 }
 
 /// Arguments for the `sync` subcommand.
 #[derive(Debug, clap::Args)]
 pub(crate) struct SyncArgs {
-    /// Config file path.
+    /// Path to the sync config file.
     #[arg(short, long)]
     pub(crate) config: PathBuf,
-    /// Perform a dry run without making changes.
+    /// Preview what would be synced without making changes.
     #[arg(long)]
     pub(crate) dry_run: bool,
-    /// Write output to a file instead of stdout.
+    /// Output the full sync report as JSON instead of a text summary.
     #[arg(long)]
-    pub(crate) output: Option<PathBuf>,
-    /// Output format for sync results.
-    #[arg(long, value_enum)]
-    pub(crate) output_format: Option<OutputFormat>,
-}
-
-/// Output format for sync results.
-#[derive(Debug, Clone, Copy, ValueEnum)]
-pub(crate) enum OutputFormat {
-    /// Human-readable text output.
-    Text,
-    /// Structured JSON output.
-    Json,
+    pub(crate) json: bool,
 }
 
 /// Arguments for the `copy` subcommand.
 #[derive(Debug, clap::Args)]
 pub(crate) struct CopyArgs {
-    /// Source image reference (e.g. `docker.io/library/nginx:latest`).
+    /// Source image reference (e.g., `docker.io/library/nginx:latest`).
     pub(crate) source: Reference,
-    /// Destination image reference (e.g. `ghcr.io/myorg/nginx:latest`).
+    /// Destination image reference (e.g., `ghcr.io/myorg/nginx:latest`).
     pub(crate) destination: Reference,
 }
 
 /// Arguments for the `tags` subcommand.
 #[derive(Debug, clap::Args)]
 pub(crate) struct TagsArgs {
-    /// Repository to list tags from (e.g. `docker.io/library/nginx`).
+    /// Repository to list tags from (e.g., `docker.io/library/nginx`).
     pub(crate) repository: Reference,
-    /// Config file path for registry auth (optional).
+    /// Config file for registry credentials.
     #[arg(short, long)]
     pub(crate) config: Option<PathBuf>,
-    /// Filter tags by glob pattern (repeatable).
+    /// Include tags matching a glob pattern (repeatable).
     #[arg(long)]
     pub(crate) glob: Vec<String>,
-    /// Filter tags by semver range.
+    /// Include tags matching a semver range (e.g., `>=1.0, <2.0`).
     #[arg(long)]
     pub(crate) semver: Option<String>,
-    /// Exclude tags matching pattern (repeatable).
+    /// Exclude tags matching a pattern (repeatable).
     #[arg(long)]
     pub(crate) exclude: Vec<String>,
-    /// Sort order for results.
+    /// Sort order for listed tags.
     #[arg(long, value_enum)]
     pub(crate) sort: Option<TagSortOrder>,
-    /// Return only the N most recent tags.
+    /// Show only the N most recent tags.
     #[arg(long)]
     pub(crate) latest: Option<usize>,
 }
@@ -140,10 +231,10 @@ impl From<TagSortOrder> for ocync_sync::filter::SortOrder {
     }
 }
 
-/// Auth subcommands.
+/// Authentication subcommands.
 #[derive(Debug, Subcommand)]
 pub(crate) enum AuthAction {
-    /// Check credentials for all registries in config.
+    /// Verify credentials for all registries in config.
     Check {
         /// Config file path(s) containing registry definitions.
         #[arg(short, long, required = true)]
@@ -154,14 +245,14 @@ pub(crate) enum AuthAction {
 /// Arguments for the `validate` subcommand.
 #[derive(Debug, clap::Args)]
 pub(crate) struct ValidateArgs {
-    /// Config file path to validate.
+    /// Path to the config file to validate.
     pub(crate) config: PathBuf,
 }
 
 /// Arguments for the `expand` subcommand.
 #[derive(Debug, clap::Args)]
 pub(crate) struct ExpandArgs {
-    /// Config file path to expand.
+    /// Path to the config file to expand.
     pub(crate) config: PathBuf,
     /// Show secret values instead of redacting them.
     ///
@@ -174,12 +265,15 @@ pub(crate) struct ExpandArgs {
 /// Arguments for the `watch` subcommand.
 #[derive(Debug, clap::Args)]
 pub(crate) struct WatchArgs {
-    /// Config file path.
+    /// Path to the sync config file.
     #[arg(short, long)]
     pub(crate) config: PathBuf,
-    /// Sync interval in seconds (minimum 1).
+    /// Seconds between sync runs (minimum: 1).
     #[arg(long, default_value = "300", value_parser = clap::value_parser!(u64).range(1..))]
     pub(crate) interval: u64,
+    /// Output sync reports as JSON instead of text summaries.
+    #[arg(long)]
+    pub(crate) json: bool,
 }
 
 #[tokio::main]
@@ -234,6 +328,14 @@ mod tests {
         let cli = Cli::parse_from(["ocync", "sync", "--config", "c.yaml", "--dry-run"]);
         if let Commands::Sync(args) = cli.command {
             assert!(args.dry_run);
+        }
+    }
+
+    #[test]
+    fn parse_sync_json() {
+        let cli = Cli::parse_from(["ocync", "sync", "--config", "c.yaml", "--json"]);
+        if let Commands::Sync(args) = cli.command {
+            assert!(args.json);
         }
     }
 


### PR DESCRIPTION
## Summary

- Add pink/purple/cyan color scheme (ANSI 256: 213/141/75) to CLI help via clap `color` feature + `anstyle`
- Add `long_about` with usage examples at the top of `--help` for all commands; `-h` stays compact
- Separate global options (`--verbose`, `--quiet`, `--log-format`) under their own heading
- Clean up format flags: `--log-format` stays global for stderr logs, `--json` added to sync/watch for stdout output — no more dishonest global `--format` that most commands ignored
- Remove `--output` flag from sync (shell redirection `> file` does the same thing)
- Simplify `write_output` — no more file I/O, just prints to stdout
- Fix main description to accurately reflect current capabilities (removed "concurrent transfers" claim)
- Improve all command/argument descriptions for accuracy and clarity

## Test plan

- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` — 92 tests pass, no warnings
- [x] Verified `--help` and `-h` output for all commands (root, sync, copy, tags, auth, validate, expand, watch, version)
- [x] Confirmed `--json` flag works on sync and watch, does not appear on other commands
- [x] Confirmed `--log-format` correctly scoped to log output only