### PR TITLE
feat(sync): streaming blob transfers with chunked uploads

### DIFF
--- a/crates/ocync-distribution/src/blob.rs
+++ b/crates/ocync-distribution/src/blob.rs
@@ -1,9 +1,9 @@
 //! Blob operations — existence checks, pull, push, mount, and upload management.
 
 use bytes::Bytes;
-use futures_util::Stream;
+use futures_util::{Stream, StreamExt};
 use http::StatusCode;
-use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, LOCATION};
+use reqwest::header::{CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, HeaderValue, LOCATION};
 
 use crate::auth::Scope;
 use crate::client::{RegistryClient, build_url};
@@ -136,23 +136,8 @@ impl RegistryClient {
             return Err(Error::RegistryError { status, message });
         }
 
-        // Extract the upload URL from the Location header.
-        let upload_url = resp
-            .headers()
-            .get(LOCATION)
-            .and_then(|v| v.to_str().ok())
-            .ok_or_else(|| Error::Other("missing Location header in upload response".into()))?
-            .to_owned();
-
-        // Resolve relative Location URLs against the base URL.
-        let put_url = if upload_url.starts_with("http://") || upload_url.starts_with("https://") {
-            upload_url
-        } else {
-            self.base_url
-                .join(&upload_url)
-                .map_err(|e| Error::Other(format!("failed to resolve upload URL: {e}")))?
-                .to_string()
-        };
+        // Extract and resolve the upload URL from the Location header.
+        let put_url = extract_location(&resp, &self.base_url)?;
 
         // Step 2: PUT the data with digest query param.
         let digest_str = digest.to_string();
@@ -180,6 +165,194 @@ impl RegistryClient {
         Ok(digest)
     }
 
+    /// Push a blob to the given repository using a chunked streaming upload.
+    ///
+    /// 1. POST `/v2/{repository}/blobs/uploads/` to initiate the upload.
+    /// 2. Accumulate stream chunks into `chunk_size` buffers, issuing PATCH
+    ///    requests with `Content-Range` headers for each buffer.
+    /// 3. PUT to finalize with `?digest=` query param.
+    ///
+    /// If the computed digest does not match `expected_digest`, the upload is
+    /// deleted and [`Error::DigestMismatch`] is returned.
+    ///
+    /// **GAR fallback**: Google Artifact Registry does not support chunked
+    /// uploads, so hosts ending in `-docker.pkg.dev` buffer the entire stream
+    /// and delegate to [`blob_push`](Self::blob_push).
+    pub async fn blob_push_stream(
+        &self,
+        repository: &str,
+        expected_digest: &Digest,
+        _content_length: u64,
+        stream: impl Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
+    ) -> Result<Digest, Error> {
+        // GAR fallback: buffer entire stream and use monolithic push.
+        if self
+            .base_url
+            .host_str()
+            .is_some_and(|h| h.ends_with("-docker.pkg.dev"))
+        {
+            return self
+                .blob_push_stream_gar_fallback(repository, expected_digest, stream)
+                .await;
+        }
+
+        let url = build_url(&self.base_url, repository, "blobs/uploads/")?;
+        let _permit = self.semaphore.acquire().await.expect("semaphore closed");
+        let scopes = [Scope::pull_push(repository)];
+
+        // Step 1: Initiate upload with POST.
+        let resp = self
+            .send_with_retry(&scopes, "blob push stream initiate", |headers| {
+                self.http.post(url.clone()).headers(headers)
+            })
+            .await?;
+
+        let status = resp.status();
+        if status != StatusCode::ACCEPTED {
+            let message = resp.text().await.unwrap_or_default();
+            return Err(Error::RegistryError { status, message });
+        }
+
+        let upload_url = extract_location(&resp, &self.base_url)?;
+
+        // Step 2: Stream chunks, issuing PATCH for each chunk_size buffer.
+        let mut hasher = Sha256::new();
+        let mut buffer = Vec::with_capacity(self.chunk_size);
+        let mut current_url = upload_url;
+        let mut offset: u64 = 0;
+
+        futures_util::pin_mut!(stream);
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            hasher.update(&chunk);
+            buffer.extend_from_slice(&chunk);
+
+            if buffer.len() >= self.chunk_size {
+                let range_start = offset;
+                let range_end = offset + buffer.len() as u64 - 1;
+                offset += buffer.len() as u64;
+
+                let patch_data =
+                    std::mem::replace(&mut buffer, Vec::with_capacity(self.chunk_size));
+                current_url = self
+                    .send_patch_chunk(&scopes, &current_url, range_start, range_end, patch_data)
+                    .await?;
+            }
+        }
+
+        // Flush any remaining data in the buffer.
+        if !buffer.is_empty() {
+            let range_start = offset;
+            let range_end = offset + buffer.len() as u64 - 1;
+            current_url = self
+                .send_patch_chunk(&scopes, &current_url, range_start, range_end, buffer)
+                .await?;
+        }
+
+        // Verify digest before finalizing.
+        let hash = hasher.finalize();
+        let actual_digest = Digest::from_sha256(hash);
+        if actual_digest != *expected_digest {
+            // DELETE the upload to clean up.
+            let _ = self
+                .send_with_retry(&scopes, "blob push stream delete", |headers| {
+                    self.http.delete(&current_url).headers(headers)
+                })
+                .await;
+            return Err(Error::DigestMismatch {
+                expected: expected_digest.to_string(),
+                actual: actual_digest.to_string(),
+            });
+        }
+
+        // Step 3: PUT to finalize.
+        let digest_str = actual_digest.to_string();
+        let resp = self
+            .send_with_retry(&scopes, "blob push stream finalize", |headers| {
+                self.http
+                    .put(&current_url)
+                    .headers(headers)
+                    .query(&[("digest", &digest_str)])
+                    .header(CONTENT_LENGTH, "0")
+                    .header(
+                        CONTENT_TYPE,
+                        HeaderValue::from_static("application/octet-stream"),
+                    )
+            })
+            .await?;
+
+        let status = resp.status();
+        if status != StatusCode::CREATED {
+            let message = resp.text().await.unwrap_or_default();
+            return Err(Error::RegistryError { status, message });
+        }
+
+        Ok(actual_digest)
+    }
+
+    /// Send a PATCH chunk for a chunked upload and return the next upload URL.
+    async fn send_patch_chunk(
+        &self,
+        scopes: &[Scope],
+        upload_url: &str,
+        range_start: u64,
+        range_end: u64,
+        data: Vec<u8>,
+    ) -> Result<String, Error> {
+        let content_range = HeaderValue::from_str(&format!("{range_start}-{range_end}"))
+            .map_err(|e| Error::Other(format!("failed to build Content-Range header: {e}")))?;
+        let data_len = data.len();
+        let url = upload_url.to_owned();
+
+        let resp = self
+            .send_with_retry(scopes, "blob push stream patch", |headers| {
+                self.http
+                    .patch(&url)
+                    .headers(headers)
+                    .header(CONTENT_RANGE, content_range.clone())
+                    .header(CONTENT_LENGTH, data_len.to_string())
+                    .header(
+                        CONTENT_TYPE,
+                        HeaderValue::from_static("application/octet-stream"),
+                    )
+                    .body(data.clone())
+            })
+            .await?;
+
+        let status = resp.status();
+        if status != StatusCode::ACCEPTED {
+            let message = resp.text().await.unwrap_or_default();
+            return Err(Error::RegistryError { status, message });
+        }
+
+        extract_location(&resp, &self.base_url)
+    }
+
+    /// GAR fallback: buffer the entire stream and delegate to monolithic push.
+    async fn blob_push_stream_gar_fallback(
+        &self,
+        repository: &str,
+        expected_digest: &Digest,
+        stream: impl Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
+    ) -> Result<Digest, Error> {
+        let mut body = Vec::new();
+        futures_util::pin_mut!(stream);
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            body.extend_from_slice(&chunk);
+        }
+
+        let digest = self.blob_push(repository, &body).await?;
+        if digest != *expected_digest {
+            return Err(Error::DigestMismatch {
+                expected: expected_digest.to_string(),
+                actual: digest.to_string(),
+            });
+        }
+
+        Ok(digest)
+    }
+
     /// Delete an in-progress blob upload.
     ///
     /// Issues a DELETE to the given upload URL.
@@ -199,6 +372,24 @@ impl RegistryClient {
         }
 
         Ok(())
+    }
+}
+
+/// Extract and resolve the Location header from an upload response.
+fn extract_location(resp: &reqwest::Response, base_url: &url::Url) -> Result<String, Error> {
+    let raw = resp
+        .headers()
+        .get(LOCATION)
+        .and_then(|v| v.to_str().ok())
+        .ok_or_else(|| Error::Other("missing Location header in upload response".into()))?;
+
+    if raw.starts_with("http://") || raw.starts_with("https://") {
+        Ok(raw.to_owned())
+    } else {
+        base_url
+            .join(raw)
+            .map(|u| u.to_string())
+            .map_err(|e| Error::Other(format!("failed to resolve upload URL: {e}")))
     }
 }
 
@@ -238,5 +429,129 @@ mod tests {
             blob_path(&digest),
             "blobs/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         );
+    }
+
+    #[test]
+    fn extract_location_absolute() {
+        let resp = http::Response::builder()
+            .header("Location", "https://registry.example.com/upload/uuid-1")
+            .body("")
+            .unwrap();
+        let reqwest_resp = reqwest::Response::from(resp);
+        let base = url::Url::parse("https://registry.example.com").unwrap();
+        let result = extract_location(&reqwest_resp, &base).unwrap();
+        assert_eq!(result, "https://registry.example.com/upload/uuid-1");
+    }
+
+    #[test]
+    fn extract_location_relative() {
+        let resp = http::Response::builder()
+            .header("Location", "/v2/repo/blobs/uploads/uuid-1")
+            .body("")
+            .unwrap();
+        let reqwest_resp = reqwest::Response::from(resp);
+        let base = url::Url::parse("https://registry.example.com").unwrap();
+        let result = extract_location(&reqwest_resp, &base).unwrap();
+        assert_eq!(
+            result,
+            "https://registry.example.com/v2/repo/blobs/uploads/uuid-1"
+        );
+    }
+
+    #[test]
+    fn extract_location_missing() {
+        let resp = http::Response::builder().body("").unwrap();
+        let reqwest_resp = reqwest::Response::from(resp);
+        let base = url::Url::parse("https://registry.example.com").unwrap();
+        let result = extract_location(&reqwest_resp, &base);
+        assert!(result.is_err());
+    }
+
+    /// Build a `RegistryClient` with a GAR hostname resolving to a local port.
+    fn build_gar_client(port: u16) -> RegistryClient {
+        let base_url = url::Url::parse(&format!("http://us-docker.pkg.dev:{port}")).unwrap();
+        let http = reqwest::Client::builder()
+            .resolve(
+                "us-docker.pkg.dev",
+                std::net::SocketAddr::from(([127, 0, 0, 1], port)),
+            )
+            .build()
+            .unwrap();
+
+        RegistryClient {
+            base_url,
+            http,
+            auth: None,
+            semaphore: tokio::sync::Semaphore::new(8),
+            chunk_size: 4,
+        }
+    }
+
+    fn test_digest(data: &[u8]) -> Digest {
+        Digest::from_sha256(Sha256::digest(data))
+    }
+
+    fn data_stream(
+        data: &[u8],
+        chunk_size: usize,
+    ) -> impl Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static {
+        let chunks: Vec<Result<Bytes, reqwest::Error>> = data
+            .chunks(chunk_size)
+            .map(|c| Ok(Bytes::copy_from_slice(c)))
+            .collect();
+        futures_util::stream::iter(chunks)
+    }
+
+    #[tokio::test]
+    async fn blob_push_stream_gar_uses_monolithic_upload() {
+        let server = wiremock::MockServer::start().await;
+        let data = b"gar blob content";
+        let digest = test_digest(data);
+        let port = url::Url::parse(&server.uri()).unwrap().port().unwrap();
+
+        // POST: initiate monolithic upload.
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/v2/my-project/my-repo/blobs/uploads/",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(202)
+                    .append_header("Location", "/v2/my-project/my-repo/blobs/uploads/gar-uuid"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // PUT: monolithic upload with full body.
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::query_param(
+                "digest",
+                digest.to_string(),
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(201))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // PATCH: must NOT be called for GAR.
+        wiremock::Mock::given(wiremock::matchers::method("PATCH"))
+            .respond_with(wiremock::ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let client = build_gar_client(port);
+
+        let result = client
+            .blob_push_stream(
+                "my-project/my-repo",
+                &digest,
+                data.len() as u64,
+                data_stream(data, 4),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result, digest);
     }
 }

--- a/crates/ocync-distribution/src/blob.rs
+++ b/crates/ocync-distribution/src/blob.rs
@@ -55,18 +55,6 @@ impl RegistryClient {
         }
     }
 
-    /// Pull a blob and return the complete bytes.
-    ///
-    /// Issues a GET request to `/v2/{repository}/blobs/{digest}` and returns
-    /// the full response body as a `Vec<u8>`. For large blobs, prefer
-    /// [`blob_pull`](Self::blob_pull) which returns a streaming response.
-    pub async fn blob_pull_all(&self, repository: &str, digest: &Digest) -> Result<Vec<u8>, Error> {
-        let path = blob_path(digest);
-        let resp = self.get(repository, &path, None).await?;
-        let bytes = resp.bytes().await?;
-        Ok(bytes.into())
-    }
-
     /// Pull a blob as a streaming response.
     ///
     /// Issues a GET request to `/v2/{repository}/blobs/{digest}` and returns

--- a/crates/ocync-distribution/src/blob.rs
+++ b/crates/ocync-distribution/src/blob.rs
@@ -159,10 +159,8 @@ impl RegistryClient {
     /// 1. POST `/v2/{repository}/blobs/uploads/` to initiate the upload.
     /// 2. Accumulate stream chunks into `chunk_size` buffers, issuing PATCH
     ///    requests with `Content-Range` headers for each buffer.
-    /// 3. PUT to finalize with `?digest=` query param.
-    ///
-    /// If the computed digest does not match `expected_digest`, the upload is
-    /// deleted and [`Error::DigestMismatch`] is returned.
+    /// 3. PUT to finalize with `?digest=` query param — the registry verifies
+    ///    the uploaded content matches the digest.
     ///
     /// **GAR fallback**: Google Artifact Registry does not support chunked
     /// uploads, so hosts ending in `-docker.pkg.dev` buffer the entire stream
@@ -213,7 +211,6 @@ impl RegistryClient {
         let upload_url = extract_location(&resp, &self.base_url)?;
 
         // Step 2: Stream chunks, issuing PATCH for each chunk_size buffer.
-        let mut hasher = Sha256::new();
         let mut buffer = Vec::with_capacity(self.chunk_size);
         let mut current_url = upload_url;
         let mut offset: u64 = 0;
@@ -221,7 +218,6 @@ impl RegistryClient {
         futures_util::pin_mut!(stream);
         while let Some(chunk) = stream.next().await {
             let chunk = chunk?;
-            hasher.update(&chunk);
             buffer.extend_from_slice(&chunk);
 
             if buffer.len() >= self.chunk_size {
@@ -246,24 +242,8 @@ impl RegistryClient {
                 .await?;
         }
 
-        // Verify digest before finalizing.
-        let hash = hasher.finalize();
-        let actual_digest = Digest::from_sha256(hash);
-        if actual_digest != *expected_digest {
-            // DELETE the upload to clean up.
-            let _ = self
-                .send_with_retry(&scopes, "blob push stream delete", |headers| {
-                    self.http.delete(&current_url).headers(headers)
-                })
-                .await;
-            return Err(Error::DigestMismatch {
-                expected: expected_digest.to_string(),
-                actual: actual_digest.to_string(),
-            });
-        }
-
-        // Step 3: PUT to finalize.
-        let digest_str = actual_digest.to_string();
+        // Step 3: PUT to finalize — the registry verifies the digest.
+        let digest_str = expected_digest.to_string();
         let resp = self
             .send_with_retry(&scopes, "blob push stream finalize", |headers| {
                 self.http
@@ -284,7 +264,7 @@ impl RegistryClient {
             return Err(Error::RegistryError { status, message });
         }
 
-        Ok(actual_digest)
+        Ok(expected_digest.clone())
     }
 
     /// Send a PATCH chunk for a chunked upload and return the next upload URL.
@@ -335,7 +315,7 @@ impl RegistryClient {
     async fn blob_push_stream_gar_fallback(
         &self,
         repository: &str,
-        expected_digest: &Digest,
+        _expected_digest: &Digest,
         stream: impl Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
     ) -> Result<Digest, Error> {
         warn!(
@@ -350,15 +330,7 @@ impl RegistryClient {
             body.extend_from_slice(&chunk);
         }
 
-        let digest = self.blob_push(repository, &body).await?;
-        if digest != *expected_digest {
-            return Err(Error::DigestMismatch {
-                expected: expected_digest.to_string(),
-                actual: digest.to_string(),
-            });
-        }
-
-        Ok(digest)
+        self.blob_push(repository, &body).await
     }
 
     /// Delete an in-progress blob upload.

--- a/crates/ocync-distribution/src/blob.rs
+++ b/crates/ocync-distribution/src/blob.rs
@@ -169,7 +169,6 @@ impl RegistryClient {
         &self,
         repository: &str,
         expected_digest: &Digest,
-        content_length: u64,
         stream: impl Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
     ) -> Result<Digest, Error> {
         // GAR fallback: buffer entire stream and use monolithic push.
@@ -186,7 +185,6 @@ impl RegistryClient {
         debug!(
             repository,
             %expected_digest,
-            content_length,
             chunk_size = self.chunk_size,
             "starting chunked blob upload"
         );
@@ -225,10 +223,10 @@ impl RegistryClient {
                 let range_end = offset + buffer.len() as u64 - 1;
                 offset += buffer.len() as u64;
 
-                let patch_data =
+                let patch_chunk =
                     std::mem::replace(&mut buffer, Vec::with_capacity(self.chunk_size));
                 current_url = self
-                    .send_patch_chunk(&scopes, &current_url, range_start, range_end, patch_data)
+                    .send_patch_chunk(&scopes, &current_url, range_start, range_end, patch_chunk)
                     .await?;
             }
         }
@@ -274,15 +272,15 @@ impl RegistryClient {
         upload_url: &str,
         range_start: u64,
         range_end: u64,
-        data: Vec<u8>,
+        chunk: Vec<u8>,
     ) -> Result<String, Error> {
         let content_range = HeaderValue::from_str(&format!("{range_start}-{range_end}"))
             .map_err(|e| Error::Other(format!("failed to build Content-Range header: {e}")))?;
-        let data_len = data.len();
+        let chunk_len = chunk.len();
         let url = upload_url.to_owned();
         // Convert to Bytes so .clone() in the retry closure is a cheap
         // reference-count increment instead of a full memcpy per chunk.
-        let data = Bytes::from(data);
+        let chunk = Bytes::from(chunk);
 
         let resp = self
             .send_with_retry(scopes, "blob push stream patch", |headers| {
@@ -290,12 +288,12 @@ impl RegistryClient {
                     .patch(&url)
                     .headers(headers)
                     .header(CONTENT_RANGE, content_range.clone())
-                    .header(CONTENT_LENGTH, data_len.to_string())
+                    .header(CONTENT_LENGTH, chunk_len.to_string())
                     .header(
                         CONTENT_TYPE,
                         HeaderValue::from_static("application/octet-stream"),
                     )
-                    .body(data.clone())
+                    .body(chunk.clone())
             })
             .await?;
 
@@ -312,10 +310,12 @@ impl RegistryClient {
     ///
     /// Google Artifact Registry does not support chunked uploads, so the
     /// entire stream is buffered in memory and sent as a monolithic upload.
+    /// The digest returned by the monolithic push is verified against the
+    /// caller's expected digest to catch data corruption.
     async fn blob_push_stream_gar_fallback(
         &self,
         repository: &str,
-        _expected_digest: &Digest,
+        expected_digest: &Digest,
         stream: impl Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
     ) -> Result<Digest, Error> {
         warn!(
@@ -330,7 +330,15 @@ impl RegistryClient {
             body.extend_from_slice(&chunk);
         }
 
-        self.blob_push(repository, &body).await
+        let actual_digest = self.blob_push(repository, &body).await?;
+
+        if &actual_digest != expected_digest {
+            return Err(Error::Other(format!(
+                "GAR fallback digest mismatch: expected {expected_digest}, got {actual_digest}"
+            )));
+        }
+
+        Ok(actual_digest)
     }
 
     /// Delete an in-progress blob upload.
@@ -447,6 +455,24 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[test]
+    fn extract_location_preserves_query_params() {
+        let resp = http::Response::builder()
+            .header(
+                "Location",
+                "/v2/repo/blobs/uploads/uuid-1?_state=token123&foo=bar",
+            )
+            .body("")
+            .unwrap();
+        let reqwest_resp = reqwest::Response::from(resp);
+        let base = url::Url::parse("https://registry.example.com").unwrap();
+        let result = extract_location(&reqwest_resp, &base).unwrap();
+        assert_eq!(
+            result,
+            "https://registry.example.com/v2/repo/blobs/uploads/uuid-1?_state=token123&foo=bar"
+        );
+    }
+
     /// Build a `RegistryClient` with a GAR hostname resolving to a local port.
     fn build_gar_client(port: u16) -> RegistryClient {
         let base_url = url::Url::parse(&format!("http://us-docker.pkg.dev:{port}")).unwrap();
@@ -523,12 +549,7 @@ mod tests {
         let client = build_gar_client(port);
 
         let result = client
-            .blob_push_stream(
-                "my-project/my-repo",
-                &digest,
-                data.len() as u64,
-                data_stream(data, 4),
-            )
+            .blob_push_stream("my-project/my-repo", &digest, data_stream(data, 4))
             .await
             .unwrap();
 

--- a/crates/ocync-distribution/src/blob.rs
+++ b/crates/ocync-distribution/src/blob.rs
@@ -75,7 +75,7 @@ impl RegistryClient {
         &self,
         repository: &str,
         digest: &Digest,
-    ) -> Result<impl Stream<Item = Result<Bytes, reqwest::Error>>, Error> {
+    ) -> Result<impl Stream<Item = Result<Bytes, reqwest::Error>> + 'static, Error> {
         let path = blob_path(digest);
         let resp = self.get(repository, &path, None).await?;
         Ok(resp.bytes_stream())

--- a/crates/ocync-distribution/src/blob.rs
+++ b/crates/ocync-distribution/src/blob.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 use futures_util::{Stream, StreamExt};
 use http::StatusCode;
 use reqwest::header::{CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, HeaderValue, LOCATION};
+use tracing::{debug, warn};
 
 use crate::auth::Scope;
 use crate::client::{RegistryClient, build_url};
@@ -182,7 +183,7 @@ impl RegistryClient {
         &self,
         repository: &str,
         expected_digest: &Digest,
-        _content_length: u64,
+        content_length: u64,
         stream: impl Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
     ) -> Result<Digest, Error> {
         // GAR fallback: buffer entire stream and use monolithic push.
@@ -195,6 +196,14 @@ impl RegistryClient {
                 .blob_push_stream_gar_fallback(repository, expected_digest, stream)
                 .await;
         }
+
+        debug!(
+            repository,
+            %expected_digest,
+            content_length,
+            chunk_size = self.chunk_size,
+            "starting chunked blob upload"
+        );
 
         let url = build_url(&self.base_url, repository, "blobs/uploads/")?;
         let _permit = self.semaphore.acquire().await.expect("semaphore closed");
@@ -303,6 +312,9 @@ impl RegistryClient {
             .map_err(|e| Error::Other(format!("failed to build Content-Range header: {e}")))?;
         let data_len = data.len();
         let url = upload_url.to_owned();
+        // Convert to Bytes so .clone() in the retry closure is a cheap
+        // reference-count increment instead of a full memcpy per chunk.
+        let data = Bytes::from(data);
 
         let resp = self
             .send_with_retry(scopes, "blob push stream patch", |headers| {
@@ -329,12 +341,20 @@ impl RegistryClient {
     }
 
     /// GAR fallback: buffer the entire stream and delegate to monolithic push.
+    ///
+    /// Google Artifact Registry does not support chunked uploads, so the
+    /// entire stream is buffered in memory and sent as a monolithic upload.
     async fn blob_push_stream_gar_fallback(
         &self,
         repository: &str,
         expected_digest: &Digest,
         stream: impl Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
     ) -> Result<Digest, Error> {
+        warn!(
+            repository,
+            host = self.base_url.host_str().unwrap_or("unknown"),
+            "GAR does not support chunked uploads; buffering entire blob in memory"
+        );
         let mut body = Vec::new();
         futures_util::pin_mut!(stream);
         while let Some(chunk) = stream.next().await {

--- a/crates/ocync-distribution/tests/blob_push_stream.rs
+++ b/crates/ocync-distribution/tests/blob_push_stream.rs
@@ -1,0 +1,281 @@
+//! Integration tests for `blob_push_stream` — chunked streaming uploads.
+
+use bytes::Bytes;
+use futures_util::stream;
+use http::StatusCode;
+use ocync_distribution::client::RegistryClientBuilder;
+use ocync_distribution::{Digest, Error};
+use url::Url;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+/// Compute the SHA-256 digest for test data.
+fn test_digest(data: &[u8]) -> Digest {
+    let hash = ocync_distribution::sha256::Sha256::digest(data);
+    Digest::from_sha256(hash)
+}
+
+/// Build a stream of `Bytes` from raw data, split into the given chunk size.
+fn data_stream(
+    data: &[u8],
+    chunk_size: usize,
+) -> impl futures_util::Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static {
+    let chunks: Vec<Result<Bytes, reqwest::Error>> = data
+        .chunks(chunk_size)
+        .map(|c| Ok(Bytes::copy_from_slice(c)))
+        .collect();
+    stream::iter(chunks)
+}
+
+fn mock_base_url(server: &MockServer) -> Url {
+    Url::parse(&server.uri()).unwrap()
+}
+
+/// Custom matcher for Content-Range header values.
+struct ContentRangeMatcher {
+    expected: String,
+}
+
+impl ContentRangeMatcher {
+    fn new(expected: &str) -> Self {
+        Self {
+            expected: expected.to_owned(),
+        }
+    }
+}
+
+impl wiremock::Match for ContentRangeMatcher {
+    fn matches(&self, request: &Request) -> bool {
+        request
+            .headers
+            .get(http::header::CONTENT_RANGE)
+            .and_then(|v| v.to_str().ok())
+            .map_or(false, |v| v == self.expected)
+    }
+}
+
+// ─── Happy path: POST → PATCH → PUT ────────────────────────────────────────
+
+#[tokio::test]
+async fn happy_path() {
+    let server = MockServer::start().await;
+    let data = b"hello world!";
+    let digest = test_digest(data);
+    let upload_path = "/v2/myrepo/blobs/uploads/test-uuid";
+
+    // POST: initiate upload.
+    Mock::given(method("POST"))
+        .and(path("/v2/myrepo/blobs/uploads/"))
+        .respond_with(
+            ResponseTemplate::new(StatusCode::ACCEPTED).append_header("Location", upload_path),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // PATCH: single chunk (data fits in one chunk_size=64 buffer).
+    let patch_next = format!("{upload_path}?after-patch");
+    Mock::given(method("PATCH"))
+        .and(path(upload_path))
+        .and(ContentRangeMatcher::new("0-11"))
+        .respond_with(
+            ResponseTemplate::new(StatusCode::ACCEPTED)
+                .append_header("Location", patch_next.as_str()),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // PUT: finalize with digest query param.
+    Mock::given(method("PUT"))
+        .and(query_param("digest", digest.to_string()))
+        .respond_with(ResponseTemplate::new(StatusCode::CREATED))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .chunk_size(64)
+        .build()
+        .unwrap();
+
+    let result = client
+        .blob_push_stream("myrepo", &digest, data.len() as u64, data_stream(data, 4))
+        .await
+        .unwrap();
+
+    assert_eq!(result, digest);
+}
+
+// ─── Multi-chunk: small chunk_size produces multiple PATCHes ────────────────
+
+#[tokio::test]
+async fn multi_chunk() {
+    let server = MockServer::start().await;
+    let data = b"abcdefghijkl"; // 12 bytes
+    let digest = test_digest(data);
+
+    // chunk_size=4, stream chunk=2 → buffer accumulates to 4 before each PATCH.
+    // Expected: 3 PATCH requests with ranges 0-3, 4-7, 8-11.
+    let upload_path = "/v2/repo/blobs/uploads/uuid-1";
+
+    // POST: initiate.
+    Mock::given(method("POST"))
+        .and(path("/v2/repo/blobs/uploads/"))
+        .respond_with(
+            ResponseTemplate::new(StatusCode::ACCEPTED).append_header("Location", upload_path),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // PATCH 1: bytes 0-3.
+    Mock::given(method("PATCH"))
+        .and(ContentRangeMatcher::new("0-3"))
+        .respond_with(
+            ResponseTemplate::new(StatusCode::ACCEPTED)
+                .append_header("Location", "/v2/repo/blobs/uploads/uuid-2"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // PATCH 2: bytes 4-7.
+    Mock::given(method("PATCH"))
+        .and(ContentRangeMatcher::new("4-7"))
+        .respond_with(
+            ResponseTemplate::new(StatusCode::ACCEPTED)
+                .append_header("Location", "/v2/repo/blobs/uploads/uuid-3"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // PATCH 3: bytes 8-11.
+    Mock::given(method("PATCH"))
+        .and(ContentRangeMatcher::new("8-11"))
+        .respond_with(
+            ResponseTemplate::new(StatusCode::ACCEPTED)
+                .append_header("Location", "/v2/repo/blobs/uploads/uuid-4"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // PUT: finalize.
+    Mock::given(method("PUT"))
+        .and(query_param("digest", digest.to_string()))
+        .respond_with(ResponseTemplate::new(StatusCode::CREATED))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .chunk_size(4)
+        .build()
+        .unwrap();
+
+    let result = client
+        .blob_push_stream("repo", &digest, data.len() as u64, data_stream(data, 2))
+        .await
+        .unwrap();
+
+    assert_eq!(result, digest);
+}
+
+// ─── Digest mismatch: DELETE and error ──────────────────────────────────────
+
+#[tokio::test]
+async fn digest_mismatch() {
+    let server = MockServer::start().await;
+    let data = b"actual data";
+    let wrong_digest: Digest =
+        "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+    let upload_path = "/v2/myrepo/blobs/uploads/uuid-mismatch";
+
+    // POST: initiate.
+    Mock::given(method("POST"))
+        .and(path("/v2/myrepo/blobs/uploads/"))
+        .respond_with(
+            ResponseTemplate::new(StatusCode::ACCEPTED).append_header("Location", upload_path),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // PATCH: accept data.
+    let patched_path = format!("{upload_path}?patched");
+    Mock::given(method("PATCH"))
+        .respond_with(
+            ResponseTemplate::new(StatusCode::ACCEPTED)
+                .append_header("Location", patched_path.as_str()),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // DELETE: cleanup after mismatch.
+    Mock::given(method("DELETE"))
+        .respond_with(ResponseTemplate::new(StatusCode::NO_CONTENT))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .chunk_size(256)
+        .build()
+        .unwrap();
+
+    let err = client
+        .blob_push_stream(
+            "myrepo",
+            &wrong_digest,
+            data.len() as u64,
+            data_stream(data, 4),
+        )
+        .await
+        .unwrap_err();
+
+    match err {
+        Error::DigestMismatch { expected, actual } => {
+            assert_eq!(expected, wrong_digest.to_string());
+            let real_digest = test_digest(data);
+            assert_eq!(actual, real_digest.to_string());
+        }
+        other => panic!("expected DigestMismatch, got: {other}"),
+    }
+}
+
+/// Verify GAR hostname detection matches the expected pattern.
+#[test]
+fn gar_hostname_detection() {
+    let gar_hosts = [
+        "us-docker.pkg.dev",
+        "europe-docker.pkg.dev",
+        "asia-docker.pkg.dev",
+        "us-central1-docker.pkg.dev",
+    ];
+    for host in gar_hosts {
+        assert!(
+            host.ends_with("-docker.pkg.dev"),
+            "{host} should match GAR pattern"
+        );
+    }
+
+    let non_gar_hosts = [
+        "docker.io",
+        "ghcr.io",
+        "registry-1.docker.io",
+        "docker.pkg.dev",
+        "pkg.dev",
+        "127.0.0.1",
+    ];
+    for host in non_gar_hosts {
+        assert!(
+            !host.ends_with("-docker.pkg.dev"),
+            "{host} should NOT match GAR pattern"
+        );
+    }
+}

--- a/crates/ocync-distribution/tests/blob_push_stream.rs
+++ b/crates/ocync-distribution/tests/blob_push_stream.rs
@@ -6,7 +6,7 @@ use http::StatusCode;
 use ocync_distribution::Digest;
 use ocync_distribution::client::RegistryClientBuilder;
 use url::Url;
-use wiremock::matchers::{method, path, query_param};
+use wiremock::matchers::{header, method, path, query_param};
 use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
 /// Compute the SHA-256 digest for test data.
@@ -78,6 +78,8 @@ async fn happy_path() {
     Mock::given(method("PATCH"))
         .and(path(upload_path))
         .and(ContentRangeMatcher::new("0-11"))
+        .and(header("content-type", "application/octet-stream"))
+        .and(header("content-length", "12"))
         .respond_with(
             ResponseTemplate::new(StatusCode::ACCEPTED)
                 .append_header("Location", patch_next.as_str()),
@@ -86,9 +88,11 @@ async fn happy_path() {
         .mount(&server)
         .await;
 
-    // PUT: finalize with digest query param.
+    // PUT: finalize with digest query param, Content-Length: 0.
     Mock::given(method("PUT"))
         .and(query_param("digest", digest.to_string()))
+        .and(header("content-type", "application/octet-stream"))
+        .and(header("content-length", "0"))
         .respond_with(ResponseTemplate::new(StatusCode::CREATED))
         .expect(1)
         .mount(&server)
@@ -100,7 +104,7 @@ async fn happy_path() {
         .unwrap();
 
     let result = client
-        .blob_push_stream("myrepo", &digest, data.len() as u64, data_stream(data, 4))
+        .blob_push_stream("myrepo", &digest, data_stream(data, 4))
         .await
         .unwrap();
 
@@ -176,11 +180,309 @@ async fn multi_chunk() {
         .unwrap();
 
     let result = client
-        .blob_push_stream("repo", &digest, data.len() as u64, data_stream(data, 2))
+        .blob_push_stream("repo", &digest, data_stream(data, 2))
         .await
         .unwrap();
 
     assert_eq!(result, digest);
+}
+
+// ─── Exact chunk boundary: data_len == chunk_size, no remainder flush ────────
+
+#[tokio::test]
+async fn exact_chunk_boundary() {
+    let server = MockServer::start().await;
+    let data = b"abcd"; // 4 bytes == chunk_size
+    let digest = test_digest(data);
+    let upload_path = "/v2/repo/blobs/uploads/uuid-1";
+
+    Mock::given(method("POST"))
+        .and(path("/v2/repo/blobs/uploads/"))
+        .respond_with(
+            ResponseTemplate::new(StatusCode::ACCEPTED).append_header("Location", upload_path),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Single PATCH: bytes 0-3, no remainder flush.
+    Mock::given(method("PATCH"))
+        .and(ContentRangeMatcher::new("0-3"))
+        .respond_with(
+            ResponseTemplate::new(StatusCode::ACCEPTED)
+                .append_header("Location", "/v2/repo/blobs/uploads/uuid-2"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("PUT"))
+        .and(query_param("digest", digest.to_string()))
+        .respond_with(ResponseTemplate::new(StatusCode::CREATED))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .chunk_size(4)
+        .build()
+        .unwrap();
+
+    let result = client
+        .blob_push_stream("repo", &digest, data_stream(data, 4))
+        .await
+        .unwrap();
+
+    assert_eq!(result, digest);
+}
+
+// ─── Empty stream: zero-byte blob, POST + PUT only, no PATCH ────────────────
+
+#[tokio::test]
+async fn empty_stream() {
+    let server = MockServer::start().await;
+    let data = b"";
+    let digest = test_digest(data);
+
+    Mock::given(method("POST"))
+        .and(path("/v2/repo/blobs/uploads/"))
+        .respond_with(
+            ResponseTemplate::new(StatusCode::ACCEPTED)
+                .append_header("Location", "/v2/repo/blobs/uploads/uuid-1"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // PATCH must NOT be called for empty data.
+    Mock::given(method("PATCH"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("PUT"))
+        .and(query_param("digest", digest.to_string()))
+        .respond_with(ResponseTemplate::new(StatusCode::CREATED))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .chunk_size(64)
+        .build()
+        .unwrap();
+
+    let result = client
+        .blob_push_stream("repo", &digest, data_stream(data, 1))
+        .await
+        .unwrap();
+
+    assert_eq!(result, digest);
+}
+
+// ─── Error: POST initiation returns 403 ─────────────────────────────────────
+
+#[tokio::test]
+async fn post_initiation_rejected() {
+    let server = MockServer::start().await;
+    let data = b"some data";
+    let digest = test_digest(data);
+
+    Mock::given(method("POST"))
+        .and(path("/v2/repo/blobs/uploads/"))
+        .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .chunk_size(64)
+        .build()
+        .unwrap();
+
+    let err = client
+        .blob_push_stream("repo", &digest, data_stream(data, 4))
+        .await
+        .unwrap_err();
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("403") || msg.contains("forbidden"),
+        "expected 403 error: {msg}"
+    );
+}
+
+// ─── Error: PATCH chunk fails mid-upload ────────────────────────────────────
+
+#[tokio::test]
+async fn patch_chunk_failure() {
+    let server = MockServer::start().await;
+    let data = b"abcdefgh"; // 8 bytes, chunk_size=4 → 2 PATCHes
+    let digest = test_digest(data);
+    let upload_path = "/v2/repo/blobs/uploads/uuid-1";
+
+    Mock::given(method("POST"))
+        .and(path("/v2/repo/blobs/uploads/"))
+        .respond_with(
+            ResponseTemplate::new(StatusCode::ACCEPTED).append_header("Location", upload_path),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // First PATCH succeeds.
+    Mock::given(method("PATCH"))
+        .and(ContentRangeMatcher::new("0-3"))
+        .respond_with(
+            ResponseTemplate::new(StatusCode::ACCEPTED)
+                .append_header("Location", "/v2/repo/blobs/uploads/uuid-2"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Second PATCH returns 500.
+    Mock::given(method("PATCH"))
+        .and(ContentRangeMatcher::new("4-7"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("internal error"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .chunk_size(4)
+        .build()
+        .unwrap();
+
+    let err = client
+        .blob_push_stream("repo", &digest, data_stream(data, 4))
+        .await
+        .unwrap_err();
+
+    let msg = err.to_string();
+    assert!(msg.contains("500"), "expected 500 error: {msg}");
+}
+
+// ─── Error: PUT finalize rejected by registry ───────────────────────────────
+
+#[tokio::test]
+async fn put_finalize_rejected() {
+    let server = MockServer::start().await;
+    let data = b"payload";
+    let digest = test_digest(data);
+    let upload_path = "/v2/repo/blobs/uploads/uuid-1";
+
+    Mock::given(method("POST"))
+        .and(path("/v2/repo/blobs/uploads/"))
+        .respond_with(
+            ResponseTemplate::new(StatusCode::ACCEPTED).append_header("Location", upload_path),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("PATCH"))
+        .respond_with(
+            ResponseTemplate::new(StatusCode::ACCEPTED)
+                .append_header("Location", "/v2/repo/blobs/uploads/uuid-2"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // PUT: registry rejects the finalization (e.g., digest mismatch).
+    Mock::given(method("PUT"))
+        .respond_with(ResponseTemplate::new(400).set_body_string("digest invalid"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .chunk_size(64)
+        .build()
+        .unwrap();
+
+    let err = client
+        .blob_push_stream("repo", &digest, data_stream(data, 4))
+        .await
+        .unwrap_err();
+
+    let msg = err.to_string();
+    assert!(msg.contains("400"), "expected 400 error: {msg}");
+}
+
+// ─── Error: source stream yields an error ───────────────────────────────────
+
+#[tokio::test]
+async fn stream_error_propagates() {
+    let server = MockServer::start().await;
+    let data = b"test";
+    let digest = test_digest(data);
+    let upload_path = "/v2/repo/blobs/uploads/uuid-1";
+
+    Mock::given(method("POST"))
+        .and(path("/v2/repo/blobs/uploads/"))
+        .respond_with(
+            ResponseTemplate::new(StatusCode::ACCEPTED).append_header("Location", upload_path),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Build a stream that yields one chunk then an error.
+    let error_stream = stream::iter(vec![
+        Ok(Bytes::from_static(b"ok")),
+        Err(reqwest::Client::new()
+            .get("http://[::0]:1") // unreachable address
+            .send()
+            .await
+            .unwrap_err()),
+    ]);
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .chunk_size(64)
+        .build()
+        .unwrap();
+
+    let result = client.blob_push_stream("repo", &digest, error_stream).await;
+
+    assert!(result.is_err(), "stream error should propagate");
+}
+
+// ─── Error: POST returns 200 instead of expected 202 ────────────────────────
+
+#[tokio::test]
+async fn post_returns_200_is_rejected() {
+    let server = MockServer::start().await;
+    let data = b"data";
+    let digest = test_digest(data);
+
+    // POST returns 200 OK instead of 202 Accepted — some registries do this.
+    Mock::given(method("POST"))
+        .and(path("/v2/repo/blobs/uploads/"))
+        .respond_with(
+            ResponseTemplate::new(200).append_header("Location", "/v2/repo/blobs/uploads/uuid-1"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .chunk_size(64)
+        .build()
+        .unwrap();
+
+    let err = client
+        .blob_push_stream("repo", &digest, data_stream(data, 4))
+        .await
+        .unwrap_err();
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("200"),
+        "should reject 200 as unexpected status: {msg}"
+    );
 }
 
 /// Verify GAR hostname detection matches the expected pattern.

--- a/crates/ocync-distribution/tests/blob_push_stream.rs
+++ b/crates/ocync-distribution/tests/blob_push_stream.rs
@@ -3,8 +3,8 @@
 use bytes::Bytes;
 use futures_util::stream;
 use http::StatusCode;
+use ocync_distribution::Digest;
 use ocync_distribution::client::RegistryClientBuilder;
-use ocync_distribution::{Digest, Error};
 use url::Url;
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, Request, ResponseTemplate};
@@ -181,71 +181,6 @@ async fn multi_chunk() {
         .unwrap();
 
     assert_eq!(result, digest);
-}
-
-// ─── Digest mismatch: DELETE and error ──────────────────────────────────────
-
-#[tokio::test]
-async fn digest_mismatch() {
-    let server = MockServer::start().await;
-    let data = b"actual data";
-    let wrong_digest: Digest =
-        "sha256:0000000000000000000000000000000000000000000000000000000000000000"
-            .parse()
-            .unwrap();
-    let upload_path = "/v2/myrepo/blobs/uploads/uuid-mismatch";
-
-    // POST: initiate.
-    Mock::given(method("POST"))
-        .and(path("/v2/myrepo/blobs/uploads/"))
-        .respond_with(
-            ResponseTemplate::new(StatusCode::ACCEPTED).append_header("Location", upload_path),
-        )
-        .expect(1)
-        .mount(&server)
-        .await;
-
-    // PATCH: accept data.
-    let patched_path = format!("{upload_path}?patched");
-    Mock::given(method("PATCH"))
-        .respond_with(
-            ResponseTemplate::new(StatusCode::ACCEPTED)
-                .append_header("Location", patched_path.as_str()),
-        )
-        .expect(1)
-        .mount(&server)
-        .await;
-
-    // DELETE: cleanup after mismatch.
-    Mock::given(method("DELETE"))
-        .respond_with(ResponseTemplate::new(StatusCode::NO_CONTENT))
-        .expect(1)
-        .mount(&server)
-        .await;
-
-    let client = RegistryClientBuilder::new(mock_base_url(&server))
-        .chunk_size(256)
-        .build()
-        .unwrap();
-
-    let err = client
-        .blob_push_stream(
-            "myrepo",
-            &wrong_digest,
-            data.len() as u64,
-            data_stream(data, 4),
-        )
-        .await
-        .unwrap_err();
-
-    match err {
-        Error::DigestMismatch { expected, actual } => {
-            assert_eq!(expected, wrong_digest.to_string());
-            let real_digest = test_digest(data);
-            assert_eq!(actual, real_digest.to_string());
-        }
-        other => panic!("expected DigestMismatch, got: {other}"),
-    }
 }
 
 /// Verify GAR hostname detection matches the expected pattern.

--- a/crates/ocync-distribution/tests/blob_push_stream.rs
+++ b/crates/ocync-distribution/tests/blob_push_stream.rs
@@ -50,7 +50,7 @@ impl wiremock::Match for ContentRangeMatcher {
             .headers
             .get(http::header::CONTENT_RANGE)
             .and_then(|v| v.to_str().ok())
-            .map_or(false, |v| v == self.expected)
+            .is_some_and(|v| v == self.expected)
     }
 }
 

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -318,34 +318,9 @@ impl SyncEngine {
         // Phase 2: Fan-out blob transfer — pull each blob once, push to all active targets.
         let active_targets: Vec<&Endpoint<'_>> = active.iter().map(|&(i, _)| &targets[i]).collect();
 
-        let blob_results = match self
+        let blob_results = self
             .transfer_blobs_fanout(source, &active_targets, &all_blobs)
-            .await
-        {
-            Ok(results) => results,
-            Err(err) => {
-                // Source blob pull failed — all active targets fail.
-                let error_str = err.to_string();
-                for &(i, start) in &active {
-                    let target = &targets[i];
-                    let result = ImageResult {
-                        image_id: Uuid::now_v7(),
-                        source: format!("{}:{source_tag}", source.repo),
-                        target: format!("{}:{target_tag}", target.repo),
-                        status: ImageStatus::Failed {
-                            error: error_str.clone(),
-                            retries: self.retry.max_retries,
-                        },
-                        bytes_transferred: 0,
-                        blob_stats: BlobTransferStats::default(),
-                        duration: start.elapsed(),
-                    };
-                    progress.image_completed(&result);
-                    images.push(result);
-                }
-                return;
-            }
-        };
+            .await;
 
         // Phase 3: Push manifests to targets whose blobs all succeeded.
         for (br, &(i, start)) in blob_results.into_iter().zip(active.iter()) {
@@ -528,7 +503,7 @@ impl SyncEngine {
         source: &Endpoint<'_>,
         targets: &[&Endpoint<'_>],
         blobs: &[(&Digest, u64)],
-    ) -> Result<Vec<BlobTransferResult>, crate::Error> {
+    ) -> Vec<BlobTransferResult> {
         let mut results: Vec<BlobTransferResult> = targets
             .iter()
             .map(|_| BlobTransferResult::default())
@@ -619,7 +594,7 @@ impl SyncEngine {
                         self.dedup.set_completed(target.name, digest, target.repo);
                     }
                     Err(e) => {
-                        let err = crate::Error::BlobPush {
+                        let err = crate::Error::BlobTransfer {
                             digest: digest.to_string(),
                             source: e,
                         };
@@ -631,7 +606,7 @@ impl SyncEngine {
             }
         }
 
-        Ok(results)
+        results
     }
 }
 

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -6,10 +6,10 @@ use std::time::Instant;
 
 use std::time::Duration;
 
+use ocync_distribution::RegistryClient;
 use ocync_distribution::blob::MountResult;
 use ocync_distribution::manifest::ManifestPull;
-use ocync_distribution::spec::{ImageManifest, ManifestKind};
-use ocync_distribution::{Digest, RegistryClient};
+use ocync_distribution::spec::{Descriptor, ImageManifest, ManifestKind};
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
@@ -94,12 +94,12 @@ struct Endpoint<'a> {
     name: &'a str,
 }
 
-/// Collect all blob digests with their declared sizes from an image manifest.
-fn collect_image_blobs(manifest: &ImageManifest) -> Vec<(Digest, u64)> {
+/// Collect all blob descriptors (config + layers) from an image manifest.
+fn collect_image_blobs(manifest: &ImageManifest) -> Vec<&Descriptor> {
     let mut blobs = Vec::with_capacity(1 + manifest.layers.len());
-    blobs.push((manifest.config.digest.clone(), manifest.config.size));
+    blobs.push(&manifest.config);
     for layer in &manifest.layers {
-        blobs.push((layer.digest.clone(), layer.size));
+        blobs.push(layer);
     }
     blobs
 }
@@ -111,15 +111,9 @@ fn collect_image_blobs(manifest: &ImageManifest) -> Vec<(Digest, u64)> {
 struct SourceData {
     /// The top-level manifest (image or index).
     pull: ManifestPull,
-    /// For index manifests: pre-pulled child image manifests with their blob lists.
+    /// For index manifests: pre-pulled child manifests.
     /// Empty for single-image manifests (blobs are derived from `pull.manifest`).
-    children: Vec<ChildData>,
-}
-
-/// A pre-pulled child manifest within an index.
-struct ChildData {
-    pull: ManifestPull,
-    blobs: Vec<(Digest, u64)>,
+    children: Vec<ManifestPull>,
 }
 
 /// Per-target result of a fan-out blob transfer phase.
@@ -301,17 +295,16 @@ impl SyncEngine {
             return;
         }
 
-        // Collect all blob digests (with sizes) from the source data.
-        let owned_blobs;
-        let all_blobs: Vec<(&Digest, u64)> = match &source_data.pull.manifest {
-            ManifestKind::Image(m) => {
-                owned_blobs = collect_image_blobs(m);
-                owned_blobs.iter().map(|(d, s)| (d, *s)).collect()
-            }
+        // Collect all blob descriptors from the source data.
+        let all_blobs: Vec<&Descriptor> = match &source_data.pull.manifest {
+            ManifestKind::Image(m) => collect_image_blobs(m),
             ManifestKind::Index(_) => source_data
                 .children
                 .iter()
-                .flat_map(|c| c.blobs.iter().map(|(d, s)| (d, *s)))
+                .flat_map(|c| match &c.manifest {
+                    ManifestKind::Image(m) => collect_image_blobs(m),
+                    ManifestKind::Index(_) => Vec::new(),
+                })
                 .collect(),
         };
 
@@ -425,12 +418,8 @@ impl SyncEngine {
                     })?;
 
                     match &child_pull.manifest {
-                        ManifestKind::Image(child_image) => {
-                            let blobs = collect_image_blobs(child_image);
-                            children.push(ChildData {
-                                pull: child_pull,
-                                blobs,
-                            });
+                        ManifestKind::Image(_) => {
+                            children.push(child_pull);
                         }
                         ManifestKind::Index(_) => {
                             return Err(crate::Error::Manifest {
@@ -458,13 +447,13 @@ impl SyncEngine {
     ) -> Result<(), crate::Error> {
         // For index manifests, push each child by digest first.
         for child in &source_data.children {
-            let child_digest_str = child.pull.digest.to_string();
+            let child_digest_str = child.digest.to_string();
             with_retry(&self.retry, "manifest push", || {
                 target.client.manifest_push(
                     target.repo,
                     &child_digest_str,
-                    &child.pull.media_type,
-                    &child.pull.raw_bytes,
+                    &child.media_type,
+                    &child.raw_bytes,
                 )
             })
             .await
@@ -502,14 +491,16 @@ impl SyncEngine {
         &mut self,
         source: &Endpoint<'_>,
         targets: &[&Endpoint<'_>],
-        blobs: &[(&Digest, u64)],
+        blobs: &[&Descriptor],
     ) -> Vec<BlobTransferResult> {
         let mut results: Vec<BlobTransferResult> = targets
             .iter()
             .map(|_| BlobTransferResult::default())
             .collect();
 
-        for &(digest, size) in blobs {
+        for blob in blobs {
+            let digest = &blob.digest;
+            let size = blob.size;
             // Determine which targets need this blob pulled+pushed.
             let mut needs_pull: Vec<usize> = Vec::new();
 
@@ -675,6 +666,7 @@ fn compute_stats(images: &[ImageResult]) -> SyncStats {
 
 #[cfg(test)]
 mod tests {
+    use ocync_distribution::Digest;
     use ocync_distribution::spec::{Descriptor, MediaType};
 
     use super::*;
@@ -727,9 +719,12 @@ mod tests {
 
         let blobs = collect_image_blobs(&manifest);
         assert_eq!(blobs.len(), 3);
-        assert_eq!(blobs[0], (config_digest, 50));
-        assert_eq!(blobs[1], (layer1_digest, 200));
-        assert_eq!(blobs[2], (layer2_digest, 300));
+        assert_eq!(blobs[0].digest, config_digest);
+        assert_eq!(blobs[0].size, 50);
+        assert_eq!(blobs[1].digest, layer1_digest);
+        assert_eq!(blobs[1].size, 200);
+        assert_eq!(blobs[2].digest, layer2_digest);
+        assert_eq!(blobs[2].size, 300);
     }
 
     #[test]
@@ -753,7 +748,8 @@ mod tests {
 
         let blobs = collect_image_blobs(&manifest);
         assert_eq!(blobs.len(), 1);
-        assert_eq!(blobs[0], (config_digest, 42));
+        assert_eq!(blobs[0].digest, config_digest);
+        assert_eq!(blobs[0].size, 42);
     }
 
     fn make_image_result(status: ImageStatus, bytes: u64) -> ImageResult {

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -116,9 +116,9 @@ struct SourceData {
     children: Vec<ManifestPull>,
 }
 
-/// Per-target result of a fan-out blob transfer phase.
+/// Per-target outcome of the blob transfer phase.
 #[derive(Default)]
-struct BlobTransferResult {
+struct TargetBlobOutcome {
     bytes_transferred: u64,
     stats: BlobTransferStats,
     /// `Some` if a target-specific push failed. Other targets are unaffected.
@@ -312,7 +312,7 @@ impl SyncEngine {
         let active_targets: Vec<&Endpoint<'_>> = active.iter().map(|&(i, _)| &targets[i]).collect();
 
         let blob_results = self
-            .transfer_blobs_fanout(source, &active_targets, &all_blobs)
+            .transfer_blobs(source, &active_targets, &all_blobs)
             .await;
 
         // Phase 3: Push manifests to targets whose blobs all succeeded.
@@ -481,21 +481,21 @@ impl SyncEngine {
         Ok(())
     }
 
-    /// Fan-out blob transfer: stream each blob from source to each target.
+    /// Transfer blobs from source to each target that needs them.
     ///
     /// For each blob, checks dedup/HEAD/mount per target. If any target
     /// needs a pull, streams from source directly to that target (one stream
     /// per target since streams are consumed). Transfer failures are per-target
-    /// (recorded in the returned results, other targets continue).
-    async fn transfer_blobs_fanout(
+    /// (recorded in the returned outcomes, other targets continue).
+    async fn transfer_blobs(
         &mut self,
         source: &Endpoint<'_>,
         targets: &[&Endpoint<'_>],
         blobs: &[&Descriptor],
-    ) -> Vec<BlobTransferResult> {
-        let mut results: Vec<BlobTransferResult> = targets
+    ) -> Vec<TargetBlobOutcome> {
+        let mut results: Vec<TargetBlobOutcome> = targets
             .iter()
-            .map(|_| BlobTransferResult::default())
+            .map(|_| TargetBlobOutcome::default())
             .collect();
 
         for blob in blobs {
@@ -573,7 +573,7 @@ impl SyncEngine {
                     let stream = source.client.blob_pull(source.repo, digest).await?;
                     target
                         .client
-                        .blob_push_stream(target.repo, digest, size, stream)
+                        .blob_push_stream(target.repo, digest, stream)
                         .await
                 })
                 .await;
@@ -586,7 +586,7 @@ impl SyncEngine {
                     }
                     Err(e) => {
                         let err = crate::Error::BlobTransfer {
-                            digest: digest.to_string(),
+                            digest: digest.clone(),
                             source: e,
                         };
                         self.dedup.set_failed(target.name, digest, err.to_string());

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -94,14 +94,14 @@ struct Endpoint<'a> {
     name: &'a str,
 }
 
-/// Collect all blob digests from an image manifest (config + layers).
-fn collect_image_blobs(manifest: &ImageManifest) -> Vec<Digest> {
-    let mut digests = Vec::with_capacity(1 + manifest.layers.len());
-    digests.push(manifest.config.digest.clone());
+/// Collect all blob digests with their declared sizes from an image manifest.
+fn collect_image_blobs(manifest: &ImageManifest) -> Vec<(Digest, u64)> {
+    let mut blobs = Vec::with_capacity(1 + manifest.layers.len());
+    blobs.push((manifest.config.digest.clone(), manifest.config.size));
     for layer in &manifest.layers {
-        digests.push(layer.digest.clone());
+        blobs.push((layer.digest.clone(), layer.size));
     }
-    digests
+    blobs
 }
 
 /// Source manifest data pre-pulled once per tag.
@@ -119,7 +119,7 @@ struct SourceData {
 /// A pre-pulled child manifest within an index.
 struct ChildData {
     pull: ManifestPull,
-    blobs: Vec<Digest>,
+    blobs: Vec<(Digest, u64)>,
 }
 
 /// Per-target result of a fan-out blob transfer phase.
@@ -301,14 +301,18 @@ impl SyncEngine {
             return;
         }
 
-        // Collect all blob digests from the source data.
+        // Collect all blob digests (with sizes) from the source data.
         let owned_blobs;
-        let all_blobs: Vec<&Digest> = match &source_data.pull.manifest {
+        let all_blobs: Vec<(&Digest, u64)> = match &source_data.pull.manifest {
             ManifestKind::Image(m) => {
                 owned_blobs = collect_image_blobs(m);
-                owned_blobs.iter().collect()
+                owned_blobs.iter().map(|(d, s)| (d, *s)).collect()
             }
-            ManifestKind::Index(_) => source_data.children.iter().flat_map(|c| &c.blobs).collect(),
+            ManifestKind::Index(_) => source_data
+                .children
+                .iter()
+                .flat_map(|c| c.blobs.iter().map(|(d, s)| (d, *s)))
+                .collect(),
         };
 
         // Phase 2: Fan-out blob transfer — pull each blob once, push to all active targets.
@@ -513,24 +517,24 @@ impl SyncEngine {
         Ok(())
     }
 
-    /// Fan-out blob transfer: pull each blob once from source, push to all targets.
+    /// Fan-out blob transfer: stream each blob from source to each target.
     ///
-    /// For each digest, checks dedup/HEAD/mount per target. If any target
-    /// needs a pull, pulls from source once and pushes to all targets that need it.
-    /// Source pull failure is fatal (returns `Err`). Target push failures are
-    /// per-target (recorded in the returned results, other targets continue).
+    /// For each blob, checks dedup/HEAD/mount per target. If any target
+    /// needs a pull, streams from source directly to that target (one stream
+    /// per target since streams are consumed). Transfer failures are per-target
+    /// (recorded in the returned results, other targets continue).
     async fn transfer_blobs_fanout(
         &mut self,
         source: &Endpoint<'_>,
         targets: &[&Endpoint<'_>],
-        digests: &[&Digest],
+        blobs: &[(&Digest, u64)],
     ) -> Result<Vec<BlobTransferResult>, crate::Error> {
         let mut results: Vec<BlobTransferResult> = targets
             .iter()
             .map(|_| BlobTransferResult::default())
             .collect();
 
-        for &digest in digests {
+        for &(digest, size) in blobs {
             // Determine which targets need this blob pulled+pushed.
             let mut needs_pull: Vec<usize> = Vec::new();
 
@@ -592,39 +596,38 @@ impl SyncEngine {
                 continue;
             }
 
-            // Pull from source ONCE.
-            let data = with_retry(&self.retry, "blob pull", || {
-                source.client.blob_pull_all(source.repo, digest)
-            })
-            .await
-            .map_err(|e| crate::Error::BlobPull {
-                digest: digest.to_string(),
-                source: e,
-            })?;
-            let blob_size = data.len() as u64;
-
-            // Push to each target that needs it.
+            // Stream from source to each target independently.
+            // Each target gets its own pull stream since streams are consumed.
+            // On retry, both pull and push are re-initiated (stream is not resumable).
             for &i in &needs_pull {
                 let target = targets[i];
                 self.dedup.set_in_progress(target.name, digest);
 
-                if let Err(e) = with_retry(&self.retry, "blob push", || {
-                    target.client.blob_push(target.repo, &data)
+                let transfer_result = with_retry(&self.retry, "blob transfer", || async {
+                    let stream = source.client.blob_pull(source.repo, digest).await?;
+                    target
+                        .client
+                        .blob_push_stream(target.repo, digest, size, stream)
+                        .await
                 })
-                .await
-                {
-                    let err = crate::Error::BlobPush {
-                        digest: digest.to_string(),
-                        source: e,
-                    };
-                    self.dedup.set_failed(target.name, digest, err.to_string());
-                    results[i].error = Some(err);
-                    continue; // other targets may still succeed
-                }
+                .await;
 
-                results[i].bytes_transferred += blob_size;
-                results[i].stats.transferred += 1;
-                self.dedup.set_completed(target.name, digest, target.repo);
+                match transfer_result {
+                    Ok(_digest) => {
+                        results[i].bytes_transferred += size;
+                        results[i].stats.transferred += 1;
+                        self.dedup.set_completed(target.name, digest, target.repo);
+                    }
+                    Err(e) => {
+                        let err = crate::Error::BlobPush {
+                            digest: digest.to_string(),
+                            source: e,
+                        };
+                        self.dedup.set_failed(target.name, digest, err.to_string());
+                        results[i].error = Some(err);
+                        // other targets may still succeed
+                    }
+                }
             }
         }
 
@@ -724,14 +727,24 @@ mod tests {
         let layer1_digest = test_digest("a1");
         let layer2_digest = test_digest("b2");
 
+        let config_desc = Descriptor {
+            size: 50,
+            ..test_descriptor(config_digest.clone(), MediaType::OciConfig)
+        };
+        let layer1_desc = Descriptor {
+            size: 200,
+            ..test_descriptor(layer1_digest.clone(), MediaType::OciLayerGzip)
+        };
+        let layer2_desc = Descriptor {
+            size: 300,
+            ..test_descriptor(layer2_digest.clone(), MediaType::OciLayerGzip)
+        };
+
         let manifest = ImageManifest {
             schema_version: 2,
             media_type: None,
-            config: test_descriptor(config_digest.clone(), MediaType::OciConfig),
-            layers: vec![
-                test_descriptor(layer1_digest.clone(), MediaType::OciLayerGzip),
-                test_descriptor(layer2_digest.clone(), MediaType::OciLayerGzip),
-            ],
+            config: config_desc,
+            layers: vec![layer1_desc, layer2_desc],
             subject: None,
             artifact_type: None,
             annotations: None,
@@ -739,19 +752,24 @@ mod tests {
 
         let blobs = collect_image_blobs(&manifest);
         assert_eq!(blobs.len(), 3);
-        assert_eq!(blobs[0], config_digest);
-        assert_eq!(blobs[1], layer1_digest);
-        assert_eq!(blobs[2], layer2_digest);
+        assert_eq!(blobs[0], (config_digest, 50));
+        assert_eq!(blobs[1], (layer1_digest, 200));
+        assert_eq!(blobs[2], (layer2_digest, 300));
     }
 
     #[test]
     fn collect_blobs_no_layers() {
         let config_digest = test_digest("cc");
 
+        let config_desc = Descriptor {
+            size: 42,
+            ..test_descriptor(config_digest.clone(), MediaType::OciConfig)
+        };
+
         let manifest = ImageManifest {
             schema_version: 2,
             media_type: None,
-            config: test_descriptor(config_digest.clone(), MediaType::OciConfig),
+            config: config_desc,
             layers: vec![],
             subject: None,
             artifact_type: None,
@@ -760,7 +778,7 @@ mod tests {
 
         let blobs = collect_image_blobs(&manifest);
         assert_eq!(blobs.len(), 1);
-        assert_eq!(blobs[0], config_digest);
+        assert_eq!(blobs[0], (config_digest, 42));
     }
 
     fn make_image_result(status: ImageStatus, bytes: u64) -> ImageResult {

--- a/crates/ocync-sync/src/error.rs
+++ b/crates/ocync-sync/src/error.rs
@@ -45,16 +45,7 @@ pub enum Error {
         source: ocync_distribution::Error,
     },
 
-    /// A blob pull failed during sync.
-    #[error("blob pull failed for {digest}: {source}")]
-    BlobPull {
-        /// The digest of the blob that could not be pulled.
-        digest: String,
-        /// The underlying distribution error.
-        source: ocync_distribution::Error,
-    },
-
-    /// A blob push failed during sync.
+    /// A blob transfer (pull or push) failed during sync.
     #[error("blob push failed for {digest}: {source}")]
     BlobPush {
         /// The digest of the blob that could not be pushed.
@@ -68,9 +59,7 @@ impl Error {
     /// Extract the HTTP status code from the underlying distribution error, if any.
     pub fn status_code(&self) -> Option<http::StatusCode> {
         match self {
-            Self::Manifest { source, .. }
-            | Self::BlobPull { source, .. }
-            | Self::BlobPush { source, .. } => source.status_code(),
+            Self::Manifest { source, .. } | Self::BlobPush { source, .. } => source.status_code(),
             _ => None,
         }
     }
@@ -138,20 +127,6 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("latest"));
         assert!(msg.contains("manifest"));
-    }
-
-    #[test]
-    fn display_blob_pull_error() {
-        let err = Error::BlobPull {
-            digest: "sha256:abc".into(),
-            source: ocync_distribution::Error::RegistryError {
-                status: http::StatusCode::NOT_FOUND,
-                message: "missing".into(),
-            },
-        };
-        let msg = err.to_string();
-        assert!(msg.contains("sha256:abc"));
-        assert!(msg.contains("blob pull"));
     }
 
     #[test]

--- a/crates/ocync-sync/src/error.rs
+++ b/crates/ocync-sync/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types for sync operations.
 
+use ocync_distribution::Digest;
 use thiserror::Error;
 
 /// Errors returned by sync operations.
@@ -49,7 +50,7 @@ pub enum Error {
     #[error("blob transfer failed for {digest}: {source}")]
     BlobTransfer {
         /// The digest of the blob that could not be transferred.
-        digest: String,
+        digest: Digest,
         /// The underlying distribution error.
         source: ocync_distribution::Error,
     },
@@ -133,13 +134,17 @@ mod tests {
 
     #[test]
     fn display_blob_transfer_error() {
+        let digest: Digest =
+            "sha256:def0000000000000000000000000000000000000000000000000000000000000"
+                .parse()
+                .unwrap();
         let err = Error::BlobTransfer {
-            digest: "sha256:def".into(),
+            digest: digest.clone(),
             source: ocync_distribution::Error::Other("timeout".into()),
         };
         let msg = err.to_string();
         assert!(msg.contains("blob transfer"));
-        assert!(msg.contains("sha256:def"));
+        assert!(msg.contains(&digest.to_string()));
     }
 
     #[test]

--- a/crates/ocync-sync/src/error.rs
+++ b/crates/ocync-sync/src/error.rs
@@ -47,8 +47,8 @@ pub enum Error {
 
     /// A blob transfer failed during sync.
     #[error("blob transfer failed for {digest}: {source}")]
-    BlobPush {
-        /// The digest of the blob that could not be pushed.
+    BlobTransfer {
+        /// The digest of the blob that could not be transferred.
         digest: String,
         /// The underlying distribution error.
         source: ocync_distribution::Error,
@@ -59,7 +59,9 @@ impl Error {
     /// Extract the HTTP status code from the underlying distribution error, if any.
     pub fn status_code(&self) -> Option<http::StatusCode> {
         match self {
-            Self::Manifest { source, .. } | Self::BlobPush { source, .. } => source.status_code(),
+            Self::Manifest { source, .. } | Self::BlobTransfer { source, .. } => {
+                source.status_code()
+            }
             _ => None,
         }
     }
@@ -131,7 +133,7 @@ mod tests {
 
     #[test]
     fn display_blob_push_error() {
-        let err = Error::BlobPush {
+        let err = Error::BlobTransfer {
             digest: "sha256:def".into(),
             source: ocync_distribution::Error::Other("timeout".into()),
         };

--- a/crates/ocync-sync/src/error.rs
+++ b/crates/ocync-sync/src/error.rs
@@ -132,7 +132,7 @@ mod tests {
     }
 
     #[test]
-    fn display_blob_push_error() {
+    fn display_blob_transfer_error() {
         let err = Error::BlobTransfer {
             digest: "sha256:def".into(),
             source: ocync_distribution::Error::Other("timeout".into()),

--- a/crates/ocync-sync/src/error.rs
+++ b/crates/ocync-sync/src/error.rs
@@ -45,8 +45,8 @@ pub enum Error {
         source: ocync_distribution::Error,
     },
 
-    /// A blob transfer (pull or push) failed during sync.
-    #[error("blob push failed for {digest}: {source}")]
+    /// A blob transfer failed during sync.
+    #[error("blob transfer failed for {digest}: {source}")]
     BlobPush {
         /// The digest of the blob that could not be pushed.
         digest: String,
@@ -136,7 +136,7 @@ mod tests {
             source: ocync_distribution::Error::Other("timeout".into()),
         };
         let msg = err.to_string();
-        assert!(msg.contains("blob push"));
+        assert!(msg.contains("blob transfer"));
         assert!(msg.contains("sha256:def"));
     }
 

--- a/crates/ocync-sync/tests/engine_integration.rs
+++ b/crates/ocync-sync/tests/engine_integration.rs
@@ -592,7 +592,7 @@ async fn sync_empty_mappings() {
 }
 
 #[tokio::test]
-async fn sync_blob_push_failure() {
+async fn sync_blob_transfer_failure() {
     let source_server = MockServer::start().await;
     let target_server = MockServer::start().await;
 

--- a/crates/ocync-sync/tests/engine_integration.rs
+++ b/crates/ocync-sync/tests/engine_integration.rs
@@ -76,6 +76,24 @@ fn simple_image_manifest(config_digest: &Digest, layer_digest: &Digest) -> Image
     }
 }
 
+/// Compute the real SHA-256 digest for test blob data.
+fn blob_digest(data: &[u8]) -> Digest {
+    let hash = ocync_distribution::sha256::Sha256::digest(data);
+    Digest::from_sha256(hash)
+}
+
+/// Build a descriptor with the real digest and size of the given data.
+fn blob_descriptor(data: &[u8], media_type: MediaType) -> Descriptor {
+    Descriptor {
+        media_type,
+        digest: blob_digest(data),
+        size: data.len() as u64,
+        platform: None,
+        artifact_type: None,
+        annotations: None,
+    }
+}
+
 /// Mount mock endpoints for a full image sync on the source server:
 /// - GET manifest (returns the given JSON bytes with media type header)
 async fn mount_source_manifest(server: &MockServer, repo: &str, tag: &str, bytes: &[u8]) {
@@ -192,9 +210,19 @@ async fn sync_image_happy_path() {
     let source_server = MockServer::start().await;
     let target_server = MockServer::start().await;
 
-    let config_digest = test_digest("c0c0");
-    let layer_digest = test_digest("1a1a");
-    let manifest = simple_image_manifest(&config_digest, &layer_digest);
+    let config_data = b"config-data";
+    let layer_data = b"layer-data";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
     let (manifest_bytes, _manifest_digest) = serialize_manifest(&manifest);
 
     // Source: serve manifest and blobs.
@@ -202,22 +230,22 @@ async fn sync_image_happy_path() {
     mount_blob_pull(
         &source_server,
         "library/nginx",
-        &config_digest,
-        b"config-data",
+        &config_desc.digest,
+        config_data,
     )
     .await;
     mount_blob_pull(
         &source_server,
         "library/nginx",
-        &layer_digest,
-        b"layer-data",
+        &layer_desc.digest,
+        layer_data,
     )
     .await;
 
     // Target: manifest HEAD 404, blobs not found, push endpoints.
     mount_manifest_head_not_found(&target_server, "mirror/nginx", "latest").await;
-    mount_blob_not_found(&target_server, "mirror/nginx", &config_digest).await;
-    mount_blob_not_found(&target_server, "mirror/nginx", &layer_digest).await;
+    mount_blob_not_found(&target_server, "mirror/nginx", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "mirror/nginx", &layer_desc.digest).await;
     mount_blob_push(&target_server, "mirror/nginx").await;
     mount_manifest_push(&target_server, "mirror/nginx", "latest").await;
 
@@ -382,32 +410,42 @@ async fn sync_image_blob_pull_retries_on_500() {
     let source_server = MockServer::start().await;
     let target_server = MockServer::start().await;
 
-    let config_digest = test_digest("c2");
-    let layer_digest = test_digest("b2");
-    let manifest = simple_image_manifest(&config_digest, &layer_digest);
+    let config_data = b"config";
+    let layer_data = b"layer-data";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
     let (manifest_bytes, _) = serialize_manifest(&manifest);
 
     // Source: manifest succeeds, config blob succeeds.
     mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
-    mount_blob_pull(&source_server, "repo", &config_digest, b"config").await;
+    mount_blob_pull(&source_server, "repo", &config_desc.digest, config_data).await;
 
     // Layer blob: first attempt 500, second attempt succeeds.
     Mock::given(method("GET"))
-        .and(path(format!("/v2/repo/blobs/{layer_digest}")))
+        .and(path(format!("/v2/repo/blobs/{}", layer_desc.digest)))
         .respond_with(ResponseTemplate::new(500))
         .up_to_n_times(1)
         .mount(&source_server)
         .await;
     Mock::given(method("GET"))
-        .and(path(format!("/v2/repo/blobs/{layer_digest}")))
-        .respond_with(ResponseTemplate::new(200).set_body_bytes(b"layer-data".to_vec()))
+        .and(path(format!("/v2/repo/blobs/{}", layer_desc.digest)))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(layer_data.to_vec()))
         .mount(&source_server)
         .await;
 
     // Target: standard setup.
     mount_manifest_head_not_found(&target_server, "repo", "v1").await;
-    mount_blob_not_found(&target_server, "repo", &config_digest).await;
-    mount_blob_not_found(&target_server, "repo", &layer_digest).await;
+    mount_blob_not_found(&target_server, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_desc.digest).await;
     mount_blob_push(&target_server, "repo").await;
     mount_manifest_push(&target_server, "repo", "v1").await;
 
@@ -439,22 +477,32 @@ async fn sync_dedup_across_tags() {
     let target_server = MockServer::start().await;
 
     // Two tags share the same blobs.
-    let config_digest = test_digest("aa00");
-    let layer_digest = test_digest("bb00");
-    let manifest = simple_image_manifest(&config_digest, &layer_digest);
+    let config_data = b"config";
+    let layer_data = b"layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
     let (manifest_bytes, _) = serialize_manifest(&manifest);
 
     // Source: both tags serve the same manifest.
     mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
     mount_source_manifest(&source_server, "repo", "v2", &manifest_bytes).await;
-    mount_blob_pull(&source_server, "repo", &config_digest, b"config").await;
-    mount_blob_pull(&source_server, "repo", &layer_digest, b"layer").await;
+    mount_blob_pull(&source_server, "repo", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo", &layer_desc.digest, layer_data).await;
 
     // Target: manifest HEAD 404 for both, blobs not found initially.
     mount_manifest_head_not_found(&target_server, "repo", "v1").await;
     mount_manifest_head_not_found(&target_server, "repo", "v2").await;
-    mount_blob_not_found(&target_server, "repo", &config_digest).await;
-    mount_blob_not_found(&target_server, "repo", &layer_digest).await;
+    mount_blob_not_found(&target_server, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_desc.digest).await;
     mount_blob_push(&target_server, "repo").await;
     mount_manifest_push(&target_server, "repo", "v1").await;
     mount_manifest_push(&target_server, "repo", "v2").await;
@@ -493,20 +541,30 @@ async fn sync_multiple_targets() {
     let target_a = MockServer::start().await;
     let target_b = MockServer::start().await;
 
-    let config_digest = test_digest("c3");
-    let layer_digest = test_digest("b3");
-    let manifest = simple_image_manifest(&config_digest, &layer_digest);
+    let config_data = b"config";
+    let layer_data = b"layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
     let (manifest_bytes, _) = serialize_manifest(&manifest);
 
     mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
-    mount_blob_pull(&source_server, "repo", &config_digest, b"config").await;
-    mount_blob_pull(&source_server, "repo", &layer_digest, b"layer").await;
+    mount_blob_pull(&source_server, "repo", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo", &layer_desc.digest, layer_data).await;
 
     // Both targets: no manifest, no blobs, accept pushes.
     for target in [&target_a, &target_b] {
         mount_manifest_head_not_found(target, "repo", "v1").await;
-        mount_blob_not_found(target, "repo", &config_digest).await;
-        mount_blob_not_found(target, "repo", &layer_digest).await;
+        mount_blob_not_found(target, "repo", &config_desc.digest).await;
+        mount_blob_not_found(target, "repo", &layer_desc.digest).await;
         mount_blob_push(target, "repo").await;
         mount_manifest_push(target, "repo", "v1").await;
     }
@@ -543,20 +601,30 @@ async fn sync_retag() {
     let source_server = MockServer::start().await;
     let target_server = MockServer::start().await;
 
-    let config_digest = test_digest("c4");
-    let layer_digest = test_digest("b4");
-    let manifest = simple_image_manifest(&config_digest, &layer_digest);
+    let config_data = b"config";
+    let layer_data = b"layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
     let (manifest_bytes, _) = serialize_manifest(&manifest);
 
     // Source: serve manifest at source tag.
     mount_source_manifest(&source_server, "repo", "latest", &manifest_bytes).await;
-    mount_blob_pull(&source_server, "repo", &config_digest, b"config").await;
-    mount_blob_pull(&source_server, "repo", &layer_digest, b"layer").await;
+    mount_blob_pull(&source_server, "repo", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo", &layer_desc.digest, layer_data).await;
 
     // Target: HEAD for target tag, blobs missing, push at target tag.
     mount_manifest_head_not_found(&target_server, "repo", "stable").await;
-    mount_blob_not_found(&target_server, "repo", &config_digest).await;
-    mount_blob_not_found(&target_server, "repo", &layer_digest).await;
+    mount_blob_not_found(&target_server, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_desc.digest).await;
     mount_blob_push(&target_server, "repo").await;
     mount_manifest_push(&target_server, "repo", "stable").await;
 
@@ -647,14 +715,34 @@ async fn sync_index_manifest_multi_platform() {
     let target_server = MockServer::start().await;
 
     // Build two child image manifests (simulating amd64 and arm64).
-    let amd64_config = test_digest("a0");
-    let amd64_layer = test_digest("a1");
-    let amd64_manifest = simple_image_manifest(&amd64_config, &amd64_layer);
+    let amd64_config_data = b"amd64-config";
+    let amd64_layer_data = b"amd64-layer";
+    let amd64_config_desc = blob_descriptor(amd64_config_data, MediaType::OciConfig);
+    let amd64_layer_desc = blob_descriptor(amd64_layer_data, MediaType::OciLayerGzip);
+    let amd64_manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: amd64_config_desc.clone(),
+        layers: vec![amd64_layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
     let (amd64_bytes, amd64_digest) = serialize_manifest(&amd64_manifest);
 
-    let arm64_config = test_digest("b0");
-    let arm64_layer = test_digest("b1");
-    let arm64_manifest = simple_image_manifest(&arm64_config, &arm64_layer);
+    let arm64_config_data = b"arm64-config";
+    let arm64_layer_data = b"arm64-layer";
+    let arm64_config_desc = blob_descriptor(arm64_config_data, MediaType::OciConfig);
+    let arm64_layer_desc = blob_descriptor(arm64_layer_data, MediaType::OciLayerGzip);
+    let arm64_manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: arm64_config_desc.clone(),
+        layers: vec![arm64_layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
     let (arm64_bytes, arm64_digest) = serialize_manifest(&arm64_manifest);
 
     // Build the index manifest referencing both children.
@@ -703,17 +791,41 @@ async fn sync_index_manifest_multi_platform() {
         .await;
 
     // Source: blobs.
-    mount_blob_pull(&source_server, "repo", &amd64_config, b"amd64-config").await;
-    mount_blob_pull(&source_server, "repo", &amd64_layer, b"amd64-layer").await;
-    mount_blob_pull(&source_server, "repo", &arm64_config, b"arm64-config").await;
-    mount_blob_pull(&source_server, "repo", &arm64_layer, b"arm64-layer").await;
+    mount_blob_pull(
+        &source_server,
+        "repo",
+        &amd64_config_desc.digest,
+        amd64_config_data,
+    )
+    .await;
+    mount_blob_pull(
+        &source_server,
+        "repo",
+        &amd64_layer_desc.digest,
+        amd64_layer_data,
+    )
+    .await;
+    mount_blob_pull(
+        &source_server,
+        "repo",
+        &arm64_config_desc.digest,
+        arm64_config_data,
+    )
+    .await;
+    mount_blob_pull(
+        &source_server,
+        "repo",
+        &arm64_layer_desc.digest,
+        arm64_layer_data,
+    )
+    .await;
 
     // Target: no manifest, no blobs, accept all pushes.
     mount_manifest_head_not_found(&target_server, "repo", "latest").await;
-    mount_blob_not_found(&target_server, "repo", &amd64_config).await;
-    mount_blob_not_found(&target_server, "repo", &amd64_layer).await;
-    mount_blob_not_found(&target_server, "repo", &arm64_config).await;
-    mount_blob_not_found(&target_server, "repo", &arm64_layer).await;
+    mount_blob_not_found(&target_server, "repo", &amd64_config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &amd64_layer_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &arm64_config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &arm64_layer_desc.digest).await;
     mount_blob_push(&target_server, "repo").await;
 
     // Accept child manifest pushes (by digest) and index push (by tag).
@@ -750,21 +862,31 @@ async fn sync_head_different_digest_proceeds_with_sync() {
     let source_server = MockServer::start().await;
     let target_server = MockServer::start().await;
 
-    let config_digest = test_digest("d0");
-    let layer_digest = test_digest("d1");
-    let manifest = simple_image_manifest(&config_digest, &layer_digest);
+    let config_data = b"config";
+    let layer_data = b"layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
     let (manifest_bytes, _manifest_digest) = serialize_manifest(&manifest);
 
     // Source: serve manifest and blobs.
     mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
-    mount_blob_pull(&source_server, "repo", &config_digest, b"config").await;
-    mount_blob_pull(&source_server, "repo", &layer_digest, b"layer").await;
+    mount_blob_pull(&source_server, "repo", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo", &layer_desc.digest, layer_data).await;
 
     // Target: manifest HEAD returns a DIFFERENT digest → should proceed.
     let stale_digest = test_digest("5ca1e");
     mount_manifest_head_matching(&target_server, "repo", "v1", &stale_digest).await;
-    mount_blob_not_found(&target_server, "repo", &config_digest).await;
-    mount_blob_not_found(&target_server, "repo", &layer_digest).await;
+    mount_blob_not_found(&target_server, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_desc.digest).await;
     mount_blob_push(&target_server, "repo").await;
     mount_manifest_push(&target_server, "repo", "v1").await;
 
@@ -817,20 +939,30 @@ async fn sync_manifest_push_failure() {
     let source_server = MockServer::start().await;
     let target_server = MockServer::start().await;
 
-    let config_digest = test_digest("c6");
-    let layer_digest = test_digest("b6");
-    let manifest = simple_image_manifest(&config_digest, &layer_digest);
+    let config_data = b"config";
+    let layer_data = b"layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
     let (manifest_bytes, _) = serialize_manifest(&manifest);
 
     // Source: serve everything normally.
     mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
-    mount_blob_pull(&source_server, "repo", &config_digest, b"config").await;
-    mount_blob_pull(&source_server, "repo", &layer_digest, b"layer").await;
+    mount_blob_pull(&source_server, "repo", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo", &layer_desc.digest, layer_data).await;
 
     // Target: blobs succeed, but manifest PUT fails with 403.
     mount_manifest_head_not_found(&target_server, "repo", "v1").await;
-    mount_blob_not_found(&target_server, "repo", &config_digest).await;
-    mount_blob_not_found(&target_server, "repo", &layer_digest).await;
+    mount_blob_not_found(&target_server, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_desc.digest).await;
     mount_blob_push(&target_server, "repo").await;
 
     Mock::given(method("PUT"))
@@ -872,24 +1004,34 @@ async fn sync_retry_exhaustion_returns_final_error() {
     let source_server = MockServer::start().await;
     let target_server = MockServer::start().await;
 
-    let config_digest = test_digest("c7");
-    let layer_digest = test_digest("b7");
-    let manifest = simple_image_manifest(&config_digest, &layer_digest);
+    let config_data = b"config";
+    let layer_data = b"layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
     let (manifest_bytes, _) = serialize_manifest(&manifest);
 
     mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
-    mount_blob_pull(&source_server, "repo", &config_digest, b"config").await;
+    mount_blob_pull(&source_server, "repo", &config_desc.digest, config_data).await;
 
     // Layer blob: always returns 429 (retryable) — should exhaust retries.
     Mock::given(method("GET"))
-        .and(path(format!("/v2/repo/blobs/{layer_digest}")))
+        .and(path(format!("/v2/repo/blobs/{}", layer_desc.digest)))
         .respond_with(ResponseTemplate::new(429).set_body_string("rate limited"))
         .mount(&source_server)
         .await;
 
     mount_manifest_head_not_found(&target_server, "repo", "v1").await;
-    mount_blob_not_found(&target_server, "repo", &config_digest).await;
-    mount_blob_not_found(&target_server, "repo", &layer_digest).await;
+    mount_blob_not_found(&target_server, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_desc.digest).await;
     mount_blob_push(&target_server, "repo").await;
 
     let mapping = ResolvedMapping {
@@ -923,31 +1065,49 @@ async fn sync_cross_repo_mount_success() {
     let target_server = MockServer::start().await;
 
     // Shared blobs across two different source repos.
-    let config_digest = test_digest("ac00");
-    let layer_digest = test_digest("ac01");
+    let config_data = b"config";
+    let layer_data = b"layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
 
-    let manifest_a = simple_image_manifest(&config_digest, &layer_digest);
+    let manifest_a = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
     let (manifest_a_bytes, _) = serialize_manifest(&manifest_a);
-    let manifest_b = simple_image_manifest(&config_digest, &layer_digest);
+    let manifest_b = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
     let (manifest_b_bytes, _) = serialize_manifest(&manifest_b);
 
     // Source: two repos with the same blobs.
     mount_source_manifest(&source_server, "repo-a", "v1", &manifest_a_bytes).await;
     mount_source_manifest(&source_server, "repo-b", "v1", &manifest_b_bytes).await;
-    mount_blob_pull(&source_server, "repo-a", &config_digest, b"config").await;
-    mount_blob_pull(&source_server, "repo-a", &layer_digest, b"layer").await;
+    mount_blob_pull(&source_server, "repo-a", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo-a", &layer_desc.digest, layer_data).await;
 
     // Target for repo-a: no manifest, no blobs, push succeeds.
     mount_manifest_head_not_found(&target_server, "repo-a", "v1").await;
-    mount_blob_not_found(&target_server, "repo-a", &config_digest).await;
-    mount_blob_not_found(&target_server, "repo-a", &layer_digest).await;
+    mount_blob_not_found(&target_server, "repo-a", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo-a", &layer_desc.digest).await;
     mount_blob_push(&target_server, "repo-a").await;
     mount_manifest_push(&target_server, "repo-a", "v1").await;
 
     // Target for repo-b: no manifest, blobs not found, mount succeeds (201 Created).
     mount_manifest_head_not_found(&target_server, "repo-b", "v1").await;
-    mount_blob_not_found(&target_server, "repo-b", &config_digest).await;
-    mount_blob_not_found(&target_server, "repo-b", &layer_digest).await;
+    mount_blob_not_found(&target_server, "repo-b", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo-b", &layer_desc.digest).await;
     Mock::given(method("POST"))
         .and(path("/v2/repo-b/blobs/uploads/"))
         .respond_with(ResponseTemplate::new(201))
@@ -1001,34 +1161,52 @@ async fn sync_cross_repo_mount_fallback_to_pull_push() {
     let source_server = MockServer::start().await;
     let target_server = MockServer::start().await;
 
-    let config_digest = test_digest("f0");
-    let layer_digest = test_digest("f1");
+    let config_data = b"config";
+    let layer_data = b"layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
 
-    let manifest_a = simple_image_manifest(&config_digest, &layer_digest);
+    let manifest_a = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
     let (manifest_a_bytes, _) = serialize_manifest(&manifest_a);
-    let manifest_b = simple_image_manifest(&config_digest, &layer_digest);
+    let manifest_b = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
     let (manifest_b_bytes, _) = serialize_manifest(&manifest_b);
 
     // Source: two repos.
     mount_source_manifest(&source_server, "repo-a", "v1", &manifest_a_bytes).await;
     mount_source_manifest(&source_server, "repo-b", "v1", &manifest_b_bytes).await;
-    mount_blob_pull(&source_server, "repo-a", &config_digest, b"config").await;
-    mount_blob_pull(&source_server, "repo-a", &layer_digest, b"layer").await;
+    mount_blob_pull(&source_server, "repo-a", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo-a", &layer_desc.digest, layer_data).await;
     // repo-b blob pulls needed for fallback.
-    mount_blob_pull(&source_server, "repo-b", &config_digest, b"config").await;
-    mount_blob_pull(&source_server, "repo-b", &layer_digest, b"layer").await;
+    mount_blob_pull(&source_server, "repo-b", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo-b", &layer_desc.digest, layer_data).await;
 
     // Target for repo-a: normal sync.
     mount_manifest_head_not_found(&target_server, "repo-a", "v1").await;
-    mount_blob_not_found(&target_server, "repo-a", &config_digest).await;
-    mount_blob_not_found(&target_server, "repo-a", &layer_digest).await;
+    mount_blob_not_found(&target_server, "repo-a", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo-a", &layer_desc.digest).await;
     mount_blob_push(&target_server, "repo-a").await;
     mount_manifest_push(&target_server, "repo-a", "v1").await;
 
     // Target for repo-b: mount returns 202 Accepted (fallback).
     mount_manifest_head_not_found(&target_server, "repo-b", "v1").await;
-    mount_blob_not_found(&target_server, "repo-b", &config_digest).await;
-    mount_blob_not_found(&target_server, "repo-b", &layer_digest).await;
+    mount_blob_not_found(&target_server, "repo-b", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo-b", &layer_desc.digest).await;
     Mock::given(method("POST"))
         .and(path("/v2/repo-b/blobs/uploads/"))
         .respond_with(
@@ -1093,33 +1271,51 @@ async fn sync_cross_repo_mount_failure_falls_back() {
     let source_server = MockServer::start().await;
     let target_server = MockServer::start().await;
 
-    let config_digest = test_digest("e0");
-    let layer_digest = test_digest("e1");
+    let config_data = b"config";
+    let layer_data = b"layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
 
-    let manifest_a = simple_image_manifest(&config_digest, &layer_digest);
+    let manifest_a = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
     let (manifest_a_bytes, _) = serialize_manifest(&manifest_a);
-    let manifest_b = simple_image_manifest(&config_digest, &layer_digest);
+    let manifest_b = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
     let (manifest_b_bytes, _) = serialize_manifest(&manifest_b);
 
     // Source: two repos.
     mount_source_manifest(&source_server, "repo-a", "v1", &manifest_a_bytes).await;
     mount_source_manifest(&source_server, "repo-b", "v1", &manifest_b_bytes).await;
-    mount_blob_pull(&source_server, "repo-a", &config_digest, b"config").await;
-    mount_blob_pull(&source_server, "repo-a", &layer_digest, b"layer").await;
-    mount_blob_pull(&source_server, "repo-b", &config_digest, b"config").await;
-    mount_blob_pull(&source_server, "repo-b", &layer_digest, b"layer").await;
+    mount_blob_pull(&source_server, "repo-a", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo-a", &layer_desc.digest, layer_data).await;
+    mount_blob_pull(&source_server, "repo-b", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo-b", &layer_desc.digest, layer_data).await;
 
     // Target for repo-a: normal sync.
     mount_manifest_head_not_found(&target_server, "repo-a", "v1").await;
-    mount_blob_not_found(&target_server, "repo-a", &config_digest).await;
-    mount_blob_not_found(&target_server, "repo-a", &layer_digest).await;
+    mount_blob_not_found(&target_server, "repo-a", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo-a", &layer_desc.digest).await;
     mount_blob_push(&target_server, "repo-a").await;
     mount_manifest_push(&target_server, "repo-a", "v1").await;
 
     // Target for repo-b: mount returns 500 (error), falls back to pull+push.
     mount_manifest_head_not_found(&target_server, "repo-b", "v1").await;
-    mount_blob_not_found(&target_server, "repo-b", &config_digest).await;
-    mount_blob_not_found(&target_server, "repo-b", &layer_digest).await;
+    mount_blob_not_found(&target_server, "repo-b", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo-b", &layer_desc.digest).await;
     Mock::given(method("POST"))
         .and(path("/v2/repo-b/blobs/uploads/"))
         .respond_with(ResponseTemplate::new(500))

--- a/crates/ocync-sync/tests/engine_integration.rs
+++ b/crates/ocync-sync/tests/engine_integration.rs
@@ -635,9 +635,6 @@ async fn sync_blob_push_failure() {
         report.images[0].status,
         ImageStatus::Failed { .. }
     ));
-    if let ImageStatus::Failed { error, .. } = &report.images[0].status {
-        assert!(error.contains("blob transfer"));
-    }
     assert_eq!(report.stats.images_failed, 1);
     assert_eq!(report.exit_code(), 2);
 }
@@ -914,11 +911,7 @@ async fn sync_retry_exhaustion_returns_final_error() {
         report.images[0].status,
         ImageStatus::Failed { .. }
     ));
-    if let ImageStatus::Failed { error, retries } = &report.images[0].status {
-        assert!(
-            error.contains("blob transfer"),
-            "error should mention blob transfer: {error}"
-        );
+    if let ImageStatus::Failed { retries, .. } = &report.images[0].status {
         assert_eq!(*retries, 2); // max_retries from fast_retry()
     }
     assert_eq!(report.stats.images_failed, 1);

--- a/crates/ocync-sync/tests/engine_integration.rs
+++ b/crates/ocync-sync/tests/engine_integration.rs
@@ -121,9 +121,9 @@ async fn mount_blob_exists(server: &MockServer, repo: &str, digest: &Digest) {
         .await;
 }
 
-/// Mount mock for blob push: POST initiate + PUT upload.
+/// Mount mock for blob push: POST initiate + PATCH chunked data + PUT finalize.
 async fn mount_blob_push(server: &MockServer, repo: &str) {
-    // POST initiate upload — return 202 with Location.
+    // POST: initiate upload.
     Mock::given(method("POST"))
         .and(path(format!("/v2/{repo}/blobs/uploads/")))
         .respond_with(
@@ -133,7 +133,17 @@ async fn mount_blob_push(server: &MockServer, repo: &str) {
         .mount(server)
         .await;
 
-    // PUT the blob data — return 201 Created.
+    // PATCH: accept chunked data (may be called 1+ times).
+    Mock::given(method("PATCH"))
+        .and(path(format!("/v2/{repo}/blobs/uploads/upload-id")))
+        .respond_with(
+            ResponseTemplate::new(202)
+                .insert_header("location", format!("/v2/{repo}/blobs/uploads/upload-id")),
+        )
+        .mount(server)
+        .await;
+
+    // PUT: finalize with digest query param.
     Mock::given(method("PUT"))
         .and(path(format!("/v2/{repo}/blobs/uploads/upload-id")))
         .respond_with(ResponseTemplate::new(201))
@@ -906,8 +916,8 @@ async fn sync_retry_exhaustion_returns_final_error() {
     ));
     if let ImageStatus::Failed { error, retries } = &report.images[0].status {
         assert!(
-            error.contains("blob pull"),
-            "error should mention blob pull: {error}"
+            error.contains("blob push"),
+            "error should mention blob push: {error}"
         );
         assert_eq!(*retries, 2); // max_retries from fast_retry()
     }
@@ -1034,6 +1044,14 @@ async fn sync_cross_repo_mount_fallback_to_pull_push() {
         )
         .mount(&target_server)
         .await;
+    Mock::given(method("PATCH"))
+        .and(path("/v2/repo-b/blobs/uploads/fallback-id"))
+        .respond_with(
+            ResponseTemplate::new(202)
+                .insert_header("location", "/v2/repo-b/blobs/uploads/fallback-id"),
+        )
+        .mount(&target_server)
+        .await;
     Mock::given(method("PUT"))
         .and(path("/v2/repo-b/blobs/uploads/fallback-id"))
         .respond_with(ResponseTemplate::new(201))
@@ -1118,6 +1136,14 @@ async fn sync_cross_repo_mount_failure_falls_back() {
     // Subsequent POSTs succeed (fallback upload initiation).
     Mock::given(method("POST"))
         .and(path("/v2/repo-b/blobs/uploads/"))
+        .respond_with(
+            ResponseTemplate::new(202)
+                .insert_header("location", "/v2/repo-b/blobs/uploads/retry-id"),
+        )
+        .mount(&target_server)
+        .await;
+    Mock::given(method("PATCH"))
+        .and(path("/v2/repo-b/blobs/uploads/retry-id"))
         .respond_with(
             ResponseTemplate::new(202)
                 .insert_header("location", "/v2/repo-b/blobs/uploads/retry-id"),

--- a/crates/ocync-sync/tests/engine_integration.rs
+++ b/crates/ocync-sync/tests/engine_integration.rs
@@ -636,7 +636,7 @@ async fn sync_blob_push_failure() {
         ImageStatus::Failed { .. }
     ));
     if let ImageStatus::Failed { error, .. } = &report.images[0].status {
-        assert!(error.contains("blob push"));
+        assert!(error.contains("blob transfer"));
     }
     assert_eq!(report.stats.images_failed, 1);
     assert_eq!(report.exit_code(), 2);
@@ -916,8 +916,8 @@ async fn sync_retry_exhaustion_returns_final_error() {
     ));
     if let ImageStatus::Failed { error, retries } = &report.images[0].status {
         assert!(
-            error.contains("blob push"),
-            "error should mention blob push: {error}"
+            error.contains("blob transfer"),
+            "error should mention blob transfer: {error}"
         );
         assert_eq!(*retries, 2); // max_retries from fast_retry()
     }

--- a/crates/ocync-sync/tests/engine_integration.rs
+++ b/crates/ocync-sync/tests/engine_integration.rs
@@ -206,7 +206,7 @@ async fn mount_manifest_push(server: &MockServer, repo: &str, reference: &str) {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn sync_image_happy_path() {
+async fn sync_happy_path() {
     let source_server = MockServer::start().await;
     let target_server = MockServer::start().await;
 
@@ -277,7 +277,7 @@ async fn sync_image_happy_path() {
 }
 
 #[tokio::test]
-async fn sync_image_skip_on_digest_match() {
+async fn sync_skip_on_digest_match() {
     let source_server = MockServer::start().await;
     let target_server = MockServer::start().await;
 
@@ -323,7 +323,7 @@ async fn sync_image_skip_on_digest_match() {
 }
 
 #[tokio::test]
-async fn sync_image_blob_exists_at_target_skips_transfer() {
+async fn sync_blob_exists_at_target_skips_transfer() {
     let source_server = MockServer::start().await;
     let target_server = MockServer::start().await;
 
@@ -368,7 +368,7 @@ async fn sync_image_blob_exists_at_target_skips_transfer() {
 }
 
 #[tokio::test]
-async fn sync_image_manifest_pull_failure() {
+async fn sync_manifest_pull_failure() {
     let source_server = MockServer::start().await;
     let target_server = MockServer::start().await;
 
@@ -406,7 +406,7 @@ async fn sync_image_manifest_pull_failure() {
 }
 
 #[tokio::test]
-async fn sync_image_blob_pull_retries_on_500() {
+async fn sync_blob_transfer_retries_on_source_500() {
     let source_server = MockServer::start().await;
     let target_server = MockServer::start().await;
 
@@ -1380,4 +1380,85 @@ async fn sync_cross_repo_mount_failure_falls_back() {
     // Mount failed → fell back to pull+push.
     assert_eq!(report.images[1].blob_stats.mounted, 0);
     assert_eq!(report.images[1].blob_stats.transferred, 2);
+}
+
+#[tokio::test]
+async fn sync_multi_target_partial_blob_failure_isolates_targets() {
+    let source_server = MockServer::start().await;
+    let target_a = MockServer::start().await;
+    let target_b = MockServer::start().await;
+
+    let config_data = b"config";
+    let layer_data = b"layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (manifest_bytes, _) = serialize_manifest(&manifest);
+
+    // Source: serve manifest and blobs.
+    mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo", &layer_desc.digest, layer_data).await;
+
+    // Target A: everything succeeds.
+    mount_manifest_head_not_found(&target_a, "repo", "v1").await;
+    mount_blob_not_found(&target_a, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_a, "repo", &layer_desc.digest).await;
+    mount_blob_push(&target_a, "repo").await;
+    mount_manifest_push(&target_a, "repo", "v1").await;
+
+    // Target B: blob push initiation returns 403 (non-retryable).
+    mount_manifest_head_not_found(&target_b, "repo", "v1").await;
+    mount_blob_not_found(&target_b, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_b, "repo", &layer_desc.digest).await;
+    Mock::given(method("POST"))
+        .and(path("/v2/repo/blobs/uploads/"))
+        .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+        .mount(&target_b)
+        .await;
+
+    let mapping = ResolvedMapping {
+        source_client: mock_client(&source_server),
+        source_repo: "repo".into(),
+        target_repo: "repo".into(),
+        targets: vec![
+            TargetEntry {
+                name: "target-a".into(),
+                client: mock_client(&target_a),
+            },
+            TargetEntry {
+                name: "target-b".into(),
+                client: mock_client(&target_b),
+            },
+        ],
+        tags: vec![TagPair::same("v1")],
+    };
+
+    let mut engine = SyncEngine::new(fast_retry());
+    let report = engine.run(vec![mapping], &NullProgress).await;
+
+    assert_eq!(report.images.len(), 2);
+    // Target A succeeds despite target B's failure.
+    assert!(
+        matches!(report.images[0].status, ImageStatus::Synced),
+        "target A should succeed: {:?}",
+        report.images[0].status
+    );
+    assert_eq!(report.images[0].blob_stats.transferred, 2);
+    // Target B fails.
+    assert!(
+        matches!(report.images[1].status, ImageStatus::Failed { .. }),
+        "target B should fail: {:?}",
+        report.images[1].status
+    );
+    assert_eq!(report.stats.images_synced, 1);
+    assert_eq!(report.stats.images_failed, 1);
 }


### PR DESCRIPTION
## Summary

- Replace buffered blob transfers with streaming `blob_pull` → `blob_push_stream` — blobs stream directly from source to target without buffering to disk or memory
- Add `blob_push_stream` to `RegistryClient` — chunked uploads via the OCI distribution spec's POST→PATCH→PUT protocol with Content-Range headers
- GAR fallback: Google Artifact Registry doesn't support chunked uploads, so `*-docker.pkg.dev` hosts buffer the stream and use monolithic upload with digest verification
- Refactor engine to use `&Descriptor` instead of `Digest` tuples — carries size alongside digest, eliminates the separate `ChildData` struct
- Consolidate `BlobPull` + `BlobPush` error variants into `BlobTransfer` with a typed `Digest` field (not `String`)
- Remove dead code: `blob_pull_all` (no callers), unused `content_length` parameter, unreachable error arm

## Key design decisions

- **Per-target streaming**: Each target gets its own pull stream since streams are consumed. For 1:N fan-out, this means N source pulls per blob, but prevents OOM on multi-GB layers. The architecture doc explicitly allows blob pulls to repeat per target.
- **Retry wraps pull+push together**: Streams aren't resumable, so on retry both pull and push are re-initiated from scratch. The retry closure creates a fresh stream each attempt.
- **`Bytes` for retry clones**: Chunk data is converted to `Bytes` before the retry closure so `.clone()` is a cheap refcount increment instead of a full memcpy per PATCH retry.
- **Per-target failure isolation**: `TargetBlobOutcome` tracks errors per-target — if target B's blob push fails, target A still gets its manifests pushed and reports success.
- **GAR digest verification**: The GAR monolithic fallback verifies the digest returned by `blob_push` matches the caller's `expected_digest` to catch data corruption.
- **Content-Range format**: Uses OCI spec format `{start}-{end}` (e.g., `0-3`), NOT RFC 7233 `bytes 0-3/*`. Verified against CNCF Distribution source and OCI conformance tests.

## Test plan

- [x] `blob_push_stream` happy path — single chunk POST→PATCH→PUT with Content-Type and Content-Length header assertions
- [x] Multi-chunk — 12 bytes / 4-byte chunks = 3 PATCH requests with correct Content-Range values
- [x] Exact chunk boundary — data_len == chunk_size, no remainder flush
- [x] Empty stream — zero-byte blob, POST+PUT only, PATCH expect(0)
- [x] POST initiation failure — 403 on POST surfaces correct error
- [x] PATCH chunk failure — 500 on second PATCH propagates correctly
- [x] PUT finalize failure — 400 on PUT surfaces correct error
- [x] POST returns 200 — rejected as unexpected (expects 202)
- [x] Stream error propagation — source stream `Err` propagates through `?`
- [x] GAR fallback — monolithic upload, zero PATCH calls, digest verified
- [x] GAR hostname detection — positive and negative pattern matching
- [x] Location header query param preservation — `?_state=` tokens survive URL resolution
- [x] `extract_location` — absolute, relative, missing, query params
- [x] Multi-target isolation — target A succeeds despite target B's blob push failure
- [x] Engine: happy path, digest skip, blob exists skip, manifest pull failure, blob transfer retry on 500, retry exhaustion, dedup across tags, multiple targets, retagging, index manifest multi-platform, stale digest proceeds, manifest push failure, cross-repo mount (success, fallback, error recovery)
- [x] CI gate: `cargo fmt --check && cargo clippy -- -D warnings && cargo test && cargo deny check`