### PR TITLE
docs: add README files and update repository metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,144 @@
 # ocync
 
-OCI registry sync tool — copies container images between registries.
+Fast, concurrent OCI registry sync — copies container images between registries with zero wasted bandwidth.
+
+[![CI](https://github.com/clowdhaus/ocync/actions/workflows/ci.yml/badge.svg)](https://github.com/clowdhaus/ocync/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## Features
 
-- **Library-first** — `ocync-distribution` is a standalone OCI Distribution client; `ocync-sync` will provide sync orchestration
-- **Pure OCI Distribution API** — no skopeo, no Docker daemon, direct HTTPS
-- **Additive sync only** — never deletes; registries handle lifecycle
-- **ECR-first** with broad registry support (GCR, ACR, GHCR, Docker Hub, Chainguard)
-- **FIPS 140-3** by default via aws-lc-rs (NIST Certificate #4816)
-- **Two-phase sync** — resolve all manifests, deduplicate blobs globally, then transfer
-- **Cross-repo blob mounting** — zero data transfer for shared layers
-- **Tag filtering** — glob, semver ranges, exclude patterns, sort + latest-N
+**Available now:**
 
-## Installation
+- **Pure OCI Distribution API** — no Docker daemon, no shelling out, direct HTTPS to registries
+- **Additive sync only** — never deletes; registries handle lifecycle and retention
+- **ECR-native with broad registry support** — automatic provider detection for registry-specific optimizations
+- **FIPS 140-3 by default** — aws-lc-rs with NIST Certificate #4816
+- **Cross-repo blob mounting** — zero data transfer for shared layers within a registry
+- **Tag filtering** — glob patterns, semver ranges, exclude patterns, sort, latest-N
+- **Platform filtering** — sync only the architectures you need (e.g., `linux/amd64`, `linux/arm64`)
+- **Adaptive rate limiting** — per-action AIMD concurrency that adjusts to each registry's limits
+- **Transfer state cache** — persistent cache skips already-synced images across runs
+- **Graceful shutdown** — SIGINT/SIGTERM drains in-flight transfers before exiting
+
+**Coming soon:**
+
+- **Progress reporting** — TTY-aware progress bars with transfer rates
+- **Structured JSON output** — machine-readable sync reports for CI/CD pipelines
+- **Credential helpers** — native auth for GCR/GAR, ACR, GHCR, Docker Hub
+- **Dry-run preview** — see what would sync without making changes
+
+## Quick start
+
+Install:
 
 ```bash
 cargo install ocync
 ```
 
+Copy a single image:
+
+```
+$ ocync copy cgr.dev/chainguard/nginx:latest \
+    123456789012.dkr.ecr.us-east-1.amazonaws.com/nginx:latest
+
+  nginx:latest ✓ synced (3 blobs, 1 mounted, 42 MB transferred) [1.8s]
+```
+
+Sync from a config file:
+
+```
+$ ocync sync -c sync.yaml
+
+  nginx:1.27          ✓ synced → us-east-1, us-west-2 (6 blobs, 4 mounted) [2.1s]
+  nginx:1.26          ✓ skipped (already synced)
+  python:3.12-slim    ✓ synced → us-east-1, us-west-2 (8 blobs, 3 mounted) [3.4s]
+
+  3 images, 2 synced, 1 skipped
+  14 blobs (7 deduplicated, 7 mounted), 89 MB transferred [5.2s]
+```
+
+> **Note:** The output format shown above is aspirational and represents the intended design. The current CLI output may differ.
+
+## How it works
+
+- **Pull once, push everywhere** — source images are pulled once per tag. Fan-out to N target registries happens simultaneously, never re-pulling the source.
+- **Global blob deduplication** — shared layers across all images in a sync run are transferred only once, regardless of how many images reference them.
+- **Cross-repo mounting** — when a blob already exists in another repository on the same target registry, it is mounted instead of transferred. Zero bytes over the wire.
+- **Streaming transfers** — bytes flow directly from source registry to target registry. No intermediate disk storage required.
+- **Adaptive concurrency** — each registry action type (manifest pull, blob push, etc.) has its own AIMD window that adjusts based on rate limit feedback. A throttled blob push does not slow down manifest pulls.
+
 ## Usage
 
-```bash
-# Sync from config
-ocync sync --config config.yaml
-
-# Copy a single image
-ocync copy docker.io/library/nginx:1.27 ghcr.io/myorg/nginx:1.27
-
-# List and filter tags
-ocync tags docker.io/library/nginx --glob "1.*" --semver ">=1.26" --sort semver --latest 10
-
-# Validate config
-ocync validate config.yaml
+```
+ocync sync -c config.yaml              # Sync images from config
+ocync sync -c config.yaml --dry-run    # Preview what would sync           (coming soon)
+ocync sync -c config.yaml --json       # Output sync report as JSON        (coming soon)
+ocync copy <source> <destination>      # Copy a single image
+ocync tags <repository>                # List and filter tags
+ocync watch -c config.yaml             # Continuous sync on a schedule
+ocync auth check -c config.yaml        # Verify registry credentials
+ocync validate config.yaml             # Validate config without connecting
+ocync expand config.yaml               # Show config with env vars resolved
 ```
 
 ## Configuration
 
-See [docs/specs/2026-04-10-ocync-design.md](docs/specs/2026-04-10-ocync-design.md) for the full specification.
+```yaml
+registries:
+  chainguard:
+    url: cgr.dev
+  ecr-east:
+    url: 123456789012.dkr.ecr.us-east-1.amazonaws.com
+    auth_type: ecr
+  ecr-west:
+    url: 123456789012.dkr.ecr.us-west-2.amazonaws.com
+    auth_type: ecr
+
+target_groups:
+  prod:
+    - ecr-east
+    - ecr-west
+
+defaults:
+  source: chainguard
+  targets: prod
+  platforms:
+    - linux/amd64
+    - linux/arm64
+  tags:
+    semver: ">=1.0"
+    sort: semver
+    latest: 10
+
+mappings:
+  - from: chainguard/nginx
+    to: nginx
+  - from: chainguard/python
+    to: python
+    tags:
+      glob: "*-slim"
+```
+
+- **Registries** — named registry definitions with optional auth type (auto-detected from hostname when omitted)
+- **Target groups** — logical groupings for 1:N fan-out
+- **Defaults** — tags, platforms, and skip_existing applied to all mappings unless overridden
+- **Mappings** — source-to-target image relationships with optional per-mapping overrides
+
+## Supported registries
+
+| Registry | Auth | Status |
+|---|---|---|
+| Amazon ECR (private) | Automatic (IAM) | Available |
+| Amazon ECR Public | Automatic (IAM) | Available |
+| Chainguard | Token exchange | Available |
+| Docker Hub | Anonymous / docker config | Available |
+| GitHub Container Registry | `GITHUB_TOKEN` | Coming soon |
+| Google Artifact Registry | Application Default Credentials | Coming soon |
+| Azure Container Registry | Service principal | Coming soon |
+| Quay.io | Token exchange | Coming soon |
+| Any OCI-compliant registry | Basic / token / anonymous | Available |
+
+ECR includes provider-specific optimizations: batch blob existence checks, cross-repo mounts, and per-action rate limit adaptation. Auth type is auto-detected from the registry hostname when not explicitly configured.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ ocync sync -c sync.yaml
   14 blobs (7 deduplicated, 7 mounted), 89 MB transferred [5.2s]
 ```
 
-> **Note:** The output format shown above is aspirational and represents the intended design. The current CLI output may differ.
+*Output format is under active development and may differ from what is shown above.*
 
 ## How it works
 
@@ -89,13 +89,13 @@ registries:
     url: cgr.dev
   ecr-east:
     url: 123456789012.dkr.ecr.us-east-1.amazonaws.com
-    auth_type: ecr
+    auth_type: ecr # auto-detected from hostname when omitted
   ecr-west:
     url: 123456789012.dkr.ecr.us-west-2.amazonaws.com
     auth_type: ecr
 
 target_groups:
-  prod:
+  prod: # logical name for a set of target registries
     - ecr-east
     - ecr-west
 
@@ -106,17 +106,17 @@ defaults:
     - linux/amd64
     - linux/arm64
   tags:
-    semver: ">=1.0"
+    semver: ">=1.0" # matches any semver tag >= 1.0
     sort: semver
-    latest: 10
+    latest: 10 # keep only the 10 most recent after filtering
 
 mappings:
-  - from: chainguard/nginx
-    to: nginx
+  - from: chainguard/nginx # source repository path
+    to: nginx # target repository path (same across all targets)
   - from: chainguard/python
     to: python
     tags:
-      glob: "*-slim"
+      glob: "*-slim" # override default tag filter for this mapping
 ```
 
 - **Registries** — named registry definitions with optional auth type (auto-detected from hostname when omitted)

--- a/crates/ocync-distribution/README.md
+++ b/crates/ocync-distribution/README.md
@@ -1,0 +1,46 @@
+# ocync-distribution
+
+OCI Distribution Specification client library.
+
+This crate is part of [ocync](https://github.com/clowdhaus/ocync), a fast OCI registry sync tool. The primary interface is the `ocync` CLI — this crate is the underlying library, exposed for embedding in other Rust applications.
+
+## What it does
+
+Standalone client for the [OCI Distribution Spec](https://github.com/opencontainers/distribution-spec). Handles authentication, content-addressable blob operations, manifest negotiation, tag listing, and adaptive rate limiting against any OCI-compliant registry.
+
+## Capabilities
+
+- Registry client with per-provider auth (ECR, anonymous, token exchange)
+- Blob operations: streaming pull, chunked upload, cross-repo mount, existence check
+- Manifest operations: pull, push, HEAD, content negotiation for OCI and Docker media types
+- Tag listing with automatic pagination
+- Content-addressable SHA-256 digest computation and verification
+- AIMD-based adaptive concurrency per registry action
+- ECR batch blob existence checks
+- FIPS 140-3 cryptography by default (aws-lc-rs)
+
+## Example
+
+```rust
+use ocync_distribution::{RegistryClient, RegistryClientBuilder};
+use url::Url;
+
+let client = RegistryClientBuilder::new(
+        Url::parse("https://registry-1.docker.io").unwrap(),
+    )
+    .build()
+    .unwrap();
+
+let manifest = client
+    .pull_manifest("library/nginx", "latest")
+    .await
+    .unwrap();
+
+println!("digest: {}", manifest.digest);
+```
+
+## Links
+
+- [ocync CLI](https://github.com/clowdhaus/ocync) — the primary interface
+- [API documentation](https://docs.rs/ocync-distribution)
+- License: Apache-2.0

--- a/crates/ocync-sync/README.md
+++ b/crates/ocync-sync/README.md
@@ -1,0 +1,41 @@
+# ocync-sync
+
+OCI registry sync orchestration engine.
+
+This crate is part of [ocync](https://github.com/clowdhaus/ocync), a fast OCI registry sync tool. The primary interface is the `ocync` CLI — this crate is the underlying library, exposed for embedding in other Rust applications.
+
+## What it does
+
+Sync orchestration engine that coordinates image transfers between OCI registries. Handles tag filtering, transfer planning, blob deduplication, concurrent execution with graceful shutdown, and persistent caching.
+
+## Capabilities
+
+- Tag filtering pipeline: glob patterns, semver ranges, prerelease handling, exclude patterns, sort, latest-N
+- Pipelined concurrent sync engine with overlapping discovery and execution
+- Global blob deduplication across all images in a sync run
+- Cross-repo blob mounting when source blob exists elsewhere on target registry
+- Content-addressable disk staging for multi-target blob reuse
+- Persistent transfer state cache with TTL and lazy invalidation
+- Cooperative graceful shutdown with configurable drain deadline
+- Structured sync reports with per-image and aggregate statistics
+
+## Example
+
+```rust
+use ocync_sync::engine::{ResolvedMapping, SyncEngine};
+use ocync_sync::retry::RetryConfig;
+use ocync_sync::SyncReport;
+
+let engine = SyncEngine::new(RetryConfig::default(), 50);
+
+let mappings: Vec<ResolvedMapping> = vec![/* ... */];
+let report: SyncReport = engine.run(mappings, cache, staging, &progress, None).await;
+
+println!("synced: {}, skipped: {}", report.stats.images_synced, report.stats.images_skipped);
+```
+
+## Links
+
+- [ocync CLI](https://github.com/clowdhaus/ocync) — the primary interface
+- [API documentation](https://docs.rs/ocync-sync)
+- License: Apache-2.0


### PR DESCRIPTION
## Summary

- Rewrite root README: features (available/coming soon), quick start with CLI output examples, how-it-works section, usage, configuration with inline comments, supported registries table
- Add per-crate READMEs for crates.io (`ocync-distribution`, `ocync-sync`) — frame crates as internals of the CLI
- Update GitHub repo description and topics (11 topics for discoverability)

## Details

Root README targets ops/platform engineers evaluating sync tools. Aspirational but honest — full CLI surface documented with clear status markers for what's built vs coming soon. "How it works" section explains the performance architecture (pull-once fan-out, blob dedup, cross-repo mounting, streaming, adaptive concurrency) — a gap no competitor fills.

Per-crate READMEs are minimal (~40 lines each) and clearly direct users to the `ocync` CLI as the primary interface.