### PR TITLE
feat: platform filtering and skip_existing for sync engine

### DIFF
--- a/crates/ocync-distribution/src/spec.rs
+++ b/crates/ocync-distribution/src/spec.rs
@@ -167,6 +167,43 @@ impl fmt::Display for Platform {
     }
 }
 
+impl Platform {
+    /// Returns `true` if this platform matches the given filter string.
+    ///
+    /// The filter must be `"os/arch"` or `"os/arch/variant"`. Comparison is
+    /// case-insensitive. An empty filter never matches. When the filter
+    /// specifies only `os/arch`, the platform's `variant` field is ignored —
+    /// any variant (or none) will match.
+    pub fn matches(&self, filter: &str) -> bool {
+        if filter.is_empty() {
+            return false;
+        }
+        let mut parts = filter.splitn(3, '/');
+        let Some(filter_os) = parts.next() else {
+            return false;
+        };
+        let Some(filter_arch) = parts.next() else {
+            return false;
+        };
+        let filter_variant = parts.next();
+
+        if !self.os.eq_ignore_ascii_case(filter_os) {
+            return false;
+        }
+        if !self.architecture.eq_ignore_ascii_case(filter_arch) {
+            return false;
+        }
+        if let Some(fv) = filter_variant {
+            match &self.variant {
+                Some(pv) => pv.eq_ignore_ascii_case(fv),
+                None => false,
+            }
+        } else {
+            true
+        }
+    }
+}
+
 /// OCI image manifest (single-platform).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -492,6 +529,84 @@ mod tests {
         let m = ManifestKind::from_json(&MediaType::OciIndex, &bytes).unwrap();
         let digests = m.referenced_digests();
         assert_eq!(digests.len(), 2);
+    }
+
+    // -- Platform::matches tests --
+
+    fn linux_amd64() -> Platform {
+        Platform {
+            architecture: "amd64".into(),
+            os: "linux".into(),
+            variant: None,
+            os_version: None,
+            os_features: None,
+        }
+    }
+
+    fn linux_arm64_v8() -> Platform {
+        Platform {
+            architecture: "arm64".into(),
+            os: "linux".into(),
+            variant: Some("v8".into()),
+            os_version: None,
+            os_features: None,
+        }
+    }
+
+    #[test]
+    fn platform_matches_os_arch() {
+        assert!(linux_amd64().matches("linux/amd64"));
+    }
+
+    #[test]
+    fn platform_matches_os_arch_variant() {
+        assert!(linux_arm64_v8().matches("linux/arm64/v8"));
+    }
+
+    #[test]
+    fn platform_matches_case_insensitive() {
+        assert!(linux_amd64().matches("Linux/AMD64"));
+        assert!(linux_arm64_v8().matches("LINUX/ARM64/V8"));
+    }
+
+    #[test]
+    fn platform_matches_empty_filter_returns_false() {
+        assert!(!linux_amd64().matches(""));
+    }
+
+    #[test]
+    fn platform_matches_variant_mismatch_returns_false() {
+        // filter specifies v7 but platform has v8
+        let p = Platform {
+            architecture: "arm".into(),
+            os: "linux".into(),
+            variant: Some("v8".into()),
+            os_version: None,
+            os_features: None,
+        };
+        assert!(!p.matches("linux/arm/v7"));
+    }
+
+    #[test]
+    fn platform_matches_filter_variant_no_platform_variant_returns_false() {
+        // filter requires a specific variant but platform has none
+        assert!(!linux_amd64().matches("linux/amd64/v1"));
+    }
+
+    #[test]
+    fn platform_matches_os_arch_ignores_platform_variant() {
+        // os/arch filter matches regardless of what variant the platform has
+        assert!(linux_arm64_v8().matches("linux/arm64"));
+    }
+
+    #[test]
+    fn platform_matches_wrong_os_returns_false() {
+        assert!(!linux_amd64().matches("windows/amd64"));
+    }
+
+    #[test]
+    fn platform_matches_wrong_arch_returns_false() {
+        assert!(!linux_amd64().matches("linux/arm64"));
     }
 
     #[test]

--- a/crates/ocync-sync/Cargo.toml
+++ b/crates/ocync-sync/Cargo.toml
@@ -21,13 +21,13 @@ postcard = { version = "1", default-features = false, features = ["alloc"] }
 reqwest.workspace = true
 semver = { version = "1", default-features = false, features = ["std"] }
 serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "sync", "time"] }
 tracing.workspace = true
 uuid = { version = "1", default-features = false, features = ["v7", "serde"] }
 
 [dev-dependencies]
-serde_json.workspace = true
 tempfile = { version = "3", default-features = false }
 tokio = { workspace = true, features = ["macros", "rt", "test-util"] }
 url.workspace = true

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -33,7 +33,8 @@ use ocync_distribution::Digest;
 use ocync_distribution::RegistryClient;
 use ocync_distribution::blob::MountResult;
 use ocync_distribution::manifest::ManifestPull;
-use ocync_distribution::spec::{Descriptor, ImageManifest, ManifestKind};
+use ocync_distribution::sha256::Sha256;
+use ocync_distribution::spec::{Descriptor, ImageIndex, ImageManifest, ManifestKind};
 use tokio::sync::Semaphore;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
@@ -61,6 +62,19 @@ pub struct ResolvedMapping {
     pub targets: Vec<TargetEntry>,
     /// Tag pairs to sync (already filtered).
     pub tags: Vec<TagPair>,
+    /// Optional platform filter list (e.g., `["linux/amd64"]`).
+    ///
+    /// When `Some`, index manifests are filtered to only include descriptors
+    /// whose platform matches one of the filter strings (using
+    /// [`Platform::matches()`]). Child manifests and blobs for non-matching
+    /// platforms are never pulled from the source.
+    pub platforms: Option<Vec<String>>,
+    /// When `true`, skip syncing when the target already has any manifest for
+    /// the tag, regardless of digest comparison.
+    ///
+    /// This avoids the overhead of full digest comparison when the user only
+    /// cares that *some* version exists at the target.
+    pub skip_existing: bool,
 }
 
 /// A single target registry entry.
@@ -314,17 +328,21 @@ impl SyncEngine {
                 let target_tag = tag_pair.target.clone();
                 let retry = self.retry.clone();
                 let targets = mapping.targets.clone();
+                let platforms = mapping.platforms.clone();
+                let skip_existing = mapping.skip_existing;
 
                 discovery_futures.push(async move {
-                    discover_tag(
+                    discover_tag(DiscoveryParams {
                         source_client,
-                        &source_repo,
-                        &target_repo,
-                        &source_tag,
-                        &target_tag,
-                        &targets,
-                        &retry,
-                    )
+                        source_repo: &source_repo,
+                        target_repo: &target_repo,
+                        source_tag: &source_tag,
+                        target_tag: &target_tag,
+                        targets: &targets,
+                        retry: &retry,
+                        platforms: platforms.as_deref(),
+                        skip_existing,
+                    })
                     .await
                 });
             }
@@ -442,22 +460,48 @@ impl SyncEngine {
     }
 }
 
+/// Parameters for [`discover_tag`], bundled to keep the argument count under
+/// clippy's limit while preserving readability.
+struct DiscoveryParams<'a> {
+    source_client: Arc<RegistryClient>,
+    source_repo: &'a str,
+    target_repo: &'a str,
+    source_tag: &'a str,
+    target_tag: &'a str,
+    targets: &'a [TargetEntry],
+    retry: &'a RetryConfig,
+    /// Optional platform filter list (e.g., `["linux/amd64"]`).
+    platforms: Option<&'a [String]>,
+    /// When `true`, skip syncing when the target already has any manifest.
+    skip_existing: bool,
+}
+
 /// Discover a single (mapping, tag) pair: pull source manifest, HEAD-check targets.
 ///
 /// Returns a `DiscoveryOutcome` indicating whether all targets can be skipped,
 /// some need sync, or the source pull failed.
-async fn discover_tag(
-    source_client: Arc<RegistryClient>,
-    source_repo: &str,
-    target_repo: &str,
-    source_tag: &str,
-    target_tag: &str,
-    targets: &[TargetEntry],
-    retry: &RetryConfig,
-) -> DiscoveryOutcome {
+///
+/// When `platforms` is `Some`, index manifests are filtered to only include
+/// descriptors matching the given platform filters before pulling children.
+///
+/// When `skip_existing` is `true`, targets that return any manifest HEAD response
+/// (regardless of digest) are skipped without further comparison.
+async fn discover_tag(params: DiscoveryParams<'_>) -> DiscoveryOutcome {
+    let DiscoveryParams {
+        source_client,
+        source_repo,
+        target_repo,
+        source_tag,
+        target_tag,
+        targets,
+        retry,
+        platforms,
+        skip_existing,
+    } = params;
     // Pull source manifest (shared across all targets for this tag).
     let source_data =
-        match pull_source_manifest(&source_client, source_repo, source_tag, retry).await {
+        match pull_source_manifest(&source_client, source_repo, source_tag, retry, platforms).await
+        {
             Ok(data) => Rc::new(data),
             Err(err) => {
                 let error_str = err.to_string();
@@ -509,6 +553,26 @@ async fn discover_tag(
 
     while let Some((target_name, target_client, batch_checker, result)) = head_checks.next().await {
         match result {
+            Ok(Some(_)) if skip_existing => {
+                info!(
+                    source_repo = %source_repo,
+                    target_repo = %target_repo,
+                    tag = %source_tag,
+                    "skipping -- target manifest exists (skip_existing)"
+                );
+                tracing::debug!(target: "ocync::metrics", "skip_existing");
+                skipped_results.push(ImageResult {
+                    image_id: Uuid::now_v7(),
+                    source: format!("{source_repo}:{source_tag}"),
+                    target: format!("{target_repo}:{target_tag}"),
+                    status: ImageStatus::Skipped {
+                        reason: SkipReason::SkipExisting,
+                    },
+                    bytes_transferred: 0,
+                    blob_stats: BlobTransferStats::default(),
+                    duration: Duration::ZERO,
+                });
+            }
             Ok(Some(head)) if head.digest == *source_digest => {
                 info!(
                     source_repo = %source_repo,
@@ -665,11 +729,17 @@ async fn execute_item(
 ///
 /// For image manifests, returns just the manifest. For index manifests,
 /// also pulls all child manifests.
+///
+/// When `platforms` is `Some`, index manifests are filtered to only include
+/// descriptors whose platform matches one of the filter strings. Only
+/// matching child manifests are pulled, and the index's `raw_bytes` are
+/// re-serialized to reflect only the kept descriptors.
 async fn pull_source_manifest(
     client: &RegistryClient,
     repo: &str,
     tag: &str,
     retry: &RetryConfig,
+    platforms: Option<&[String]>,
 ) -> Result<PulledManifest, crate::Error> {
     let pull = with_retry(retry, "manifest pull", || client.manifest_pull(repo, tag))
         .await
@@ -681,8 +751,35 @@ async fn pull_source_manifest(
     let children = match &pull.manifest {
         ManifestKind::Image(_) => Vec::new(),
         ManifestKind::Index(index) => {
-            let mut children = Vec::with_capacity(index.manifests.len());
-            for child_desc in &index.manifests {
+            // When platform filters are active, only pull children for matching platforms.
+            let descriptors: Vec<&Descriptor> = if let Some(filters) = platforms {
+                let total = index.manifests.len();
+                let kept: Vec<&Descriptor> = index
+                    .manifests
+                    .iter()
+                    .filter(|desc| {
+                        desc.platform
+                            .as_ref()
+                            .is_some_and(|p| filters.iter().any(|f| p.matches(f)))
+                    })
+                    .collect();
+
+                info!(
+                    repo = %repo,
+                    tag = %tag,
+                    kept = kept.len(),
+                    total = total,
+                    "filtered index: {}/{} platforms",
+                    kept.len(),
+                    total,
+                );
+                kept
+            } else {
+                index.manifests.iter().collect()
+            };
+
+            let mut children = Vec::with_capacity(descriptors.len());
+            for child_desc in &descriptors {
                 let child_digest_str = child_desc.digest.to_string();
                 let child_pull = with_retry(retry, "manifest pull", || {
                     client.manifest_pull(repo, &child_digest_str)
@@ -707,6 +804,39 @@ async fn pull_source_manifest(
                     }
                 }
             }
+
+            // When platform filtering is active, rebuild the index manifest with
+            // only the matching descriptors. The raw_bytes and digest must be
+            // recomputed so targets receive the filtered index.
+            if platforms.is_some() && descriptors.len() != index.manifests.len() {
+                let filtered_index = ImageIndex {
+                    schema_version: index.schema_version,
+                    media_type: index.media_type.clone(),
+                    manifests: descriptors.into_iter().cloned().collect(),
+                    subject: index.subject.clone(),
+                    artifact_type: index.artifact_type.clone(),
+                    annotations: index.annotations.clone(),
+                };
+                let new_bytes =
+                    serde_json::to_vec(&filtered_index).map_err(|e| crate::Error::Manifest {
+                        reference: tag.to_owned(),
+                        source: ocync_distribution::Error::Other(format!(
+                            "failed to serialize filtered index: {e}"
+                        )),
+                    })?;
+                let new_digest = Digest::from_sha256(Sha256::digest(&new_bytes));
+                let filtered_pull = ManifestPull {
+                    manifest: ManifestKind::Index(Box::new(filtered_index)),
+                    raw_bytes: new_bytes,
+                    media_type: pull.media_type,
+                    digest: new_digest,
+                };
+                return Ok(PulledManifest {
+                    pull: filtered_pull,
+                    children,
+                });
+            }
+
             children
         }
     };

--- a/crates/ocync-sync/src/lib.rs
+++ b/crates/ocync-sync/src/lib.rs
@@ -117,12 +117,19 @@ pub enum ImageStatus {
 pub enum SkipReason {
     /// Source and target digests already match.
     DigestMatch,
+    /// `skip_existing` is enabled and the target already has a manifest for this tag.
+    SkipExisting,
+    /// ECR returned HTTP 400 `ImageTagAlreadyExistsException`, meaning immutable tagging is
+    /// enabled and the tag already exists at the target.
+    ImmutableTag,
 }
 
 impl std::fmt::Display for SkipReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::DigestMatch => f.write_str("digest match"),
+            Self::SkipExisting => f.write_str("skip existing"),
+            Self::ImmutableTag => f.write_str("immutable tag"),
         }
     }
 }
@@ -237,6 +244,16 @@ mod tests {
     #[test]
     fn skip_reason_display() {
         assert_eq!(SkipReason::DigestMatch.to_string(), "digest match");
+    }
+
+    #[test]
+    fn skip_reason_display_skip_existing() {
+        assert_eq!(SkipReason::SkipExisting.to_string(), "skip existing");
+    }
+
+    #[test]
+    fn skip_reason_display_immutable_tag() {
+        assert_eq!(SkipReason::ImmutableTag.to_string(), "immutable tag");
     }
 
     #[test]

--- a/crates/ocync-sync/src/lib.rs
+++ b/crates/ocync-sync/src/lib.rs
@@ -119,9 +119,6 @@ pub enum SkipReason {
     DigestMatch,
     /// `skip_existing` is enabled and the target already has a manifest for this tag.
     SkipExisting,
-    /// ECR returned HTTP 400 `ImageTagAlreadyExistsException`, meaning immutable tagging is
-    /// enabled and the tag already exists at the target.
-    ImmutableTag,
 }
 
 impl std::fmt::Display for SkipReason {
@@ -129,7 +126,6 @@ impl std::fmt::Display for SkipReason {
         match self {
             Self::DigestMatch => f.write_str("digest match"),
             Self::SkipExisting => f.write_str("skip existing"),
-            Self::ImmutableTag => f.write_str("immutable tag"),
         }
     }
 }
@@ -249,11 +245,6 @@ mod tests {
     #[test]
     fn skip_reason_display_skip_existing() {
         assert_eq!(SkipReason::SkipExisting.to_string(), "skip existing");
-    }
-
-    #[test]
-    fn skip_reason_display_immutable_tag() {
-        assert_eq!(SkipReason::ImmutableTag.to_string(), "immutable tag");
     }
 
     #[test]

--- a/crates/ocync-sync/tests/engine_integration.rs
+++ b/crates/ocync-sync/tests/engine_integration.rs
@@ -64,28 +64,6 @@ fn target_entry(name: &str, client: Arc<ocync_distribution::RegistryClient>) -> 
     }
 }
 
-/// Build a [`ResolvedMapping`] with default `platforms` and `skip_existing`.
-///
-/// Avoids boilerplate in the majority of tests that don't exercise platform
-/// filtering or skip-existing behavior.
-fn resolved_mapping(
-    source_client: Arc<ocync_distribution::RegistryClient>,
-    source_repo: &str,
-    target_repo: &str,
-    targets: Vec<TargetEntry>,
-    tags: Vec<TagPair>,
-) -> ResolvedMapping {
-    ResolvedMapping {
-        source_client,
-        source_repo: source_repo.into(),
-        target_repo: target_repo.into(),
-        targets,
-        tags,
-        platforms: None,
-        skip_existing: false,
-    }
-}
-
 /// Serialize an `ImageManifest` to JSON bytes and compute its digest.
 fn serialize_manifest(manifest: &ImageManifest) -> (Vec<u8>, Digest) {
     let bytes = serde_json::to_vec(manifest).unwrap();
@@ -5336,4 +5314,403 @@ async fn sync_skip_existing_false_syncs_on_different_digest() {
     assert_eq!(report.stats.images_synced, 1);
     assert_eq!(report.stats.blobs_transferred, 2);
     assert_eq!(report.stats.bytes_transferred, expected_bytes);
+}
+
+// ---------------------------------------------------------------------------
+// Multi-target independence tests
+// ---------------------------------------------------------------------------
+
+/// With two targets and `skip_existing = true`, each target is evaluated
+/// independently:
+/// - Target A has an existing manifest (different digest) → skipped
+/// - Target B has no manifest → synced
+///
+/// Verifies that the source manifest is pulled exactly once (pull-once
+/// fan-out invariant), that target A receives no blob or manifest pushes,
+/// and that per-target and aggregate stats are correct.
+#[tokio::test]
+async fn sync_skip_existing_multi_target_independent() {
+    let source_server = MockServer::start().await;
+    let target_a = MockServer::start().await;
+    let target_b = MockServer::start().await;
+
+    let config_data = b"config-skip-multi";
+    let layer_data = b"layer-skip-multi";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (manifest_bytes, _manifest_digest) = serialize_manifest(&manifest);
+
+    // Source: manifest pulled exactly once (pull-once fan-out invariant).
+    Mock::given(method("GET"))
+        .and(path("/v2/repo/manifests/latest"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(manifest_bytes)
+                .insert_header("content-type", MediaType::OciManifest.as_str()),
+        )
+        .expect(1)
+        .mount(&source_server)
+        .await;
+
+    // Source blobs: only target B needs them; expect(1) each since only one
+    // target actually transfers.
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/blobs/{}", config_desc.digest)))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(config_data.to_vec())
+                .insert_header("content-length", config_data.len().to_string()),
+        )
+        .expect(1)
+        .mount(&source_server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/blobs/{}", layer_desc.digest)))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(layer_data.to_vec())
+                .insert_header("content-length", layer_data.len().to_string()),
+        )
+        .expect(1)
+        .mount(&source_server)
+        .await;
+
+    // Target A: HEAD returns 200 with a different digest -- skip_existing
+    // means the engine skips without comparing digests.  No blob or manifest
+    // push endpoints are mounted; an unexpected request would fail the mock.
+    let different_digest = test_digest("d1ff");
+    Mock::given(method("HEAD"))
+        .and(path("/v2/repo/manifests/latest"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("docker-content-digest", different_digest.to_string())
+                .insert_header("content-type", MediaType::OciManifest.as_str())
+                .insert_header("content-length", "100"),
+        )
+        .expect(1)
+        .mount(&target_a)
+        .await;
+
+    // Target B: HEAD returns 404 -- engine must sync.
+    mount_manifest_head_not_found(&target_b, "repo", "latest").await;
+    mount_blob_not_found(&target_b, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_b, "repo", &layer_desc.digest).await;
+    mount_blob_push(&target_b, "repo").await;
+    mount_manifest_push(&target_b, "repo", "latest").await;
+
+    let mapping = ResolvedMapping {
+        source_client: mock_client(&source_server),
+        source_repo: "repo".into(),
+        target_repo: "repo".into(),
+        targets: vec![
+            target_entry("target-a", mock_client(&target_a)),
+            target_entry("target-b", mock_client(&target_b)),
+        ],
+        tags: vec![TagPair::same("latest")],
+        platforms: None,
+        skip_existing: true,
+    };
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    // Exactly 2 image results (1 tag x 2 targets).
+    assert_eq!(report.images.len(), 2);
+
+    // Find results by status since target and source strings are identical.
+    let result_a = report
+        .images
+        .iter()
+        .find(|r| {
+            matches!(
+                r.status,
+                ImageStatus::Skipped {
+                    reason: SkipReason::SkipExisting,
+                }
+            )
+        })
+        .expect("target-a result (SkipExisting) not found");
+
+    let result_b = report
+        .images
+        .iter()
+        .find(|r| matches!(r.status, ImageStatus::Synced))
+        .expect("target-b result (Synced) not found");
+
+    // Target A: skipped, zero bytes, zero blob transfers.
+    assert_eq!(result_a.bytes_transferred, 0);
+    assert_eq!(result_a.blob_stats.transferred, 0);
+    assert_eq!(result_a.blob_stats.skipped, 0);
+
+    // Target B: synced, both blobs transferred.
+    assert_eq!(result_b.blob_stats.transferred, 2);
+    assert_eq!(result_b.blob_stats.skipped, 0);
+    let expected_bytes = (config_data.len() + layer_data.len()) as u64;
+    assert_eq!(result_b.bytes_transferred, expected_bytes);
+
+    // Aggregate stats.
+    assert_eq!(report.stats.images_synced, 1);
+    assert_eq!(report.stats.images_skipped, 1);
+    assert_eq!(report.stats.blobs_transferred, 2);
+    assert_eq!(report.stats.bytes_transferred, expected_bytes);
+    // wiremock expect(N) assertions verify pull-once and no target-A pushes.
+}
+
+/// With two targets, an index manifest containing linux/amd64 and linux/arm64,
+/// and a platform filter for linux/amd64 only:
+/// - Source index is pulled exactly once
+/// - Only the amd64 child manifest is pulled (arm64 filtered out)
+/// - Both targets receive amd64 blobs and manifest pushes
+/// - Neither target receives arm64 blobs or manifest pushes
+///
+/// Source blobs are pulled once per target (staging disabled), so each blob
+/// GET has `.expect(2)`.
+#[tokio::test]
+async fn sync_platform_filter_multi_target() {
+    let source_server = MockServer::start().await;
+    let target_a = MockServer::start().await;
+    let target_b = MockServer::start().await;
+
+    // --- Build two child image manifests: linux/amd64 and linux/arm64 ---
+
+    let amd64_config_data = b"amd64-config-multi";
+    let amd64_layer_data = b"amd64-layer-multi";
+    let amd64_config_desc = blob_descriptor(amd64_config_data, MediaType::OciConfig);
+    let amd64_layer_desc = blob_descriptor(amd64_layer_data, MediaType::OciLayerGzip);
+    let amd64_manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: amd64_config_desc.clone(),
+        layers: vec![amd64_layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (amd64_bytes, amd64_digest) = serialize_manifest(&amd64_manifest);
+
+    let arm64_config_data = b"arm64-config-multi";
+    let arm64_layer_data = b"arm64-layer-multi";
+    let arm64_config_desc = blob_descriptor(arm64_config_data, MediaType::OciConfig);
+    let arm64_layer_desc = blob_descriptor(arm64_layer_data, MediaType::OciLayerGzip);
+    let arm64_manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: arm64_config_desc.clone(),
+        layers: vec![arm64_layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (arm64_bytes, arm64_digest) = serialize_manifest(&arm64_manifest);
+
+    // --- Build index with platform-annotated descriptors ---
+
+    let index = ImageIndex {
+        schema_version: 2,
+        media_type: None,
+        manifests: vec![
+            Descriptor {
+                media_type: MediaType::OciManifest,
+                digest: amd64_digest.clone(),
+                size: amd64_bytes.len() as u64,
+                platform: Some(Platform {
+                    architecture: "amd64".into(),
+                    os: "linux".into(),
+                    variant: None,
+                    os_version: None,
+                    os_features: None,
+                }),
+                artifact_type: None,
+                annotations: None,
+            },
+            Descriptor {
+                media_type: MediaType::OciManifest,
+                digest: arm64_digest.clone(),
+                size: arm64_bytes.len() as u64,
+                platform: Some(Platform {
+                    architecture: "arm64".into(),
+                    os: "linux".into(),
+                    variant: None,
+                    os_version: None,
+                    os_features: None,
+                }),
+                artifact_type: None,
+                annotations: None,
+            },
+        ],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let index_bytes = serde_json::to_vec(&index).unwrap();
+
+    // --- Source: serve index by tag, children by digest ---
+
+    // Index pulled exactly once (pull-once fan-out invariant).
+    Mock::given(method("GET"))
+        .and(path("/v2/repo/manifests/latest"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(index_bytes.clone())
+                .insert_header("content-type", MediaType::OciIndex.as_str()),
+        )
+        .expect(1)
+        .mount(&source_server)
+        .await;
+
+    // amd64 child: expect exactly 1 pull (platform matches; pulled once
+    // during discovery and cached for both targets).
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/manifests/{amd64_digest}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(amd64_bytes)
+                .insert_header("content-type", MediaType::OciManifest.as_str()),
+        )
+        .expect(1)
+        .mount(&source_server)
+        .await;
+
+    // arm64 child: expect 0 pulls (filtered out).
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/manifests/{arm64_digest}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(arm64_bytes)
+                .insert_header("content-type", MediaType::OciManifest.as_str()),
+        )
+        .expect(0)
+        .mount(&source_server)
+        .await;
+
+    // amd64 blobs: each pulled once per target (staging disabled → 2 pulls total).
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/blobs/{}", amd64_config_desc.digest)))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(amd64_config_data.to_vec())
+                .insert_header("content-length", amd64_config_data.len().to_string()),
+        )
+        .expect(2)
+        .mount(&source_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/blobs/{}", amd64_layer_desc.digest)))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(amd64_layer_data.to_vec())
+                .insert_header("content-length", amd64_layer_data.len().to_string()),
+        )
+        .expect(2)
+        .mount(&source_server)
+        .await;
+
+    // arm64 blobs: expect 0 pulls (filtered out).
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/blobs/{}", arm64_config_desc.digest)))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(arm64_config_data.to_vec())
+                .insert_header("content-length", arm64_config_data.len().to_string()),
+        )
+        .expect(0)
+        .mount(&source_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/blobs/{}", arm64_layer_desc.digest)))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(arm64_layer_data.to_vec())
+                .insert_header("content-length", arm64_layer_data.len().to_string()),
+        )
+        .expect(0)
+        .mount(&source_server)
+        .await;
+
+    // --- Both targets: no existing manifest, no blobs, accept pushes ---
+
+    for target in [&target_a, &target_b] {
+        // HEAD check for index tag.
+        mount_manifest_head_not_found(target, "repo", "latest").await;
+        // Blob checks and pushes for amd64 only.
+        mount_blob_not_found(target, "repo", &amd64_config_desc.digest).await;
+        mount_blob_not_found(target, "repo", &amd64_layer_desc.digest).await;
+        mount_blob_push(target, "repo").await;
+        // Accept amd64 child manifest push (by digest).
+        mount_manifest_push(target, "repo", &amd64_digest.to_string()).await;
+        // Accept filtered index push (by tag).
+        mount_manifest_push(target, "repo", "latest").await;
+        // arm64 manifest pushes must NOT arrive -- no mock mounted for them.
+    }
+
+    let mapping = ResolvedMapping {
+        source_client: mock_client(&source_server),
+        source_repo: "repo".into(),
+        target_repo: "repo".into(),
+        targets: vec![
+            target_entry("target-a", mock_client(&target_a)),
+            target_entry("target-b", mock_client(&target_b)),
+        ],
+        tags: vec![TagPair::same("latest")],
+        platforms: Some(vec!["linux/amd64".to_string()]),
+        skip_existing: false,
+    };
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    // 2 image results (1 tag x 2 targets).
+    assert_eq!(report.images.len(), 2);
+    assert!(
+        report
+            .images
+            .iter()
+            .all(|r| matches!(r.status, ImageStatus::Synced)),
+        "both targets must be Synced"
+    );
+
+    // Each target transfers 2 blobs (amd64 config + layer).
+    let expected_blob_bytes = (amd64_config_data.len() + amd64_layer_data.len()) as u64;
+    for result in &report.images {
+        assert_eq!(
+            result.blob_stats.transferred, 2,
+            "each target must transfer exactly 2 amd64 blobs"
+        );
+        assert_eq!(result.blob_stats.skipped, 0);
+        assert_eq!(result.bytes_transferred, expected_blob_bytes);
+    }
+
+    // Aggregate stats: 2 synced images, 4 blob transfers (2 per target).
+    assert_eq!(report.stats.images_synced, 2);
+    assert_eq!(report.stats.blobs_transferred, 4);
+    assert_eq!(report.stats.bytes_transferred, expected_blob_bytes * 2);
+    // wiremock expect(N) assertions verify platform filtering and pull-once
+    // on index and amd64 child manifests.
 }

--- a/crates/ocync-sync/tests/engine_integration.rs
+++ b/crates/ocync-sync/tests/engine_integration.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use ocync_distribution::spec::{Descriptor, ImageIndex, ImageManifest, MediaType};
+use ocync_distribution::spec::{Descriptor, ImageIndex, ImageManifest, MediaType, Platform};
 use ocync_distribution::{BatchBlobChecker, Digest, RegistryClientBuilder};
 use ocync_sync::cache::TransferStateCache;
 use ocync_sync::engine::{ResolvedMapping, SyncEngine, TagPair, TargetEntry};
@@ -61,6 +61,28 @@ fn target_entry(name: &str, client: Arc<ocync_distribution::RegistryClient>) -> 
         name: name.into(),
         client,
         batch_checker: None,
+    }
+}
+
+/// Build a [`ResolvedMapping`] with default `platforms` and `skip_existing`.
+///
+/// Avoids boilerplate in the majority of tests that don't exercise platform
+/// filtering or skip-existing behavior.
+fn resolved_mapping(
+    source_client: Arc<ocync_distribution::RegistryClient>,
+    source_repo: &str,
+    target_repo: &str,
+    targets: Vec<TargetEntry>,
+    tags: Vec<TagPair>,
+) -> ResolvedMapping {
+    ResolvedMapping {
+        source_client,
+        source_repo: source_repo.into(),
+        target_repo: target_repo.into(),
+        targets,
+        tags,
+        platforms: None,
+        skip_existing: false,
     }
 }
 
@@ -374,6 +396,8 @@ async fn sync_happy_path() {
         target_repo: "mirror/nginx".into(),
         targets: vec![target_entry("target-reg", target_client)],
         tags: vec![TagPair::same("latest")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -428,6 +452,8 @@ async fn sync_skip_on_digest_match() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", target_client)],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -482,6 +508,8 @@ async fn sync_blob_exists_at_target_skips_transfer() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", target_client)],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -525,6 +553,8 @@ async fn sync_manifest_pull_failure() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", target_client)],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -600,6 +630,8 @@ async fn sync_blob_transfer_retries_on_source_500() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", target_client)],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -663,6 +695,8 @@ async fn sync_dedup_across_tags() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", target_client)],
         tags: vec![TagPair::same("v1"), TagPair::same("v2")],
+        platforms: None,
+        skip_existing: false,
     };
 
     // Use max_concurrent=1 to ensure sequential execution so dedup works across tags.
@@ -743,6 +777,8 @@ async fn sync_multiple_targets() {
             target_entry("target-b", mock_client(&target_b)),
         ],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -812,6 +848,8 @@ async fn sync_retag() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", target_client)],
         tags: vec![TagPair::retag("latest", "stable")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -878,6 +916,8 @@ async fn sync_blob_transfer_failure() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", mock_client(&target_server))],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -1032,6 +1072,8 @@ async fn sync_index_manifest_multi_platform() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", mock_client(&target_server))],
         tags: vec![TagPair::same("latest")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -1101,6 +1143,8 @@ async fn sync_head_different_digest_proceeds_with_sync() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", mock_client(&target_server))],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -1131,6 +1175,8 @@ async fn sync_empty_tags_produces_no_images() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", mock_client(&target_server))],
         tags: vec![],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -1192,6 +1238,8 @@ async fn sync_manifest_push_failure() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", mock_client(&target_server))],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -1260,6 +1308,8 @@ async fn sync_retry_exhaustion_returns_final_error() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", mock_client(&target_server))],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -1350,6 +1400,8 @@ async fn sync_cross_repo_mount_success() {
         target_repo: "repo-a".into(),
         targets: vec![target_entry("target", target_client.clone())],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     // Second mapping: repo-b should mount from repo-a.
@@ -1359,6 +1411,8 @@ async fn sync_cross_repo_mount_success() {
         target_repo: "repo-b".into(),
         targets: vec![target_entry("target", target_client)],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     // Use max_concurrent=1 to ensure mapping_a completes before mapping_b starts,
@@ -1468,6 +1522,8 @@ async fn sync_cross_repo_mount_fallback_to_pull_push() {
         target_repo: "repo-a".into(),
         targets: vec![target_entry("target", target_client.clone())],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let mapping_b = ResolvedMapping {
@@ -1476,6 +1532,8 @@ async fn sync_cross_repo_mount_fallback_to_pull_push() {
         target_repo: "repo-b".into(),
         targets: vec![target_entry("target", target_client)],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     // Use max_concurrent=1 to ensure mapping_a completes first so mapping_b
@@ -1588,6 +1646,8 @@ async fn sync_cross_repo_mount_failure_falls_back() {
         target_repo: "repo-a".into(),
         targets: vec![target_entry("target", target_client.clone())],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let mapping_b = ResolvedMapping {
@@ -1596,6 +1656,8 @@ async fn sync_cross_repo_mount_failure_falls_back() {
         target_repo: "repo-b".into(),
         targets: vec![target_entry("target", target_client)],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     // Use max_concurrent=1 to ensure mapping_a completes first so mapping_b
@@ -1671,6 +1733,8 @@ async fn sync_multi_target_partial_blob_failure_isolates_targets() {
             target_entry("target-b", mock_client(&target_b)),
         ],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -1794,6 +1858,8 @@ async fn sync_progressive_cache_skips_shared_blob_head_check() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", mock_client(&target_server))],
         tags: vec![TagPair::same("v1"), TagPair::same("v2")],
+        platforms: None,
+        skip_existing: false,
     };
 
     // Sequential execution ensures v1 completes and populates the cache before v2 starts.
@@ -1878,6 +1944,8 @@ async fn sync_warm_cache_triggers_cross_repo_mount() {
         target_repo: "repo-b".into(),
         targets: vec![target_entry("target", target_client)],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -1962,6 +2030,8 @@ async fn sync_small_blob_uses_monolithic_upload() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", mock_client(&target_server))],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -2066,6 +2136,8 @@ async fn sync_lazy_invalidation_on_mount_failure() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", target_client)],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -2123,6 +2195,8 @@ async fn sync_cache_persist_and_load_round_trip() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target-reg", mock_client(&target_server))],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let cache = empty_cache();
@@ -2209,6 +2283,8 @@ async fn sync_shutdown_stops_new_work() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", mock_client(&target_server))],
         tags: vec![TagPair::same("v1"), TagPair::same("v2")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let shutdown = ShutdownSignal::new();
@@ -2287,6 +2363,8 @@ async fn sync_shutdown_drains_in_flight() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", mock_client(&target_server))],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let shutdown = ShutdownSignal::new();
@@ -2379,6 +2457,8 @@ async fn sync_dedup_across_tags_concurrent() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", mock_client(&target_server))],
         tags: vec![TagPair::same("v1"), TagPair::same("v2")],
+        platforms: None,
+        skip_existing: false,
     };
 
     // Use higher concurrency — both tags can execute simultaneously.
@@ -2469,6 +2549,8 @@ async fn sync_cross_repo_mount_concurrent() {
         target_repo: "repo-a".into(),
         targets: vec![target_entry("target", Arc::clone(&target_client))],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
     let mapping_b = ResolvedMapping {
         source_client,
@@ -2476,6 +2558,8 @@ async fn sync_cross_repo_mount_concurrent() {
         target_repo: "repo-b".into(),
         targets: vec![target_entry("target", target_client)],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     // max_concurrent=10: both mappings can execute concurrently.
@@ -2568,6 +2652,8 @@ async fn sync_nested_index_manifest_returns_error() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", mock_client(&target_server))],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -2668,6 +2754,8 @@ async fn sync_lazy_invalidation_clears_cache_and_records_completion() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", mock_client(&target_server))],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -2799,6 +2887,8 @@ async fn sync_index_manifest_child_pull_failure() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", mock_client(&target_server))],
         tags: vec![TagPair::same("latest")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -2889,6 +2979,8 @@ async fn sync_partial_blob_failure_stops_remaining() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", mock_client(&target_server))],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     // Use max_concurrent=1 to ensure sequential blob processing (config first).
@@ -2991,6 +3083,8 @@ async fn sync_concurrent_dedup_at_real_concurrency() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", mock_client(&target_server))],
         tags: vec![TagPair::same("v1"), TagPair::same("v2")],
+        platforms: None,
+        skip_existing: false,
     };
 
     // Real concurrency — NOT 1.
@@ -3120,6 +3214,8 @@ async fn sync_staging_pulls_once_pushes_twice() {
             target_entry("target-b", mock_client(&target_b)),
         ],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     // Use max_concurrent=1 so target-a completes and stages blobs before
@@ -3204,6 +3300,8 @@ async fn sync_shutdown_deadline_abandons_stuck_transfers() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", mock_client(&target_server))],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let shutdown = ShutdownSignal::new();
@@ -3304,6 +3402,8 @@ async fn sync_custom_drain_deadline_abandons_before_default_would() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", mock_client(&target_server))],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let shutdown = ShutdownSignal::new();
@@ -3416,6 +3516,8 @@ async fn sync_staging_writes_blobs_to_disk() {
             target_entry("target-b", mock_client(&target_b)),
         ],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 1);
@@ -3510,6 +3612,8 @@ async fn sync_warm_cache_skips_blob_head_check() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", mock_client(&target_server))],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -3604,6 +3708,8 @@ async fn sync_batch_checker_all_blobs_exist_skips_head() {
             batch_checker: Some(Rc::new(checker)),
         }],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -3725,6 +3831,8 @@ async fn sync_batch_checker_partial_existence_transfers_missing() {
             batch_checker: Some(Rc::new(checker)),
         }],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -3827,6 +3935,8 @@ async fn sync_no_batch_checker_falls_back_to_per_blob_head() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", target_client)],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -3918,6 +4028,8 @@ async fn sync_batch_checker_failure_falls_back_to_per_blob_head() {
             batch_checker: Some(Rc::new(checker)),
         }],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -4056,6 +4168,8 @@ async fn sync_batch_checker_multi_target_independent_checkers() {
             },
         ],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -4198,6 +4312,8 @@ async fn sync_batch_checker_empty_result_transfers_all() {
             batch_checker: Some(Rc::new(checker)),
         }],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -4316,6 +4432,8 @@ async fn sync_mixed_batch_and_no_batch_multi_target() {
             target_entry("target-b", mock_client(&target_b_server)),
         ],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -4437,6 +4555,8 @@ async fn sync_batch_checker_multi_tag_shares_rc() {
             batch_checker: Some(Rc::new(checker)),
         }],
         tags: vec![TagPair::same("v1"), TagPair::same("v2")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -4630,6 +4750,8 @@ async fn sync_batch_checker_index_manifest_all_exist() {
             batch_checker: Some(Rc::new(checker)),
         }],
         tags: vec![TagPair::same("latest")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -4748,6 +4870,8 @@ async fn sync_batch_checker_with_prewarmed_cache() {
             batch_checker: Some(Rc::new(checker)),
         }],
         tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -4780,4 +4904,436 @@ async fn sync_batch_checker_with_prewarmed_cache() {
     assert_eq!(report.stats.blobs_transferred, 0);
     assert_eq!(report.stats.bytes_transferred, 0);
     // wiremock expect(0) on blob HEADs verifies no fallback path was used.
+}
+
+// ---------------------------------------------------------------------------
+// Platform filtering tests
+// ---------------------------------------------------------------------------
+
+/// Platform filtering: only the matching platform's child manifest and blobs
+/// are pulled from source and pushed to target. Non-matching platforms are
+/// never touched.
+#[tokio::test]
+async fn sync_index_manifest_platform_filter() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    // --- Build three child image manifests (linux/amd64, linux/arm64, windows/amd64) ---
+
+    let amd64_config_data = b"amd64-config";
+    let amd64_layer_data = b"amd64-layer";
+    let amd64_config_desc = blob_descriptor(amd64_config_data, MediaType::OciConfig);
+    let amd64_layer_desc = blob_descriptor(amd64_layer_data, MediaType::OciLayerGzip);
+    let amd64_manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: amd64_config_desc.clone(),
+        layers: vec![amd64_layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (amd64_bytes, amd64_digest) = serialize_manifest(&amd64_manifest);
+
+    let arm64_config_data = b"arm64-config";
+    let arm64_layer_data = b"arm64-layer";
+    let arm64_config_desc = blob_descriptor(arm64_config_data, MediaType::OciConfig);
+    let arm64_layer_desc = blob_descriptor(arm64_layer_data, MediaType::OciLayerGzip);
+    let arm64_manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: arm64_config_desc.clone(),
+        layers: vec![arm64_layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (arm64_bytes, arm64_digest) = serialize_manifest(&arm64_manifest);
+
+    let win_config_data = b"win-config";
+    let win_layer_data = b"win-layer";
+    let win_config_desc = blob_descriptor(win_config_data, MediaType::OciConfig);
+    let win_layer_desc = blob_descriptor(win_layer_data, MediaType::OciLayerGzip);
+    let win_manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: win_config_desc.clone(),
+        layers: vec![win_layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (win_bytes, win_digest) = serialize_manifest(&win_manifest);
+
+    // --- Build index with platform-annotated descriptors ---
+
+    let index = ImageIndex {
+        schema_version: 2,
+        media_type: None,
+        manifests: vec![
+            Descriptor {
+                media_type: MediaType::OciManifest,
+                digest: amd64_digest.clone(),
+                size: amd64_bytes.len() as u64,
+                platform: Some(Platform {
+                    architecture: "amd64".into(),
+                    os: "linux".into(),
+                    variant: None,
+                    os_version: None,
+                    os_features: None,
+                }),
+                artifact_type: None,
+                annotations: None,
+            },
+            Descriptor {
+                media_type: MediaType::OciManifest,
+                digest: arm64_digest.clone(),
+                size: arm64_bytes.len() as u64,
+                platform: Some(Platform {
+                    architecture: "arm64".into(),
+                    os: "linux".into(),
+                    variant: None,
+                    os_version: None,
+                    os_features: None,
+                }),
+                artifact_type: None,
+                annotations: None,
+            },
+            Descriptor {
+                media_type: MediaType::OciManifest,
+                digest: win_digest.clone(),
+                size: win_bytes.len() as u64,
+                platform: Some(Platform {
+                    architecture: "amd64".into(),
+                    os: "windows".into(),
+                    variant: None,
+                    os_version: None,
+                    os_features: None,
+                }),
+                artifact_type: None,
+                annotations: None,
+            },
+        ],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let index_bytes = serde_json::to_vec(&index).unwrap();
+
+    // --- Source: serve index by tag, children by digest ---
+
+    Mock::given(method("GET"))
+        .and(path("/v2/repo/manifests/latest"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(index_bytes.clone())
+                .insert_header("content-type", MediaType::OciIndex.as_str()),
+        )
+        .expect(1)
+        .mount(&source_server)
+        .await;
+
+    // amd64 child: expect exactly 1 pull (matching platform).
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/manifests/{amd64_digest}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(amd64_bytes)
+                .insert_header("content-type", MediaType::OciManifest.as_str()),
+        )
+        .expect(1)
+        .mount(&source_server)
+        .await;
+
+    // arm64 child: expect 0 pulls (filtered out).
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/manifests/{arm64_digest}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(arm64_bytes)
+                .insert_header("content-type", MediaType::OciManifest.as_str()),
+        )
+        .expect(0)
+        .mount(&source_server)
+        .await;
+
+    // windows child: expect 0 pulls (filtered out).
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/manifests/{win_digest}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(win_bytes)
+                .insert_header("content-type", MediaType::OciManifest.as_str()),
+        )
+        .expect(0)
+        .mount(&source_server)
+        .await;
+
+    // Source blobs: amd64 blobs expect 1 pull each, others expect 0.
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/blobs/{}", amd64_config_desc.digest)))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(amd64_config_data.to_vec())
+                .insert_header("content-length", amd64_config_data.len().to_string()),
+        )
+        .expect(1)
+        .mount(&source_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/blobs/{}", amd64_layer_desc.digest)))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(amd64_layer_data.to_vec())
+                .insert_header("content-length", amd64_layer_data.len().to_string()),
+        )
+        .expect(1)
+        .mount(&source_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/blobs/{}", arm64_config_desc.digest)))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(arm64_config_data.to_vec())
+                .insert_header("content-length", arm64_config_data.len().to_string()),
+        )
+        .expect(0)
+        .mount(&source_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/blobs/{}", arm64_layer_desc.digest)))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(arm64_layer_data.to_vec())
+                .insert_header("content-length", arm64_layer_data.len().to_string()),
+        )
+        .expect(0)
+        .mount(&source_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/blobs/{}", win_config_desc.digest)))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(win_config_data.to_vec())
+                .insert_header("content-length", win_config_data.len().to_string()),
+        )
+        .expect(0)
+        .mount(&source_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/blobs/{}", win_layer_desc.digest)))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(win_layer_data.to_vec())
+                .insert_header("content-length", win_layer_data.len().to_string()),
+        )
+        .expect(0)
+        .mount(&source_server)
+        .await;
+
+    // --- Target: no existing manifest, no blobs, accept all pushes ---
+
+    mount_manifest_head_not_found(&target_server, "repo", "latest").await;
+    mount_blob_not_found(&target_server, "repo", &amd64_config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &amd64_layer_desc.digest).await;
+    mount_blob_push(&target_server, "repo").await;
+
+    // Accept amd64 child manifest push (by digest).
+    mount_manifest_push(&target_server, "repo", &amd64_digest.to_string()).await;
+
+    // Accept filtered index push (by tag).
+    mount_manifest_push(&target_server, "repo", "latest").await;
+
+    // arm64 and windows manifest pushes should NOT happen -- wiremock will
+    // fail verification if unexpected requests arrive (no mock mounted).
+
+    let mapping = ResolvedMapping {
+        source_client: mock_client(&source_server),
+        source_repo: "repo".into(),
+        target_repo: "repo".into(),
+        targets: vec![target_entry("target", mock_client(&target_server))],
+        tags: vec![TagPair::same("latest")],
+        platforms: Some(vec!["linux/amd64".to_string()]),
+        skip_existing: false,
+    };
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(matches!(report.images[0].status, ImageStatus::Synced));
+    // Only 2 blobs transferred: amd64 config + amd64 layer.
+    assert_eq!(report.images[0].blob_stats.transferred, 2);
+    assert_eq!(report.images[0].blob_stats.skipped, 0);
+    let expected_bytes = (amd64_config_data.len() + amd64_layer_data.len()) as u64;
+    assert_eq!(report.images[0].bytes_transferred, expected_bytes);
+    // Aggregate stats.
+    assert_eq!(report.stats.images_synced, 1);
+    assert_eq!(report.stats.blobs_transferred, 2);
+    assert_eq!(report.stats.bytes_transferred, expected_bytes);
+    // wiremock .expect(N) assertions verify the platform filtering path.
+}
+
+// ---------------------------------------------------------------------------
+// skip_existing tests
+// ---------------------------------------------------------------------------
+
+/// When `skip_existing` is true, a target HEAD returning any manifest (even
+/// with a different digest) causes the image to be skipped.
+#[tokio::test]
+async fn sync_skip_existing_skips_without_digest_comparison() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_data = b"config-data";
+    let layer_data = b"layer-data";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (manifest_bytes, _manifest_digest) = serialize_manifest(&manifest);
+
+    // Source: serve manifest (will be pulled during discovery).
+    mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
+
+    // Target: HEAD returns 200 with a DIFFERENT digest -- normally would sync.
+    let stale_digest = test_digest("d1ff");
+    mount_manifest_head_matching(&target_server, "repo", "v1", &stale_digest).await;
+
+    // No blob endpoints needed -- skip_existing should prevent any blob work.
+    // If the engine incorrectly proceeds to sync, it will fail on missing
+    // blob endpoints.
+
+    let mapping = ResolvedMapping {
+        source_client: mock_client(&source_server),
+        source_repo: "repo".into(),
+        target_repo: "repo".into(),
+        targets: vec![target_entry("target", mock_client(&target_server))],
+        tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: true,
+    };
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(
+        matches!(
+            report.images[0].status,
+            ImageStatus::Skipped {
+                reason: SkipReason::SkipExisting,
+            }
+        ),
+        "expected SkipExisting, got {:?}",
+        report.images[0].status
+    );
+    assert_eq!(report.images[0].bytes_transferred, 0);
+    assert_eq!(report.images[0].blob_stats.transferred, 0);
+    assert_eq!(report.images[0].blob_stats.skipped, 0);
+    // Aggregate stats.
+    assert_eq!(report.stats.images_skipped, 1);
+    assert_eq!(report.stats.images_synced, 0);
+    assert_eq!(report.stats.blobs_transferred, 0);
+}
+
+/// When `skip_existing` is false (default), a target HEAD returning a different
+/// digest triggers a full sync.
+#[tokio::test]
+async fn sync_skip_existing_false_syncs_on_different_digest() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_data = b"config-data";
+    let layer_data = b"layer-data";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (manifest_bytes, _manifest_digest) = serialize_manifest(&manifest);
+
+    // Source: serve manifest and blobs.
+    mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo", &layer_desc.digest, layer_data).await;
+
+    // Target: HEAD returns 200 with a DIFFERENT digest -- should proceed to sync.
+    let stale_digest = test_digest("d1ff");
+    mount_manifest_head_matching(&target_server, "repo", "v1", &stale_digest).await;
+    mount_blob_not_found(&target_server, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_desc.digest).await;
+    mount_blob_push(&target_server, "repo").await;
+    mount_manifest_push(&target_server, "repo", "v1").await;
+
+    let mapping = ResolvedMapping {
+        source_client: mock_client(&source_server),
+        source_repo: "repo".into(),
+        target_repo: "repo".into(),
+        targets: vec![target_entry("target", mock_client(&target_server))],
+        tags: vec![TagPair::same("v1")],
+        platforms: None,
+        skip_existing: false,
+    };
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(
+        matches!(report.images[0].status, ImageStatus::Synced),
+        "expected Synced, got {:?}",
+        report.images[0].status
+    );
+    // Both blobs transferred.
+    assert_eq!(report.images[0].blob_stats.transferred, 2);
+    assert_eq!(report.images[0].blob_stats.skipped, 0);
+    let expected_bytes = (config_data.len() + layer_data.len()) as u64;
+    assert_eq!(report.images[0].bytes_transferred, expected_bytes);
+    // Aggregate stats.
+    assert_eq!(report.stats.images_synced, 1);
+    assert_eq!(report.stats.blobs_transferred, 2);
+    assert_eq!(report.stats.bytes_transferred, expected_bytes);
 }

--- a/src/cli/commands/copy.rs
+++ b/src/cli/commands/copy.rs
@@ -40,6 +40,8 @@ pub(crate) async fn run(args: &CopyArgs) -> Result<ExitCode, CliError> {
             batch_checker: None,
         }],
         tags: vec![TagPair::retag(src_tag.to_owned(), dst_tag.to_owned())],
+        platforms: None,
+        skip_existing: false,
     };
 
     let engine = SyncEngine::new(RetryConfig::default(), DEFAULT_MAX_CONCURRENT_TRANSFERS);

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -319,14 +319,25 @@ async fn resolve_mapping(
     // --- Target repo ---
     let target_repo = mapping.to.as_deref().unwrap_or(&mapping.from).to_owned();
 
+    // --- Resolve platforms and skip_existing (mapping overrides defaults) ---
+    let platforms = mapping
+        .platforms
+        .clone()
+        .or_else(|| config.defaults.as_ref().and_then(|d| d.platforms.clone()));
+
+    let skip_existing = mapping
+        .skip_existing
+        .or_else(|| config.defaults.as_ref().and_then(|d| d.skip_existing))
+        .unwrap_or(false);
+
     Ok(Some(ResolvedMapping {
         source_client,
         source_repo: mapping.from.clone(),
         target_repo,
         targets,
         tags: filtered.into_iter().map(TagPair::same).collect(),
-        platforms: None,
-        skip_existing: false,
+        platforms,
+        skip_existing,
     }))
 }
 

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -325,6 +325,8 @@ async fn resolve_mapping(
         target_repo,
         targets,
         tags: filtered.into_iter().map(TagPair::same).collect(),
+        platforms: None,
+        skip_existing: false,
     }))
 }
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -42,6 +42,9 @@ pub(crate) fn load_config(path: &Path) -> Result<Config, ConfigError> {
         if let Some(ref tags) = defaults.tags {
             validate_tags(tags)?;
         }
+        if let Some(ref platforms) = defaults.platforms {
+            validate_platforms("defaults", platforms)?;
+        }
     }
     validate_references(&config)?;
 
@@ -203,6 +206,18 @@ pub(crate) struct DefaultsConfig {
 
     #[serde(default)]
     pub tags: Option<TagsConfig>,
+
+    /// Platform filter applied to all mappings unless overridden.
+    ///
+    /// Each entry must be `os/arch` or `os/arch/variant` (e.g. `linux/amd64`,
+    /// `linux/arm/v7`).
+    #[serde(default)]
+    pub platforms: Option<Vec<String>>,
+
+    /// When `true`, mappings that already exist at the target are skipped
+    /// without re-syncing.
+    #[serde(default)]
+    pub skip_existing: Option<bool>,
 }
 
 // ---------------------------------------------------------------------------
@@ -224,6 +239,18 @@ pub(crate) struct MappingConfig {
 
     #[serde(default)]
     pub tags: Option<TagsConfig>,
+
+    /// Platform filter for this mapping, overriding any value in `defaults`.
+    ///
+    /// Each entry must be `os/arch` or `os/arch/variant` (e.g. `linux/amd64`,
+    /// `linux/arm/v7`).
+    #[serde(default)]
+    pub platforms: Option<Vec<String>>,
+
+    /// When `true`, this mapping is skipped if the image already exists at the
+    /// target, overriding any value in `defaults`.
+    #[serde(default)]
+    pub skip_existing: Option<bool>,
 }
 
 // ---------------------------------------------------------------------------
@@ -466,12 +493,38 @@ fn validate_tags(tags: &TagsConfig) -> Result<(), ConfigError> {
 ///
 /// A mapping must have its own `tags` block OR inherit from `defaults.tags`.
 /// If neither is present, this returns a validation error.
+///
+/// Platform strings are also validated: each entry must be `os/arch` or
+/// `os/arch/variant`.
 fn validate_mapping(mapping: &MappingConfig, has_default_tags: bool) -> Result<(), ConfigError> {
     if mapping.tags.is_none() && !has_default_tags {
         return Err(ConfigError::Validation(format!(
             "mapping '{}' is missing a tags block (and no defaults.tags is set)",
             mapping.from,
         )));
+    }
+    if let Some(ref platforms) = mapping.platforms {
+        validate_platforms(&mapping.from, platforms)?;
+    }
+    Ok(())
+}
+
+/// Validate that every platform string has the form `os/arch` or
+/// `os/arch/variant`.
+fn validate_platforms(mapping_from: &str, platforms: &[String]) -> Result<(), ConfigError> {
+    if platforms.is_empty() {
+        return Err(ConfigError::Validation(format!(
+            "mapping '{mapping_from}': platforms list must not be empty",
+        )));
+    }
+    for platform in platforms {
+        let parts: Vec<&str> = platform.splitn(3, '/').collect();
+        if parts.len() < 2 || parts.iter().any(|p| p.is_empty()) {
+            return Err(ConfigError::Validation(format!(
+                "mapping '{mapping_from}': invalid platform '{platform}' \
+                 (expected os/arch or os/arch/variant)",
+            )));
+        }
     }
     Ok(())
 }
@@ -843,6 +896,8 @@ mappings:
             source: None,
             targets: None,
             tags: None,
+            platforms: None,
+            skip_existing: None,
         };
         let err = validate_mapping(&mapping, false).unwrap_err();
         assert!(matches!(err, ConfigError::Validation(_)));
@@ -856,8 +911,134 @@ mappings:
             source: None,
             targets: None,
             tags: None,
+            platforms: None,
+            skip_existing: None,
         };
         validate_mapping(&mapping, true).unwrap();
+    }
+
+    #[test]
+    fn invalid_platform_format_rejected() {
+        let mapping = MappingConfig {
+            from: "nginx".to_string(),
+            to: None,
+            source: None,
+            targets: None,
+            tags: Some(TagsConfig {
+                glob: Some(GlobOrList::Single("*".to_string())),
+                ..Default::default()
+            }),
+            platforms: Some(vec!["linux-amd64".to_string()]),
+            skip_existing: None,
+        };
+        let err = validate_mapping(&mapping, false).unwrap_err();
+        match err {
+            ConfigError::Validation(msg) => assert!(msg.contains("linux-amd64")),
+            other => panic!("expected Validation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn valid_platform_formats_accepted() {
+        for platform in &[
+            "linux/amd64",
+            "linux/arm64",
+            "linux/arm/v7",
+            "windows/amd64",
+        ] {
+            let mapping = MappingConfig {
+                from: "nginx".to_string(),
+                to: None,
+                source: None,
+                targets: None,
+                tags: Some(TagsConfig {
+                    glob: Some(GlobOrList::Single("*".to_string())),
+                    ..Default::default()
+                }),
+                platforms: Some(vec![platform.to_string()]),
+                skip_existing: None,
+            };
+            validate_mapping(&mapping, false)
+                .unwrap_or_else(|e| panic!("expected valid platform '{platform}': {e}"));
+        }
+    }
+
+    #[test]
+    fn empty_platform_parts_rejected() {
+        for bad in &["/", "/amd64", "linux/", "//", "linux//v8"] {
+            let err = validate_platforms("test", &[bad.to_string()]).unwrap_err();
+            match err {
+                ConfigError::Validation(msg) => {
+                    assert!(msg.contains(bad), "expected '{bad}' in: {msg}")
+                }
+                other => panic!("expected Validation for '{bad}', got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn empty_platforms_list_rejected() {
+        let err = validate_platforms("test", &[]).unwrap_err();
+        assert!(matches!(err, ConfigError::Validation(_)));
+    }
+
+    #[test]
+    fn deserialize_mapping_with_new_fields() {
+        let yaml = r#"
+mappings:
+  - from: library/nginx
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    skip_existing: true
+    tags:
+      glob: "*"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let m = &config.mappings[0];
+        assert_eq!(
+            m.platforms,
+            Some(vec!["linux/amd64".to_string(), "linux/arm64".to_string()])
+        );
+        assert_eq!(m.skip_existing, Some(true));
+    }
+
+    #[test]
+    fn deserialize_defaults_with_new_fields() {
+        let yaml = r#"
+defaults:
+  platforms:
+    - linux/amd64
+  skip_existing: false
+mappings:
+  - from: library/nginx
+    tags:
+      glob: "*"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let d = config.defaults.as_ref().unwrap();
+        assert_eq!(d.platforms, Some(vec!["linux/amd64".to_string()]));
+        assert_eq!(d.skip_existing, Some(false));
+    }
+
+    #[test]
+    fn invalid_platform_in_defaults_rejected() {
+        let yaml = r#"
+defaults:
+  platforms:
+    - linux-amd64
+mappings:
+  - from: library/nginx
+    tags:
+      glob: "*"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let defaults = config.defaults.as_ref().unwrap();
+        let err = validate_platforms("defaults", defaults.platforms.as_ref().unwrap()).unwrap_err();
+        match err {
+            ConfigError::Validation(msg) => assert!(msg.contains("linux-amd64")),
+            other => panic!("expected Validation, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `platforms` and `skip_existing` fields to config (defaults + per-mapping with override semantics)
- Wire platform filtering and skip_existing from config through CLI into the sync engine
- Add `Platform::matches()` with case-insensitive os/arch/variant filter parsing
- Remove unused `ImmutableTag` skip reason variant
- Config validation for platform string format (`os/arch` or `os/arch/variant`)

## Test plan

- [ ] Config validation: invalid platform formats rejected, valid formats accepted, empty list rejected
- [ ] Config deserialization: new fields round-trip through YAML for both defaults and mappings
- [ ] Engine integration: skip_existing skips when target has manifest, syncs when missing
- [ ] Engine integration: skip_existing with multi-target independence (Target A skipped, Target B synced)
- [ ] Engine integration: platform filtering with index manifests (only matching platforms synced)
- [ ] Engine integration: platform filtering with single-image manifests (no filtering applied)
- [ ] Pull-once fan-out invariant: source manifest pulled exactly once across all targets
- [ ] Aggregate and per-image stats asserted for all new test cases