### PR TITLE
refactor: introduce domain newtypes for type-safe OCI operations

### DIFF
--- a/crates/ocync-distribution/src/blob.rs
+++ b/crates/ocync-distribution/src/blob.rs
@@ -13,6 +13,7 @@ use crate::client::{RegistryClient, build_url};
 use crate::digest::Digest;
 use crate::error::Error;
 use crate::sha256::Sha256;
+use crate::spec::RepositoryName;
 
 /// Blobs at or below this size are uploaded monolithically (POST + PUT) to
 /// save the extra round-trip cost of chunked upload negotiation.
@@ -80,7 +81,7 @@ impl RegistryClient {
     /// Returns `Some(size)` if the blob exists, `None` if not found.
     pub async fn blob_exists(
         &self,
-        repository: &str,
+        repository: &RepositoryName,
         digest: &Digest,
     ) -> Result<Option<u64>, Error> {
         let path = blob_path(digest);
@@ -105,7 +106,7 @@ impl RegistryClient {
     /// a byte stream for the response body.
     pub async fn blob_pull(
         &self,
-        repository: &str,
+        repository: &RepositoryName,
         digest: &Digest,
     ) -> Result<impl Stream<Item = Result<Bytes, reqwest::Error>> + 'static, Error> {
         let path = blob_path(digest);
@@ -122,14 +123,17 @@ impl RegistryClient {
     /// falls back to a regular upload URL.
     pub async fn blob_mount(
         &self,
-        repository: &str,
+        repository: &RepositoryName,
         digest: &Digest,
-        from_repo: &str,
+        from_repo: &RepositoryName,
     ) -> Result<MountResult, Error> {
         let url = build_url(&self.base_url, repository, "blobs/uploads/")?;
-        let scopes = [Scope::pull_push(repository), Scope::pull(from_repo)];
+        let scopes = [
+            Scope::pull_push(repository.as_str()),
+            Scope::pull(from_repo.as_str()),
+        ];
         let digest_str = digest.to_string();
-        let from = from_repo.to_owned();
+        let from = from_repo.to_string();
 
         let resp = self
             .send_with_aimd(
@@ -154,12 +158,16 @@ impl RegistryClient {
     /// 2. PUT the entire data with the computed digest.
     ///
     /// Returns the digest of the uploaded blob.
-    pub async fn blob_push(&self, repository: &str, data: &[u8]) -> Result<Digest, Error> {
+    pub async fn blob_push(
+        &self,
+        repository: &RepositoryName,
+        data: &[u8],
+    ) -> Result<Digest, Error> {
         let hash = Sha256::digest(data);
         let digest = Digest::from_sha256(hash);
 
         let url = build_url(&self.base_url, repository, "blobs/uploads/")?;
-        let scopes = [Scope::pull_push(repository)];
+        let scopes = [Scope::pull_push(repository.as_str())];
 
         let resp = self
             .send_with_aimd(
@@ -214,7 +222,7 @@ impl RegistryClient {
     /// and delegate to [`blob_push`](Self::blob_push).
     pub async fn blob_push_stream<E>(
         &self,
-        repository: &str,
+        repository: &RepositoryName,
         expected_digest: &Digest,
         known_size: Option<u64>,
         stream: impl Stream<Item = Result<Bytes, E>>,
@@ -229,7 +237,7 @@ impl RegistryClient {
         // Monolithic threshold: small blobs skip chunked upload entirely.
         if known_size.is_some_and(|s| s <= MONOLITHIC_THRESHOLD) {
             debug!(
-                repository,
+                repository = repository.as_str(),
                 %expected_digest,
                 size = known_size.unwrap(),
                 "blob below monolithic threshold, using POST+PUT upload"
@@ -266,14 +274,14 @@ impl RegistryClient {
         }
 
         debug!(
-            repository,
+            repository = repository.as_str(),
             %expected_digest,
             chunk_size = self.chunk_size,
             "starting chunked blob upload"
         );
 
         let url = build_url(&self.base_url, repository, "blobs/uploads/")?;
-        let scopes = [Scope::pull_push(repository)];
+        let scopes = [Scope::pull_push(repository.as_str())];
 
         let resp = self
             .send_with_aimd(
@@ -385,12 +393,12 @@ impl RegistryClient {
     /// caller's expected digest to catch data corruption.
     async fn blob_push_stream_gar_fallback(
         &self,
-        repository: &str,
+        repository: &RepositoryName,
         expected_digest: &Digest,
         stream: impl Stream<Item = Result<Bytes, Error>>,
     ) -> Result<Digest, Error> {
         warn!(
-            repository,
+            repository = repository.as_str(),
             host = self.base_url.host_str().unwrap_or("unknown"),
             "GAR does not support chunked uploads; buffering entire blob in memory"
         );
@@ -414,18 +422,18 @@ impl RegistryClient {
     /// PATCH with no `Content-Range` header, followed by a PUT to finalize.
     async fn blob_push_stream_ghcr(
         &self,
-        repository: &str,
+        repository: &RepositoryName,
         expected_digest: &Digest,
         known_size: Option<u64>,
         stream: impl Stream<Item = Result<Bytes, Error>>,
     ) -> Result<Digest, Error> {
         warn!(
-            repository,
+            repository = repository.as_str(),
             "GHCR multi-PATCH chunked upload is broken; buffering blob for single-PATCH upload"
         );
 
         let url = build_url(&self.base_url, repository, "blobs/uploads/")?;
-        let scopes = [Scope::pull_push(repository)];
+        let scopes = [Scope::pull_push(repository.as_str())];
 
         // Initiate upload.
         let resp = self
@@ -690,8 +698,9 @@ mod tests {
 
         let client = build_gar_client(port);
 
+        let repo = RepositoryName::new("my-project/my-repo");
         let result = client
-            .blob_push_stream("my-project/my-repo", &digest, None, data_stream(data, 4))
+            .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
             .await
             .unwrap();
 
@@ -747,8 +756,9 @@ mod tests {
 
         // Pass None so the monolithic threshold does not intercept the call;
         // we are verifying the GHCR-specific single-PATCH path directly.
+        let repo = RepositoryName::new("my-org/my-image");
         let result = client
-            .blob_push_stream("my-org/my-image", &digest, None, data_stream(data, 4))
+            .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
             .await
             .unwrap();
 
@@ -797,8 +807,9 @@ mod tests {
         let client = build_ghcr_client(port);
 
         // No known_size — GHCR path still taken based on hostname alone.
+        let repo = RepositoryName::new("repo");
         let result = client
-            .blob_push_stream("repo", &digest, None, data_stream(data, 4))
+            .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
             .await
             .unwrap();
 

--- a/crates/ocync-distribution/src/client.rs
+++ b/crates/ocync-distribution/src/client.rs
@@ -7,6 +7,7 @@ use url::Url;
 use crate::aimd::{AimdController, RegistryAction};
 use crate::auth::{AuthProvider, Scope};
 use crate::error::Error;
+use crate::spec::RepositoryName;
 
 const DEFAULT_MAX_CONCURRENT_REQUESTS: usize = 50;
 const DEFAULT_CHUNK_SIZE: usize = 8 * 1024 * 1024; // 8 MiB
@@ -135,13 +136,13 @@ impl RegistryClient {
     /// throttle on 429 so the AIMD window adapts.
     pub async fn get(
         &self,
-        repository: &str,
+        repository: &RepositoryName,
         path: &str,
         accept: Option<&str>,
         op: RegistryAction,
     ) -> Result<reqwest::Response, Error> {
         let url = build_url(&self.base_url, repository, path)?;
-        let scopes = [Scope::pull(repository)];
+        let scopes = [Scope::pull(repository.as_str())];
 
         let resp = self
             .send_with_aimd(op, &scopes, "GET", |mut headers| {
@@ -162,12 +163,12 @@ impl RegistryClient {
     /// Same AIMD and retry logic as [`get`](Self::get).
     pub async fn head(
         &self,
-        repository: &str,
+        repository: &RepositoryName,
         path: &str,
         op: RegistryAction,
     ) -> Result<reqwest::Response, Error> {
         let url = build_url(&self.base_url, repository, path)?;
-        let scopes = [Scope::pull(repository)];
+        let scopes = [Scope::pull(repository.as_str())];
 
         let resp = self
             .send_with_aimd(op, &scopes, "HEAD", |headers| {
@@ -443,9 +444,10 @@ mod tests {
             .mount(&server)
             .await;
 
+        let repo = RepositoryName::new("repo");
         let _ = client
             .get(
-                "repo",
+                &repo,
                 "manifests/latest",
                 None,
                 RegistryAction::ManifestRead,
@@ -465,7 +467,7 @@ mod tests {
 
         let result = client
             .get(
-                "repo",
+                &repo,
                 "manifests/latest",
                 None,
                 RegistryAction::ManifestRead,

--- a/crates/ocync-distribution/src/ecr.rs
+++ b/crates/ocync-distribution/src/ecr.rs
@@ -20,6 +20,7 @@ use tracing::warn;
 
 use crate::digest::Digest;
 use crate::error::Error;
+use crate::spec::RepositoryName;
 
 /// Extract the AWS region from an ECR hostname.
 ///
@@ -93,7 +94,11 @@ pub trait BatchBlobChecker {
     /// Returns the set of input digests that exist at the target. Digests
     /// absent from the returned set are missing and need transfer. Digests
     /// that the API reports as failures are treated as missing.
-    fn check_blob_existence<'a>(&'a self, repo: &'a str, digests: &'a [Digest]) -> CheckFuture<'a>;
+    fn check_blob_existence<'a>(
+        &'a self,
+        repo: &'a RepositoryName,
+        digests: &'a [Digest],
+    ) -> CheckFuture<'a>;
 }
 
 /// Abstraction over ECR batch API calls for testability.
@@ -224,7 +229,7 @@ impl BatchChecker {
     /// Check blob existence, splitting into batches of 100.
     async fn check_batched(
         &self,
-        repo: &str,
+        repo: &RepositoryName,
         digests: &[Digest],
     ) -> Result<HashSet<Digest>, Error> {
         let mut existing = HashSet::with_capacity(digests.len());
@@ -238,7 +243,7 @@ impl BatchChecker {
 
             let response = match self
                 .api
-                .batch_check_layer_availability(repo, &digest_strings)
+                .batch_check_layer_availability(repo.as_str(), &digest_strings)
                 .await
             {
                 Ok(r) => r,
@@ -293,7 +298,11 @@ impl BatchChecker {
 }
 
 impl BatchBlobChecker for BatchChecker {
-    fn check_blob_existence<'a>(&'a self, repo: &'a str, digests: &'a [Digest]) -> CheckFuture<'a> {
+    fn check_blob_existence<'a>(
+        &'a self,
+        repo: &'a RepositoryName,
+        digests: &'a [Digest],
+    ) -> CheckFuture<'a> {
         Box::pin(self.check_batched(repo, digests))
     }
 }
@@ -498,7 +507,7 @@ mod tests {
         let checker = BatchChecker::with_api(mock);
 
         let result = checker
-            .check_blob_existence("my-repo", &[d1.clone(), d2.clone()])
+            .check_blob_existence(&RepositoryName::new("my-repo"), &[d1.clone(), d2.clone()])
             .await
             .unwrap();
 
@@ -525,7 +534,10 @@ mod tests {
         let checker = BatchChecker::with_api(mock);
 
         let result = checker
-            .check_blob_existence("my-repo", &[d1.clone(), d2.clone(), d3.clone()])
+            .check_blob_existence(
+                &RepositoryName::new("my-repo"),
+                &[d1.clone(), d2.clone(), d3.clone()],
+            )
             .await
             .unwrap();
 
@@ -564,7 +576,7 @@ mod tests {
         let checker = BatchChecker::with_api(mock);
 
         let result = checker
-            .check_blob_existence("my-repo", &digests)
+            .check_blob_existence(&RepositoryName::new("my-repo"), &digests)
             .await
             .unwrap();
 
@@ -587,7 +599,10 @@ mod tests {
         let mock = MockEcrBatchApi::new("my-repo", counts.clone());
         let checker = BatchChecker::with_api(mock);
 
-        let result = checker.check_blob_existence("my-repo", &[]).await.unwrap();
+        let result = checker
+            .check_blob_existence(&RepositoryName::new("my-repo"), &[])
+            .await
+            .unwrap();
 
         assert!(result.is_empty());
         assert_eq!(counts.check.load(Ordering::Relaxed), 0);
@@ -601,7 +616,7 @@ mod tests {
         let checker = BatchChecker::with_api(mock);
 
         let result = checker
-            .check_blob_existence("my-repo", &[test_digest(1)])
+            .check_blob_existence(&RepositoryName::new("my-repo"), &[test_digest(1)])
             .await;
 
         assert!(result.is_err());
@@ -624,7 +639,7 @@ mod tests {
         let checker = BatchChecker::with_api(mock);
 
         let result = checker
-            .check_blob_existence("my-repo", &[d1, d2])
+            .check_blob_existence(&RepositoryName::new("my-repo"), &[d1, d2])
             .await
             .unwrap();
 
@@ -647,7 +662,7 @@ mod tests {
         let checker = BatchChecker::with_api(mock);
 
         let result = checker
-            .check_blob_existence("my-repo", &[d1.clone(), d2.clone()])
+            .check_blob_existence(&RepositoryName::new("my-repo"), &[d1.clone(), d2.clone()])
             .await
             .unwrap();
 
@@ -683,7 +698,7 @@ mod tests {
         let checker = BatchChecker::with_api(mock);
 
         let result = checker
-            .check_blob_existence("my-repo", &digests)
+            .check_blob_existence(&RepositoryName::new("my-repo"), &digests)
             .await
             .unwrap();
 

--- a/crates/ocync-distribution/src/error.rs
+++ b/crates/ocync-distribution/src/error.rs
@@ -23,6 +23,15 @@ pub enum Error {
         reason: String,
     },
 
+    /// A platform filter string could not be parsed.
+    #[error("invalid platform filter '{input}': {reason}")]
+    InvalidPlatformFilter {
+        /// The raw filter string that failed to parse.
+        input: String,
+        /// Why the filter is invalid.
+        reason: String,
+    },
+
     /// The manifest media type is not recognized.
     #[error("unsupported manifest media type: {media_type}")]
     UnsupportedMediaType {

--- a/crates/ocync-distribution/src/lib.rs
+++ b/crates/ocync-distribution/src/lib.rs
@@ -32,4 +32,7 @@ pub use ecr::BatchBlobChecker;
 pub use error::Error;
 pub use manifest::{ManifestHead, ManifestPull};
 pub use reference::Reference;
-pub use spec::{Descriptor, ImageIndex, ImageManifest, ManifestKind, MediaType, Platform};
+pub use spec::{
+    Descriptor, ImageIndex, ImageManifest, ManifestKind, MediaType, Platform, PlatformFilter,
+    RepositoryName,
+};

--- a/crates/ocync-distribution/src/manifest.rs
+++ b/crates/ocync-distribution/src/manifest.rs
@@ -9,7 +9,7 @@ use crate::client::{RegistryClient, build_url};
 use crate::digest::Digest;
 use crate::error::Error;
 use crate::sha256::Sha256;
-use crate::spec::{ImageIndex, ManifestKind, MediaType};
+use crate::spec::{ImageIndex, ManifestKind, MediaType, RepositoryName};
 
 /// OCI-specific header returned by registries to provide the content-addressable
 /// digest of a manifest. Not part of the HTTP standard, so no constant exists in
@@ -67,7 +67,7 @@ impl RegistryClient {
     /// Returns `None` if the manifest is not found (404).
     pub async fn manifest_head(
         &self,
-        repository: &str,
+        repository: &RepositoryName,
         reference: &str,
     ) -> Result<Option<ManifestHead>, Error> {
         let path = manifest_path(reference);
@@ -117,7 +117,7 @@ impl RegistryClient {
     /// the manifest, and computes the digest from the raw bytes.
     pub async fn manifest_pull(
         &self,
-        repository: &str,
+        repository: &RepositoryName,
         reference: &str,
     ) -> Result<ManifestPull, Error> {
         let path = manifest_path(reference);
@@ -159,7 +159,7 @@ impl RegistryClient {
     /// exactly as provided. Returns the digest computed from those bytes.
     pub async fn manifest_push(
         &self,
-        repository: &str,
+        repository: &RepositoryName,
         reference: &str,
         media_type: &MediaType,
         raw_bytes: &[u8],
@@ -168,7 +168,7 @@ impl RegistryClient {
         let digest = Digest::from_sha256(hash);
 
         let url = build_url(&self.base_url, repository, &manifest_path(reference))?;
-        let scopes = [Scope::pull_push(repository)];
+        let scopes = [Scope::pull_push(repository.as_str())];
 
         let content_type = HeaderValue::from_str(media_type.as_str())
             .map_err(|e| Error::Other(format!("invalid media type header value: {e}")))?;
@@ -205,7 +205,7 @@ impl RegistryClient {
     /// e.g. `application/vnd.dev.cosign.simplesigning.v1+json`).
     pub async fn referrers(
         &self,
-        repository: &str,
+        repository: &RepositoryName,
         digest: &Digest,
         artifact_type: Option<&str>,
     ) -> Result<Option<ImageIndex>, Error> {
@@ -218,7 +218,7 @@ impl RegistryClient {
             url.query_pairs_mut().append_pair("artifactType", at);
         }
 
-        let scopes = [Scope::pull(repository)];
+        let scopes = [Scope::pull(repository.as_str())];
 
         let resp = self
             .send_with_aimd(

--- a/crates/ocync-distribution/src/spec.rs
+++ b/crates/ocync-distribution/src/spec.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::fmt;
+use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
@@ -168,39 +169,132 @@ impl fmt::Display for Platform {
 }
 
 impl Platform {
-    /// Returns `true` if this platform matches the given filter string.
+    /// Returns `true` if this platform matches the given filter.
     ///
-    /// The filter must be `"os/arch"` or `"os/arch/variant"`. Comparison is
-    /// case-insensitive. An empty filter never matches. When the filter
-    /// specifies only `os/arch`, the platform's `variant` field is ignored —
-    /// any variant (or none) will match.
-    pub fn matches(&self, filter: &str) -> bool {
-        if filter.is_empty() {
+    /// Comparison is case-insensitive. When the filter specifies only `os/arch`,
+    /// the platform's `variant` field is ignored — any variant (or none) will
+    /// match.
+    pub fn matches(&self, filter: &PlatformFilter) -> bool {
+        if !self.os.eq_ignore_ascii_case(&filter.os)
+            || !self.architecture.eq_ignore_ascii_case(&filter.arch)
+        {
             return false;
         }
-        let mut parts = filter.splitn(3, '/');
-        let Some(filter_os) = parts.next() else {
-            return false;
-        };
-        let Some(filter_arch) = parts.next() else {
-            return false;
-        };
-        let filter_variant = parts.next();
 
-        if !self.os.eq_ignore_ascii_case(filter_os) {
-            return false;
+        match (&filter.variant, &self.variant) {
+            (Some(fv), Some(pv)) => pv.eq_ignore_ascii_case(fv),
+            (Some(_), None) => false,
+            (None, _) => true,
         }
-        if !self.architecture.eq_ignore_ascii_case(filter_arch) {
-            return false;
+    }
+}
+
+/// A parsed platform filter for matching against [`Platform`] values.
+///
+/// Constructed from strings like `"linux/amd64"` or `"linux/arm64/v8"` via
+/// [`FromStr`]. Parsing validates the format upfront so matching is a simple
+/// field comparison with no runtime splitting.
+#[derive(Debug, Clone)]
+pub struct PlatformFilter {
+    /// Operating system (e.g. `linux`, `windows`).
+    os: String,
+    /// CPU architecture (e.g. `amd64`, `arm64`).
+    arch: String,
+    /// Optional CPU variant (e.g. `v8`).
+    variant: Option<String>,
+}
+
+impl FromStr for PlatformFilter {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.splitn(3, '/');
+        let (Some(os), Some(arch)) = (parts.next(), parts.next()) else {
+            return Err(Error::InvalidPlatformFilter {
+                input: s.into(),
+                reason: "expected 'os/arch' or 'os/arch/variant'".into(),
+            });
+        };
+
+        if os.is_empty() || arch.is_empty() {
+            return Err(Error::InvalidPlatformFilter {
+                input: s.into(),
+                reason: "os and arch must be non-empty".into(),
+            });
         }
-        if let Some(fv) = filter_variant {
-            match &self.variant {
-                Some(pv) => pv.eq_ignore_ascii_case(fv),
-                None => false,
+
+        let variant = parts.next().map(|v| {
+            if v.is_empty() {
+                Err(Error::InvalidPlatformFilter {
+                    input: s.into(),
+                    reason: "variant must be non-empty when specified".into(),
+                })
+            } else {
+                Ok(v.to_owned())
             }
-        } else {
-            true
+        });
+
+        Ok(Self {
+            os: os.to_owned(),
+            arch: arch.to_owned(),
+            variant: variant.transpose()?,
+        })
+    }
+}
+
+impl fmt::Display for PlatformFilter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.os, self.arch)?;
+        if let Some(ref v) = self.variant {
+            write!(f, "/{v}")?;
         }
+        Ok(())
+    }
+}
+
+/// An OCI repository name (e.g. `library/nginx`, `mirror/nginx`).
+///
+/// Wraps a raw string to distinguish repository names from tag names,
+/// registry hostnames, and other string-typed values. Implements
+/// [`Deref<Target=str>`] for transparent borrowing in functions that
+/// accept `&str`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct RepositoryName(String);
+
+impl RepositoryName {
+    /// Create a new repository name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+
+    /// Return the name as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for RepositoryName {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for RepositoryName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for RepositoryName {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for RepositoryName {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
     }
 }
 
@@ -553,25 +647,25 @@ mod tests {
         }
     }
 
+    /// Helper to parse a filter string, panicking on invalid input.
+    fn filter(s: &str) -> PlatformFilter {
+        s.parse().unwrap()
+    }
+
     #[test]
     fn platform_matches_os_arch() {
-        assert!(linux_amd64().matches("linux/amd64"));
+        assert!(linux_amd64().matches(&filter("linux/amd64")));
     }
 
     #[test]
     fn platform_matches_os_arch_variant() {
-        assert!(linux_arm64_v8().matches("linux/arm64/v8"));
+        assert!(linux_arm64_v8().matches(&filter("linux/arm64/v8")));
     }
 
     #[test]
     fn platform_matches_case_insensitive() {
-        assert!(linux_amd64().matches("Linux/AMD64"));
-        assert!(linux_arm64_v8().matches("LINUX/ARM64/V8"));
-    }
-
-    #[test]
-    fn platform_matches_empty_filter_returns_false() {
-        assert!(!linux_amd64().matches(""));
+        assert!(linux_amd64().matches(&filter("Linux/AMD64")));
+        assert!(linux_arm64_v8().matches(&filter("LINUX/ARM64/V8")));
     }
 
     #[test]
@@ -584,29 +678,108 @@ mod tests {
             os_version: None,
             os_features: None,
         };
-        assert!(!p.matches("linux/arm/v7"));
+        assert!(!p.matches(&filter("linux/arm/v7")));
     }
 
     #[test]
     fn platform_matches_filter_variant_no_platform_variant_returns_false() {
         // filter requires a specific variant but platform has none
-        assert!(!linux_amd64().matches("linux/amd64/v1"));
+        assert!(!linux_amd64().matches(&filter("linux/amd64/v1")));
     }
 
     #[test]
     fn platform_matches_os_arch_ignores_platform_variant() {
         // os/arch filter matches regardless of what variant the platform has
-        assert!(linux_arm64_v8().matches("linux/arm64"));
+        assert!(linux_arm64_v8().matches(&filter("linux/arm64")));
     }
 
     #[test]
     fn platform_matches_wrong_os_returns_false() {
-        assert!(!linux_amd64().matches("windows/amd64"));
+        assert!(!linux_amd64().matches(&filter("windows/amd64")));
     }
 
     #[test]
     fn platform_matches_wrong_arch_returns_false() {
-        assert!(!linux_amd64().matches("linux/arm64"));
+        assert!(!linux_amd64().matches(&filter("linux/arm64")));
+    }
+
+    // --- PlatformFilter parsing tests ---
+
+    #[test]
+    fn platform_filter_parse_os_arch() {
+        let f: PlatformFilter = "linux/amd64".parse().unwrap();
+        assert_eq!(f.to_string(), "linux/amd64");
+    }
+
+    #[test]
+    fn platform_filter_parse_os_arch_variant() {
+        let f: PlatformFilter = "linux/arm64/v8".parse().unwrap();
+        assert_eq!(f.to_string(), "linux/arm64/v8");
+    }
+
+    #[test]
+    fn platform_filter_parse_empty_fails() {
+        let err = "".parse::<PlatformFilter>().unwrap_err();
+        assert!(matches!(err, Error::InvalidPlatformFilter { .. }));
+        let Error::InvalidPlatformFilter { input, reason } = &err else {
+            panic!("expected InvalidPlatformFilter, got {err:?}");
+        };
+        assert_eq!(input, "");
+        assert!(reason.contains("os/arch"), "reason: {reason}");
+    }
+
+    #[test]
+    fn platform_filter_parse_os_only_fails() {
+        let err = "linux".parse::<PlatformFilter>().unwrap_err();
+        assert!(matches!(err, Error::InvalidPlatformFilter { .. }));
+        let Error::InvalidPlatformFilter { input, reason } = &err else {
+            panic!("expected InvalidPlatformFilter, got {err:?}");
+        };
+        assert_eq!(input, "linux");
+        assert!(reason.contains("os/arch"), "reason: {reason}");
+    }
+
+    #[test]
+    fn platform_filter_parse_empty_os_fails() {
+        let err = "/amd64".parse::<PlatformFilter>().unwrap_err();
+        assert!(matches!(err, Error::InvalidPlatformFilter { .. }));
+        let Error::InvalidPlatformFilter { input, reason } = &err else {
+            panic!("expected InvalidPlatformFilter, got {err:?}");
+        };
+        assert_eq!(input, "/amd64");
+        assert!(reason.contains("non-empty"), "reason: {reason}");
+    }
+
+    #[test]
+    fn platform_filter_parse_empty_arch_fails() {
+        let err = "linux/".parse::<PlatformFilter>().unwrap_err();
+        assert!(matches!(err, Error::InvalidPlatformFilter { .. }));
+        let Error::InvalidPlatformFilter { input, reason } = &err else {
+            panic!("expected InvalidPlatformFilter, got {err:?}");
+        };
+        assert_eq!(input, "linux/");
+        assert!(reason.contains("non-empty"), "reason: {reason}");
+    }
+
+    #[test]
+    fn platform_filter_parse_empty_variant_fails() {
+        let err = "linux/amd64/".parse::<PlatformFilter>().unwrap_err();
+        assert!(matches!(err, Error::InvalidPlatformFilter { .. }));
+        let Error::InvalidPlatformFilter { input, reason } = &err else {
+            panic!("expected InvalidPlatformFilter, got {err:?}");
+        };
+        assert_eq!(input, "linux/amd64/");
+        assert!(
+            reason.contains("variant") && reason.contains("non-empty"),
+            "reason: {reason}"
+        );
+    }
+
+    #[test]
+    fn platform_filter_display_roundtrip() {
+        let input = "linux/arm64/v8";
+        let f: PlatformFilter = input.parse().unwrap();
+        assert_eq!(f.to_string(), input);
     }
 
     #[test]

--- a/crates/ocync-distribution/src/tags.rs
+++ b/crates/ocync-distribution/src/tags.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use crate::aimd::RegistryAction;
 use crate::client::RegistryClient;
 use crate::error::Error;
+use crate::spec::RepositoryName;
 
 /// Response body from the tag listing API.
 #[derive(Debug, Clone, Deserialize)]
@@ -53,7 +54,7 @@ impl RegistryClient {
     /// List all tags in a repository, automatically following pagination.
     ///
     /// Returns a complete list of tags by following `Link: rel="next"` headers.
-    pub async fn list_tags(&self, repository: &str) -> Result<Vec<String>, Error> {
+    pub async fn list_tags(&self, repository: &RepositoryName) -> Result<Vec<String>, Error> {
         let mut all_tags = Vec::new();
         let mut path = "tags/list".to_owned();
 

--- a/crates/ocync-distribution/tests/blob_push_stream.rs
+++ b/crates/ocync-distribution/tests/blob_push_stream.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 use futures_util::stream;
 use http::StatusCode;
 use ocync_distribution::Digest;
+use ocync_distribution::RepositoryName;
 use ocync_distribution::client::RegistryClientBuilder;
 use url::Url;
 use wiremock::matchers::{header, method, path, query_param};
@@ -103,8 +104,9 @@ async fn happy_path() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("myrepo");
     let result = client
-        .blob_push_stream("myrepo", &digest, None, data_stream(data, 4))
+        .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
         .await
         .unwrap();
 
@@ -179,8 +181,9 @@ async fn multi_chunk() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("repo");
     let result = client
-        .blob_push_stream("repo", &digest, None, data_stream(data, 2))
+        .blob_push_stream(&repo, &digest, None, data_stream(data, 2))
         .await
         .unwrap();
 
@@ -228,8 +231,9 @@ async fn exact_chunk_boundary() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("repo");
     let result = client
-        .blob_push_stream("repo", &digest, None, data_stream(data, 4))
+        .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
         .await
         .unwrap();
 
@@ -273,8 +277,9 @@ async fn empty_stream() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("repo");
     let result = client
-        .blob_push_stream("repo", &digest, None, data_stream(data, 1))
+        .blob_push_stream(&repo, &digest, None, data_stream(data, 1))
         .await
         .unwrap();
 
@@ -301,8 +306,9 @@ async fn post_initiation_rejected() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("repo");
     let err = client
-        .blob_push_stream("repo", &digest, None, data_stream(data, 4))
+        .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
         .await
         .unwrap_err();
 
@@ -355,8 +361,9 @@ async fn patch_chunk_failure() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("repo");
     let err = client
-        .blob_push_stream("repo", &digest, None, data_stream(data, 4))
+        .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
         .await
         .unwrap_err();
 
@@ -403,8 +410,9 @@ async fn put_finalize_rejected() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("repo");
     let err = client
-        .blob_push_stream("repo", &digest, None, data_stream(data, 4))
+        .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
         .await
         .unwrap_err();
 
@@ -445,8 +453,9 @@ async fn stream_error_propagates() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("repo");
     let result = client
-        .blob_push_stream("repo", &digest, None, error_stream)
+        .blob_push_stream(&repo, &digest, None, error_stream)
         .await;
 
     assert!(result.is_err(), "stream error should propagate");
@@ -475,8 +484,9 @@ async fn post_returns_200_is_rejected() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("repo");
     let err = client
-        .blob_push_stream("repo", &digest, None, data_stream(data, 4))
+        .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
         .await
         .unwrap_err();
 
@@ -528,9 +538,10 @@ async fn small_blob_uses_monolithic_upload() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("repo");
     let result = client
         .blob_push_stream(
-            "repo",
+            &repo,
             &digest,
             Some(data.len() as u64),
             data_stream(data, 4),
@@ -577,8 +588,9 @@ async fn unknown_size_skips_monolithic_threshold() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("repo");
     let result = client
-        .blob_push_stream("repo", &digest, None, data_stream(data, 4))
+        .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
         .await
         .unwrap();
 

--- a/crates/ocync-distribution/tests/client_integration.rs
+++ b/crates/ocync-distribution/tests/client_integration.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use http::StatusCode;
 use ocync_distribution::Error;
+use ocync_distribution::RepositoryName;
 use ocync_distribution::auth::{AuthProvider, Scope, Token};
 use ocync_distribution::client::RegistryClientBuilder;
 use url::Url;
@@ -99,9 +100,10 @@ async fn get_success_no_retry() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("library/nginx");
     let resp = client
         .get(
-            "library/nginx",
+            &repo,
             "manifests/latest",
             None,
             ocync_distribution::aimd::RegistryAction::ManifestRead,
@@ -135,9 +137,10 @@ async fn get_401_triggers_invalidate_and_retry() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("library/nginx");
     let resp = client
         .get(
-            "library/nginx",
+            &repo,
             "manifests/latest",
             None,
             ocync_distribution::aimd::RegistryAction::ManifestRead,
@@ -163,9 +166,10 @@ async fn get_double_401_returns_unauthorized() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("repo");
     let result = client
         .get(
-            "repo",
+            &repo,
             "manifests/latest",
             None,
             ocync_distribution::aimd::RegistryAction::ManifestRead,
@@ -193,9 +197,10 @@ async fn get_401_retry_only_happens_once() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("repo");
     let result = client
         .get(
-            "repo",
+            &repo,
             "manifests/latest",
             None,
             ocync_distribution::aimd::RegistryAction::ManifestRead,
@@ -220,9 +225,10 @@ async fn get_403_returns_forbidden() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("private/repo");
     let result = client
         .get(
-            "private/repo",
+            &repo,
             "manifests/latest",
             None,
             ocync_distribution::aimd::RegistryAction::ManifestRead,
@@ -248,9 +254,10 @@ async fn get_404_returns_not_found() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("repo");
     let result = client
         .get(
-            "repo",
+            &repo,
             "manifests/nonexistent",
             None,
             ocync_distribution::aimd::RegistryAction::ManifestRead,
@@ -275,9 +282,10 @@ async fn get_500_returns_registry_error() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("repo");
     let result = client
         .get(
-            "repo",
+            &repo,
             "manifests/latest",
             None,
             ocync_distribution::aimd::RegistryAction::ManifestRead,
@@ -301,9 +309,10 @@ async fn no_auth_provider_sends_no_header() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("repo");
     let resp = client
         .get(
-            "repo",
+            &repo,
             "manifests/latest",
             None,
             ocync_distribution::aimd::RegistryAction::ManifestRead,
@@ -388,9 +397,10 @@ async fn head_401_triggers_retry() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("repo");
     let resp = client
         .head(
-            "repo",
+            &repo,
             "manifests/latest",
             ocync_distribution::aimd::RegistryAction::ManifestHead,
         )
@@ -415,9 +425,10 @@ async fn head_double_401_returns_unauthorized() {
         .build()
         .unwrap();
 
+    let repo = RepositoryName::new("repo");
     let result = client
         .head(
-            "repo",
+            &repo,
             "manifests/latest",
             ocync_distribution::aimd::RegistryAction::ManifestHead,
         )

--- a/crates/ocync-sync/src/cache.rs
+++ b/crates/ocync-sync/src/cache.rs
@@ -21,6 +21,7 @@ use std::path::Path;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use ocync_distribution::Digest;
+use ocync_distribution::spec::RepositoryName;
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
@@ -78,13 +79,13 @@ impl TransferStateCache {
         &'a self,
         target: &str,
         digest: &Digest,
-        current_repo: &str,
-    ) -> Option<&'a str> {
+        current_repo: &RepositoryName,
+    ) -> Option<&'a RepositoryName> {
         self.dedup.mount_source(target, digest, current_repo)
     }
 
     /// Mark a blob as already existing at the target in the given repo.
-    pub fn set_blob_exists(&mut self, target: &str, digest: Digest, repo: String) {
+    pub fn set_blob_exists(&mut self, target: &str, digest: Digest, repo: RepositoryName) {
         self.dedup.set_exists(target, &digest, &repo);
     }
 
@@ -94,7 +95,7 @@ impl TransferStateCache {
     }
 
     /// Mark a blob as successfully transferred to the given repo at the target.
-    pub fn set_blob_completed(&mut self, target: &str, digest: Digest, repo: String) {
+    pub fn set_blob_completed(&mut self, target: &str, digest: Digest, repo: RepositoryName) {
         self.dedup.set_completed(target, &digest, &repo);
     }
 
@@ -109,7 +110,7 @@ impl TransferStateCache {
     /// `set_blob_completed`) at the given `(target, repo)` pair. This is the
     /// repo-scoped skip check: a blob known at `repo-a` is NOT accessible from
     /// `repo-b` without a mount.
-    pub fn blob_known_at_repo(&self, target: &str, digest: &Digest, repo: &str) -> bool {
+    pub fn blob_known_at_repo(&self, target: &str, digest: &Digest, repo: &RepositoryName) -> bool {
         self.dedup
             .known_repos(target, digest)
             .is_some_and(|repos| repos.contains(repo))
@@ -323,6 +324,10 @@ mod tests {
             .unwrap()
     }
 
+    fn repo(name: &str) -> RepositoryName {
+        RepositoryName::new(name)
+    }
+
     #[test]
     fn new_cache_is_empty() {
         assert!(TransferStateCache::new().is_empty());
@@ -345,8 +350,8 @@ mod tests {
         cache.set_blob_completed("reg.io", digest(), "repo/a".into());
         cache.set_blob_completed("reg.io", digest(), "repo/b".into());
         assert_eq!(
-            cache.blob_mount_source("reg.io", &digest(), "repo/b"),
-            Some("repo/a")
+            cache.blob_mount_source("reg.io", &digest(), &repo("repo/b")),
+            Some(&repo("repo/a"))
         );
     }
 
@@ -354,9 +359,9 @@ mod tests {
     fn blob_known_at_repo_checks_specific_repo() {
         let mut cache = TransferStateCache::new();
         cache.set_blob_completed("reg.io", digest(), "repo/a".into());
-        assert!(cache.blob_known_at_repo("reg.io", &digest(), "repo/a"));
-        assert!(!cache.blob_known_at_repo("reg.io", &digest(), "repo/b"));
-        assert!(!cache.blob_known_at_repo("other.io", &digest(), "repo/a"));
+        assert!(cache.blob_known_at_repo("reg.io", &digest(), &repo("repo/a")));
+        assert!(!cache.blob_known_at_repo("reg.io", &digest(), &repo("repo/b")));
+        assert!(!cache.blob_known_at_repo("other.io", &digest(), &repo("repo/a")));
     }
 
     #[test]
@@ -370,7 +375,7 @@ mod tests {
     #[test]
     fn build_cache_bytes_roundtrip() {
         let mut dedup = BlobDedupMap::new();
-        dedup.set_completed("reg.io", &digest(), "repo/a");
+        dedup.set_completed("reg.io", &digest(), &repo("repo/a"));
         let bytes = build_cache_bytes(&dedup).unwrap();
         // Verify CRC covers the entire payload
         let (payload, crc_bytes) = bytes.split_at(bytes.len() - 4);

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -19,6 +19,7 @@
 
 use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
+use std::fmt;
 use std::future::Future;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -34,7 +35,9 @@ use ocync_distribution::RegistryClient;
 use ocync_distribution::blob::MountResult;
 use ocync_distribution::manifest::ManifestPull;
 use ocync_distribution::sha256::Sha256;
-use ocync_distribution::spec::{Descriptor, ImageIndex, ImageManifest, ManifestKind};
+use ocync_distribution::spec::{
+    Descriptor, ImageIndex, ImageManifest, ManifestKind, PlatformFilter, RepositoryName,
+};
 use tokio::sync::Semaphore;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
@@ -44,6 +47,55 @@ use crate::retry::{self, RetryConfig};
 use crate::shutdown::ShutdownSignal;
 use crate::staging::BlobStage;
 use crate::{BlobTransferStats, ImageResult, ImageStatus, SkipReason, SyncReport, SyncStats};
+
+/// An image reference within a single registry (repository name + tag).
+///
+/// Bundles the two fields that always travel together in discovery and
+/// transfer operations. The [`Display`] impl formats as `repo:tag`.
+///
+/// This is **not** a full OCI reference (which includes the registry hostname).
+/// The registry is tracked separately via the associated [`RegistryClient`].
+#[derive(Debug, Clone)]
+struct ImageRef {
+    /// Repository path (e.g. `library/nginx`).
+    repo: RepositoryName,
+    /// Tag name (e.g. `latest`, `1.25`).
+    tag: String,
+}
+
+impl fmt::Display for ImageRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.repo, self.tag)
+    }
+}
+
+/// A registry identifier used as the blob deduplication key.
+///
+/// Wraps the config-defined name (e.g. `us-ecr`) or bare hostname for
+/// ad-hoc commands. Must be unique per mapping -- it is used as the outer
+/// key in the blob dedup map.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RegistryName(String);
+
+impl RegistryName {
+    /// Create a new registry name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+}
+
+impl std::ops::Deref for RegistryName {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for RegistryName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
 
 /// A fully resolved mapping ready for the sync engine.
 ///
@@ -55,9 +107,9 @@ pub struct ResolvedMapping {
     /// Client for the source registry.
     pub source_client: Arc<RegistryClient>,
     /// Repository path at the source (e.g. `library/nginx`).
-    pub source_repo: String,
+    pub source_repo: RepositoryName,
     /// Repository path at the target (e.g. `mirror/nginx`).
-    pub target_repo: String,
+    pub target_repo: RepositoryName,
     /// Target registries to sync to.
     pub targets: Vec<TargetEntry>,
     /// Tag pairs to sync (already filtered).
@@ -65,10 +117,10 @@ pub struct ResolvedMapping {
     /// Optional platform filter list (e.g., `["linux/amd64"]`).
     ///
     /// When `Some`, index manifests are filtered to only include descriptors
-    /// whose platform matches one of the filter strings (using
+    /// whose platform matches one of the filters (using
     /// [`Platform::matches()`]). Child manifests and blobs for non-matching
     /// platforms are never pulled from the source.
-    pub platforms: Option<Vec<String>>,
+    pub platforms: Option<Vec<PlatformFilter>>,
     /// When `true`, skip syncing when the target already has any manifest for
     /// the tag, regardless of digest comparison.
     ///
@@ -87,7 +139,7 @@ pub struct TargetEntry {
     ///
     /// Must be unique per mapping. Typically the config-defined registry name
     /// (e.g. `us-ecr`) or the bare hostname for ad-hoc commands.
-    pub name: String,
+    pub name: RegistryName,
     /// Client for this target registry.
     pub client: Arc<RegistryClient>,
     /// Optional batch blob checker for this target (ECR batch API).
@@ -107,8 +159,8 @@ impl Clone for TargetEntry {
     }
 }
 
-impl std::fmt::Debug for TargetEntry {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for TargetEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TargetEntry")
             .field("name", &self.name)
             .field("client", &self.client)
@@ -186,17 +238,13 @@ struct TransferTask {
     /// Source client for pulling blobs.
     source_client: Arc<RegistryClient>,
     /// Target registry name (dedup key).
-    target_name: String,
+    target_name: RegistryName,
     /// Target client for pushing.
     target_client: Arc<RegistryClient>,
-    /// Target repository path.
-    target_repo: String,
-    /// Source repository path.
-    source_repo: String,
-    /// Source tag (for display/logging).
-    source_tag: String,
-    /// Target tag (for pushing manifests).
-    target_tag: String,
+    /// Source image reference (repo + tag, for display/logging and blob pulls).
+    source: ImageRef,
+    /// Target image reference (repo + tag, for pushing manifests and blobs).
+    target: ImageRef,
     /// Optional batch blob checker for pre-populating the cache.
     batch_checker: Option<Rc<dyn BatchBlobChecker>>,
 }
@@ -321,30 +369,23 @@ impl SyncEngine {
         // Seed discovery with all (mapping, tag) pairs.
         for mapping in &mappings {
             for tag_pair in &mapping.tags {
-                let source_client = Arc::clone(&mapping.source_client);
-                let source_repo = mapping.source_repo.clone();
-                let target_repo = mapping.target_repo.clone();
-                let source_tag = tag_pair.source.clone();
-                let target_tag = tag_pair.target.clone();
-                let retry = self.retry.clone();
-                let targets = mapping.targets.clone();
-                let platforms = mapping.platforms.clone();
-                let skip_existing = mapping.skip_existing;
+                let params = DiscoveryParams {
+                    source_client: Arc::clone(&mapping.source_client),
+                    source: ImageRef {
+                        repo: mapping.source_repo.clone(),
+                        tag: tag_pair.source.clone(),
+                    },
+                    target: ImageRef {
+                        repo: mapping.target_repo.clone(),
+                        tag: tag_pair.target.clone(),
+                    },
+                    targets: mapping.targets.clone(),
+                    retry: self.retry.clone(),
+                    platforms: mapping.platforms.clone(),
+                    skip_existing: mapping.skip_existing,
+                };
 
-                discovery_futures.push(async move {
-                    discover_tag(DiscoveryParams {
-                        source_client,
-                        source_repo: &source_repo,
-                        target_repo: &target_repo,
-                        source_tag: &source_tag,
-                        target_tag: &target_tag,
-                        targets: &targets,
-                        retry: &retry,
-                        platforms: platforms.as_deref(),
-                        skip_existing,
-                    })
-                    .await
-                });
+                discovery_futures.push(async move { discover_tag(params).await });
             }
         }
 
@@ -366,11 +407,8 @@ impl SyncEngine {
                     };
 
                     let staging_ref = Rc::clone(&staging);
-                    let source_display = format!(
-                        "{}:{} -> {}",
-                        item.source_repo, item.source_tag, item.target_name
-                    );
-                    let target_display = format!("{}:{}", item.target_repo, item.target_tag);
+                    let source_display = format!("{} -> {}", item.source, item.target_name);
+                    let target_display = item.target.to_string();
 
                     execution_futures.push(Box::pin(async move {
                         let _permit = sem.acquire().await.unwrap();
@@ -462,16 +500,17 @@ impl SyncEngine {
 
 /// Parameters for [`discover_tag`], bundled to keep the argument count under
 /// clippy's limit while preserving readability.
-struct DiscoveryParams<'a> {
+///
+/// Owns all data so it can be moved directly into the async discovery future
+/// without intermediate borrows.
+struct DiscoveryParams {
     source_client: Arc<RegistryClient>,
-    source_repo: &'a str,
-    target_repo: &'a str,
-    source_tag: &'a str,
-    target_tag: &'a str,
-    targets: &'a [TargetEntry],
-    retry: &'a RetryConfig,
+    source: ImageRef,
+    target: ImageRef,
+    targets: Vec<TargetEntry>,
+    retry: RetryConfig,
     /// Optional platform filter list (e.g., `["linux/amd64"]`).
-    platforms: Option<&'a [String]>,
+    platforms: Option<Vec<PlatformFilter>>,
     /// When `true`, skip syncing when the target already has any manifest.
     skip_existing: bool,
 }
@@ -486,61 +525,65 @@ struct DiscoveryParams<'a> {
 ///
 /// When `skip_existing` is `true`, targets that return any manifest HEAD response
 /// (regardless of digest) are skipped without further comparison.
-async fn discover_tag(params: DiscoveryParams<'_>) -> DiscoveryOutcome {
+async fn discover_tag(params: DiscoveryParams) -> DiscoveryOutcome {
     let DiscoveryParams {
         source_client,
-        source_repo,
-        target_repo,
-        source_tag,
-        target_tag,
+        source,
+        target,
         targets,
         retry,
         platforms,
         skip_existing,
     } = params;
     // Pull source manifest (shared across all targets for this tag).
-    let source_data =
-        match pull_source_manifest(&source_client, source_repo, source_tag, retry, platforms).await
-        {
-            Ok(data) => Rc::new(data),
-            Err(err) => {
-                let error_str = err.to_string();
-                warn!(
-                    source_repo = %source_repo,
-                    tag = %source_tag,
-                    error = %error_str,
-                    "source pull failed, skipping all targets"
-                );
-                let fail_results: Vec<ImageResult> = targets
-                    .iter()
-                    .map(|target| ImageResult {
-                        image_id: Uuid::now_v7(),
-                        source: format!("{source_repo}:{source_tag}"),
-                        target: format!("{target_repo} ({}):{target_tag}", target.name),
-                        status: ImageStatus::Failed {
-                            error: error_str.clone(),
-                            retries: retry.max_retries,
-                        },
-                        bytes_transferred: 0,
-                        blob_stats: BlobTransferStats::default(),
-                        duration: Duration::ZERO,
-                    })
-                    .collect();
-                return DiscoveryOutcome::Failed(fail_results);
-            }
-        };
+    let source_data = match pull_source_manifest(
+        &source_client,
+        &source.repo,
+        &source.tag,
+        &retry,
+        platforms.as_deref(),
+    )
+    .await
+    {
+        Ok(data) => Rc::new(data),
+        Err(err) => {
+            let error_str = err.to_string();
+            warn!(
+                source_repo = %source.repo,
+                source_tag = %source.tag,
+                error = %error_str,
+                "source pull failed, skipping all targets"
+            );
+            let fail_results: Vec<ImageResult> = targets
+                .iter()
+                .map(|t| ImageResult {
+                    image_id: Uuid::now_v7(),
+                    source: source.to_string(),
+                    target: format!("{} ({}):{}", target.repo, t.name, target.tag),
+                    status: ImageStatus::Failed {
+                        error: error_str.clone(),
+                        retries: retry.max_retries,
+                    },
+                    bytes_transferred: 0,
+                    blob_stats: BlobTransferStats::default(),
+                    duration: Duration::ZERO,
+                })
+                .collect();
+            return DiscoveryOutcome::Failed(fail_results);
+        }
+    };
 
     let source_digest = &source_data.pull.digest;
 
     // HEAD-check all targets concurrently.
     let mut head_checks = FuturesUnordered::new();
 
-    for target in targets {
-        let client = Arc::clone(&target.client);
-        let repo = target_repo.to_owned();
-        let tag = target_tag.to_owned();
-        let name = target.name.clone();
-        let checker = target.batch_checker.clone();
+    for entry in &targets {
+        let client = Arc::clone(&entry.client);
+        let repo = target.repo.clone();
+        let tag = target.tag.clone();
+        let name = entry.name.clone();
+        let checker = entry.batch_checker.clone();
 
         head_checks.push(async move {
             let result = client.manifest_head(&repo, &tag).await;
@@ -555,16 +598,16 @@ async fn discover_tag(params: DiscoveryParams<'_>) -> DiscoveryOutcome {
         match result {
             Ok(Some(_)) if skip_existing => {
                 info!(
-                    source_repo = %source_repo,
-                    target_repo = %target_repo,
-                    tag = %source_tag,
+                    source_repo = %source.repo,
+                    source_tag = %source.tag,
+                    target_repo = %target.repo,
                     "skipping -- target manifest exists (skip_existing)"
                 );
                 tracing::debug!(target: "ocync::metrics", "skip_existing");
                 skipped_results.push(ImageResult {
                     image_id: Uuid::now_v7(),
-                    source: format!("{source_repo}:{source_tag}"),
-                    target: format!("{target_repo}:{target_tag}"),
+                    source: source.to_string(),
+                    target: target.to_string(),
                     status: ImageStatus::Skipped {
                         reason: SkipReason::SkipExisting,
                     },
@@ -575,17 +618,17 @@ async fn discover_tag(params: DiscoveryParams<'_>) -> DiscoveryOutcome {
             }
             Ok(Some(head)) if head.digest == *source_digest => {
                 info!(
-                    source_repo = %source_repo,
-                    target_repo = %target_repo,
-                    tag = %source_tag,
+                    source_repo = %source.repo,
+                    source_tag = %source.tag,
+                    target_repo = %target.repo,
                     digest = %source_digest,
                     "skipping -- digest matches at target"
                 );
                 tracing::debug!(target: "ocync::metrics", "unchanged_skip");
                 skipped_results.push(ImageResult {
                     image_id: Uuid::now_v7(),
-                    source: format!("{source_repo}:{source_tag}"),
-                    target: format!("{target_repo}:{target_tag}"),
+                    source: source.to_string(),
+                    target: target.to_string(),
                     status: ImageStatus::Skipped {
                         reason: SkipReason::DigestMatch,
                     },
@@ -594,35 +637,22 @@ async fn discover_tag(params: DiscoveryParams<'_>) -> DiscoveryOutcome {
                     duration: Duration::ZERO,
                 });
             }
-            Ok(_) => {
+            other => {
+                if let Err(e) = &other {
+                    warn!(
+                        target_repo = %target.repo,
+                        target_tag = %target.tag,
+                        error = %e,
+                        "target manifest HEAD failed, proceeding with sync"
+                    );
+                }
                 active_items.push(TransferTask {
                     source_data: Rc::clone(&source_data),
                     source_client: Arc::clone(&source_client),
                     target_name,
                     target_client,
-                    target_repo: target_repo.to_owned(),
-                    source_repo: source_repo.to_owned(),
-                    source_tag: source_tag.to_owned(),
-                    target_tag: target_tag.to_owned(),
-                    batch_checker,
-                });
-            }
-            Err(e) => {
-                warn!(
-                    target_repo = %target_repo,
-                    target_tag = %target_tag,
-                    error = %e,
-                    "target manifest HEAD failed, proceeding with sync"
-                );
-                active_items.push(TransferTask {
-                    source_data: Rc::clone(&source_data),
-                    source_client: Arc::clone(&source_client),
-                    target_name,
-                    target_client,
-                    target_repo: target_repo.to_owned(),
-                    source_repo: source_repo.to_owned(),
-                    source_tag: source_tag.to_owned(),
-                    target_tag: target_tag.to_owned(),
+                    source: source.clone(),
+                    target: target.clone(),
                     batch_checker,
                 });
             }
@@ -654,10 +684,10 @@ async fn execute_item(
         staging,
         retry,
         source_client: &item.source_client,
-        source_repo: &item.source_repo,
+        source_repo: &item.source.repo,
         target_client: &item.target_client,
         target_name: &item.target_name,
-        target_repo: &item.target_repo,
+        target_repo: &item.target.repo,
         batch_checker: item.batch_checker.as_ref(),
     };
     let outcome = transfer_image_blobs(&ctx, &item.source_data, freq_counts).await;
@@ -666,8 +696,8 @@ async fn execute_item(
         warn!(target_name = %item.target_name, error = %err, "blob transfer failed");
         return ImageResult {
             image_id: Uuid::now_v7(),
-            source: format!("{}:{}", item.source_repo, item.source_tag),
-            target: format!("{}:{}", item.target_repo, item.target_tag),
+            source: item.source.to_string(),
+            target: item.target.to_string(),
             status: ImageStatus::Failed {
                 error: err.to_string(),
                 retries: retry.max_retries,
@@ -682,25 +712,25 @@ async fn execute_item(
     match push_manifests(
         retry,
         &item.target_client,
-        &item.target_repo,
-        &item.target_tag,
+        &item.target.repo,
+        &item.target.tag,
         &item.source_data,
     )
     .await
     {
         Ok(()) => {
             info!(
-                source_repo = %item.source_repo,
-                target_repo = %item.target_repo,
-                source_tag = %item.source_tag,
-                target_tag = %item.target_tag,
+                source_repo = %item.source.repo,
+                source_tag = %item.source.tag,
+                target_repo = %item.target.repo,
+                target_tag = %item.target.tag,
                 bytes = outcome.bytes_transferred,
                 "image synced"
             );
             ImageResult {
                 image_id: Uuid::now_v7(),
-                source: format!("{}:{}", item.source_repo, item.source_tag),
-                target: format!("{}:{}", item.target_repo, item.target_tag),
+                source: item.source.to_string(),
+                target: item.target.to_string(),
                 status: ImageStatus::Synced,
                 bytes_transferred: outcome.bytes_transferred,
                 blob_stats: outcome.stats,
@@ -711,8 +741,8 @@ async fn execute_item(
             warn!(target_name = %item.target_name, error = %err, "manifest push failed");
             ImageResult {
                 image_id: Uuid::now_v7(),
-                source: format!("{}:{}", item.source_repo, item.source_tag),
-                target: format!("{}:{}", item.target_repo, item.target_tag),
+                source: item.source.to_string(),
+                target: item.target.to_string(),
                 status: ImageStatus::Failed {
                     error: err.to_string(),
                     retries: retry.max_retries,
@@ -736,10 +766,10 @@ async fn execute_item(
 /// re-serialized to reflect only the kept descriptors.
 async fn pull_source_manifest(
     client: &RegistryClient,
-    repo: &str,
+    repo: &RepositoryName,
     tag: &str,
     retry: &RetryConfig,
-    platforms: Option<&[String]>,
+    platforms: Option<&[PlatformFilter]>,
 ) -> Result<PulledManifest, crate::Error> {
     let pull = with_retry(retry, "manifest pull", || client.manifest_pull(repo, tag))
         .await
@@ -869,10 +899,10 @@ struct TransferContext<'a> {
     staging: &'a Rc<BlobStage>,
     retry: &'a RetryConfig,
     source_client: &'a RegistryClient,
-    source_repo: &'a str,
+    source_repo: &'a RepositoryName,
     target_client: &'a RegistryClient,
-    target_name: &'a str,
-    target_repo: &'a str,
+    target_name: &'a RegistryName,
+    target_repo: &'a RepositoryName,
     /// Optional batch blob checker for pre-populating the cache.
     batch_checker: Option<&'a Rc<dyn BatchBlobChecker>>,
 }
@@ -961,11 +991,11 @@ async fn transfer_image_blobs(
         let mount_source = {
             let c = ctx.cache.borrow();
             c.blob_mount_source(ctx.target_name, digest, ctx.target_repo)
-                .map(|s| s.to_owned())
+                .cloned()
         };
 
         if let Some(from_repo) = mount_source {
-            debug!(%digest, %from_repo, target = ctx.target_name, "attempting mount");
+            debug!(%digest, %from_repo, target = %ctx.target_name, "attempting mount");
             match ctx
                 .target_client
                 .blob_mount(ctx.target_repo, digest, &from_repo)
@@ -982,7 +1012,7 @@ async fn transfer_image_blobs(
                     continue;
                 }
                 Ok(MountResult::FallbackUpload { .. }) | Err(_) => {
-                    debug!(%digest, target = ctx.target_name, "mount failed, falling back to HEAD+push");
+                    debug!(%digest, target = %ctx.target_name, "mount failed, falling back to HEAD+push");
                     // Invalidate the stale mount source entry.
                     ctx.cache
                         .borrow_mut()
@@ -1011,7 +1041,7 @@ async fn transfer_image_blobs(
             Err(e) => {
                 debug!(
                     %digest,
-                    target = ctx.target_name,
+                    target = %ctx.target_name,
                     error = %e,
                     "blob HEAD failed, proceeding with push"
                 );
@@ -1129,7 +1159,7 @@ async fn transfer_image_blobs(
 async fn push_manifests(
     retry: &RetryConfig,
     target_client: &RegistryClient,
-    target_repo: &str,
+    target_repo: &RepositoryName,
     target_tag: &str,
     source_data: &PulledManifest,
 ) -> Result<(), crate::Error> {

--- a/crates/ocync-sync/src/plan.rs
+++ b/crates/ocync-sync/src/plan.rs
@@ -3,6 +3,7 @@
 use std::collections::{BTreeSet, HashMap};
 
 use ocync_distribution::Digest;
+use ocync_distribution::spec::RepositoryName;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
@@ -28,7 +29,7 @@ pub(crate) struct BlobInfo {
     ///
     /// `BTreeSet` guarantees deterministic iteration order, which makes
     /// [`BlobDedupMap::mount_source`] return a consistent result.
-    pub repos: BTreeSet<String>,
+    pub repos: BTreeSet<RepositoryName>,
 }
 
 /// Per-registry index of tracked blobs.
@@ -73,7 +74,7 @@ impl BlobDedupMap {
     }
 
     /// Mark a blob as existing at the target in the given repo.
-    pub(crate) fn set_exists(&mut self, target: &str, digest: &Digest, repo: &str) {
+    pub(crate) fn set_exists(&mut self, target: &str, digest: &Digest, repo: &RepositoryName) {
         let entry = self.entry_mut(target, digest);
         if matches!(entry.status, BlobStatus::Completed | BlobStatus::Failed(_)) {
             warn!(
@@ -85,7 +86,7 @@ impl BlobDedupMap {
             );
         }
         entry.status = BlobStatus::ExistsAtTarget;
-        entry.repos.insert(repo.to_owned());
+        entry.repos.insert(repo.clone());
     }
 
     /// Mark a blob as in-progress at the target.
@@ -108,7 +109,7 @@ impl BlobDedupMap {
     }
 
     /// Mark a blob as completed at the target in the given repo.
-    pub(crate) fn set_completed(&mut self, target: &str, digest: &Digest, repo: &str) {
+    pub(crate) fn set_completed(&mut self, target: &str, digest: &Digest, repo: &RepositoryName) {
         let entry = self.entry_mut(target, digest);
         if matches!(entry.status, BlobStatus::Failed(_)) {
             warn!(
@@ -120,7 +121,7 @@ impl BlobDedupMap {
             );
         }
         entry.status = BlobStatus::Completed;
-        entry.repos.insert(repo.to_owned());
+        entry.repos.insert(repo.clone());
     }
 
     /// Mark a blob as failed at the target.
@@ -142,7 +143,11 @@ impl BlobDedupMap {
     }
 
     /// Return the set of known repos for a blob at a target.
-    pub(crate) fn known_repos(&self, target: &str, digest: &Digest) -> Option<&BTreeSet<String>> {
+    pub(crate) fn known_repos(
+        &self,
+        target: &str,
+        digest: &Digest,
+    ) -> Option<&BTreeSet<RepositoryName>> {
         self.inner.get(target)?.get(digest).map(|info| &info.repos)
     }
 
@@ -154,13 +159,10 @@ impl BlobDedupMap {
         &'a self,
         target: &str,
         digest: &Digest,
-        target_repo: &str,
-    ) -> Option<&'a str> {
+        target_repo: &RepositoryName,
+    ) -> Option<&'a RepositoryName> {
         let info = self.inner.get(target)?.get(digest)?;
-        info.repos
-            .iter()
-            .find(|r| r.as_str() != target_repo)
-            .map(|r| r.as_str())
+        info.repos.iter().find(|r| *r != target_repo)
     }
 
     /// Remove the entry for the given blob at the target.
@@ -233,13 +235,17 @@ mod tests {
             .unwrap()
     }
 
+    fn repo(name: &str) -> RepositoryName {
+        RepositoryName::new(name)
+    }
+
     #[test]
     fn insert_and_check_status() {
         let mut map = BlobDedupMap::new();
         let d = test_digest();
 
         assert!(map.status("reg.io", &d).is_none());
-        map.set_exists("reg.io", &d, "library/alpine");
+        map.set_exists("reg.io", &d, &repo("library/alpine"));
         assert_eq!(map.status("reg.io", &d), Some(&BlobStatus::ExistsAtTarget));
     }
 
@@ -248,12 +254,12 @@ mod tests {
         let mut map = BlobDedupMap::new();
         let d = test_digest();
 
-        map.set_completed("reg.io", &d, "library/alpine");
-        map.set_completed("reg.io", &d, "library/nginx");
+        map.set_completed("reg.io", &d, &repo("library/alpine"));
+        map.set_completed("reg.io", &d, &repo("library/nginx"));
 
         let repos = map.known_repos("reg.io", &d).unwrap();
-        assert!(repos.contains("library/alpine"));
-        assert!(repos.contains("library/nginx"));
+        assert!(repos.contains(&repo("library/alpine")));
+        assert!(repos.contains(&repo("library/nginx")));
         assert_eq!(repos.len(), 2);
     }
 
@@ -262,11 +268,11 @@ mod tests {
         let mut map = BlobDedupMap::new();
         let d = test_digest();
 
-        map.set_completed("reg.io", &d, "library/alpine");
-        map.set_completed("reg.io", &d, "library/nginx");
+        map.set_completed("reg.io", &d, &repo("library/alpine"));
+        map.set_completed("reg.io", &d, &repo("library/nginx"));
 
-        let source = map.mount_source("reg.io", &d, "library/nginx");
-        assert_eq!(source, Some("library/alpine"));
+        let source = map.mount_source("reg.io", &d, &repo("library/nginx"));
+        assert_eq!(source, Some(&repo("library/alpine")));
     }
 
     #[test]
@@ -274,9 +280,9 @@ mod tests {
         let mut map = BlobDedupMap::new();
         let d = test_digest();
 
-        map.set_completed("reg.io", &d, "library/alpine");
+        map.set_completed("reg.io", &d, &repo("library/alpine"));
 
-        let source = map.mount_source("reg.io", &d, "library/alpine");
+        let source = map.mount_source("reg.io", &d, &repo("library/alpine"));
         assert!(source.is_none());
     }
 
@@ -286,16 +292,16 @@ mod tests {
         let d = test_digest();
 
         // Insert in non-alphabetical order to verify BTreeSet ordering
-        map.set_completed("reg.io", &d, "library/redis");
-        map.set_completed("reg.io", &d, "library/nginx");
-        map.set_completed("reg.io", &d, "library/alpine");
+        map.set_completed("reg.io", &d, &repo("library/redis"));
+        map.set_completed("reg.io", &d, &repo("library/nginx"));
+        map.set_completed("reg.io", &d, &repo("library/alpine"));
 
         // BTreeSet iterates alphabetically: alpine, nginx, redis
-        let source = map.mount_source("reg.io", &d, "library/redis");
-        assert_eq!(source, Some("library/alpine"));
+        let source = map.mount_source("reg.io", &d, &repo("library/redis"));
+        assert_eq!(source, Some(&repo("library/alpine")));
 
-        let source = map.mount_source("reg.io", &d, "library/alpine");
-        assert_eq!(source, Some("library/nginx"));
+        let source = map.mount_source("reg.io", &d, &repo("library/alpine"));
+        assert_eq!(source, Some(&repo("library/nginx")));
     }
 
     #[test]
@@ -303,7 +309,7 @@ mod tests {
         let mut map = BlobDedupMap::new();
         let d = test_digest();
 
-        map.set_completed("reg-a.io", &d, "library/alpine");
+        map.set_completed("reg-a.io", &d, &repo("library/alpine"));
         map.set_in_progress("reg-b.io", &d);
 
         assert_eq!(map.status("reg-a.io", &d), Some(&BlobStatus::Completed));
@@ -319,7 +325,7 @@ mod tests {
         map.set_in_progress("reg.io", &d);
         assert_eq!(map.status("reg.io", &d), Some(&BlobStatus::InProgress));
 
-        map.set_completed("reg.io", &d, "library/alpine");
+        map.set_completed("reg.io", &d, &repo("library/alpine"));
         assert_eq!(map.status("reg.io", &d), Some(&BlobStatus::Completed));
     }
 

--- a/crates/ocync-sync/tests/cache_persistence.rs
+++ b/crates/ocync-sync/tests/cache_persistence.rs
@@ -7,6 +7,7 @@
 use std::time::Duration;
 
 use ocync_distribution::Digest;
+use ocync_distribution::spec::RepositoryName;
 use ocync_sync::cache::TransferStateCache;
 use ocync_sync::plan::BlobStatus;
 
@@ -77,8 +78,8 @@ fn round_trip_mount_source_survives() {
 
     let loaded = TransferStateCache::load(&path, long_ttl());
     assert_eq!(
-        loaded.blob_mount_source("reg.io", &digest_a(), "repo/b"),
-        Some("repo/a")
+        loaded.blob_mount_source("reg.io", &digest_a(), &RepositoryName::from("repo/b")),
+        Some(&RepositoryName::from("repo/a"))
     );
 }
 

--- a/crates/ocync-sync/tests/engine_integration.rs
+++ b/crates/ocync-sync/tests/engine_integration.rs
@@ -8,10 +8,12 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use ocync_distribution::spec::{Descriptor, ImageIndex, ImageManifest, MediaType, Platform};
+use ocync_distribution::spec::{
+    Descriptor, ImageIndex, ImageManifest, MediaType, Platform, PlatformFilter, RepositoryName,
+};
 use ocync_distribution::{BatchBlobChecker, Digest, RegistryClientBuilder};
 use ocync_sync::cache::TransferStateCache;
-use ocync_sync::engine::{ResolvedMapping, SyncEngine, TagPair, TargetEntry};
+use ocync_sync::engine::{RegistryName, ResolvedMapping, SyncEngine, TagPair, TargetEntry};
 use ocync_sync::progress::NullProgress;
 use ocync_sync::retry::RetryConfig;
 use ocync_sync::shutdown::ShutdownSignal;
@@ -58,7 +60,7 @@ fn empty_cache() -> Rc<RefCell<TransferStateCache>> {
 /// Shorthand for a [`TargetEntry`] without a batch checker.
 fn target_entry(name: &str, client: Arc<ocync_distribution::RegistryClient>) -> TargetEntry {
     TargetEntry {
-        name: name.into(),
+        name: RegistryName::new(name),
         client,
         batch_checker: None,
     }
@@ -246,12 +248,13 @@ impl MockBatchChecker {
 impl BatchBlobChecker for MockBatchChecker {
     fn check_blob_existence<'a>(
         &'a self,
-        repo: &'a str,
+        repo: &'a RepositoryName,
         digests: &'a [Digest],
     ) -> Pin<Box<dyn Future<Output = Result<HashSet<Digest>, ocync_distribution::Error>> + 'a>>
     {
         assert_eq!(
-            repo, self.expected_repo,
+            repo.as_str(),
+            self.expected_repo,
             "mock: batch checker called with wrong repo"
         );
         Box::pin(async {
@@ -291,12 +294,13 @@ impl FailingBatchChecker {
 impl BatchBlobChecker for FailingBatchChecker {
     fn check_blob_existence<'a>(
         &'a self,
-        repo: &'a str,
+        repo: &'a RepositoryName,
         _digests: &'a [Digest],
     ) -> Pin<Box<dyn Future<Output = Result<HashSet<Digest>, ocync_distribution::Error>> + 'a>>
     {
         assert_eq!(
-            repo, self.expected_repo,
+            repo.as_str(),
+            self.expected_repo,
             "mock: failing batch checker called with wrong repo"
         );
         Box::pin(async {
@@ -2200,15 +2204,27 @@ async fn sync_cache_persist_and_load_round_trip() {
     let loaded = TransferStateCache::load(&cache_path, std::time::Duration::from_secs(3600));
 
     assert!(
-        loaded.blob_known_at_repo("target-reg", &config_desc.digest, "repo"),
+        loaded.blob_known_at_repo(
+            "target-reg",
+            &config_desc.digest,
+            &RepositoryName::from("repo")
+        ),
         "config blob should be recorded as completed at repo"
     );
     assert!(
-        loaded.blob_known_at_repo("target-reg", &layer_desc.digest, "repo"),
+        loaded.blob_known_at_repo(
+            "target-reg",
+            &layer_desc.digest,
+            &RepositoryName::from("repo")
+        ),
         "layer blob should be recorded as completed at repo"
     );
     assert!(
-        !loaded.blob_known_at_repo("target-reg", &config_desc.digest, "other-repo"),
+        !loaded.blob_known_at_repo(
+            "target-reg",
+            &config_desc.digest,
+            &RepositoryName::from("other-repo")
+        ),
         "blob should not appear at an unrelated repo"
     );
 }
@@ -2753,19 +2769,27 @@ async fn sync_lazy_invalidation_clears_cache_and_records_completion() {
     // Verify: stale mount source is gone, blobs are now recorded at "repo".
     let c = cache.borrow();
     assert!(
-        !c.blob_known_at_repo("target", &config_desc.digest, "stale-repo"),
+        !c.blob_known_at_repo(
+            "target",
+            &config_desc.digest,
+            &RepositoryName::from("stale-repo")
+        ),
         "stale cache entry for config at stale-repo should be invalidated"
     );
     assert!(
-        !c.blob_known_at_repo("target", &layer_desc.digest, "stale-repo"),
+        !c.blob_known_at_repo(
+            "target",
+            &layer_desc.digest,
+            &RepositoryName::from("stale-repo")
+        ),
         "stale cache entry for layer at stale-repo should be invalidated"
     );
     assert!(
-        c.blob_known_at_repo("target", &config_desc.digest, "repo"),
+        c.blob_known_at_repo("target", &config_desc.digest, &RepositoryName::from("repo")),
         "config blob should be recorded as completed at repo after fallback push"
     );
     assert!(
-        c.blob_known_at_repo("target", &layer_desc.digest, "repo"),
+        c.blob_known_at_repo("target", &layer_desc.digest, &RepositoryName::from("repo")),
         "layer blob should be recorded as completed at repo after fallback push"
     );
 }
@@ -3649,39 +3673,41 @@ async fn sync_batch_checker_all_blobs_exist_skips_head() {
     let (manifest_bytes, _) = serialize_manifest(&manifest);
 
     // Source: serve manifest only (no blob endpoints -- they shouldn't be needed).
-    mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
+    // Use different repo names to ensure the engine passes target_repo (not
+    // source_repo) to the batch checker.
+    mount_source_manifest(&source_server, "src/nginx", "v1", &manifest_bytes).await;
 
     // Target: manifest HEAD 404 (image needs sync), manifest PUT (for pushing).
     // Blob HEAD endpoints: expect(0) -- batch pre-population must prevent all
     // per-blob HEAD checks. This is the explicit negative assertion per CLAUDE.md.
-    mount_manifest_head_not_found(&target_server, "repo", "v1").await;
+    mount_manifest_head_not_found(&target_server, "tgt/nginx", "v1").await;
     Mock::given(method("HEAD"))
-        .and(path(format!("/v2/repo/blobs/{}", config_desc.digest)))
+        .and(path(format!("/v2/tgt/nginx/blobs/{}", config_desc.digest)))
         .respond_with(ResponseTemplate::new(200))
         .expect(0)
         .mount(&target_server)
         .await;
     Mock::given(method("HEAD"))
-        .and(path(format!("/v2/repo/blobs/{}", layer_desc.digest)))
+        .and(path(format!("/v2/tgt/nginx/blobs/{}", layer_desc.digest)))
         .respond_with(ResponseTemplate::new(200))
         .expect(0)
         .mount(&target_server)
         .await;
-    mount_manifest_push(&target_server, "repo", "v1").await;
+    mount_manifest_push(&target_server, "tgt/nginx", "v1").await;
 
-    // Batch checker: both blobs exist.
+    // Batch checker: both blobs exist. Expected repo is target repo, not source.
     let existing = HashSet::from([config_desc.digest.clone(), layer_desc.digest.clone()]);
-    let (checker, batch_call_count) = MockBatchChecker::new("repo", existing);
+    let (checker, batch_call_count) = MockBatchChecker::new("tgt/nginx", existing);
 
     let source_client = mock_client(&source_server);
     let target_client = mock_client(&target_server);
 
     let mapping = ResolvedMapping {
         source_client,
-        source_repo: "repo".into(),
-        target_repo: "repo".into(),
+        source_repo: "src/nginx".into(),
+        target_repo: "tgt/nginx".into(),
         targets: vec![TargetEntry {
-            name: "target".into(),
+            name: RegistryName::new("target"),
             client: target_client,
             batch_checker: Some(Rc::new(checker)),
         }],
@@ -3804,7 +3830,7 @@ async fn sync_batch_checker_partial_existence_transfers_missing() {
         source_repo: "repo".into(),
         target_repo: "repo".into(),
         targets: vec![TargetEntry {
-            name: "target".into(),
+            name: RegistryName::new("target"),
             client: target_client,
             batch_checker: Some(Rc::new(checker)),
         }],
@@ -4001,7 +4027,7 @@ async fn sync_batch_checker_failure_falls_back_to_per_blob_head() {
         source_repo: "repo".into(),
         target_repo: "repo".into(),
         targets: vec![TargetEntry {
-            name: "target".into(),
+            name: RegistryName::new("target"),
             client: target_client,
             batch_checker: Some(Rc::new(checker)),
         }],
@@ -4135,12 +4161,12 @@ async fn sync_batch_checker_multi_target_independent_checkers() {
         target_repo: "repo".into(),
         targets: vec![
             TargetEntry {
-                name: "target-a".into(),
+                name: RegistryName::new("target-a"),
                 client: mock_client(&target_a_server),
                 batch_checker: Some(Rc::new(checker_a)),
             },
             TargetEntry {
-                name: "target-b".into(),
+                name: RegistryName::new("target-b"),
                 client: mock_client(&target_b_server),
                 batch_checker: Some(Rc::new(checker_b)),
             },
@@ -4285,7 +4311,7 @@ async fn sync_batch_checker_empty_result_transfers_all() {
         source_repo: "repo".into(),
         target_repo: "repo".into(),
         targets: vec![TargetEntry {
-            name: "target".into(),
+            name: RegistryName::new("target"),
             client: mock_client(&target_server),
             batch_checker: Some(Rc::new(checker)),
         }],
@@ -4403,7 +4429,7 @@ async fn sync_mixed_batch_and_no_batch_multi_target() {
         target_repo: "repo".into(),
         targets: vec![
             TargetEntry {
-                name: "target-a".into(),
+                name: RegistryName::new("target-a"),
                 client: mock_client(&target_a_server),
                 batch_checker: Some(Rc::new(checker)),
             },
@@ -4528,7 +4554,7 @@ async fn sync_batch_checker_multi_tag_shares_rc() {
         source_repo: "repo".into(),
         target_repo: "repo".into(),
         targets: vec![TargetEntry {
-            name: "target".into(),
+            name: RegistryName::new("target"),
             client: mock_client(&target_server),
             batch_checker: Some(Rc::new(checker)),
         }],
@@ -4723,7 +4749,7 @@ async fn sync_batch_checker_index_manifest_all_exist() {
         source_repo: "repo".into(),
         target_repo: "repo".into(),
         targets: vec![TargetEntry {
-            name: "target".into(),
+            name: RegistryName::new("target"),
             client: mock_client(&target_server),
             batch_checker: Some(Rc::new(checker)),
         }],
@@ -4843,7 +4869,7 @@ async fn sync_batch_checker_with_prewarmed_cache() {
         source_repo: "repo".into(),
         target_repo: "repo".into(),
         targets: vec![TargetEntry {
-            name: "target".into(),
+            name: RegistryName::new("target"),
             client: mock_client(&target_server),
             batch_checker: Some(Rc::new(checker)),
         }],
@@ -5136,7 +5162,7 @@ async fn sync_index_manifest_platform_filter() {
         target_repo: "repo".into(),
         targets: vec![target_entry("target", mock_client(&target_server))],
         tags: vec![TagPair::same("latest")],
-        platforms: Some(vec!["linux/amd64".to_string()]),
+        platforms: Some(vec!["linux/amd64".parse::<PlatformFilter>().unwrap()]),
         skip_existing: false,
     };
 
@@ -5671,7 +5697,7 @@ async fn sync_platform_filter_multi_target() {
             target_entry("target-b", mock_client(&target_b)),
         ],
         tags: vec![TagPair::same("latest")],
-        platforms: Some(vec!["linux/amd64".to_string()]),
+        platforms: Some(vec!["linux/amd64".parse::<PlatformFilter>().unwrap()]),
         skip_existing: false,
     };
 

--- a/src/cli/commands/copy.rs
+++ b/src/cli/commands/copy.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 use ocync_sync::ImageStatus;
 use ocync_sync::cache::TransferStateCache;
 use ocync_sync::engine::{
-    DEFAULT_MAX_CONCURRENT_TRANSFERS, ResolvedMapping, SyncEngine, TagPair, TargetEntry,
+    DEFAULT_MAX_CONCURRENT_TRANSFERS, RegistryName, ResolvedMapping, SyncEngine, TagPair,
+    TargetEntry,
 };
 use ocync_sync::progress::NullProgress;
 use ocync_sync::retry::RetryConfig;
@@ -32,10 +33,10 @@ pub(crate) async fn run(args: &CopyArgs) -> Result<ExitCode, CliError> {
 
     let mapping = ResolvedMapping {
         source_client,
-        source_repo: args.source.repository().to_owned(),
-        target_repo: args.destination.repository().to_owned(),
+        source_repo: args.source.repository().into(),
+        target_repo: args.destination.repository().into(),
         targets: vec![TargetEntry {
-            name: bare_hostname(args.destination.registry()).to_owned(),
+            name: RegistryName::new(bare_hostname(args.destination.registry())),
             client: target_client,
             batch_checker: None,
         }],

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -7,13 +7,14 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
-use ocync_distribution::RegistryClient;
 use ocync_distribution::auth::detect::{ProviderKind, detect_provider_kind};
 use ocync_distribution::ecr::{BatchBlobChecker, BatchChecker};
+use ocync_distribution::{RegistryClient, RepositoryName};
 use ocync_sync::SyncReport;
 use ocync_sync::cache::TransferStateCache;
 use ocync_sync::engine::{
-    DEFAULT_MAX_CONCURRENT_TRANSFERS, ResolvedMapping, SyncEngine, TagPair, TargetEntry,
+    DEFAULT_MAX_CONCURRENT_TRANSFERS, RegistryName, ResolvedMapping, SyncEngine, TagPair,
+    TargetEntry,
 };
 use ocync_sync::filter::FilterConfig;
 use ocync_sync::progress::NullProgress;
@@ -289,7 +290,7 @@ async fn resolve_mapping(
             })?;
             let batch_checker = batch_checkers.get(&name).cloned();
             Ok(TargetEntry {
-                name,
+                name: RegistryName::new(name),
                 client,
                 batch_checker,
             })
@@ -297,7 +298,8 @@ async fn resolve_mapping(
         .collect::<Result<Vec<_>, CliError>>()?;
 
     // --- Fetch and filter tags ---
-    let all_tags = source_client.list_tags(&mapping.from).await?;
+    let source_repo_path = RepositoryName::new(&mapping.from);
+    let all_tags = source_client.list_tags(&source_repo_path).await?;
 
     let tags_config = mapping
         .tags
@@ -320,10 +322,17 @@ async fn resolve_mapping(
     let target_repo = mapping.to.as_deref().unwrap_or(&mapping.from).to_owned();
 
     // --- Resolve platforms and skip_existing (mapping overrides defaults) ---
-    let platforms = mapping
+    let platform_strs = mapping
         .platforms
         .clone()
         .or_else(|| config.defaults.as_ref().and_then(|d| d.platforms.clone()));
+    let platforms = platform_strs
+        .map(|strs| {
+            strs.iter()
+                .map(|s| s.parse())
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?;
 
     let skip_existing = mapping
         .skip_existing
@@ -332,8 +341,8 @@ async fn resolve_mapping(
 
     Ok(Some(ResolvedMapping {
         source_client,
-        source_repo: mapping.from.clone(),
-        target_repo,
+        source_repo: mapping.from.clone().into(),
+        target_repo: target_repo.into(),
         targets,
         tags: filtered.into_iter().map(TagPair::same).collect(),
         platforms,
@@ -375,7 +384,7 @@ fn print_dry_run(mappings: &[ResolvedMapping]) {
     }
 
     for mapping in mappings {
-        let target_names: Vec<&str> = mapping.targets.iter().map(|t| t.name.as_str()).collect();
+        let target_names: Vec<&str> = mapping.targets.iter().map(|t| &*t.name).collect();
         println!(
             "dry-run: {} -> {} ({} tag(s)) => [{}]",
             mapping.source_repo,

--- a/src/cli/commands/tags.rs
+++ b/src/cli/commands/tags.rs
@@ -1,5 +1,6 @@
 //! The `tags` subcommand — lists and filters tags from a repository.
 
+use ocync_distribution::RepositoryName;
 use ocync_sync::filter::FilterConfig;
 
 use crate::TagsArgs;
@@ -24,7 +25,8 @@ pub(crate) async fn run(args: &TagsArgs) -> Result<ExitCode, CliError> {
 
     let client = build_registry_client(registry, auth_type.as_ref(), None).await?;
 
-    let all_tags = client.list_tags(repository).await?;
+    let repo_path = RepositoryName::from(repository);
+    let all_tags = client.list_tags(&repo_path).await?;
 
     let filter = FilterConfig {
         glob: args.glob.clone(),


### PR DESCRIPTION
## Summary

- Introduce `RepositoryName`, `RegistryName`, `PlatformFilter`, and `ImageRef` newtypes to replace raw `String`/`&str` for domain concepts across all three workspace crates
- `DiscoveryParams` switched from borrows to owned data, eliminating intermediate clones for async futures
- Deduplicate identical match arms in `discover_tag`
- `BlobInfo.repos` upgraded from `BTreeSet<String>` to `BTreeSet<RepositoryName>`
- `PlatformFilter` validates format at config boundary via `FromStr`, replacing silent failures on malformed input like `"linux"` (no arch)
- Batch checker test uses different source/target repo names so mock contract assertions are non-tautological
- PlatformFilter error tests assert error variant, input field, and reason content

## Test plan

- [ ] `cargo fmt --check && cargo clippy -- -D warnings && cargo test && cargo deny check` passes locally (603 tests, 0 warnings)
- [ ] Cache persistence roundtrip tests verify `BTreeSet<RepositoryName>` serialization
- [ ] Batch checker test (`sync_batch_checker_all_blobs_exist_skips_head`) validates engine passes `target_repo` not `source_repo` to batch checker
- [ ] PlatformFilter parsing tests cover all error paths with message assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)