### PR TITLE
feat: auth providers, credentials config, and ECR immutable tag handling

### DIFF
--- a/crates/ocync-distribution/src/auth/anonymous.rs
+++ b/crates/ocync-distribution/src/auth/anonymous.rs
@@ -4,17 +4,12 @@ use std::collections::HashMap;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
-use std::time::Duration;
 
-use http::header::WWW_AUTHENTICATE;
-use serde::Deserialize;
 use tokio::sync::Mutex;
 
+use super::token_exchange::{exchange_token, scope_cache_key};
 use super::{AuthProvider, Scope, Token};
 use crate::error::Error;
-
-/// The `Bearer` auth scheme prefix used in `WWW-Authenticate` challenges.
-const BEARER_SCHEME: &str = "bearer";
 
 /// Anonymous auth provider that performs the Docker token-exchange flow.
 ///
@@ -63,13 +58,6 @@ impl AnonymousAuth {
             cache: Mutex::new(HashMap::new()),
         }
     }
-
-    /// Build a cache key from a set of scopes.
-    fn cache_key(scopes: &[Scope]) -> String {
-        let mut parts: Vec<String> = scopes.iter().map(|s| s.to_string()).collect();
-        parts.sort();
-        parts.join(" ")
-    }
 }
 
 impl AuthProvider for AnonymousAuth {
@@ -82,7 +70,23 @@ impl AuthProvider for AnonymousAuth {
         scopes: &[Scope],
     ) -> Pin<Box<dyn Future<Output = Result<Token, Error>> + Send + '_>> {
         let scopes = scopes.to_vec();
-        Box::pin(async move { self.get_token_inner(&scopes).await })
+        Box::pin(async move {
+            let key = scope_cache_key(&scopes);
+
+            // Hold the mutex for the entire check-then-fetch to prevent thundering herd.
+            let mut cache = self.cache.lock().await;
+
+            if let Some(token) = cache.get(&key) {
+                if !token.should_refresh() {
+                    return Ok(token.clone());
+                }
+            }
+
+            let token = exchange_token(&self.http, &self.base_url, &scopes, None).await?;
+            cache.insert(key, token.clone());
+
+            Ok(token)
+        })
     }
 
     fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
@@ -93,318 +97,106 @@ impl AuthProvider for AnonymousAuth {
     }
 }
 
-impl AnonymousAuth {
-    async fn get_token_inner(&self, scopes: &[Scope]) -> Result<Token, Error> {
-        let key = Self::cache_key(scopes);
-
-        // Hold the mutex for the entire check-then-fetch to prevent thundering herd.
-        let mut cache = self.cache.lock().await;
-
-        // Check cache with scope awareness.
-        if let Some(token) = cache.get(&key) {
-            if !token.should_refresh() {
-                return Ok(token.clone());
-            }
-        }
-
-        // Need a fresh token — perform the exchange.
-        let token = self.exchange_token(scopes).await?;
-        cache.insert(key, token.clone());
-
-        Ok(token)
-    }
-
-    /// Ping the registry's `/v2/` endpoint, parse the WWW-Authenticate header,
-    /// then exchange for a token.
-    async fn exchange_token(&self, scopes: &[Scope]) -> Result<Token, Error> {
-        let v2_url = format!("{}/v2/", self.base_url);
-        let resp = self.http.get(&v2_url).send().await?;
-
-        if resp.status().is_success() {
-            // No auth required — return a dummy token.
-            return Ok(Token::new(""));
-        }
-
-        let www_auth = resp
-            .headers()
-            .get(WWW_AUTHENTICATE)
-            .and_then(|v| v.to_str().ok())
-            .ok_or_else(|| Error::AuthFailed {
-                registry: self.base_url.clone(),
-                reason: "401 response missing WWW-Authenticate header".into(),
-            })?;
-
-        let challenge = WwwAuthenticate::parse(www_auth).map_err(|reason| Error::AuthFailed {
-            registry: self.base_url.clone(),
-            reason,
-        })?;
-
-        // Build token request URL.
-        let mut url = reqwest::Url::parse(&challenge.realm).map_err(|e| Error::AuthFailed {
-            registry: self.base_url.clone(),
-            reason: format!("invalid realm URL: {e}"),
-        })?;
-
-        {
-            let mut query = url.query_pairs_mut();
-            if let Some(ref service) = challenge.service {
-                query.append_pair("service", service);
-            }
-            for scope in scopes {
-                query.append_pair("scope", &scope.to_string());
-            }
-        }
-
-        let token_resp = self
-            .http
-            .get(url)
-            .send()
-            .await?
-            .error_for_status()?
-            .json::<TokenResponse>()
-            .await?;
-
-        let token_value = token_resp
-            .token
-            .or(token_resp.access_token)
-            .ok_or_else(|| Error::AuthFailed {
-                registry: self.base_url.clone(),
-                reason: "token response missing both 'token' and 'access_token' fields".into(),
-            })?;
-
-        let token = match token_resp.expires_in {
-            Some(secs) if secs > 0 => Token::with_ttl(token_value, Duration::from_secs(secs)),
-            _ => Token::new(token_value),
-        };
-
-        Ok(token)
-    }
-}
-
-/// Parsed `WWW-Authenticate: Bearer realm="...",service="..."` header.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct WwwAuthenticate {
-    /// The token endpoint URL.
-    realm: String,
-    /// The service name (optional).
-    service: Option<String>,
-}
-
-impl WwwAuthenticate {
-    /// Parse a `WWW-Authenticate` header value.
-    ///
-    /// Only `Bearer` challenges are supported. Returns an error string on failure.
-    fn parse(header: &str) -> Result<Self, String> {
-        let header = header.trim();
-
-        // Must start with "Bearer " (case-insensitive).
-        let scheme_len = BEARER_SCHEME.len();
-        let prefix_len = scheme_len + 1; // "bearer" + space
-        if header.len() < prefix_len
-            || !header[..scheme_len].eq_ignore_ascii_case(BEARER_SCHEME)
-            || header.as_bytes()[scheme_len] != b' '
-        {
-            return Err(format!(
-                "unsupported WWW-Authenticate scheme (expected Bearer): {header}"
-            ));
-        }
-
-        let params = &header[prefix_len..];
-        let mut realm = None;
-        let mut service = None;
-
-        for part in split_params(params) {
-            let part = part.trim();
-            if let Some((key, value)) = part.split_once('=') {
-                let key = key.trim().to_ascii_lowercase();
-                let value = value.trim().trim_matches('"');
-                match key.as_str() {
-                    "realm" => realm = Some(value.to_owned()),
-                    "service" => service = Some(value.to_owned()),
-                    _ => {} // Ignore unknown parameters.
-                }
-            }
-        }
-
-        let realm = realm.ok_or("WWW-Authenticate Bearer missing 'realm' parameter")?;
-
-        Ok(Self { realm, service })
-    }
-}
-
-/// Split parameter string on commas, respecting quoted strings.
-fn split_params(s: &str) -> Vec<&str> {
-    let mut parts = Vec::new();
-    let mut start = 0;
-    let mut in_quotes = false;
-
-    for (i, ch) in s.char_indices() {
-        match ch {
-            '"' => in_quotes = !in_quotes,
-            ',' if !in_quotes => {
-                parts.push(&s[start..i]);
-                start = i + 1;
-            }
-            _ => {}
-        }
-    }
-    if start < s.len() {
-        parts.push(&s[start..]);
-    }
-    parts
-}
-
-/// Token response from a registry auth endpoint.
-#[derive(Deserialize)]
-struct TokenResponse {
-    /// The token (Docker Hub uses this field).
-    token: Option<String>,
-    /// Alternative field name (some registries use this).
-    access_token: Option<String>,
-    /// Token lifetime in seconds.
-    expires_in: Option<u64>,
-}
-
-impl fmt::Debug for TokenResponse {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TokenResponse")
-            .field("token", &"[REDACTED]")
-            .field("access_token", &"[REDACTED]")
-            .field("expires_in", &self.expires_in)
-            .finish()
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
     use super::*;
 
-    #[test]
-    fn parse_www_authenticate_bearer() {
-        let header = r#"Bearer realm="https://auth.docker.io/token",service="registry.docker.io""#;
-        let parsed = WwwAuthenticate::parse(header).unwrap();
-        assert_eq!(parsed.realm, "https://auth.docker.io/token");
-        assert_eq!(parsed.service.as_deref(), Some("registry.docker.io"));
+    #[tokio::test]
+    async fn anonymous_auth_exchanges_token() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v2/"))
+            .respond_with(ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!(r#"Bearer realm="{}/token",service="test""#, server.uri()),
+            ))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/token"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"token": "anon-123", "expires_in": 300})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let auth = AnonymousAuth::with_base_url(server.uri(), reqwest::Client::new());
+        let token = auth.get_token(&[Scope::pull("library/nginx")]).await.unwrap();
+        assert_eq!(token.value(), "anon-123");
+    }
+
+    #[tokio::test]
+    async fn anonymous_auth_caches_per_scope() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v2/"))
+            .respond_with(ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!(r#"Bearer realm="{}/token""#, server.uri()),
+            ))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/token"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"token": "cached", "expires_in": 3600})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let auth = AnonymousAuth::with_base_url(server.uri(), reqwest::Client::new());
+        let t1 = auth.get_token(&[Scope::pull("repo")]).await.unwrap();
+        let t2 = auth.get_token(&[Scope::pull("repo")]).await.unwrap();
+        assert_eq!(t1.value(), "cached");
+        assert_eq!(t2.value(), "cached");
+    }
+
+    #[tokio::test]
+    async fn anonymous_auth_invalidate_clears_cache() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v2/"))
+            .respond_with(ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!(r#"Bearer realm="{}/token""#, server.uri()),
+            ))
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/token"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"token": "fresh", "expires_in": 3600})),
+            )
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let auth = AnonymousAuth::with_base_url(server.uri(), reqwest::Client::new());
+        auth.get_token(&[Scope::pull("repo")]).await.unwrap();
+        auth.invalidate().await;
+        auth.get_token(&[Scope::pull("repo")]).await.unwrap();
     }
 
     #[test]
-    fn parse_www_authenticate_no_service() {
-        let header = r#"Bearer realm="https://ghcr.io/token""#;
-        let parsed = WwwAuthenticate::parse(header).unwrap();
-        assert_eq!(parsed.realm, "https://ghcr.io/token");
-        assert!(parsed.service.is_none());
-    }
-
-    #[test]
-    fn parse_www_authenticate_case_insensitive() {
-        let header = r#"BEARER realm="https://auth.example.com/token",service="example""#;
-        let parsed = WwwAuthenticate::parse(header).unwrap();
-        assert_eq!(parsed.realm, "https://auth.example.com/token");
-        assert_eq!(parsed.service.as_deref(), Some("example"));
-    }
-
-    #[test]
-    fn parse_www_authenticate_basic_is_error() {
-        let header = r#"Basic realm="Registry""#;
-        let result = WwwAuthenticate::parse(header);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("unsupported"));
-    }
-
-    #[test]
-    fn parse_www_authenticate_missing_realm() {
-        let header = r#"Bearer service="registry.docker.io""#;
-        let result = WwwAuthenticate::parse(header);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("realm"));
-    }
-
-    #[test]
-    fn token_response_with_token_field() {
-        let json = r#"{"token": "abc123", "expires_in": 300}"#;
-        let resp: TokenResponse = serde_json::from_str(json).unwrap();
-        assert_eq!(resp.token.as_deref(), Some("abc123"));
-        assert!(resp.access_token.is_none());
-        assert_eq!(resp.expires_in, Some(300));
-    }
-
-    #[test]
-    fn token_response_with_access_token_field() {
-        let json = r#"{"access_token": "xyz789"}"#;
-        let resp: TokenResponse = serde_json::from_str(json).unwrap();
-        assert!(resp.token.is_none());
-        assert_eq!(resp.access_token.as_deref(), Some("xyz789"));
-        assert!(resp.expires_in.is_none());
-    }
-
-    #[test]
-    fn token_response_with_both_fields() {
-        let json = r#"{"token": "primary", "access_token": "fallback", "expires_in": 600}"#;
-        let resp: TokenResponse = serde_json::from_str(json).unwrap();
-        assert_eq!(resp.token.as_deref(), Some("primary"));
-        assert_eq!(resp.access_token.as_deref(), Some("fallback"));
-    }
-
-    #[test]
-    fn split_params_basic() {
-        let parts = split_params(r#"realm="https://example.com",service="test""#);
-        assert_eq!(parts.len(), 2);
-    }
-
-    #[test]
-    fn split_params_with_comma_in_quotes() {
-        let parts = split_params(r#"realm="https://example.com/a,b",service="test""#);
-        assert_eq!(parts.len(), 2);
-        assert!(parts[0].contains("a,b"));
-    }
-
-    #[test]
-    fn parse_www_authenticate_empty_string() {
-        let result = WwwAuthenticate::parse("");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn parse_www_authenticate_short_strings() {
-        for input in ["B", "Be", "Bea", "Bear", "Beare", "Bearer"] {
-            let result = WwwAuthenticate::parse(input);
-            assert!(result.is_err(), "expected Err for input: {input:?}");
-        }
-    }
-
-    #[test]
-    fn parse_www_authenticate_whitespace_only() {
-        let result = WwwAuthenticate::parse("   ");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn parse_www_authenticate_bearer_space_only() {
-        // "Bearer " trims to "Bearer" (6 chars) — rejected as too short
-        let result = WwwAuthenticate::parse("Bearer ");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn parse_www_authenticate_with_scope_param() {
-        let header = r#"Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:library/nginx:pull""#;
-        let parsed = WwwAuthenticate::parse(header).unwrap();
-        assert_eq!(parsed.realm, "https://auth.docker.io/token");
-        assert_eq!(parsed.service.as_deref(), Some("registry.docker.io"));
-    }
-
-    #[test]
-    fn parse_www_authenticate_extra_whitespace() {
-        let header = r#"Bearer  realm="https://auth.example.com/token" , service="svc" "#;
-        let parsed = WwwAuthenticate::parse(header).unwrap();
-        assert_eq!(parsed.realm, "https://auth.example.com/token");
-        assert_eq!(parsed.service.as_deref(), Some("svc"));
-    }
-
-    #[test]
-    fn parse_www_authenticate_realm_with_query_params() {
-        let header = r#"Bearer realm="https://auth.example.com/token?foo=bar&baz=1",service="svc""#;
-        let parsed = WwwAuthenticate::parse(header).unwrap();
-        assert!(parsed.realm.contains("foo=bar"));
+    fn anonymous_auth_name() {
+        let auth = AnonymousAuth::new("example.com", reqwest::Client::new());
+        assert_eq!(auth.name(), "anonymous");
     }
 }

--- a/crates/ocync-distribution/src/auth/anonymous.rs
+++ b/crates/ocync-distribution/src/auth/anonymous.rs
@@ -129,7 +129,10 @@ mod tests {
             .await;
 
         let auth = AnonymousAuth::with_base_url(server.uri(), reqwest::Client::new());
-        let token = auth.get_token(&[Scope::pull("library/nginx")]).await.unwrap();
+        let token = auth
+            .get_token(&[Scope::pull("library/nginx")])
+            .await
+            .unwrap();
         assert_eq!(token.value(), "anon-123");
     }
 

--- a/crates/ocync-distribution/src/auth/anonymous.rs
+++ b/crates/ocync-distribution/src/auth/anonymous.rs
@@ -7,8 +7,8 @@ use std::pin::Pin;
 
 use tokio::sync::Mutex;
 
-use super::token_exchange::{exchange_token, scope_cache_key};
-use super::{AuthProvider, Scope, Token};
+use super::token_exchange::exchange_token;
+use super::{AuthProvider, Scope, Token, scopes_cache_key};
 use crate::error::Error;
 
 /// Anonymous auth provider that performs the Docker token-exchange flow.
@@ -71,7 +71,7 @@ impl AuthProvider for AnonymousAuth {
     ) -> Pin<Box<dyn Future<Output = Result<Token, Error>> + Send + '_>> {
         let scopes = scopes.to_vec();
         Box::pin(async move {
-            let key = scope_cache_key(&scopes);
+            let key = scopes_cache_key(&scopes);
 
             // Hold the mutex for the entire check-then-fetch to prevent thundering herd.
             let mut cache = self.cache.lock().await;

--- a/crates/ocync-distribution/src/auth/anonymous.rs
+++ b/crates/ocync-distribution/src/auth/anonymous.rs
@@ -7,7 +7,7 @@ use std::pin::Pin;
 
 use tokio::sync::Mutex;
 
-use super::token_exchange::exchange_token;
+use super::token_exchange;
 use super::{AuthProvider, Scope, Token, scopes_cache_key};
 use crate::error::Error;
 
@@ -82,7 +82,7 @@ impl AuthProvider for AnonymousAuth {
                 }
             }
 
-            let token = exchange_token(&self.http, &self.base_url, &scopes, None).await?;
+            let token = token_exchange::exchange(&self.http, &self.base_url, &scopes, None).await?;
             cache.insert(key, token.clone());
 
             Ok(token)

--- a/crates/ocync-distribution/src/auth/basic.rs
+++ b/crates/ocync-distribution/src/auth/basic.rs
@@ -10,7 +10,7 @@ use std::pin::Pin;
 
 use tokio::sync::Mutex;
 
-use super::token_exchange::exchange_token;
+use super::token_exchange;
 use super::{AuthProvider, Credentials, Scope, Token, scopes_cache_key};
 use crate::error::Error;
 
@@ -99,9 +99,13 @@ impl AuthProvider for BasicAuth {
                 }
             }
 
-            let token =
-                exchange_token(&self.http, &self.base_url, &scopes, Some(&self.credentials))
-                    .await?;
+            let token = token_exchange::exchange(
+                &self.http,
+                &self.base_url,
+                &scopes,
+                Some(&self.credentials),
+            )
+            .await?;
             cache.insert(key, token.clone());
 
             Ok(token)

--- a/crates/ocync-distribution/src/auth/basic.rs
+++ b/crates/ocync-distribution/src/auth/basic.rs
@@ -7,19 +7,12 @@ use std::collections::HashMap;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
-use std::time::Duration;
 
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD as BASE64;
-use http::header::WWW_AUTHENTICATE;
-use serde::Deserialize;
 use tokio::sync::Mutex;
 
+use super::token_exchange::{exchange_token, scope_cache_key};
 use super::{AuthProvider, Credentials, Scope, Token};
 use crate::error::Error;
-
-/// The `Bearer` auth scheme prefix used in `WWW-Authenticate` challenges.
-const BEARER_SCHEME: &str = "bearer";
 
 /// Auth provider that performs the Docker token-exchange flow with HTTP Basic credentials.
 ///
@@ -81,23 +74,6 @@ impl BasicAuth {
             cache: Mutex::new(HashMap::new()),
         }
     }
-
-    /// Build a cache key from a set of scopes.
-    fn cache_key(scopes: &[Scope]) -> String {
-        let mut parts: Vec<String> = scopes.iter().map(|s| s.to_string()).collect();
-        parts.sort();
-        parts.join(" ")
-    }
-
-    /// Build the `Authorization: Basic ...` header value from credentials.
-    fn basic_header_value(&self) -> String {
-        let Credentials::Basic {
-            ref username,
-            ref password,
-        } = self.credentials;
-        let encoded = BASE64.encode(format!("{username}:{password}"));
-        format!("Basic {encoded}")
-    }
 }
 
 impl AuthProvider for BasicAuth {
@@ -110,7 +86,29 @@ impl AuthProvider for BasicAuth {
         scopes: &[Scope],
     ) -> Pin<Box<dyn Future<Output = Result<Token, Error>> + Send + '_>> {
         let scopes = scopes.to_vec();
-        Box::pin(async move { self.get_token_inner(&scopes).await })
+        Box::pin(async move {
+            let key = scope_cache_key(&scopes);
+
+            // Hold the mutex for the entire check-then-fetch to prevent thundering herd.
+            let mut cache = self.cache.lock().await;
+
+            if let Some(token) = cache.get(&key) {
+                if !token.should_refresh() {
+                    return Ok(token.clone());
+                }
+            }
+
+            let token = exchange_token(
+                &self.http,
+                &self.base_url,
+                &scopes,
+                Some(&self.credentials),
+            )
+            .await?;
+            cache.insert(key, token.clone());
+
+            Ok(token)
+        })
     }
 
     fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
@@ -121,187 +119,15 @@ impl AuthProvider for BasicAuth {
     }
 }
 
-impl BasicAuth {
-    async fn get_token_inner(&self, scopes: &[Scope]) -> Result<Token, Error> {
-        let key = Self::cache_key(scopes);
-
-        // Hold the mutex for the entire check-then-fetch to prevent thundering herd.
-        let mut cache = self.cache.lock().await;
-
-        // Check cache with scope awareness.
-        if let Some(token) = cache.get(&key) {
-            if !token.should_refresh() {
-                return Ok(token.clone());
-            }
-        }
-
-        // Need a fresh token — perform the exchange.
-        let token = self.exchange_token(scopes).await?;
-        cache.insert(key, token.clone());
-
-        Ok(token)
-    }
-
-    /// Ping the registry's `/v2/` endpoint, parse the WWW-Authenticate header,
-    /// then exchange for a token with Basic auth credentials.
-    async fn exchange_token(&self, scopes: &[Scope]) -> Result<Token, Error> {
-        let v2_url = format!("{}/v2/", self.base_url);
-        let resp = self.http.get(&v2_url).send().await?;
-
-        if resp.status().is_success() {
-            // No auth required — return a dummy token.
-            return Ok(Token::new(""));
-        }
-
-        let www_auth = resp
-            .headers()
-            .get(WWW_AUTHENTICATE)
-            .and_then(|v| v.to_str().ok())
-            .ok_or_else(|| Error::AuthFailed {
-                registry: self.base_url.clone(),
-                reason: "401 response missing WWW-Authenticate header".into(),
-            })?;
-
-        let challenge = WwwAuthenticate::parse(www_auth).map_err(|reason| Error::AuthFailed {
-            registry: self.base_url.clone(),
-            reason,
-        })?;
-
-        // Build token request URL.
-        let mut url = reqwest::Url::parse(&challenge.realm).map_err(|e| Error::AuthFailed {
-            registry: self.base_url.clone(),
-            reason: format!("invalid realm URL: {e}"),
-        })?;
-
-        {
-            let mut query = url.query_pairs_mut();
-            if let Some(ref service) = challenge.service {
-                query.append_pair("service", service);
-            }
-            for scope in scopes {
-                query.append_pair("scope", &scope.to_string());
-            }
-        }
-
-        let token_resp = self
-            .http
-            .get(url)
-            .header("Authorization", self.basic_header_value())
-            .send()
-            .await?
-            .error_for_status()?
-            .json::<TokenResponse>()
-            .await?;
-
-        let token_value = token_resp
-            .token
-            .or(token_resp.access_token)
-            .ok_or_else(|| Error::AuthFailed {
-                registry: self.base_url.clone(),
-                reason: "token response missing both 'token' and 'access_token' fields".into(),
-            })?;
-
-        let token = match token_resp.expires_in {
-            Some(secs) if secs > 0 => Token::with_ttl(token_value, Duration::from_secs(secs)),
-            _ => Token::new(token_value),
-        };
-
-        Ok(token)
-    }
-}
-
-/// Parsed `WWW-Authenticate: Bearer realm="...",service="..."` header.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct WwwAuthenticate {
-    /// The token endpoint URL.
-    realm: String,
-    /// The service name (optional).
-    service: Option<String>,
-}
-
-impl WwwAuthenticate {
-    /// Parse a `WWW-Authenticate` header value.
-    ///
-    /// Only `Bearer` challenges are supported. Returns an error string on failure.
-    fn parse(header: &str) -> Result<Self, String> {
-        let header = header.trim();
-
-        // Must start with "Bearer " (case-insensitive).
-        let scheme_len = BEARER_SCHEME.len();
-        let prefix_len = scheme_len + 1; // "bearer" + space
-        if header.len() < prefix_len
-            || !header[..scheme_len].eq_ignore_ascii_case(BEARER_SCHEME)
-            || header.as_bytes()[scheme_len] != b' '
-        {
-            return Err(format!(
-                "unsupported WWW-Authenticate scheme (expected Bearer): {header}"
-            ));
-        }
-
-        let params = &header[prefix_len..];
-        let mut realm = None;
-        let mut service = None;
-
-        for part in split_params(params) {
-            let part = part.trim();
-            if let Some((key, value)) = part.split_once('=') {
-                let key = key.trim().to_ascii_lowercase();
-                let value = value.trim().trim_matches('"');
-                match key.as_str() {
-                    "realm" => realm = Some(value.to_owned()),
-                    "service" => service = Some(value.to_owned()),
-                    _ => {} // Ignore unknown parameters.
-                }
-            }
-        }
-
-        let realm = realm.ok_or("WWW-Authenticate Bearer missing 'realm' parameter")?;
-
-        Ok(Self { realm, service })
-    }
-}
-
-/// Split parameter string on commas, respecting quoted strings.
-fn split_params(s: &str) -> Vec<&str> {
-    let mut parts = Vec::new();
-    let mut start = 0;
-    let mut in_quotes = false;
-
-    for (i, ch) in s.char_indices() {
-        match ch {
-            '"' => in_quotes = !in_quotes,
-            ',' if !in_quotes => {
-                parts.push(&s[start..i]);
-                start = i + 1;
-            }
-            _ => {}
-        }
-    }
-    if start < s.len() {
-        parts.push(&s[start..]);
-    }
-    parts
-}
-
-/// Token response from a registry auth endpoint.
-#[derive(Deserialize)]
-struct TokenResponse {
-    /// The token (Docker Hub uses this field).
-    token: Option<String>,
-    /// Alternative field name (some registries use this).
-    access_token: Option<String>,
-    /// Token lifetime in seconds.
-    expires_in: Option<u64>,
-}
-
 #[cfg(test)]
 mod tests {
-    use wiremock::matchers::{method, path};
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::*;
 
-    /// Create test credentials with known values.
     fn test_credentials() -> Credentials {
         Credentials::Basic {
             username: "testuser".into(),
@@ -309,34 +135,29 @@ mod tests {
         }
     }
 
-    /// Expected base64 encoding of "testuser:testpass".
     fn expected_basic_header() -> String {
         let encoded = BASE64.encode("testuser:testpass");
         format!("Basic {encoded}")
     }
 
-    /// Mount a `/v2/` endpoint that returns 401 with a Bearer challenge.
     async fn mount_v2_challenge(server: &MockServer, expect: u64) {
-        let realm = format!("{}/token", server.uri());
-        let www_auth = format!(r#"Bearer realm="{}",service="test-registry""#, realm);
         Mock::given(method("GET"))
             .and(path("/v2/"))
             .respond_with(
-                ResponseTemplate::new(401).insert_header("WWW-Authenticate", www_auth.as_str()),
+                ResponseTemplate::new(401).insert_header(
+                    "WWW-Authenticate",
+                    format!(r#"Bearer realm="{}/token",service="test-registry""#, server.uri()),
+                ),
             )
             .expect(expect)
             .mount(server)
             .await;
     }
 
-    /// Mount a `/token` endpoint that returns a token and validates the Basic auth header.
     async fn mount_token_endpoint(server: &MockServer, token_value: &str, expect: u64) {
         Mock::given(method("GET"))
             .and(path("/token"))
-            .and(wiremock::matchers::header(
-                "Authorization",
-                expected_basic_header().as_str(),
-            ))
+            .and(header("Authorization", expected_basic_header().as_str()))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "token": token_value,
                 "expires_in": 3600
@@ -352,14 +173,9 @@ mod tests {
         mount_v2_challenge(&server, 1).await;
         mount_token_endpoint(&server, "tok123", 1).await;
 
-        // Also verify query params by adding a more specific mock
-        // (the mount_token_endpoint already matched, but let's verify the params
-        // are present by checking the received requests after)
         let auth =
             BasicAuth::with_base_url(server.uri(), reqwest::Client::new(), test_credentials());
-        let scopes = vec![Scope::pull("library/nginx")];
-
-        let token = auth.get_token(&scopes).await.unwrap();
+        let token = auth.get_token(&[Scope::pull("library/nginx")]).await.unwrap();
         assert_eq!(token.value(), "tok123");
 
         // Verify query params on the token request.
@@ -368,17 +184,12 @@ mod tests {
             .iter()
             .find(|r| r.url.path() == "/token")
             .expect("token request not found");
-
-        let query_pairs: HashMap<String, String> = token_req
+        let query_pairs: std::collections::HashMap<String, String> = token_req
             .url
             .query_pairs()
             .map(|(k, v)| (k.into_owned(), v.into_owned()))
             .collect();
-
-        assert_eq!(
-            query_pairs.get("service").map(String::as_str),
-            Some("test-registry")
-        );
+        assert_eq!(query_pairs.get("service").map(String::as_str), Some("test-registry"));
         assert_eq!(
             query_pairs.get("scope").map(String::as_str),
             Some("repository:library/nginx:pull")
@@ -388,47 +199,35 @@ mod tests {
     #[tokio::test]
     async fn basic_auth_caches_tokens_per_scope() {
         let server = MockServer::start().await;
-        // expect(1) — the /v2/ and /token endpoints should only be hit once.
         mount_v2_challenge(&server, 1).await;
         mount_token_endpoint(&server, "cached-tok", 1).await;
 
         let auth =
             BasicAuth::with_base_url(server.uri(), reqwest::Client::new(), test_credentials());
-        let scopes = vec![Scope::pull("library/nginx")];
-
-        let token1 = auth.get_token(&scopes).await.unwrap();
-        let token2 = auth.get_token(&scopes).await.unwrap();
-
-        assert_eq!(token1.value(), "cached-tok");
-        assert_eq!(token2.value(), "cached-tok");
-        // wiremock expect(1) enforces the endpoint was called exactly once.
+        let scopes = [Scope::pull("library/nginx")];
+        let t1 = auth.get_token(&scopes).await.unwrap();
+        let t2 = auth.get_token(&scopes).await.unwrap();
+        assert_eq!(t1.value(), "cached-tok");
+        assert_eq!(t2.value(), "cached-tok");
     }
 
     #[tokio::test]
     async fn basic_auth_invalidate_clears_cache() {
         let server = MockServer::start().await;
-        // expect(2) — one before invalidate, one after.
         mount_v2_challenge(&server, 2).await;
         mount_token_endpoint(&server, "fresh-tok", 2).await;
 
         let auth =
             BasicAuth::with_base_url(server.uri(), reqwest::Client::new(), test_credentials());
-        let scopes = vec![Scope::pull("library/nginx")];
-
-        let token1 = auth.get_token(&scopes).await.unwrap();
-        assert_eq!(token1.value(), "fresh-tok");
-
+        let scopes = [Scope::pull("library/nginx")];
+        auth.get_token(&scopes).await.unwrap();
         auth.invalidate().await;
-
-        let token2 = auth.get_token(&scopes).await.unwrap();
-        assert_eq!(token2.value(), "fresh-tok");
-        // wiremock expect(2) enforces both endpoints were called exactly twice.
+        auth.get_token(&scopes).await.unwrap();
     }
 
     #[tokio::test]
     async fn basic_auth_no_auth_required() {
         let server = MockServer::start().await;
-
         Mock::given(method("GET"))
             .and(path("/v2/"))
             .respond_with(ResponseTemplate::new(200))
@@ -438,9 +237,7 @@ mod tests {
 
         let auth =
             BasicAuth::with_base_url(server.uri(), reqwest::Client::new(), test_credentials());
-        let scopes = vec![Scope::pull("library/nginx")];
-
-        let token = auth.get_token(&scopes).await.unwrap();
+        let token = auth.get_token(&[Scope::pull("repo")]).await.unwrap();
         assert_eq!(token.value(), "");
     }
 
@@ -448,42 +245,22 @@ mod tests {
     async fn basic_auth_token_endpoint_error() {
         let server = MockServer::start().await;
         mount_v2_challenge(&server, 1).await;
-
-        // Token endpoint returns 403.
         Mock::given(method("GET"))
             .and(path("/token"))
-            .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+            .respond_with(ResponseTemplate::new(403))
             .expect(1)
             .mount(&server)
             .await;
 
         let auth =
             BasicAuth::with_base_url(server.uri(), reqwest::Client::new(), test_credentials());
-        let scopes = vec![Scope::pull("library/nginx")];
-
-        let err = auth.get_token(&scopes).await.unwrap_err();
-        // reqwest translates non-success status from error_for_status() into an Http error.
-        assert!(
-            matches!(err, Error::Http(_)),
-            "expected Http error, got: {err:?}"
-        );
-    }
-
-    #[test]
-    fn basic_auth_name() {
-        let auth = BasicAuth::new(
-            "registry.example.com",
-            reqwest::Client::new(),
-            test_credentials(),
-        );
-        assert_eq!(auth.name(), "basic");
+        let err = auth.get_token(&[Scope::pull("repo")]).await.unwrap_err();
+        assert!(matches!(err, Error::Http(_)));
     }
 
     #[tokio::test]
     async fn basic_auth_missing_www_authenticate_header() {
         let server = MockServer::start().await;
-
-        // /v2/ returns 401 without WWW-Authenticate header.
         Mock::given(method("GET"))
             .and(path("/v2/"))
             .respond_with(ResponseTemplate::new(401))
@@ -491,40 +268,24 @@ mod tests {
             .mount(&server)
             .await;
 
-        let creds = Credentials::Basic {
-            username: "u".into(),
-            password: "p".into(),
-        };
-        let auth = BasicAuth::with_base_url(server.uri(), reqwest::Client::new(), creds);
-        let result = auth.get_token(&[Scope::pull("repo")]).await;
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(
-            err.to_string().contains("WWW-Authenticate"),
-            "error should mention missing header, got: {err}"
-        );
+        let auth =
+            BasicAuth::with_base_url(server.uri(), reqwest::Client::new(), test_credentials());
+        let err = auth.get_token(&[Scope::pull("repo")]).await.unwrap_err();
+        assert!(err.to_string().contains("WWW-Authenticate"));
+    }
+
+    #[test]
+    fn basic_auth_name() {
+        let auth = BasicAuth::new("example.com", reqwest::Client::new(), test_credentials());
+        assert_eq!(auth.name(), "basic");
     }
 
     #[test]
     fn basic_auth_debug_redacts_credentials() {
-        let auth = BasicAuth::new(
-            "registry.example.com",
-            reqwest::Client::new(),
-            test_credentials(),
-        );
-        let debug_output = format!("{auth:?}");
-
-        assert!(
-            debug_output.contains("[REDACTED]"),
-            "Debug output should contain [REDACTED]: {debug_output}"
-        );
-        assert!(
-            !debug_output.contains("testuser"),
-            "Debug output should not contain username: {debug_output}"
-        );
-        assert!(
-            !debug_output.contains("testpass"),
-            "Debug output should not contain password: {debug_output}"
-        );
+        let auth = BasicAuth::new("example.com", reqwest::Client::new(), test_credentials());
+        let debug = format!("{auth:?}");
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("testuser"));
+        assert!(!debug.contains("testpass"));
     }
 }

--- a/crates/ocync-distribution/src/auth/basic.rs
+++ b/crates/ocync-distribution/src/auth/basic.rs
@@ -479,6 +479,32 @@ mod tests {
         assert_eq!(auth.name(), "basic");
     }
 
+    #[tokio::test]
+    async fn basic_auth_missing_www_authenticate_header() {
+        let server = MockServer::start().await;
+
+        // /v2/ returns 401 without WWW-Authenticate header.
+        Mock::given(method("GET"))
+            .and(path("/v2/"))
+            .respond_with(ResponseTemplate::new(401))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let creds = Credentials::Basic {
+            username: "u".into(),
+            password: "p".into(),
+        };
+        let auth = BasicAuth::with_base_url(server.uri(), reqwest::Client::new(), creds);
+        let result = auth.get_token(&[Scope::pull("repo")]).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("WWW-Authenticate"),
+            "error should mention missing header, got: {err}"
+        );
+    }
+
     #[test]
     fn basic_auth_debug_redacts_credentials() {
         let auth = BasicAuth::new(

--- a/crates/ocync-distribution/src/auth/basic.rs
+++ b/crates/ocync-distribution/src/auth/basic.rs
@@ -62,7 +62,8 @@ impl BasicAuth {
     /// Create a new Basic auth provider with an explicit base URL.
     ///
     /// Use this for registries that don't use HTTPS (e.g. `http://localhost:5000`).
-    pub fn with_base_url(
+    #[cfg(test)]
+    fn with_base_url(
         base_url: impl Into<String>,
         http: reqwest::Client,
         credentials: Credentials,
@@ -98,13 +99,9 @@ impl AuthProvider for BasicAuth {
                 }
             }
 
-            let token = exchange_token(
-                &self.http,
-                &self.base_url,
-                &scopes,
-                Some(&self.credentials),
-            )
-            .await?;
+            let token =
+                exchange_token(&self.http, &self.base_url, &scopes, Some(&self.credentials))
+                    .await?;
             cache.insert(key, token.clone());
 
             Ok(token)
@@ -143,12 +140,13 @@ mod tests {
     async fn mount_v2_challenge(server: &MockServer, expect: u64) {
         Mock::given(method("GET"))
             .and(path("/v2/"))
-            .respond_with(
-                ResponseTemplate::new(401).insert_header(
-                    "WWW-Authenticate",
-                    format!(r#"Bearer realm="{}/token",service="test-registry""#, server.uri()),
+            .respond_with(ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!(
+                    r#"Bearer realm="{}/token",service="test-registry""#,
+                    server.uri()
                 ),
-            )
+            ))
             .expect(expect)
             .mount(server)
             .await;
@@ -175,7 +173,10 @@ mod tests {
 
         let auth =
             BasicAuth::with_base_url(server.uri(), reqwest::Client::new(), test_credentials());
-        let token = auth.get_token(&[Scope::pull("library/nginx")]).await.unwrap();
+        let token = auth
+            .get_token(&[Scope::pull("library/nginx")])
+            .await
+            .unwrap();
         assert_eq!(token.value(), "tok123");
 
         // Verify query params on the token request.
@@ -189,7 +190,10 @@ mod tests {
             .query_pairs()
             .map(|(k, v)| (k.into_owned(), v.into_owned()))
             .collect();
-        assert_eq!(query_pairs.get("service").map(String::as_str), Some("test-registry"));
+        assert_eq!(
+            query_pairs.get("service").map(String::as_str),
+            Some("test-registry")
+        );
         assert_eq!(
             query_pairs.get("scope").map(String::as_str),
             Some("repository:library/nginx:pull")

--- a/crates/ocync-distribution/src/auth/basic.rs
+++ b/crates/ocync-distribution/src/auth/basic.rs
@@ -1,0 +1,504 @@
+//! HTTP Basic auth provider using the Docker token-exchange flow.
+//!
+//! Performs the same challenge-response token exchange as [`super::anonymous::AnonymousAuth`],
+//! but includes an `Authorization: Basic base64(user:pass)` header on the token request.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use http::header::WWW_AUTHENTICATE;
+use serde::Deserialize;
+use tokio::sync::Mutex;
+
+use super::{AuthProvider, Credentials, Scope, Token};
+use crate::error::Error;
+
+/// The `Bearer` auth scheme prefix used in `WWW-Authenticate` challenges.
+const BEARER_SCHEME: &str = "bearer";
+
+/// Auth provider that performs the Docker token-exchange flow with HTTP Basic credentials.
+///
+/// When a registry responds with `401 Unauthorized` and a `WWW-Authenticate: Bearer ...`
+/// header, this provider extracts the realm/service and exchanges them for a token using
+/// HTTP Basic authentication. Tokens are cached per-scope and coalesced under a mutex to
+/// prevent thundering herd.
+pub struct BasicAuth {
+    /// The registry base URL (e.g. `https://registry-1.docker.io`).
+    base_url: String,
+    /// HTTP client for token requests.
+    http: reqwest::Client,
+    /// Credentials for the Basic auth header.
+    credentials: Credentials,
+    /// Cached tokens keyed by sorted scope strings.
+    cache: Mutex<HashMap<String, Token>>,
+}
+
+impl fmt::Debug for BasicAuth {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BasicAuth")
+            .field("base_url", &self.base_url)
+            .field("credentials", &"[REDACTED]")
+            .finish_non_exhaustive()
+    }
+}
+
+impl BasicAuth {
+    /// Create a new Basic auth provider for the given registry hostname.
+    ///
+    /// Uses HTTPS by default. For non-HTTPS registries (e.g. local development),
+    /// use [`BasicAuth::with_base_url`].
+    pub fn new(
+        registry: impl Into<String>,
+        http: reqwest::Client,
+        credentials: Credentials,
+    ) -> Self {
+        let registry = registry.into();
+        Self {
+            base_url: format!("https://{registry}"),
+            http,
+            credentials,
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Create a new Basic auth provider with an explicit base URL.
+    ///
+    /// Use this for registries that don't use HTTPS (e.g. `http://localhost:5000`).
+    pub fn with_base_url(
+        base_url: impl Into<String>,
+        http: reqwest::Client,
+        credentials: Credentials,
+    ) -> Self {
+        Self {
+            base_url: base_url.into(),
+            http,
+            credentials,
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Build a cache key from a set of scopes.
+    fn cache_key(scopes: &[Scope]) -> String {
+        let mut parts: Vec<String> = scopes.iter().map(|s| s.to_string()).collect();
+        parts.sort();
+        parts.join(" ")
+    }
+
+    /// Build the `Authorization: Basic ...` header value from credentials.
+    fn basic_header_value(&self) -> String {
+        let Credentials::Basic {
+            ref username,
+            ref password,
+        } = self.credentials;
+        let encoded = BASE64.encode(format!("{username}:{password}"));
+        format!("Basic {encoded}")
+    }
+}
+
+impl AuthProvider for BasicAuth {
+    fn name(&self) -> &'static str {
+        "basic"
+    }
+
+    fn get_token(
+        &self,
+        scopes: &[Scope],
+    ) -> Pin<Box<dyn Future<Output = Result<Token, Error>> + Send + '_>> {
+        let scopes = scopes.to_vec();
+        Box::pin(async move { self.get_token_inner(&scopes).await })
+    }
+
+    fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async move {
+            let mut cache = self.cache.lock().await;
+            cache.clear();
+        })
+    }
+}
+
+impl BasicAuth {
+    async fn get_token_inner(&self, scopes: &[Scope]) -> Result<Token, Error> {
+        let key = Self::cache_key(scopes);
+
+        // Hold the mutex for the entire check-then-fetch to prevent thundering herd.
+        let mut cache = self.cache.lock().await;
+
+        // Check cache with scope awareness.
+        if let Some(token) = cache.get(&key) {
+            if !token.should_refresh() {
+                return Ok(token.clone());
+            }
+        }
+
+        // Need a fresh token — perform the exchange.
+        let token = self.exchange_token(scopes).await?;
+        cache.insert(key, token.clone());
+
+        Ok(token)
+    }
+
+    /// Ping the registry's `/v2/` endpoint, parse the WWW-Authenticate header,
+    /// then exchange for a token with Basic auth credentials.
+    async fn exchange_token(&self, scopes: &[Scope]) -> Result<Token, Error> {
+        let v2_url = format!("{}/v2/", self.base_url);
+        let resp = self.http.get(&v2_url).send().await?;
+
+        if resp.status().is_success() {
+            // No auth required — return a dummy token.
+            return Ok(Token::new(""));
+        }
+
+        let www_auth = resp
+            .headers()
+            .get(WWW_AUTHENTICATE)
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| Error::AuthFailed {
+                registry: self.base_url.clone(),
+                reason: "401 response missing WWW-Authenticate header".into(),
+            })?;
+
+        let challenge = WwwAuthenticate::parse(www_auth).map_err(|reason| Error::AuthFailed {
+            registry: self.base_url.clone(),
+            reason,
+        })?;
+
+        // Build token request URL.
+        let mut url = reqwest::Url::parse(&challenge.realm).map_err(|e| Error::AuthFailed {
+            registry: self.base_url.clone(),
+            reason: format!("invalid realm URL: {e}"),
+        })?;
+
+        {
+            let mut query = url.query_pairs_mut();
+            if let Some(ref service) = challenge.service {
+                query.append_pair("service", service);
+            }
+            for scope in scopes {
+                query.append_pair("scope", &scope.to_string());
+            }
+        }
+
+        let token_resp = self
+            .http
+            .get(url)
+            .header("Authorization", self.basic_header_value())
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<TokenResponse>()
+            .await?;
+
+        let token_value = token_resp
+            .token
+            .or(token_resp.access_token)
+            .ok_or_else(|| Error::AuthFailed {
+                registry: self.base_url.clone(),
+                reason: "token response missing both 'token' and 'access_token' fields".into(),
+            })?;
+
+        let token = match token_resp.expires_in {
+            Some(secs) if secs > 0 => Token::with_ttl(token_value, Duration::from_secs(secs)),
+            _ => Token::new(token_value),
+        };
+
+        Ok(token)
+    }
+}
+
+/// Parsed `WWW-Authenticate: Bearer realm="...",service="..."` header.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WwwAuthenticate {
+    /// The token endpoint URL.
+    realm: String,
+    /// The service name (optional).
+    service: Option<String>,
+}
+
+impl WwwAuthenticate {
+    /// Parse a `WWW-Authenticate` header value.
+    ///
+    /// Only `Bearer` challenges are supported. Returns an error string on failure.
+    fn parse(header: &str) -> Result<Self, String> {
+        let header = header.trim();
+
+        // Must start with "Bearer " (case-insensitive).
+        let scheme_len = BEARER_SCHEME.len();
+        let prefix_len = scheme_len + 1; // "bearer" + space
+        if header.len() < prefix_len
+            || !header[..scheme_len].eq_ignore_ascii_case(BEARER_SCHEME)
+            || header.as_bytes()[scheme_len] != b' '
+        {
+            return Err(format!(
+                "unsupported WWW-Authenticate scheme (expected Bearer): {header}"
+            ));
+        }
+
+        let params = &header[prefix_len..];
+        let mut realm = None;
+        let mut service = None;
+
+        for part in split_params(params) {
+            let part = part.trim();
+            if let Some((key, value)) = part.split_once('=') {
+                let key = key.trim().to_ascii_lowercase();
+                let value = value.trim().trim_matches('"');
+                match key.as_str() {
+                    "realm" => realm = Some(value.to_owned()),
+                    "service" => service = Some(value.to_owned()),
+                    _ => {} // Ignore unknown parameters.
+                }
+            }
+        }
+
+        let realm = realm.ok_or("WWW-Authenticate Bearer missing 'realm' parameter")?;
+
+        Ok(Self { realm, service })
+    }
+}
+
+/// Split parameter string on commas, respecting quoted strings.
+fn split_params(s: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut in_quotes = false;
+
+    for (i, ch) in s.char_indices() {
+        match ch {
+            '"' => in_quotes = !in_quotes,
+            ',' if !in_quotes => {
+                parts.push(&s[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    if start < s.len() {
+        parts.push(&s[start..]);
+    }
+    parts
+}
+
+/// Token response from a registry auth endpoint.
+#[derive(Deserialize)]
+struct TokenResponse {
+    /// The token (Docker Hub uses this field).
+    token: Option<String>,
+    /// Alternative field name (some registries use this).
+    access_token: Option<String>,
+    /// Token lifetime in seconds.
+    expires_in: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    /// Create test credentials with known values.
+    fn test_credentials() -> Credentials {
+        Credentials::Basic {
+            username: "testuser".into(),
+            password: "testpass".into(),
+        }
+    }
+
+    /// Expected base64 encoding of "testuser:testpass".
+    fn expected_basic_header() -> String {
+        let encoded = BASE64.encode("testuser:testpass");
+        format!("Basic {encoded}")
+    }
+
+    /// Mount a `/v2/` endpoint that returns 401 with a Bearer challenge.
+    async fn mount_v2_challenge(server: &MockServer, expect: u64) {
+        let realm = format!("{}/token", server.uri());
+        let www_auth = format!(r#"Bearer realm="{}",service="test-registry""#, realm);
+        Mock::given(method("GET"))
+            .and(path("/v2/"))
+            .respond_with(
+                ResponseTemplate::new(401).insert_header("WWW-Authenticate", www_auth.as_str()),
+            )
+            .expect(expect)
+            .mount(server)
+            .await;
+    }
+
+    /// Mount a `/token` endpoint that returns a token and validates the Basic auth header.
+    async fn mount_token_endpoint(server: &MockServer, token_value: &str, expect: u64) {
+        Mock::given(method("GET"))
+            .and(path("/token"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                expected_basic_header().as_str(),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "token": token_value,
+                "expires_in": 3600
+            })))
+            .expect(expect)
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn basic_auth_sends_authorization_header() {
+        let server = MockServer::start().await;
+        mount_v2_challenge(&server, 1).await;
+        mount_token_endpoint(&server, "tok123", 1).await;
+
+        // Also verify query params by adding a more specific mock
+        // (the mount_token_endpoint already matched, but let's verify the params
+        // are present by checking the received requests after)
+        let auth =
+            BasicAuth::with_base_url(server.uri(), reqwest::Client::new(), test_credentials());
+        let scopes = vec![Scope::pull("library/nginx")];
+
+        let token = auth.get_token(&scopes).await.unwrap();
+        assert_eq!(token.value(), "tok123");
+
+        // Verify query params on the token request.
+        let requests = server.received_requests().await.unwrap();
+        let token_req = requests
+            .iter()
+            .find(|r| r.url.path() == "/token")
+            .expect("token request not found");
+
+        let query_pairs: HashMap<String, String> = token_req
+            .url
+            .query_pairs()
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+
+        assert_eq!(
+            query_pairs.get("service").map(String::as_str),
+            Some("test-registry")
+        );
+        assert_eq!(
+            query_pairs.get("scope").map(String::as_str),
+            Some("repository:library/nginx:pull")
+        );
+    }
+
+    #[tokio::test]
+    async fn basic_auth_caches_tokens_per_scope() {
+        let server = MockServer::start().await;
+        // expect(1) — the /v2/ and /token endpoints should only be hit once.
+        mount_v2_challenge(&server, 1).await;
+        mount_token_endpoint(&server, "cached-tok", 1).await;
+
+        let auth =
+            BasicAuth::with_base_url(server.uri(), reqwest::Client::new(), test_credentials());
+        let scopes = vec![Scope::pull("library/nginx")];
+
+        let token1 = auth.get_token(&scopes).await.unwrap();
+        let token2 = auth.get_token(&scopes).await.unwrap();
+
+        assert_eq!(token1.value(), "cached-tok");
+        assert_eq!(token2.value(), "cached-tok");
+        // wiremock expect(1) enforces the endpoint was called exactly once.
+    }
+
+    #[tokio::test]
+    async fn basic_auth_invalidate_clears_cache() {
+        let server = MockServer::start().await;
+        // expect(2) — one before invalidate, one after.
+        mount_v2_challenge(&server, 2).await;
+        mount_token_endpoint(&server, "fresh-tok", 2).await;
+
+        let auth =
+            BasicAuth::with_base_url(server.uri(), reqwest::Client::new(), test_credentials());
+        let scopes = vec![Scope::pull("library/nginx")];
+
+        let token1 = auth.get_token(&scopes).await.unwrap();
+        assert_eq!(token1.value(), "fresh-tok");
+
+        auth.invalidate().await;
+
+        let token2 = auth.get_token(&scopes).await.unwrap();
+        assert_eq!(token2.value(), "fresh-tok");
+        // wiremock expect(2) enforces both endpoints were called exactly twice.
+    }
+
+    #[tokio::test]
+    async fn basic_auth_no_auth_required() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v2/"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let auth =
+            BasicAuth::with_base_url(server.uri(), reqwest::Client::new(), test_credentials());
+        let scopes = vec![Scope::pull("library/nginx")];
+
+        let token = auth.get_token(&scopes).await.unwrap();
+        assert_eq!(token.value(), "");
+    }
+
+    #[tokio::test]
+    async fn basic_auth_token_endpoint_error() {
+        let server = MockServer::start().await;
+        mount_v2_challenge(&server, 1).await;
+
+        // Token endpoint returns 403.
+        Mock::given(method("GET"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let auth =
+            BasicAuth::with_base_url(server.uri(), reqwest::Client::new(), test_credentials());
+        let scopes = vec![Scope::pull("library/nginx")];
+
+        let err = auth.get_token(&scopes).await.unwrap_err();
+        // reqwest translates non-success status from error_for_status() into an Http error.
+        assert!(
+            matches!(err, Error::Http(_)),
+            "expected Http error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn basic_auth_name() {
+        let auth = BasicAuth::new(
+            "registry.example.com",
+            reqwest::Client::new(),
+            test_credentials(),
+        );
+        assert_eq!(auth.name(), "basic");
+    }
+
+    #[test]
+    fn basic_auth_debug_redacts_credentials() {
+        let auth = BasicAuth::new(
+            "registry.example.com",
+            reqwest::Client::new(),
+            test_credentials(),
+        );
+        let debug_output = format!("{auth:?}");
+
+        assert!(
+            debug_output.contains("[REDACTED]"),
+            "Debug output should contain [REDACTED]: {debug_output}"
+        );
+        assert!(
+            !debug_output.contains("testuser"),
+            "Debug output should not contain username: {debug_output}"
+        );
+        assert!(
+            !debug_output.contains("testpass"),
+            "Debug output should not contain password: {debug_output}"
+        );
+    }
+}

--- a/crates/ocync-distribution/src/auth/basic.rs
+++ b/crates/ocync-distribution/src/auth/basic.rs
@@ -10,8 +10,8 @@ use std::pin::Pin;
 
 use tokio::sync::Mutex;
 
-use super::token_exchange::{exchange_token, scope_cache_key};
-use super::{AuthProvider, Credentials, Scope, Token};
+use super::token_exchange::exchange_token;
+use super::{AuthProvider, Credentials, Scope, Token, scopes_cache_key};
 use crate::error::Error;
 
 /// Auth provider that performs the Docker token-exchange flow with HTTP Basic credentials.
@@ -88,7 +88,7 @@ impl AuthProvider for BasicAuth {
     ) -> Pin<Box<dyn Future<Output = Result<Token, Error>> + Send + '_>> {
         let scopes = scopes.to_vec();
         Box::pin(async move {
-            let key = scope_cache_key(&scopes);
+            let key = scopes_cache_key(&scopes);
 
             // Hold the mutex for the entire check-then-fetch to prevent thundering herd.
             let mut cache = self.cache.lock().await;
@@ -185,7 +185,7 @@ mod tests {
             .iter()
             .find(|r| r.url.path() == "/token")
             .expect("token request not found");
-        let query_pairs: std::collections::HashMap<String, String> = token_req
+        let query_pairs: HashMap<String, String> = token_req
             .url
             .query_pairs()
             .map(|(k, v)| (k.into_owned(), v.into_owned()))

--- a/crates/ocync-distribution/src/auth/docker.rs
+++ b/crates/ocync-distribution/src/auth/docker.rs
@@ -279,6 +279,8 @@ pub struct DockerConfigAuth {
     base_url: String,
     /// The loaded Docker config.
     config: DockerConfig,
+    /// HTTP client shared with the inner auth provider.
+    http: reqwest::Client,
     /// Lazily initialized inner provider.
     inner: tokio::sync::OnceCell<Box<dyn AuthProvider>>,
 }
@@ -296,13 +298,14 @@ impl DockerConfigAuth {
     /// Create a new Docker config auth provider for the given hostname.
     ///
     /// Uses HTTPS by default.
-    pub fn new(registry: impl Into<String>, config: DockerConfig) -> Self {
+    pub fn new(registry: impl Into<String>, config: DockerConfig, http: reqwest::Client) -> Self {
         let registry = registry.into();
         let base_url = format!("https://{registry}");
         Self {
             registry,
             base_url,
             config,
+            http,
             inner: tokio::sync::OnceCell::new(),
         }
     }
@@ -313,18 +316,20 @@ impl DockerConfigAuth {
         config: DockerConfig,
         registry: impl Into<String>,
         base_url: impl Into<String>,
+        http: reqwest::Client,
     ) -> Self {
         Self {
             registry: registry.into(),
             base_url: base_url.into(),
             config,
+            http,
             inner: tokio::sync::OnceCell::new(),
         }
     }
 
     /// Resolve credentials and build the appropriate inner provider.
     fn resolve_inner(&self) -> Result<Box<dyn AuthProvider>, Error> {
-        let http = reqwest::Client::new();
+        let http = self.http.clone();
         match resolve_from_docker_config(&self.config, &self.registry)? {
             Some(creds) => {
                 tracing::debug!(
@@ -708,8 +713,12 @@ mod tests {
             .mount(&mock)
             .await;
 
-        let auth =
-            DockerConfigAuth::with_config_and_base_url(config, mock_host.to_string(), mock.uri());
+        let auth = DockerConfigAuth::with_config_and_base_url(
+            config,
+            mock_host.to_string(),
+            mock.uri(),
+            reqwest::Client::new(),
+        );
         let token = auth
             .get_token(&[Scope::pull("library/nginx")])
             .await
@@ -745,15 +754,23 @@ mod tests {
             .mount(&mock)
             .await;
 
-        let auth =
-            DockerConfigAuth::with_config_and_base_url(config, mock_host.to_string(), mock.uri());
+        let auth = DockerConfigAuth::with_config_and_base_url(
+            config,
+            mock_host.to_string(),
+            mock.uri(),
+            reqwest::Client::new(),
+        );
         let token = auth.get_token(&[Scope::pull("public/repo")]).await.unwrap();
         assert_eq!(token.value(), "anon-token");
     }
 
     #[test]
     fn docker_config_auth_name() {
-        let auth = DockerConfigAuth::new("example.com", DockerConfig::default());
+        let auth = DockerConfigAuth::new(
+            "example.com",
+            DockerConfig::default(),
+            reqwest::Client::new(),
+        );
         assert_eq!(auth.name(), "docker-config");
     }
 }

--- a/crates/ocync-distribution/src/auth/docker.rs
+++ b/crates/ocync-distribution/src/auth/docker.rs
@@ -12,7 +12,7 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use serde::Deserialize;
 use tokio::sync::Mutex;
 
-use super::token_exchange::exchange_token;
+use super::token_exchange;
 use super::{AuthProvider, Credentials, Scope, Token, scopes_cache_key};
 use crate::error::Error;
 
@@ -354,7 +354,7 @@ impl AuthProvider for DockerConfigAuth {
                 }
             }
 
-            let token = exchange_token(
+            let token = token_exchange::exchange(
                 &self.http,
                 &self.base_url,
                 &scopes,

--- a/crates/ocync-distribution/src/auth/docker.rs
+++ b/crates/ocync-distribution/src/auth/docker.rs
@@ -12,8 +12,8 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use serde::Deserialize;
 use tokio::sync::Mutex;
 
-use super::token_exchange::{exchange_token, scope_cache_key};
-use super::{AuthProvider, Credentials, Scope, Token};
+use super::token_exchange::exchange_token;
+use super::{AuthProvider, Credentials, Scope, Token, scopes_cache_key};
 use crate::error::Error;
 
 /// Docker Hub hostnames that all resolve to the same credential entry.
@@ -344,7 +344,7 @@ impl AuthProvider for DockerConfigAuth {
     ) -> Pin<Box<dyn Future<Output = Result<Token, Error>> + Send + '_>> {
         let scopes = scopes.to_vec();
         Box::pin(async move {
-            let key = scope_cache_key(&scopes);
+            let key = scopes_cache_key(&scopes);
 
             let mut cache = self.cache.lock().await;
 

--- a/crates/ocync-distribution/src/auth/docker.rs
+++ b/crates/ocync-distribution/src/auth/docker.rs
@@ -10,9 +10,9 @@ use std::process::Command;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use serde::Deserialize;
+use tokio::sync::Mutex;
 
-use super::anonymous::AnonymousAuth;
-use super::basic::BasicAuth;
+use super::token_exchange::{exchange_token, scope_cache_key};
 use super::{AuthProvider, Credentials, Scope, Token};
 use crate::error::Error;
 
@@ -268,28 +268,27 @@ fn run_credential_helper(helper: &str, registry: &str) -> Result<Credentials, Er
 
 /// Auth provider that resolves credentials from a Docker `config.json`.
 ///
-/// On the first `get_token()` call, resolves credentials for the
-/// configured registry hostname from the provided [`DockerConfig`].
-/// If credentials are found, delegates to [`BasicAuth`]; otherwise
-/// falls back to [`AnonymousAuth`].
+/// Resolves credentials for the configured registry hostname on construction,
+/// then uses the shared token-exchange flow with those credentials (or without,
+/// for anonymous access when no credentials are found). Tokens are cached
+/// per-scope with the same pattern as [`super::basic::BasicAuth`] and
+/// [`super::anonymous::AnonymousAuth`].
 pub struct DockerConfigAuth {
-    /// The registry hostname to look up in the Docker config.
-    registry: String,
-    /// The registry base URL for the underlying auth provider.
+    /// The registry base URL for token exchange.
     base_url: String,
-    /// The loaded Docker config.
-    config: DockerConfig,
-    /// HTTP client shared with the inner auth provider.
+    /// HTTP client for token requests.
     http: reqwest::Client,
-    /// Lazily initialized inner provider.
-    inner: tokio::sync::OnceCell<Box<dyn AuthProvider>>,
+    /// Resolved credentials (None = anonymous).
+    credentials: Option<Credentials>,
+    /// Cached tokens keyed by sorted scope strings.
+    cache: Mutex<HashMap<String, Token>>,
 }
 
 impl fmt::Debug for DockerConfigAuth {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DockerConfigAuth")
-            .field("registry", &self.registry)
             .field("base_url", &self.base_url)
+            .field("has_credentials", &self.credentials.is_some())
             .finish_non_exhaustive()
     }
 }
@@ -297,61 +296,39 @@ impl fmt::Debug for DockerConfigAuth {
 impl DockerConfigAuth {
     /// Create a new Docker config auth provider for the given hostname.
     ///
-    /// Uses HTTPS by default.
-    pub fn new(registry: impl Into<String>, config: DockerConfig, http: reqwest::Client) -> Self {
+    /// Resolves credentials from `config` immediately. Uses HTTPS by default.
+    pub fn new(
+        registry: impl Into<String>,
+        config: &DockerConfig,
+        http: reqwest::Client,
+    ) -> Result<Self, Error> {
         let registry = registry.into();
-        let base_url = format!("https://{registry}");
-        Self {
-            registry,
-            base_url,
-            config,
-            http,
-            inner: tokio::sync::OnceCell::new(),
+        let credentials = resolve_from_docker_config(config, &registry)?;
+        if credentials.is_some() {
+            tracing::debug!(registry = %registry, "docker config: resolved credentials");
+        } else {
+            tracing::debug!(registry = %registry, "docker config: no credentials, using anonymous");
         }
+        Ok(Self {
+            base_url: format!("https://{registry}"),
+            http,
+            credentials,
+            cache: Mutex::new(HashMap::new()),
+        })
     }
 
     /// Create a Docker config auth provider with an explicit base URL (for testing).
     #[cfg(test)]
-    fn with_config_and_base_url(
-        config: DockerConfig,
-        registry: impl Into<String>,
+    fn with_base_url(
         base_url: impl Into<String>,
         http: reqwest::Client,
+        credentials: Option<Credentials>,
     ) -> Self {
         Self {
-            registry: registry.into(),
             base_url: base_url.into(),
-            config,
             http,
-            inner: tokio::sync::OnceCell::new(),
-        }
-    }
-
-    /// Resolve credentials and build the appropriate inner provider.
-    fn resolve_inner(&self) -> Result<Box<dyn AuthProvider>, Error> {
-        let http = self.http.clone();
-        match resolve_from_docker_config(&self.config, &self.registry)? {
-            Some(creds) => {
-                tracing::debug!(
-                    registry = %self.registry,
-                    "docker config: resolved credentials, using basic auth"
-                );
-                Ok(Box::new(BasicAuth::with_base_url(
-                    self.base_url.clone(),
-                    http,
-                    creds,
-                )))
-            }
-            None => {
-                tracing::debug!(
-                    registry = %self.registry,
-                    "docker config: no credentials found, using anonymous auth"
-                );
-                Ok(Box::new(AnonymousAuth::with_base_url(
-                    self.base_url.clone(),
-                    http,
-                )))
-            }
+            credentials,
+            cache: Mutex::new(HashMap::new()),
         }
     }
 }
@@ -367,19 +344,33 @@ impl AuthProvider for DockerConfigAuth {
     ) -> Pin<Box<dyn Future<Output = Result<Token, Error>> + Send + '_>> {
         let scopes = scopes.to_vec();
         Box::pin(async move {
-            let inner = self
-                .inner
-                .get_or_try_init(|| async { self.resolve_inner() })
-                .await?;
-            inner.get_token(&scopes).await
+            let key = scope_cache_key(&scopes);
+
+            let mut cache = self.cache.lock().await;
+
+            if let Some(token) = cache.get(&key) {
+                if !token.should_refresh() {
+                    return Ok(token.clone());
+                }
+            }
+
+            let token = exchange_token(
+                &self.http,
+                &self.base_url,
+                &scopes,
+                self.credentials.as_ref(),
+            )
+            .await?;
+            cache.insert(key, token.clone());
+
+            Ok(token)
         })
     }
 
     fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
-            if let Some(inner) = self.inner.get() {
-                inner.invalidate().await;
-            }
+            let mut cache = self.cache.lock().await;
+            cache.clear();
         })
     }
 }
@@ -666,25 +657,11 @@ mod tests {
     #[tokio::test]
     async fn docker_config_auth_with_inline_creds() {
         let mock = wiremock::MockServer::start().await;
-
-        let uri = mock.uri();
-        let mock_host = uri.trim_start_matches("http://");
         let encoded = BASE64.encode("testuser:testpass");
-        let config = DockerConfig {
-            auths: {
-                let mut m = HashMap::new();
-                m.insert(
-                    mock_host.to_string(),
-                    AuthEntry {
-                        auth: Some(encoded.clone()),
-                        username: None,
-                        password: None,
-                    },
-                );
-                m
-            },
-            cred_helpers: HashMap::new(),
-            creds_store: None,
+
+        let creds = Credentials::Basic {
+            username: "testuser".into(),
+            password: "testpass".into(),
         };
 
         // /v2/ returns 401 with Bearer challenge.
@@ -692,7 +669,7 @@ mod tests {
             .and(wiremock::matchers::path("/v2/"))
             .respond_with(wiremock::ResponseTemplate::new(401).insert_header(
                 "WWW-Authenticate",
-                format!("Bearer realm=\"{}/token\"", mock.uri()),
+                format!(r#"Bearer realm="{}/token""#, mock.uri()),
             ))
             .expect(1)
             .mount(&mock)
@@ -713,11 +690,10 @@ mod tests {
             .mount(&mock)
             .await;
 
-        let auth = DockerConfigAuth::with_config_and_base_url(
-            config,
-            mock_host.to_string(),
+        let auth = DockerConfigAuth::with_base_url(
             mock.uri(),
             reqwest::Client::new(),
+            Some(creds),
         );
         let token = auth
             .get_token(&[Scope::pull("library/nginx")])
@@ -729,16 +705,12 @@ mod tests {
     #[tokio::test]
     async fn docker_config_auth_no_creds_falls_back_to_anonymous() {
         let mock = wiremock::MockServer::start().await;
-        let uri = mock.uri();
-        let mock_host = uri.trim_start_matches("http://");
-
-        let config = DockerConfig::default();
 
         wiremock::Mock::given(wiremock::matchers::method("GET"))
             .and(wiremock::matchers::path("/v2/"))
             .respond_with(wiremock::ResponseTemplate::new(401).insert_header(
                 "WWW-Authenticate",
-                format!("Bearer realm=\"{}/token\"", mock.uri()),
+                format!(r#"Bearer realm="{}/token""#, mock.uri()),
             ))
             .expect(1)
             .mount(&mock)
@@ -754,23 +726,142 @@ mod tests {
             .mount(&mock)
             .await;
 
-        let auth = DockerConfigAuth::with_config_and_base_url(
-            config,
-            mock_host.to_string(),
+        let auth = DockerConfigAuth::with_base_url(
             mock.uri(),
             reqwest::Client::new(),
+            None,
         );
         let token = auth.get_token(&[Scope::pull("public/repo")]).await.unwrap();
         assert_eq!(token.value(), "anon-token");
+    }
+
+    #[tokio::test]
+    async fn docker_config_auth_caches_tokens() {
+        let mock = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/"))
+            .respond_with(wiremock::ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!(r#"Bearer realm="{}/token""#, mock.uri()),
+            ))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/token"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"token": "cached", "expires_in": 3600})),
+            )
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let auth = DockerConfigAuth::with_base_url(
+            mock.uri(),
+            reqwest::Client::new(),
+            None,
+        );
+        let t1 = auth.get_token(&[Scope::pull("repo")]).await.unwrap();
+        let t2 = auth.get_token(&[Scope::pull("repo")]).await.unwrap();
+        assert_eq!(t1.value(), "cached");
+        assert_eq!(t2.value(), "cached");
+        // expect(1) on both endpoints proves the second call hit cache.
+    }
+
+    #[tokio::test]
+    async fn docker_config_auth_invalidate_clears_cache() {
+        let mock = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/"))
+            .respond_with(wiremock::ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!(r#"Bearer realm="{}/token""#, mock.uri()),
+            ))
+            .expect(2)
+            .mount(&mock)
+            .await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/token"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"token": "fresh", "expires_in": 3600})),
+            )
+            .expect(2)
+            .mount(&mock)
+            .await;
+
+        let auth = DockerConfigAuth::with_base_url(
+            mock.uri(),
+            reqwest::Client::new(),
+            None,
+        );
+        auth.get_token(&[Scope::pull("repo")]).await.unwrap();
+        auth.invalidate().await;
+        auth.get_token(&[Scope::pull("repo")]).await.unwrap();
+        // expect(2) proves cache was cleared.
     }
 
     #[test]
     fn docker_config_auth_name() {
         let auth = DockerConfigAuth::new(
             "example.com",
-            DockerConfig::default(),
+            &DockerConfig::default(),
             reqwest::Client::new(),
-        );
+        )
+        .unwrap();
         assert_eq!(auth.name(), "docker-config");
+    }
+
+    #[test]
+    fn docker_config_auth_resolves_from_config() {
+        let config = DockerConfig {
+            auths: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "ghcr.io".to_string(),
+                    AuthEntry {
+                        auth: Some(BASE64.encode("user:pass")),
+                        username: None,
+                        password: None,
+                    },
+                );
+                m
+            },
+            cred_helpers: HashMap::new(),
+            creds_store: None,
+        };
+        let auth = DockerConfigAuth::new("ghcr.io", &config, reqwest::Client::new()).unwrap();
+        // Verify credentials were resolved (has_credentials in Debug output).
+        let debug = format!("{auth:?}");
+        assert!(debug.contains("has_credentials: true"));
+    }
+
+    #[test]
+    fn docker_config_auth_no_match_is_anonymous() {
+        let config = DockerConfig {
+            auths: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "ghcr.io".to_string(),
+                    AuthEntry {
+                        auth: Some(BASE64.encode("user:pass")),
+                        username: None,
+                        password: None,
+                    },
+                );
+                m
+            },
+            cred_helpers: HashMap::new(),
+            creds_store: None,
+        };
+        // quay.io not in config — should resolve as anonymous.
+        let auth = DockerConfigAuth::new("quay.io", &config, reqwest::Client::new()).unwrap();
+        let debug = format!("{auth:?}");
+        assert!(debug.contains("has_credentials: false"));
     }
 }

--- a/crates/ocync-distribution/src/auth/docker.rs
+++ b/crates/ocync-distribution/src/auth/docker.rs
@@ -2,14 +2,18 @@
 
 use std::collections::HashMap;
 use std::fmt;
+use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::process::Command;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use serde::Deserialize;
 
-use super::Credentials;
+use super::anonymous::AnonymousAuth;
+use super::basic::BasicAuth;
+use super::{AuthProvider, Credentials, Scope, Token};
 use crate::error::Error;
 
 /// Docker Hub hostnames that all resolve to the same credential entry.
@@ -260,6 +264,119 @@ fn run_credential_helper(helper: &str, registry: &str) -> Result<Credentials, Er
         username: resp.username,
         password: resp.secret,
     })
+}
+
+/// Auth provider that resolves credentials from a Docker `config.json`.
+///
+/// On the first `get_token()` call, resolves credentials for the
+/// configured registry hostname from the provided [`DockerConfig`].
+/// If credentials are found, delegates to [`BasicAuth`]; otherwise
+/// falls back to [`AnonymousAuth`].
+pub struct DockerConfigAuth {
+    /// The registry hostname to look up in the Docker config.
+    registry: String,
+    /// The registry base URL for the underlying auth provider.
+    base_url: String,
+    /// The loaded Docker config.
+    config: DockerConfig,
+    /// Lazily initialized inner provider.
+    inner: tokio::sync::OnceCell<Box<dyn AuthProvider>>,
+}
+
+impl fmt::Debug for DockerConfigAuth {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DockerConfigAuth")
+            .field("registry", &self.registry)
+            .field("base_url", &self.base_url)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DockerConfigAuth {
+    /// Create a new Docker config auth provider for the given hostname.
+    ///
+    /// Uses HTTPS by default.
+    pub fn new(registry: impl Into<String>, config: DockerConfig) -> Self {
+        let registry = registry.into();
+        let base_url = format!("https://{registry}");
+        Self {
+            registry,
+            base_url,
+            config,
+            inner: tokio::sync::OnceCell::new(),
+        }
+    }
+
+    /// Create a Docker config auth provider with an explicit base URL (for testing).
+    #[cfg(test)]
+    fn with_config_and_base_url(
+        config: DockerConfig,
+        registry: impl Into<String>,
+        base_url: impl Into<String>,
+    ) -> Self {
+        Self {
+            registry: registry.into(),
+            base_url: base_url.into(),
+            config,
+            inner: tokio::sync::OnceCell::new(),
+        }
+    }
+
+    /// Resolve credentials and build the appropriate inner provider.
+    fn resolve_inner(&self) -> Result<Box<dyn AuthProvider>, Error> {
+        let http = reqwest::Client::new();
+        match resolve_from_docker_config(&self.config, &self.registry)? {
+            Some(creds) => {
+                tracing::debug!(
+                    registry = %self.registry,
+                    "docker config: resolved credentials, using basic auth"
+                );
+                Ok(Box::new(BasicAuth::with_base_url(
+                    self.base_url.clone(),
+                    http,
+                    creds,
+                )))
+            }
+            None => {
+                tracing::debug!(
+                    registry = %self.registry,
+                    "docker config: no credentials found, using anonymous auth"
+                );
+                Ok(Box::new(AnonymousAuth::with_base_url(
+                    self.base_url.clone(),
+                    http,
+                )))
+            }
+        }
+    }
+}
+
+impl AuthProvider for DockerConfigAuth {
+    fn name(&self) -> &'static str {
+        "docker-config"
+    }
+
+    fn get_token(
+        &self,
+        scopes: &[Scope],
+    ) -> Pin<Box<dyn Future<Output = Result<Token, Error>> + Send + '_>> {
+        let scopes = scopes.to_vec();
+        Box::pin(async move {
+            let inner = self
+                .inner
+                .get_or_try_init(|| async { self.resolve_inner() })
+                .await?;
+            inner.get_token(&scopes).await
+        })
+    }
+
+    fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async move {
+            if let Some(inner) = self.inner.get() {
+                inner.invalidate().await;
+            }
+        })
+    }
 }
 
 /// Check if a hostname is a Docker Hub alias.
@@ -537,5 +654,106 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(matches!(creds, Credentials::Basic { username, .. } if username == "user"));
+    }
+
+    use crate::auth::Scope;
+
+    #[tokio::test]
+    async fn docker_config_auth_with_inline_creds() {
+        let mock = wiremock::MockServer::start().await;
+
+        let uri = mock.uri();
+        let mock_host = uri.trim_start_matches("http://");
+        let encoded = BASE64.encode("testuser:testpass");
+        let config = DockerConfig {
+            auths: {
+                let mut m = HashMap::new();
+                m.insert(
+                    mock_host.to_string(),
+                    AuthEntry {
+                        auth: Some(encoded.clone()),
+                        username: None,
+                        password: None,
+                    },
+                );
+                m
+            },
+            cred_helpers: HashMap::new(),
+            creds_store: None,
+        };
+
+        // /v2/ returns 401 with Bearer challenge.
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/"))
+            .respond_with(wiremock::ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!("Bearer realm=\"{}/token\"", mock.uri()),
+            ))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        // Token endpoint expects Basic auth.
+        let expected_basic = format!("Basic {encoded}");
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/token"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                expected_basic.as_str(),
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({"token": "docker-config-token", "expires_in": 300}),
+            ))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let auth =
+            DockerConfigAuth::with_config_and_base_url(config, mock_host.to_string(), mock.uri());
+        let token = auth
+            .get_token(&[Scope::pull("library/nginx")])
+            .await
+            .unwrap();
+        assert_eq!(token.value(), "docker-config-token");
+    }
+
+    #[tokio::test]
+    async fn docker_config_auth_no_creds_falls_back_to_anonymous() {
+        let mock = wiremock::MockServer::start().await;
+        let uri = mock.uri();
+        let mock_host = uri.trim_start_matches("http://");
+
+        let config = DockerConfig::default();
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/"))
+            .respond_with(wiremock::ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!("Bearer realm=\"{}/token\"", mock.uri()),
+            ))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/token"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"token": "anon-token"})),
+            )
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let auth =
+            DockerConfigAuth::with_config_and_base_url(config, mock_host.to_string(), mock.uri());
+        let token = auth.get_token(&[Scope::pull("public/repo")]).await.unwrap();
+        assert_eq!(token.value(), "anon-token");
+    }
+
+    #[test]
+    fn docker_config_auth_name() {
+        let auth = DockerConfigAuth::new("example.com", DockerConfig::default());
+        assert_eq!(auth.name(), "docker-config");
     }
 }

--- a/crates/ocync-distribution/src/auth/docker.rs
+++ b/crates/ocync-distribution/src/auth/docker.rs
@@ -30,25 +30,25 @@ const DOCKER_HUB_ALIASES: &[&str] = &[
 #[serde(default)]
 pub struct DockerConfig {
     /// Static credentials keyed by registry hostname.
-    pub auths: HashMap<String, AuthEntry>,
+    auths: HashMap<String, AuthEntry>,
     /// Credential helpers keyed by registry hostname.
     #[serde(rename = "credHelpers")]
-    pub cred_helpers: HashMap<String, String>,
+    cred_helpers: HashMap<String, String>,
     /// Default credential store (e.g. "desktop", "osxkeychain").
     #[serde(rename = "credsStore")]
-    pub creds_store: Option<String>,
+    creds_store: Option<String>,
 }
 
 /// A single auth entry from the `auths` map.
 #[derive(Deserialize, Default)]
 #[serde(default)]
-pub struct AuthEntry {
+struct AuthEntry {
     /// Base64-encoded `username:password`.
-    pub auth: Option<String>,
+    auth: Option<String>,
     /// Username (when stored separately).
-    pub username: Option<String>,
+    username: Option<String>,
     /// Password (when stored separately).
-    pub password: Option<String>,
+    password: Option<String>,
 }
 
 impl fmt::Debug for AuthEntry {
@@ -70,7 +70,7 @@ impl DockerConfig {
     }
 
     /// Load from a specific file path.
-    pub fn load_from(path: &Path) -> Result<Self, Error> {
+    fn load_from(path: &Path) -> Result<Self, Error> {
         let contents = std::fs::read_to_string(path).map_err(|e| {
             Error::Other(format!(
                 "failed to read docker config at {}: {e}",
@@ -690,11 +690,7 @@ mod tests {
             .mount(&mock)
             .await;
 
-        let auth = DockerConfigAuth::with_base_url(
-            mock.uri(),
-            reqwest::Client::new(),
-            Some(creds),
-        );
+        let auth = DockerConfigAuth::with_base_url(mock.uri(), reqwest::Client::new(), Some(creds));
         let token = auth
             .get_token(&[Scope::pull("library/nginx")])
             .await
@@ -726,11 +722,7 @@ mod tests {
             .mount(&mock)
             .await;
 
-        let auth = DockerConfigAuth::with_base_url(
-            mock.uri(),
-            reqwest::Client::new(),
-            None,
-        );
+        let auth = DockerConfigAuth::with_base_url(mock.uri(), reqwest::Client::new(), None);
         let token = auth.get_token(&[Scope::pull("public/repo")]).await.unwrap();
         assert_eq!(token.value(), "anon-token");
     }
@@ -759,11 +751,7 @@ mod tests {
             .mount(&mock)
             .await;
 
-        let auth = DockerConfigAuth::with_base_url(
-            mock.uri(),
-            reqwest::Client::new(),
-            None,
-        );
+        let auth = DockerConfigAuth::with_base_url(mock.uri(), reqwest::Client::new(), None);
         let t1 = auth.get_token(&[Scope::pull("repo")]).await.unwrap();
         let t2 = auth.get_token(&[Scope::pull("repo")]).await.unwrap();
         assert_eq!(t1.value(), "cached");
@@ -795,11 +783,7 @@ mod tests {
             .mount(&mock)
             .await;
 
-        let auth = DockerConfigAuth::with_base_url(
-            mock.uri(),
-            reqwest::Client::new(),
-            None,
-        );
+        let auth = DockerConfigAuth::with_base_url(mock.uri(), reqwest::Client::new(), None);
         auth.get_token(&[Scope::pull("repo")]).await.unwrap();
         auth.invalidate().await;
         auth.get_token(&[Scope::pull("repo")]).await.unwrap();

--- a/crates/ocync-distribution/src/auth/mod.rs
+++ b/crates/ocync-distribution/src/auth/mod.rs
@@ -12,6 +12,8 @@ pub mod docker;
 pub mod ecr;
 /// Static bearer token authentication provider.
 pub mod static_token;
+/// Shared Docker v2 token-exchange protocol.
+pub(crate) mod token_exchange;
 
 pub use detect::{ProviderKind, detect_provider_kind};
 

--- a/crates/ocync-distribution/src/auth/mod.rs
+++ b/crates/ocync-distribution/src/auth/mod.rs
@@ -156,6 +156,16 @@ impl Token {
     }
 }
 
+/// Build a sorted, space-joined cache key from a set of scopes.
+///
+/// Used by auth providers to key their token caches. The sort ensures
+/// that the same set of scopes in any order produces the same key.
+pub(crate) fn scopes_cache_key(scopes: &[Scope]) -> String {
+    let mut parts: Vec<String> = scopes.iter().map(|s| s.to_string()).collect();
+    parts.sort();
+    parts.join(" ")
+}
+
 /// Credentials for authenticating to a registry.
 #[derive(Clone)]
 pub enum Credentials {
@@ -270,6 +280,26 @@ mod tests {
         let token = Token::with_ttl("abc123", Duration::from_secs(1200));
         assert!(!token.is_expired());
         assert!(!token.should_refresh());
+    }
+
+    #[test]
+    fn scopes_cache_key_sorted() {
+        let scopes = vec![Scope::pull("z-repo"), Scope::pull("a-repo")];
+        let key = scopes_cache_key(&scopes);
+        assert!(key.starts_with("repository:a-repo"));
+    }
+
+    #[test]
+    fn scopes_cache_key_deterministic() {
+        let k1 = scopes_cache_key(&[Scope::pull("a"), Scope::pull("b")]);
+        let k2 = scopes_cache_key(&[Scope::pull("b"), Scope::pull("a")]);
+        assert_eq!(k1, k2);
+    }
+
+    #[test]
+    fn scopes_cache_key_single() {
+        let key = scopes_cache_key(&[Scope::pull("repo")]);
+        assert_eq!(key, "repository:repo:pull");
     }
 
     #[test]

--- a/crates/ocync-distribution/src/auth/mod.rs
+++ b/crates/ocync-distribution/src/auth/mod.rs
@@ -2,6 +2,8 @@
 
 /// Anonymous token-exchange authentication.
 pub mod anonymous;
+/// HTTP Basic credential token-exchange authentication.
+pub mod basic;
 /// Hostname-based registry provider detection.
 pub mod detect;
 /// Docker config.json credential resolution.

--- a/crates/ocync-distribution/src/auth/mod.rs
+++ b/crates/ocync-distribution/src/auth/mod.rs
@@ -10,6 +10,8 @@ pub mod detect;
 pub mod docker;
 /// AWS ECR authentication provider.
 pub mod ecr;
+/// Static bearer token authentication provider.
+pub mod static_token;
 
 pub use detect::{ProviderKind, detect_provider_kind};
 

--- a/crates/ocync-distribution/src/auth/static_token.rs
+++ b/crates/ocync-distribution/src/auth/static_token.rs
@@ -1,0 +1,100 @@
+//! Static bearer token authentication provider.
+
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+
+use super::{AuthProvider, Scope, Token};
+use crate::error::Error;
+
+/// Auth provider that returns a pre-configured bearer token.
+///
+/// Used for CI tokens, personal access tokens (PATs), and other
+/// scenarios where the caller already has a valid bearer token
+/// that doesn't require a token-exchange flow.
+///
+/// `invalidate()` is a no-op because there is no cached exchange
+/// to clear — the token is the source of truth.
+pub struct StaticTokenAuth {
+    /// The bearer token value.
+    token: String,
+}
+
+impl fmt::Debug for StaticTokenAuth {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StaticTokenAuth")
+            .field("token", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl StaticTokenAuth {
+    /// Create a new static token auth provider.
+    pub fn new(token: impl Into<String>) -> Self {
+        Self {
+            token: token.into(),
+        }
+    }
+}
+
+impl AuthProvider for StaticTokenAuth {
+    fn name(&self) -> &'static str {
+        "static-token"
+    }
+
+    fn get_token(
+        &self,
+        _scopes: &[Scope],
+    ) -> Pin<Box<dyn Future<Output = Result<Token, Error>> + Send + '_>> {
+        Box::pin(async move { Ok(Token::new(&self.token)) })
+    }
+
+    fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async {})
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::Scope;
+
+    #[tokio::test]
+    async fn static_token_returns_configured_value() {
+        let auth = StaticTokenAuth::new("my-pat-token-123");
+        let scopes = [Scope::pull("library/nginx")];
+        let token = auth.get_token(&scopes).await.unwrap();
+        assert_eq!(token.value(), "my-pat-token-123");
+    }
+
+    #[tokio::test]
+    async fn static_token_ignores_scopes() {
+        let auth = StaticTokenAuth::new("token");
+        let t1 = auth.get_token(&[Scope::pull("repo-a")]).await.unwrap();
+        let t2 = auth.get_token(&[Scope::pull_push("repo-b")]).await.unwrap();
+        assert_eq!(t1.value(), "token");
+        assert_eq!(t2.value(), "token");
+    }
+
+    #[tokio::test]
+    async fn static_token_survives_invalidate() {
+        let auth = StaticTokenAuth::new("persistent");
+        auth.invalidate().await;
+        let token = auth.get_token(&[Scope::pull("repo")]).await.unwrap();
+        assert_eq!(token.value(), "persistent");
+    }
+
+    #[test]
+    fn static_token_name() {
+        let auth = StaticTokenAuth::new("t");
+        assert_eq!(auth.name(), "static-token");
+    }
+
+    #[test]
+    fn static_token_debug_redacts() {
+        let auth = StaticTokenAuth::new("super-secret-token");
+        let debug = format!("{auth:?}");
+        assert!(!debug.contains("super-secret-token"));
+        assert!(debug.contains("[REDACTED]"));
+    }
+}

--- a/crates/ocync-distribution/src/auth/token_exchange.rs
+++ b/crates/ocync-distribution/src/auth/token_exchange.rs
@@ -98,13 +98,6 @@ pub(crate) async fn exchange_token(
     Ok(token)
 }
 
-/// Build a sorted, space-joined cache key from a set of scopes.
-pub(crate) fn scope_cache_key(scopes: &[Scope]) -> String {
-    let mut parts: Vec<String> = scopes.iter().map(|s| s.to_string()).collect();
-    parts.sort();
-    parts.join(" ")
-}
-
 /// Build the `Authorization: Basic ...` header value from credentials.
 fn basic_header_value(credentials: &Credentials) -> String {
     let Credentials::Basic { username, password } = credentials;
@@ -278,20 +271,6 @@ mod tests {
     }
 
     #[test]
-    fn scope_cache_key_sorted() {
-        let scopes = vec![Scope::pull("z-repo"), Scope::pull("a-repo")];
-        let key = scope_cache_key(&scopes);
-        assert!(key.starts_with("repository:a-repo"));
-    }
-
-    #[test]
-    fn scope_cache_key_deterministic() {
-        let k1 = scope_cache_key(&[Scope::pull("a"), Scope::pull("b")]);
-        let k2 = scope_cache_key(&[Scope::pull("b"), Scope::pull("a")]);
-        assert_eq!(k1, k2);
-    }
-
-    #[test]
     fn basic_header_value_encodes_correctly() {
         let creds = Credentials::Basic {
             username: "user".into(),
@@ -435,5 +414,151 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, Error::Http(_)));
+    }
+
+    #[tokio::test]
+    async fn exchange_token_access_token_fallback() {
+        let mock = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/"))
+            .respond_with(wiremock::ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!(r#"Bearer realm="{}/token""#, mock.uri()),
+            ))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        // Response uses access_token field instead of token.
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/token"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"access_token": "fallback-tok"})),
+            )
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let http = reqwest::Client::new();
+        let token = exchange_token(&http, &mock.uri(), &[Scope::pull("repo")], None)
+            .await
+            .unwrap();
+        assert_eq!(token.value(), "fallback-tok");
+    }
+
+    #[tokio::test]
+    async fn exchange_token_no_expiry_produces_permanent_token() {
+        let mock = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/"))
+            .respond_with(wiremock::ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!(r#"Bearer realm="{}/token""#, mock.uri()),
+            ))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        // No expires_in field — token should be permanent.
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/token"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"token": "perm-tok"})),
+            )
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let http = reqwest::Client::new();
+        let token = exchange_token(&http, &mock.uri(), &[Scope::pull("repo")], None)
+            .await
+            .unwrap();
+        assert_eq!(token.value(), "perm-tok");
+        assert!(!token.is_expired());
+        assert!(!token.should_refresh());
+    }
+
+    #[tokio::test]
+    async fn exchange_token_zero_expiry_treated_as_permanent() {
+        let mock = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/"))
+            .respond_with(wiremock::ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!(r#"Bearer realm="{}/token""#, mock.uri()),
+            ))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/token"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"token": "zero-tok", "expires_in": 0})),
+            )
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let http = reqwest::Client::new();
+        let token = exchange_token(&http, &mock.uri(), &[Scope::pull("repo")], None)
+            .await
+            .unwrap();
+        assert_eq!(token.value(), "zero-tok");
+        assert!(!token.is_expired());
+    }
+
+    #[tokio::test]
+    async fn exchange_token_multi_scope_query_params() {
+        let mock = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/"))
+            .respond_with(wiremock::ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!(r#"Bearer realm="{}/token",service="svc""#, mock.uri()),
+            ))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/token"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"token": "multi-tok"})),
+            )
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let http = reqwest::Client::new();
+        let scopes = [Scope::pull("repo-a"), Scope::pull_push("repo-b")];
+        let token = exchange_token(&http, &mock.uri(), &scopes, None)
+            .await
+            .unwrap();
+        assert_eq!(token.value(), "multi-tok");
+
+        // Verify both scope params are present in the token request URL.
+        let requests = mock.received_requests().await.unwrap();
+        let token_req = requests
+            .iter()
+            .find(|r| r.url.path() == "/token")
+            .expect("token request not found");
+        let scope_params: Vec<String> = token_req
+            .url
+            .query_pairs()
+            .filter(|(k, _)| k == "scope")
+            .map(|(_, v)| v.into_owned())
+            .collect();
+        assert_eq!(scope_params.len(), 2, "expected 2 scope params");
+        assert!(scope_params.contains(&"repository:repo-a:pull".to_string()));
+        assert!(scope_params.contains(&"repository:repo-b:pull,push".to_string()));
     }
 }

--- a/crates/ocync-distribution/src/auth/token_exchange.rs
+++ b/crates/ocync-distribution/src/auth/token_exchange.rs
@@ -319,9 +319,10 @@ mod tests {
 
         wiremock::Mock::given(wiremock::matchers::method("GET"))
             .and(wiremock::matchers::path("/token"))
-            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(
-                serde_json::json!({"token": "anon-tok", "expires_in": 300}),
-            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"token": "anon-tok", "expires_in": 300})),
+            )
             .expect(1)
             .mount(&mock)
             .await;
@@ -349,10 +350,14 @@ mod tests {
 
         wiremock::Mock::given(wiremock::matchers::method("GET"))
             .and(wiremock::matchers::path("/token"))
-            .and(wiremock::matchers::header("Authorization", "Basic dXNlcjpwYXNz"))
-            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(
-                serde_json::json!({"token": "basic-tok"}),
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Basic dXNlcjpwYXNz",
             ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"token": "basic-tok"})),
+            )
             .expect(1)
             .mount(&mock)
             .await;

--- a/crates/ocync-distribution/src/auth/token_exchange.rs
+++ b/crates/ocync-distribution/src/auth/token_exchange.rs
@@ -26,7 +26,7 @@ const BEARER_SCHEME: &str = "bearer";
 /// `Some`, an `Authorization: Basic` header is included on the token request.
 ///
 /// If `/v2/` returns 200 (no auth required), returns an empty token.
-pub(crate) async fn exchange_token(
+pub(crate) async fn exchange(
     http: &reqwest::Client,
     base_url: &str,
     scopes: &[Scope],
@@ -283,7 +283,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn exchange_token_anonymous() {
+    async fn exchange_anonymous() {
         let mock = wiremock::MockServer::start().await;
 
         wiremock::Mock::given(wiremock::matchers::method("GET"))
@@ -307,14 +307,14 @@ mod tests {
             .await;
 
         let http = reqwest::Client::new();
-        let token = exchange_token(&http, &mock.uri(), &[Scope::pull("repo")], None)
+        let token = exchange(&http, &mock.uri(), &[Scope::pull("repo")], None)
             .await
             .unwrap();
         assert_eq!(token.value(), "anon-tok");
     }
 
     #[tokio::test]
-    async fn exchange_token_with_credentials() {
+    async fn exchange_with_credentials() {
         let mock = wiremock::MockServer::start().await;
 
         wiremock::Mock::given(wiremock::matchers::method("GET"))
@@ -346,14 +346,14 @@ mod tests {
             password: "pass".into(),
         };
         let http = reqwest::Client::new();
-        let token = exchange_token(&http, &mock.uri(), &[Scope::pull("repo")], Some(&creds))
+        let token = exchange(&http, &mock.uri(), &[Scope::pull("repo")], Some(&creds))
             .await
             .unwrap();
         assert_eq!(token.value(), "basic-tok");
     }
 
     #[tokio::test]
-    async fn exchange_token_no_auth_required() {
+    async fn exchange_no_auth_required() {
         let mock = wiremock::MockServer::start().await;
 
         wiremock::Mock::given(wiremock::matchers::method("GET"))
@@ -364,14 +364,14 @@ mod tests {
             .await;
 
         let http = reqwest::Client::new();
-        let token = exchange_token(&http, &mock.uri(), &[Scope::pull("repo")], None)
+        let token = exchange(&http, &mock.uri(), &[Scope::pull("repo")], None)
             .await
             .unwrap();
         assert_eq!(token.value(), "");
     }
 
     #[tokio::test]
-    async fn exchange_token_missing_www_authenticate() {
+    async fn exchange_missing_www_authenticate() {
         let mock = wiremock::MockServer::start().await;
 
         wiremock::Mock::given(wiremock::matchers::method("GET"))
@@ -382,14 +382,14 @@ mod tests {
             .await;
 
         let http = reqwest::Client::new();
-        let err = exchange_token(&http, &mock.uri(), &[Scope::pull("repo")], None)
+        let err = exchange(&http, &mock.uri(), &[Scope::pull("repo")], None)
             .await
             .unwrap_err();
         assert!(err.to_string().contains("WWW-Authenticate"));
     }
 
     #[tokio::test]
-    async fn exchange_token_endpoint_error() {
+    async fn exchange_endpoint_error() {
         let mock = wiremock::MockServer::start().await;
 
         wiremock::Mock::given(wiremock::matchers::method("GET"))
@@ -410,14 +410,14 @@ mod tests {
             .await;
 
         let http = reqwest::Client::new();
-        let err = exchange_token(&http, &mock.uri(), &[Scope::pull("repo")], None)
+        let err = exchange(&http, &mock.uri(), &[Scope::pull("repo")], None)
             .await
             .unwrap_err();
         assert!(matches!(err, Error::Http(_)));
     }
 
     #[tokio::test]
-    async fn exchange_token_access_token_fallback() {
+    async fn exchange_access_token_fallback() {
         let mock = wiremock::MockServer::start().await;
 
         wiremock::Mock::given(wiremock::matchers::method("GET"))
@@ -442,14 +442,14 @@ mod tests {
             .await;
 
         let http = reqwest::Client::new();
-        let token = exchange_token(&http, &mock.uri(), &[Scope::pull("repo")], None)
+        let token = exchange(&http, &mock.uri(), &[Scope::pull("repo")], None)
             .await
             .unwrap();
         assert_eq!(token.value(), "fallback-tok");
     }
 
     #[tokio::test]
-    async fn exchange_token_no_expiry_produces_permanent_token() {
+    async fn exchange_no_expiry_produces_permanent_token() {
         let mock = wiremock::MockServer::start().await;
 
         wiremock::Mock::given(wiremock::matchers::method("GET"))
@@ -474,7 +474,7 @@ mod tests {
             .await;
 
         let http = reqwest::Client::new();
-        let token = exchange_token(&http, &mock.uri(), &[Scope::pull("repo")], None)
+        let token = exchange(&http, &mock.uri(), &[Scope::pull("repo")], None)
             .await
             .unwrap();
         assert_eq!(token.value(), "perm-tok");
@@ -483,7 +483,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn exchange_token_zero_expiry_treated_as_permanent() {
+    async fn exchange_zero_expiry_treated_as_permanent() {
         let mock = wiremock::MockServer::start().await;
 
         wiremock::Mock::given(wiremock::matchers::method("GET"))
@@ -507,7 +507,7 @@ mod tests {
             .await;
 
         let http = reqwest::Client::new();
-        let token = exchange_token(&http, &mock.uri(), &[Scope::pull("repo")], None)
+        let token = exchange(&http, &mock.uri(), &[Scope::pull("repo")], None)
             .await
             .unwrap();
         assert_eq!(token.value(), "zero-tok");
@@ -515,7 +515,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn exchange_token_multi_scope_query_params() {
+    async fn exchange_multi_scope_query_params() {
         let mock = wiremock::MockServer::start().await;
 
         wiremock::Mock::given(wiremock::matchers::method("GET"))
@@ -540,9 +540,7 @@ mod tests {
 
         let http = reqwest::Client::new();
         let scopes = [Scope::pull("repo-a"), Scope::pull_push("repo-b")];
-        let token = exchange_token(&http, &mock.uri(), &scopes, None)
-            .await
-            .unwrap();
+        let token = exchange(&http, &mock.uri(), &scopes, None).await.unwrap();
         assert_eq!(token.value(), "multi-tok");
 
         // Verify both scope params are present in the token request URL.

--- a/crates/ocync-distribution/src/auth/token_exchange.rs
+++ b/crates/ocync-distribution/src/auth/token_exchange.rs
@@ -1,0 +1,434 @@
+//! Shared Docker v2 token-exchange flow.
+//!
+//! Implements the challenge-response protocol used by Docker-compatible registries:
+//! ping `/v2/` → parse `WWW-Authenticate: Bearer` challenge → request token with
+//! optional credentials. Used by both [`super::anonymous::AnonymousAuth`] and
+//! [`super::basic::BasicAuth`].
+
+use std::fmt;
+use std::time::Duration;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use http::header::WWW_AUTHENTICATE;
+use serde::Deserialize;
+
+use super::{Credentials, Scope, Token};
+use crate::error::Error;
+
+/// The `Bearer` auth scheme prefix used in `WWW-Authenticate` challenges.
+const BEARER_SCHEME: &str = "bearer";
+
+/// Perform the Docker v2 token-exchange flow.
+///
+/// Pings the registry's `/v2/` endpoint, parses the `WWW-Authenticate: Bearer`
+/// challenge, then requests a token from the realm URL. When `credentials` is
+/// `Some`, an `Authorization: Basic` header is included on the token request.
+///
+/// If `/v2/` returns 200 (no auth required), returns an empty token.
+pub(crate) async fn exchange_token(
+    http: &reqwest::Client,
+    base_url: &str,
+    scopes: &[Scope],
+    credentials: Option<&Credentials>,
+) -> Result<Token, Error> {
+    let v2_url = format!("{base_url}/v2/");
+    let resp = http.get(&v2_url).send().await?;
+
+    if resp.status().is_success() {
+        // No auth required — return a dummy token.
+        return Ok(Token::new(""));
+    }
+
+    let www_auth = resp
+        .headers()
+        .get(WWW_AUTHENTICATE)
+        .and_then(|v| v.to_str().ok())
+        .ok_or_else(|| Error::AuthFailed {
+            registry: base_url.to_owned(),
+            reason: "401 response missing WWW-Authenticate header".into(),
+        })?;
+
+    let challenge = WwwAuthenticate::parse(www_auth).map_err(|reason| Error::AuthFailed {
+        registry: base_url.to_owned(),
+        reason,
+    })?;
+
+    // Build token request URL.
+    let mut url = reqwest::Url::parse(&challenge.realm).map_err(|e| Error::AuthFailed {
+        registry: base_url.to_owned(),
+        reason: format!("invalid realm URL: {e}"),
+    })?;
+
+    {
+        let mut query = url.query_pairs_mut();
+        if let Some(ref service) = challenge.service {
+            query.append_pair("service", service);
+        }
+        for scope in scopes {
+            query.append_pair("scope", &scope.to_string());
+        }
+    }
+
+    let mut request = http.get(url);
+    if let Some(creds) = credentials {
+        request = request.header("Authorization", basic_header_value(creds));
+    }
+
+    let token_resp = request
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<TokenResponse>()
+        .await?;
+
+    let token_value = token_resp
+        .token
+        .or(token_resp.access_token)
+        .ok_or_else(|| Error::AuthFailed {
+            registry: base_url.to_owned(),
+            reason: "token response missing both 'token' and 'access_token' fields".into(),
+        })?;
+
+    let token = match token_resp.expires_in {
+        Some(secs) if secs > 0 => Token::with_ttl(token_value, Duration::from_secs(secs)),
+        _ => Token::new(token_value),
+    };
+
+    Ok(token)
+}
+
+/// Build a sorted, space-joined cache key from a set of scopes.
+pub(crate) fn scope_cache_key(scopes: &[Scope]) -> String {
+    let mut parts: Vec<String> = scopes.iter().map(|s| s.to_string()).collect();
+    parts.sort();
+    parts.join(" ")
+}
+
+/// Build the `Authorization: Basic ...` header value from credentials.
+fn basic_header_value(credentials: &Credentials) -> String {
+    let Credentials::Basic { username, password } = credentials;
+    let encoded = BASE64.encode(format!("{username}:{password}"));
+    format!("Basic {encoded}")
+}
+
+/// Parsed `WWW-Authenticate: Bearer realm="...",service="..."` header.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WwwAuthenticate {
+    /// The token endpoint URL.
+    realm: String,
+    /// The service name (optional).
+    service: Option<String>,
+}
+
+impl WwwAuthenticate {
+    /// Parse a `WWW-Authenticate` header value.
+    ///
+    /// Only `Bearer` challenges are supported. Returns an error string on failure.
+    fn parse(header: &str) -> Result<Self, String> {
+        let header = header.trim();
+
+        // Must start with "Bearer " (case-insensitive).
+        let scheme_len = BEARER_SCHEME.len();
+        let prefix_len = scheme_len + 1; // "bearer" + space
+        if header.len() < prefix_len
+            || !header[..scheme_len].eq_ignore_ascii_case(BEARER_SCHEME)
+            || header.as_bytes()[scheme_len] != b' '
+        {
+            return Err(format!(
+                "unsupported WWW-Authenticate scheme (expected Bearer): {header}"
+            ));
+        }
+
+        let params = &header[prefix_len..];
+        let mut realm = None;
+        let mut service = None;
+
+        for part in split_params(params) {
+            let part = part.trim();
+            if let Some((key, value)) = part.split_once('=') {
+                let key = key.trim().to_ascii_lowercase();
+                let value = value.trim().trim_matches('"');
+                match key.as_str() {
+                    "realm" => realm = Some(value.to_owned()),
+                    "service" => service = Some(value.to_owned()),
+                    _ => {} // Ignore unknown parameters.
+                }
+            }
+        }
+
+        let realm = realm.ok_or("WWW-Authenticate Bearer missing 'realm' parameter")?;
+
+        Ok(Self { realm, service })
+    }
+}
+
+/// Split parameter string on commas, respecting quoted strings.
+fn split_params(s: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut in_quotes = false;
+
+    for (i, ch) in s.char_indices() {
+        match ch {
+            '"' => in_quotes = !in_quotes,
+            ',' if !in_quotes => {
+                parts.push(&s[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    if start < s.len() {
+        parts.push(&s[start..]);
+    }
+    parts
+}
+
+/// Token response from a registry auth endpoint.
+#[derive(Deserialize)]
+struct TokenResponse {
+    /// The token (Docker Hub uses this field).
+    token: Option<String>,
+    /// Alternative field name (some registries use this).
+    access_token: Option<String>,
+    /// Token lifetime in seconds.
+    expires_in: Option<u64>,
+}
+
+impl fmt::Debug for TokenResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TokenResponse")
+            .field("token", &"[REDACTED]")
+            .field("access_token", &"[REDACTED]")
+            .field("expires_in", &self.expires_in)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_www_authenticate_bearer() {
+        let header = r#"Bearer realm="https://auth.docker.io/token",service="registry.docker.io""#;
+        let parsed = WwwAuthenticate::parse(header).unwrap();
+        assert_eq!(parsed.realm, "https://auth.docker.io/token");
+        assert_eq!(parsed.service.as_deref(), Some("registry.docker.io"));
+    }
+
+    #[test]
+    fn parse_www_authenticate_no_service() {
+        let header = r#"Bearer realm="https://ghcr.io/token""#;
+        let parsed = WwwAuthenticate::parse(header).unwrap();
+        assert_eq!(parsed.realm, "https://ghcr.io/token");
+        assert!(parsed.service.is_none());
+    }
+
+    #[test]
+    fn parse_www_authenticate_case_insensitive() {
+        let header = r#"BEARER realm="https://auth.example.com/token",service="example""#;
+        let parsed = WwwAuthenticate::parse(header).unwrap();
+        assert_eq!(parsed.realm, "https://auth.example.com/token");
+        assert_eq!(parsed.service.as_deref(), Some("example"));
+    }
+
+    #[test]
+    fn parse_www_authenticate_basic_is_error() {
+        let header = r#"Basic realm="Registry""#;
+        let result = WwwAuthenticate::parse(header);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("unsupported"));
+    }
+
+    #[test]
+    fn parse_www_authenticate_missing_realm() {
+        let header = r#"Bearer service="registry.docker.io""#;
+        let result = WwwAuthenticate::parse(header);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("realm"));
+    }
+
+    #[test]
+    fn split_params_basic() {
+        let parts = split_params(r#"realm="https://example.com",service="test""#);
+        assert_eq!(parts.len(), 2);
+    }
+
+    #[test]
+    fn split_params_with_comma_in_quotes() {
+        let parts = split_params(r#"realm="https://example.com/a,b",service="test""#);
+        assert_eq!(parts.len(), 2);
+        assert!(parts[0].contains("a,b"));
+    }
+
+    #[test]
+    fn parse_www_authenticate_empty_string() {
+        let result = WwwAuthenticate::parse("");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_www_authenticate_short_strings() {
+        for input in ["B", "Be", "Bea", "Bear", "Beare", "Bearer"] {
+            let result = WwwAuthenticate::parse(input);
+            assert!(result.is_err(), "expected Err for input: {input:?}");
+        }
+    }
+
+    #[test]
+    fn scope_cache_key_sorted() {
+        let scopes = vec![Scope::pull("z-repo"), Scope::pull("a-repo")];
+        let key = scope_cache_key(&scopes);
+        assert!(key.starts_with("repository:a-repo"));
+    }
+
+    #[test]
+    fn scope_cache_key_deterministic() {
+        let k1 = scope_cache_key(&[Scope::pull("a"), Scope::pull("b")]);
+        let k2 = scope_cache_key(&[Scope::pull("b"), Scope::pull("a")]);
+        assert_eq!(k1, k2);
+    }
+
+    #[test]
+    fn basic_header_value_encodes_correctly() {
+        let creds = Credentials::Basic {
+            username: "user".into(),
+            password: "pass".into(),
+        };
+        let header = basic_header_value(&creds);
+        assert!(header.starts_with("Basic "));
+        // "user:pass" base64 = "dXNlcjpwYXNz"
+        assert_eq!(header, "Basic dXNlcjpwYXNz");
+    }
+
+    #[tokio::test]
+    async fn exchange_token_anonymous() {
+        let mock = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/"))
+            .respond_with(wiremock::ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!(r#"Bearer realm="{}/token",service="test""#, mock.uri()),
+            ))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/token"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({"token": "anon-tok", "expires_in": 300}),
+            ))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let http = reqwest::Client::new();
+        let token = exchange_token(&http, &mock.uri(), &[Scope::pull("repo")], None)
+            .await
+            .unwrap();
+        assert_eq!(token.value(), "anon-tok");
+    }
+
+    #[tokio::test]
+    async fn exchange_token_with_credentials() {
+        let mock = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/"))
+            .respond_with(wiremock::ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!(r#"Bearer realm="{}/token""#, mock.uri()),
+            ))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/token"))
+            .and(wiremock::matchers::header("Authorization", "Basic dXNlcjpwYXNz"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({"token": "basic-tok"}),
+            ))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let creds = Credentials::Basic {
+            username: "user".into(),
+            password: "pass".into(),
+        };
+        let http = reqwest::Client::new();
+        let token = exchange_token(&http, &mock.uri(), &[Scope::pull("repo")], Some(&creds))
+            .await
+            .unwrap();
+        assert_eq!(token.value(), "basic-tok");
+    }
+
+    #[tokio::test]
+    async fn exchange_token_no_auth_required() {
+        let mock = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/"))
+            .respond_with(wiremock::ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let http = reqwest::Client::new();
+        let token = exchange_token(&http, &mock.uri(), &[Scope::pull("repo")], None)
+            .await
+            .unwrap();
+        assert_eq!(token.value(), "");
+    }
+
+    #[tokio::test]
+    async fn exchange_token_missing_www_authenticate() {
+        let mock = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/"))
+            .respond_with(wiremock::ResponseTemplate::new(401))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let http = reqwest::Client::new();
+        let err = exchange_token(&http, &mock.uri(), &[Scope::pull("repo")], None)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("WWW-Authenticate"));
+    }
+
+    #[tokio::test]
+    async fn exchange_token_endpoint_error() {
+        let mock = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/"))
+            .respond_with(wiremock::ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!(r#"Bearer realm="{}/token""#, mock.uri()),
+            ))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/token"))
+            .respond_with(wiremock::ResponseTemplate::new(403))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let http = reqwest::Client::new();
+        let err = exchange_token(&http, &mock.uri(), &[Scope::pull("repo")], None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::Http(_)));
+    }
+}

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -742,19 +742,39 @@ async fn execute_item(
             }
         }
         Err(err) => {
-            warn!(target_name = %item.target_name, error = %err, "manifest push failed");
-            ImageResult {
-                image_id: Uuid::now_v7(),
-                source: item.source.to_string(),
-                target: item.target.to_string(),
-                status: ImageStatus::Failed {
-                    kind: ErrorKind::ManifestPush,
-                    error: err.to_string(),
-                    retries: retry.max_retries,
-                },
-                bytes_transferred: outcome.bytes_transferred,
-                blob_stats: outcome.stats,
-                duration: start.elapsed(),
+            if is_immutable_tag_error(&err) {
+                info!(
+                    source_repo = %item.source.repo,
+                    target_repo = %item.target.repo,
+                    target_tag = %item.target.tag,
+                    "target tag is immutable, skipping"
+                );
+                ImageResult {
+                    image_id: Uuid::now_v7(),
+                    source: item.source.to_string(),
+                    target: item.target.to_string(),
+                    status: ImageStatus::Skipped {
+                        reason: SkipReason::ImmutableTag,
+                    },
+                    bytes_transferred: outcome.bytes_transferred,
+                    blob_stats: outcome.stats,
+                    duration: start.elapsed(),
+                }
+            } else {
+                warn!(target_name = %item.target_name, error = %err, "manifest push failed");
+                ImageResult {
+                    image_id: Uuid::now_v7(),
+                    source: item.source.to_string(),
+                    target: item.target.to_string(),
+                    status: ImageStatus::Failed {
+                        kind: ErrorKind::ManifestPush,
+                        error: err.to_string(),
+                        retries: retry.max_retries,
+                    },
+                    bytes_transferred: outcome.bytes_transferred,
+                    blob_stats: outcome.stats,
+                    duration: start.elapsed(),
+                }
             }
         }
     }
@@ -1287,6 +1307,22 @@ fn compute_stats(images: &[ImageResult]) -> SyncStats {
     stats
 }
 
+/// Check if a manifest push error is an ECR immutable tag rejection.
+///
+/// ECR returns HTTP 400 with `ImageTagAlreadyExistsException` when a
+/// manifest push targets a tag that already exists on a repository with
+/// immutable tag settings enabled.
+fn is_immutable_tag_error(err: &crate::Error) -> bool {
+    matches!(
+        err,
+        crate::Error::Manifest {
+            source: ocync_distribution::Error::RegistryError { status, message },
+            ..
+        } if *status == http::StatusCode::BAD_REQUEST
+            && message.contains("ImageTagAlreadyExistsException")
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use ocync_distribution::Digest;
@@ -1437,5 +1473,57 @@ mod tests {
 
         assert_eq!(freq.count(&d1), 2);
         assert_eq!(freq.count(&d2), 1);
+    }
+
+    #[test]
+    fn immutable_tag_error_detected() {
+        let err = crate::Error::Manifest {
+            reference: "v1.0".into(),
+            source: ocync_distribution::Error::RegistryError {
+                status: http::StatusCode::BAD_REQUEST,
+                message: "ImageTagAlreadyExistsException: tag already exists".into(),
+            },
+        };
+        assert!(is_immutable_tag_error(&err));
+    }
+
+    #[test]
+    fn non_immutable_400_not_detected() {
+        let err = crate::Error::Manifest {
+            reference: "v1.0".into(),
+            source: ocync_distribution::Error::RegistryError {
+                status: http::StatusCode::BAD_REQUEST,
+                message: "some other 400 error".into(),
+            },
+        };
+        assert!(!is_immutable_tag_error(&err));
+    }
+
+    #[test]
+    fn non_400_not_detected_as_immutable() {
+        let err = crate::Error::Manifest {
+            reference: "v1.0".into(),
+            source: ocync_distribution::Error::RegistryError {
+                status: http::StatusCode::INTERNAL_SERVER_ERROR,
+                message: "ImageTagAlreadyExistsException".into(),
+            },
+        };
+        assert!(!is_immutable_tag_error(&err));
+    }
+
+    #[test]
+    fn blob_error_not_detected_as_immutable() {
+        let digest: ocync_distribution::Digest =
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+                .parse()
+                .unwrap();
+        let err = crate::Error::BlobTransfer {
+            digest,
+            source: ocync_distribution::Error::RegistryError {
+                status: http::StatusCode::BAD_REQUEST,
+                message: "ImageTagAlreadyExistsException".into(),
+            },
+        };
+        assert!(!is_immutable_tag_error(&err));
     }
 }

--- a/crates/ocync-sync/src/lib.rs
+++ b/crates/ocync-sync/src/lib.rs
@@ -121,6 +121,8 @@ pub enum SkipReason {
     DigestMatch,
     /// `skip_existing` is enabled and the target already has a manifest for this tag.
     SkipExisting,
+    /// Target registry has immutable tags enabled and the tag already exists.
+    ImmutableTag,
 }
 
 impl std::fmt::Display for SkipReason {
@@ -128,6 +130,7 @@ impl std::fmt::Display for SkipReason {
         match self {
             Self::DigestMatch => f.write_str("digest match"),
             Self::SkipExisting => f.write_str("skip existing"),
+            Self::ImmutableTag => f.write_str("immutable tag"),
         }
     }
 }
@@ -277,6 +280,11 @@ mod tests {
     #[test]
     fn skip_reason_display_skip_existing() {
         assert_eq!(SkipReason::SkipExisting.to_string(), "skip existing");
+    }
+
+    #[test]
+    fn skip_reason_display_immutable_tag() {
+        assert_eq!(SkipReason::ImmutableTag.to_string(), "immutable tag");
     }
 
     #[test]

--- a/crates/ocync-sync/tests/engine_integration.rs
+++ b/crates/ocync-sync/tests/engine_integration.rs
@@ -18,7 +18,7 @@ use ocync_sync::progress::NullProgress;
 use ocync_sync::retry::RetryConfig;
 use ocync_sync::shutdown::ShutdownSignal;
 use ocync_sync::staging::BlobStage;
-use ocync_sync::{ImageStatus, SkipReason};
+use ocync_sync::{ErrorKind, ImageStatus, SkipReason};
 use url::Url;
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -5746,4 +5746,264 @@ async fn sync_platform_filter_multi_target() {
     assert_eq!(report.stats.bytes_transferred, expected_blob_bytes * 2);
     // wiremock expect(N) assertions verify platform filtering and pull-once
     // on index and amd64 child manifests.
+}
+
+/// ECR immutable tag: manifest push returns HTTP 400 with
+/// `ImageTagAlreadyExistsException` → engine produces `Skipped { ImmutableTag }`,
+/// NOT `Failed`. Blobs are transferred before the manifest push, so the image
+/// result should show the blob work that was done.
+#[tokio::test]
+async fn sync_immutable_tag_skips_instead_of_failing() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_data = b"config-immutable";
+    let layer_data = b"layer-immutable";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (manifest_bytes, _) = serialize_manifest(&manifest);
+
+    // Source: serve manifest and blobs normally.
+    Mock::given(method("GET"))
+        .and(path("/v2/src/nginx/manifests/v1.0"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(manifest_bytes.clone())
+                .insert_header("content-type", MediaType::OciManifest.as_str()),
+        )
+        .expect(1)
+        .mount(&source_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/src/nginx/blobs/{}", config_desc.digest)))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(config_data.to_vec())
+                .insert_header("content-length", config_data.len().to_string()),
+        )
+        .expect(1)
+        .mount(&source_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/src/nginx/blobs/{}", layer_desc.digest)))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(layer_data.to_vec())
+                .insert_header("content-length", layer_data.len().to_string()),
+        )
+        .expect(1)
+        .mount(&source_server)
+        .await;
+
+    // Target: manifest HEAD 404, blob HEADs 404, blob push, manifest PUT → 400.
+    // All target endpoints use inline mocks with expect(N) to verify the engine
+    // transferred blobs before attempting the manifest push.
+    Mock::given(method("HEAD"))
+        .and(path("/v2/tgt/nginx/manifests/v1.0"))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&target_server)
+        .await;
+
+    // Blob HEAD checks — one per blob.
+    Mock::given(method("HEAD"))
+        .and(path(format!("/v2/tgt/nginx/blobs/{}", config_desc.digest)))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&target_server)
+        .await;
+
+    Mock::given(method("HEAD"))
+        .and(path(format!("/v2/tgt/nginx/blobs/{}", layer_desc.digest)))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&target_server)
+        .await;
+
+    // Monolithic blob push: POST initiate + PUT finalize — no PATCH for small blobs.
+    Mock::given(method("POST"))
+        .and(path("/v2/tgt/nginx/blobs/uploads/"))
+        .respond_with(
+            ResponseTemplate::new(202)
+                .insert_header("location", "/v2/tgt/nginx/blobs/uploads/mono-id"),
+        )
+        .expect(2)
+        .mount(&target_server)
+        .await;
+
+    Mock::given(method("PUT"))
+        .and(path("/v2/tgt/nginx/blobs/uploads/mono-id"))
+        .respond_with(ResponseTemplate::new(201))
+        .expect(2)
+        .mount(&target_server)
+        .await;
+
+    // No PATCH registered — any PATCH would cause a wiremock 404 and fail the test.
+
+    // Manifest PUT returns ECR immutable tag error (HTTP 400).
+    Mock::given(method("PUT"))
+        .and(path("/v2/tgt/nginx/manifests/v1.0"))
+        .respond_with(
+            ResponseTemplate::new(400).set_body_string(
+                r#"{"errors":[{"code":"TAG_INVALID","message":"ImageTagAlreadyExistsException: The image tag 'v1.0' already exists"}]}"#,
+            ),
+        )
+        .expect(1)
+        .mount(&target_server)
+        .await;
+
+    let mapping = ResolvedMapping {
+        source_client: mock_client(&source_server),
+        source_repo: "src/nginx".into(),
+        target_repo: "tgt/nginx".into(),
+        targets: vec![target_entry("ecr-target", mock_client(&target_server))],
+        tags: vec![TagPair::same("v1.0")],
+        platforms: None,
+        skip_existing: false,
+    };
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    // Per-image: skipped with ImmutableTag reason, NOT failed.
+    assert_eq!(report.images.len(), 1);
+    assert!(
+        matches!(
+            report.images[0].status,
+            ImageStatus::Skipped {
+                reason: SkipReason::ImmutableTag,
+            }
+        ),
+        "expected Skipped/ImmutableTag, got: {:?}",
+        report.images[0].status
+    );
+
+    // Blobs were transferred before the manifest push was attempted.
+    assert_eq!(report.images[0].blob_stats.transferred, 2);
+    assert_eq!(
+        report.images[0].bytes_transferred,
+        config_data.len() as u64 + layer_data.len() as u64
+    );
+
+    // Aggregate stats: counted as skipped, NOT failed.
+    assert_eq!(report.stats.images_skipped, 1);
+    assert_eq!(report.stats.images_synced, 0);
+    assert_eq!(report.stats.images_failed, 0);
+    assert_eq!(report.stats.blobs_transferred, 2);
+
+    // Exit code: 0 (skipped is success, not failure).
+    assert_eq!(report.exit_code(), 0);
+    // wiremock expect(N) verifies: 1 source manifest pull, 1 target manifest HEAD,
+    // 1 config blob pull, 1 layer blob pull, 1 manifest PUT (rejected).
+}
+
+/// Non-immutable 400 errors on manifest push still produce `Failed`, not `Skipped`.
+/// This is the negative assertion — ensures only the specific ECR exception triggers
+/// the skip path.
+#[tokio::test]
+async fn sync_non_immutable_400_still_fails() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_data = b"config-400";
+    let layer_data = b"layer-400";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (manifest_bytes, _) = serialize_manifest(&manifest);
+
+    // Source: expect(1) on manifest pull to verify pull-once.
+    Mock::given(method("GET"))
+        .and(path("/v2/src/app/manifests/latest"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(manifest_bytes.clone())
+                .insert_header("content-type", MediaType::OciManifest.as_str()),
+        )
+        .expect(1)
+        .mount(&source_server)
+        .await;
+
+    mount_blob_pull(&source_server, "src/app", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "src/app", &layer_desc.digest, layer_data).await;
+
+    mount_manifest_head_not_found(&target_server, "tgt/app", "latest").await;
+    mount_blob_not_found(&target_server, "tgt/app", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "tgt/app", &layer_desc.digest).await;
+    mount_blob_push(&target_server, "tgt/app").await;
+
+    // Manifest PUT returns 400 but NOT ImageTagAlreadyExistsException.
+    // 400 is not retryable, so expect exactly 1 attempt.
+    Mock::given(method("PUT"))
+        .and(path("/v2/tgt/app/manifests/latest"))
+        .respond_with(ResponseTemplate::new(400).set_body_string(
+            r#"{"errors":[{"code":"MANIFEST_INVALID","message":"manifest invalid"}]}"#,
+        ))
+        .expect(1)
+        .mount(&target_server)
+        .await;
+
+    let mapping = ResolvedMapping {
+        source_client: mock_client(&source_server),
+        source_repo: "src/app".into(),
+        target_repo: "tgt/app".into(),
+        targets: vec![target_entry("target", mock_client(&target_server))],
+        tags: vec![TagPair::same("latest")],
+        platforms: None,
+        skip_existing: false,
+    };
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    // Must be Failed with ManifestPush kind, NOT Skipped.
+    assert_eq!(report.images.len(), 1);
+    assert!(
+        matches!(
+            report.images[0].status,
+            ImageStatus::Failed {
+                kind: ErrorKind::ManifestPush,
+                ..
+            }
+        ),
+        "expected Failed/ManifestPush, got: {:?}",
+        report.images[0].status
+    );
+    assert_eq!(report.stats.images_failed, 1);
+    assert_eq!(report.stats.images_skipped, 0);
 }

--- a/src/cli/commands/auth.rs
+++ b/src/cli/commands/auth.rs
@@ -15,7 +15,14 @@ pub(crate) async fn run_check(configs: &[PathBuf]) -> Result<ExitCode, CliError>
 
         for (name, reg) in &config.registries {
             let safe_url = redact_url(&reg.url);
-            match build_registry_client(&reg.url, reg.auth_type.as_ref(), reg.max_concurrent).await
+            match build_registry_client(
+                &reg.url,
+                reg.auth_type.as_ref(),
+                reg.max_concurrent,
+                reg.credentials.as_ref(),
+                reg.token.as_deref(),
+            )
+            .await
             {
                 Ok(client) => match client.ping().await {
                     Ok(()) => {

--- a/src/cli/commands/auth.rs
+++ b/src/cli/commands/auth.rs
@@ -15,8 +15,7 @@ pub(crate) async fn run_check(configs: &[PathBuf]) -> Result<ExitCode, CliError>
 
         for (name, reg) in &config.registries {
             let safe_url = redact_url(&reg.url);
-            match build_registry_client(&reg.url, Some(reg)).await
-            {
+            match build_registry_client(&reg.url, Some(reg)).await {
                 Ok(client) => match client.ping().await {
                     Ok(()) => {
                         eprintln!("  OK    {name} ({safe_url})");

--- a/src/cli/commands/auth.rs
+++ b/src/cli/commands/auth.rs
@@ -15,14 +15,7 @@ pub(crate) async fn run_check(configs: &[PathBuf]) -> Result<ExitCode, CliError>
 
         for (name, reg) in &config.registries {
             let safe_url = redact_url(&reg.url);
-            match build_registry_client(
-                &reg.url,
-                reg.auth_type.as_ref(),
-                reg.max_concurrent,
-                reg.credentials.as_ref(),
-                reg.token.as_deref(),
-            )
-            .await
+            match build_registry_client(&reg.url, Some(reg)).await
             {
                 Ok(client) => match client.ping().await {
                     Ok(()) => {

--- a/src/cli/commands/copy.rs
+++ b/src/cli/commands/copy.rs
@@ -26,10 +26,25 @@ pub(crate) async fn run(
         .ok_or_else(|| CliError::Input(format!("source '{}' has no tag", args.source)))?;
     let dst_tag = args.destination.tag().unwrap_or(src_tag);
 
-    let source_client =
-        Arc::new(build_registry_client(bare_hostname(args.source.registry()), None, None).await?);
+    let source_client = Arc::new(
+        build_registry_client(
+            bare_hostname(args.source.registry()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await?,
+    );
     let target_client = Arc::new(
-        build_registry_client(bare_hostname(args.destination.registry()), None, None).await?,
+        build_registry_client(
+            bare_hostname(args.destination.registry()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await?,
     );
 
     let mapping = ResolvedMapping {

--- a/src/cli/commands/copy.rs
+++ b/src/cli/commands/copy.rs
@@ -26,25 +26,10 @@ pub(crate) async fn run(
         .ok_or_else(|| CliError::Input(format!("source '{}' has no tag", args.source)))?;
     let dst_tag = args.destination.tag().unwrap_or(src_tag);
 
-    let source_client = Arc::new(
-        build_registry_client(
-            bare_hostname(args.source.registry()),
-            None,
-            None,
-            None,
-            None,
-        )
-        .await?,
-    );
+    let source_client =
+        Arc::new(build_registry_client(bare_hostname(args.source.registry()), None).await?);
     let target_client = Arc::new(
-        build_registry_client(
-            bare_hostname(args.destination.registry()),
-            None,
-            None,
-            None,
-            None,
-        )
-        .await?,
+        build_registry_client(bare_hostname(args.destination.registry()), None).await?,
     );
 
     let mapping = ResolvedMapping {

--- a/src/cli/commands/copy.rs
+++ b/src/cli/commands/copy.rs
@@ -28,9 +28,8 @@ pub(crate) async fn run(
 
     let source_client =
         Arc::new(build_registry_client(bare_hostname(args.source.registry()), None).await?);
-    let target_client = Arc::new(
-        build_registry_client(bare_hostname(args.destination.registry()), None).await?,
-    );
+    let target_client =
+        Arc::new(build_registry_client(bare_hostname(args.destination.registry()), None).await?);
 
     let mapping = ResolvedMapping {
         source_client,

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -195,14 +195,7 @@ async fn build_clients(config: &Config) -> Result<HashMap<String, Arc<RegistryCl
     let mut clients = HashMap::with_capacity(config.registries.len());
     for (name, reg) in &config.registries {
         let hostname = bare_hostname(&reg.url);
-        let client = build_registry_client(
-            hostname,
-            reg.auth_type.as_ref(),
-            reg.max_concurrent,
-            reg.credentials.as_ref(),
-            reg.token.as_deref(),
-        )
-        .await?;
+        let client = build_registry_client(hostname, Some(reg)).await?;
         clients.insert(name.clone(), Arc::new(client));
     }
     Ok(clients)

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -195,8 +195,14 @@ async fn build_clients(config: &Config) -> Result<HashMap<String, Arc<RegistryCl
     let mut clients = HashMap::with_capacity(config.registries.len());
     for (name, reg) in &config.registries {
         let hostname = bare_hostname(&reg.url);
-        let client =
-            build_registry_client(hostname, reg.auth_type.as_ref(), reg.max_concurrent).await?;
+        let client = build_registry_client(
+            hostname,
+            reg.auth_type.as_ref(),
+            reg.max_concurrent,
+            reg.credentials.as_ref(),
+            reg.token.as_deref(),
+        )
+        .await?;
         clients.insert(name.clone(), Arc::new(client));
     }
     Ok(clients)

--- a/src/cli/commands/tags.rs
+++ b/src/cli/commands/tags.rs
@@ -11,19 +11,25 @@ pub(crate) async fn run(args: &TagsArgs) -> Result<ExitCode, CliError> {
     let registry = args.repository.registry();
     let repository = args.repository.repository();
 
-    // Resolve auth_type from config if provided, otherwise use anonymous.
-    let auth_type = if let Some(ref config_path) = args.config {
+    // Resolve auth settings from config if provided, otherwise use anonymous.
+    let reg_config = if let Some(ref config_path) = args.config {
         let config = load_config(config_path)?;
         config
             .registries
-            .values()
+            .into_values()
             .find(|r| bare_hostname(&r.url) == registry)
-            .and_then(|r| r.auth_type.clone())
     } else {
         None
     };
 
-    let client = build_registry_client(registry, auth_type.as_ref(), None).await?;
+    let client = build_registry_client(
+        registry,
+        reg_config.as_ref().and_then(|r| r.auth_type.as_ref()),
+        None,
+        reg_config.as_ref().and_then(|r| r.credentials.as_ref()),
+        reg_config.as_ref().and_then(|r| r.token.as_deref()),
+    )
+    .await?;
 
     let repo_path = RepositoryName::from(repository);
     let all_tags = client.list_tags(&repo_path).await?;

--- a/src/cli/commands/tags.rs
+++ b/src/cli/commands/tags.rs
@@ -22,14 +22,7 @@ pub(crate) async fn run(args: &TagsArgs) -> Result<ExitCode, CliError> {
         None
     };
 
-    let client = build_registry_client(
-        registry,
-        reg_config.as_ref().and_then(|r| r.auth_type.as_ref()),
-        None,
-        reg_config.as_ref().and_then(|r| r.credentials.as_ref()),
-        reg_config.as_ref().and_then(|r| r.token.as_deref()),
-    )
-    .await?;
+    let client = build_registry_client(registry, reg_config.as_ref()).await?;
 
     let repo_path = RepositoryName::from(repository);
     let all_tags = client.list_tags(&repo_path).await?;

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -207,7 +207,7 @@ impl std::fmt::Debug for RegistryConfig {
             .field("auth_type", &self.auth_type)
             .field("max_concurrent", &self.max_concurrent)
             .field("credentials", &self.credentials)
-            .field("token", &self.token.as_ref().map(|_| &"[REDACTED]"))
+            .field("token", &"[REDACTED]")
             .finish()
     }
 }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -171,8 +171,9 @@ pub(crate) enum AuthType {
     Anonymous,
     /// HTTP basic auth.
     Basic,
-    /// Bearer token.
-    Token,
+    /// Pre-obtained bearer token (PAT, CI token).
+    #[serde(alias = "token")]
+    StaticToken,
     /// Docker config.json credential store.
     DockerConfig,
 }
@@ -193,9 +194,9 @@ pub(crate) struct RegistryConfig {
 
     /// Credentials for Basic auth (`auth_type: basic`).
     #[serde(default)]
-    pub credentials: Option<CredentialsConfig>,
+    pub credentials: Option<BasicCredentials>,
 
-    /// Bearer token for Token auth (`auth_type: token`).
+    /// Bearer token for static token auth (`auth_type: static_token`).
     #[serde(default)]
     pub token: Option<String>,
 }
@@ -214,16 +215,16 @@ impl std::fmt::Debug for RegistryConfig {
 
 /// Credentials for HTTP Basic authentication.
 #[derive(Deserialize, Serialize)]
-pub(crate) struct CredentialsConfig {
+pub(crate) struct BasicCredentials {
     /// Username for authentication.
     pub username: String,
     /// Password or access token.
     pub password: String,
 }
 
-impl std::fmt::Debug for CredentialsConfig {
+impl std::fmt::Debug for BasicCredentials {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CredentialsConfig")
+        f.debug_struct("BasicCredentials")
             .field("username", &self.username)
             .field("password", &"[REDACTED]")
             .finish()
@@ -484,7 +485,7 @@ fn validate_registry(name: &str, registry: &RegistryConfig) -> Result<(), Config
                     )));
                 }
             }
-            AuthType::Token => {
+            AuthType::StaticToken => {
                 if registry.token.is_none() {
                     return Err(ConfigError::Validation(format!(
                         "registries.{name}: auth_type 'token' requires a 'token' field"
@@ -1538,7 +1539,7 @@ mappings:
 
     #[test]
     fn credentials_debug_redacts_password() {
-        let creds = CredentialsConfig {
+        let creds = BasicCredentials {
             username: "admin".to_string(),
             password: "super-secret".to_string(),
         };
@@ -1552,7 +1553,7 @@ mappings:
     fn registry_debug_redacts_token() {
         let registry = RegistryConfig {
             url: "example.com".to_string(),
-            auth_type: Some(AuthType::Token),
+            auth_type: Some(AuthType::StaticToken),
             max_concurrent: None,
             credentials: None,
             token: Some("secret-bearer-token".to_string()),

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -177,7 +177,7 @@ pub(crate) enum AuthType {
     DockerConfig,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
 pub(crate) struct RegistryConfig {
     pub url: String,
 
@@ -190,6 +190,44 @@ pub(crate) struct RegistryConfig {
     /// registry across all action types. This is independent of the global
     /// `max_concurrent_transfers` (which caps image-level parallelism).
     pub max_concurrent: Option<usize>,
+
+    /// Credentials for Basic auth (`auth_type: basic`).
+    #[serde(default)]
+    pub credentials: Option<CredentialsConfig>,
+
+    /// Bearer token for Token auth (`auth_type: token`).
+    #[serde(default)]
+    pub token: Option<String>,
+}
+
+impl std::fmt::Debug for RegistryConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegistryConfig")
+            .field("url", &self.url)
+            .field("auth_type", &self.auth_type)
+            .field("max_concurrent", &self.max_concurrent)
+            .field("credentials", &self.credentials)
+            .field("token", &self.token.as_ref().map(|_| &"[REDACTED]"))
+            .finish()
+    }
+}
+
+/// Credentials for HTTP Basic authentication.
+#[derive(Deserialize, Serialize)]
+pub(crate) struct CredentialsConfig {
+    /// Username for authentication.
+    pub username: String,
+    /// Password or access token.
+    pub password: String,
+}
+
+impl std::fmt::Debug for CredentialsConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CredentialsConfig")
+            .field("username", &self.username)
+            .field("password", &"[REDACTED]")
+            .finish()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -435,6 +473,33 @@ fn validate_registry(name: &str, registry: &RegistryConfig) -> Result<(), Config
             )));
         }
     }
+
+    if let Some(ref auth_type) = registry.auth_type {
+        match auth_type {
+            AuthType::Basic => {
+                if registry.credentials.is_none() {
+                    return Err(ConfigError::Validation(format!(
+                        "registries.{name}: auth_type 'basic' requires 'credentials' \
+                         with 'username' and 'password'"
+                    )));
+                }
+            }
+            AuthType::Token => {
+                if registry.token.is_none() {
+                    return Err(ConfigError::Validation(format!(
+                        "registries.{name}: auth_type 'token' requires a 'token' field"
+                    )));
+                }
+            }
+            AuthType::Ecr
+            | AuthType::Gcr
+            | AuthType::Acr
+            | AuthType::Ghcr
+            | AuthType::Anonymous
+            | AuthType::DockerConfig => {}
+        }
+    }
+
     Ok(())
 }
 
@@ -1332,6 +1397,8 @@ mappings:
             url: "example.com".to_string(),
             auth_type: None,
             max_concurrent: Some(0),
+            credentials: None,
+            token: None,
         };
         let err = validate_registry("example", &registry).unwrap_err();
         match err {
@@ -1349,7 +1416,149 @@ mappings:
             url: "example.com".to_string(),
             auth_type: None,
             max_concurrent: Some(25),
+            credentials: None,
+            token: None,
         };
         validate_registry("example", &registry).unwrap();
+    }
+
+    // -- Auth-type validation -------------------------------------------------
+
+    #[test]
+    fn validate_basic_without_credentials_is_error() {
+        let yaml = r#"
+registries:
+  ghcr:
+    url: ghcr.io
+    auth_type: basic
+mappings:
+  - from: library/nginx
+    source: ghcr
+    targets: [ghcr]
+    tags:
+      glob: "*"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let err = validate_registry("ghcr", config.registries.get("ghcr").unwrap());
+        assert!(err.is_err());
+        assert!(
+            err.unwrap_err().to_string().contains("credentials"),
+            "error should mention credentials"
+        );
+    }
+
+    #[test]
+    fn validate_basic_with_credentials_is_ok() {
+        let yaml = r#"
+registries:
+  ghcr:
+    url: ghcr.io
+    auth_type: basic
+    credentials:
+      username: myuser
+      password: mypass
+mappings:
+  - from: library/nginx
+    source: ghcr
+    targets: [ghcr]
+    tags:
+      glob: "*"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let result = validate_registry("ghcr", config.registries.get("ghcr").unwrap());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_token_without_token_field_is_error() {
+        let yaml = r#"
+registries:
+  quay:
+    url: quay.io
+    auth_type: token
+mappings:
+  - from: library/nginx
+    source: quay
+    targets: [quay]
+    tags:
+      glob: "*"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let err = validate_registry("quay", config.registries.get("quay").unwrap());
+        assert!(err.is_err());
+        assert!(
+            err.unwrap_err().to_string().contains("token"),
+            "error should mention token"
+        );
+    }
+
+    #[test]
+    fn validate_token_with_token_field_is_ok() {
+        let yaml = r#"
+registries:
+  quay:
+    url: quay.io
+    auth_type: token
+    token: ghp_abc123
+mappings:
+  - from: library/nginx
+    source: quay
+    targets: [quay]
+    tags:
+      glob: "*"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let result = validate_registry("quay", config.registries.get("quay").unwrap());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn credentials_config_deserializes() {
+        let yaml = r#"
+registries:
+  private:
+    url: registry.example.com
+    auth_type: basic
+    credentials:
+      username: user
+      password: pass
+mappings:
+  - from: myapp
+    source: private
+    targets: [private]
+    tags:
+      glob: "*"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let reg = config.registries.get("private").unwrap();
+        let creds = reg.credentials.as_ref().unwrap();
+        assert_eq!(creds.username, "user");
+        assert_eq!(creds.password, "pass");
+    }
+
+    #[test]
+    fn credentials_debug_redacts_password() {
+        let creds = CredentialsConfig {
+            username: "admin".to_string(),
+            password: "super-secret".to_string(),
+        };
+        let debug_output = format!("{creds:?}");
+        assert!(debug_output.contains("admin"));
+        assert!(debug_output.contains("[REDACTED]"));
+        assert!(!debug_output.contains("super-secret"));
+    }
+
+    #[test]
+    fn registry_debug_redacts_token() {
+        let registry = RegistryConfig {
+            url: "example.com".to_string(),
+            auth_type: Some(AuthType::Token),
+            max_concurrent: None,
+            credentials: None,
+            token: Some("secret-bearer-token".to_string()),
+        };
+        let debug_output = format!("{registry:?}");
+        assert!(debug_output.contains("[REDACTED]"));
+        assert!(!debug_output.contains("secret-bearer-token"));
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -14,10 +14,11 @@ use ocync_distribution::auth::detect::{ProviderKind, detect_provider_kind};
 use ocync_distribution::auth::docker::{DockerConfig, DockerConfigAuth};
 use ocync_distribution::auth::ecr::EcrAuth;
 use ocync_distribution::auth::static_token::StaticTokenAuth;
+
 use tracing_subscriber::{EnvFilter, fmt};
 use url::Url;
 
-use crate::cli::config::AuthType;
+use crate::cli::config::{AuthType, RegistryConfig};
 use crate::{Cli, LogFormat};
 
 // ---------------------------------------------------------------------------
@@ -111,18 +112,11 @@ pub(crate) fn bare_hostname(s: &str) -> &str {
 /// Build a [`RegistryClient`] for the given hostname, using the appropriate
 /// auth provider based on explicit `auth_type` or hostname auto-detection.
 ///
-/// When `max_concurrent` is `Some`, the per-registry aggregate concurrency
-/// cap is set to that value; otherwise the client default applies.
-///
-/// The `credentials` and `token` parameters supply auth material for
-/// `Basic` and `Token` auth types respectively. Config validation ensures
-/// these are present when the corresponding `auth_type` is set.
+/// Pass `None` for config when calling from commands that don't use config
+/// files (e.g. `copy`, which takes image references directly).
 pub(crate) async fn build_registry_client(
     hostname: &str,
-    auth_type: Option<&AuthType>,
-    max_concurrent: Option<usize>,
-    credentials: Option<&config::CredentialsConfig>,
-    token: Option<&str>,
+    registry_config: Option<&RegistryConfig>,
 ) -> Result<RegistryClient, CliError> {
     let base_url = if hostname.starts_with("http://") || hostname.starts_with("https://") {
         hostname.to_string()
@@ -136,6 +130,8 @@ pub(crate) async fn build_registry_client(
     let bare_host = bare_hostname(hostname);
     let http = reqwest::Client::new();
 
+    let auth_type = registry_config.and_then(|r| r.auth_type.as_ref());
+
     let mut builder = match auth_type {
         Some(AuthType::Ecr) => {
             let auth = EcrAuth::new(bare_host)
@@ -145,7 +141,9 @@ pub(crate) async fn build_registry_client(
         }
         Some(AuthType::Basic) => {
             // Config validation ensures credentials are present for Basic auth.
-            let creds = credentials.expect("basic auth requires credentials (validated)");
+            let creds = registry_config
+                .and_then(|r| r.credentials.as_ref())
+                .expect("basic auth requires credentials (validated)");
             let auth = BasicAuth::new(
                 bare_host,
                 http,
@@ -158,37 +156,35 @@ pub(crate) async fn build_registry_client(
         }
         Some(AuthType::Token) => {
             // Config validation ensures token is present for Token auth.
-            let tok = token.expect("token auth requires token field (validated)");
+            let tok = registry_config
+                .and_then(|r| r.token.as_deref())
+                .expect("token auth requires token field (validated)");
             let auth = StaticTokenAuth::new(tok);
             RegistryClient::builder(url).auth(auth)
         }
         Some(AuthType::DockerConfig | AuthType::Ghcr | AuthType::Gcr | AuthType::Acr) => {
-            let config = DockerConfig::load_default().unwrap_or_else(|e| {
-                tracing::debug!(
-                    registry = bare_host,
-                    error = %e,
-                    "failed to load docker config, using anonymous auth"
-                );
-                DockerConfig::default()
-            });
-            let auth = DockerConfigAuth::new(bare_host, config, http);
+            // User explicitly requested docker config auth — error if config can't load.
+            let docker_config = DockerConfig::load_default().map_err(|e| {
+                CliError::Input(format!(
+                    "failed to load docker config for '{bare_host}': {e}"
+                ))
+            })?;
+            let auth = DockerConfigAuth::new(bare_host, &docker_config, http)?;
             RegistryClient::builder(url).auth(auth)
         }
-        Some(AuthType::Anonymous) | None => {
-            // Explicit anonymous or no auth_type specified.
-            // For None, also try auto-detection for ECR.
-            if auth_type.is_none() {
-                if let Some(ProviderKind::Ecr | ProviderKind::EcrPublic) =
-                    detect_provider_kind(bare_host)
-                {
-                    let auth = EcrAuth::new(bare_host).await.map_err(|e| {
-                        CliError::Input(format!("ECR auth setup for '{bare_host}': {e}"))
-                    })?;
-                    RegistryClient::builder(url).auth(auth)
-                } else {
-                    let auth = AnonymousAuth::new(bare_host, http);
-                    RegistryClient::builder(url).auth(auth)
-                }
+        Some(AuthType::Anonymous) => {
+            let auth = AnonymousAuth::new(bare_host, http);
+            RegistryClient::builder(url).auth(auth)
+        }
+        None => {
+            // Auto-detect: ECR by hostname, otherwise anonymous.
+            if let Some(ProviderKind::Ecr | ProviderKind::EcrPublic) =
+                detect_provider_kind(bare_host)
+            {
+                let auth = EcrAuth::new(bare_host).await.map_err(|e| {
+                    CliError::Input(format!("ECR auth setup for '{bare_host}': {e}"))
+                })?;
+                RegistryClient::builder(url).auth(auth)
             } else {
                 let auth = AnonymousAuth::new(bare_host, http);
                 RegistryClient::builder(url).auth(auth)
@@ -196,7 +192,7 @@ pub(crate) async fn build_registry_client(
         }
     };
 
-    if let Some(n) = max_concurrent {
+    if let Some(n) = registry_config.and_then(|r| r.max_concurrent) {
         builder = builder.max_concurrent(n);
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -154,7 +154,7 @@ pub(crate) async fn build_registry_client(
             );
             RegistryClient::builder(url).auth(auth)
         }
-        Some(AuthType::Token) => {
+        Some(AuthType::StaticToken) => {
             // Config validation ensures token is present for Token auth.
             let tok = registry_config
                 .and_then(|r| r.token.as_deref())
@@ -411,7 +411,7 @@ mod tests {
             AuthType::Ghcr,
             AuthType::Anonymous,
             AuthType::Basic,
-            AuthType::Token,
+            AuthType::StaticToken,
             AuthType::DockerConfig,
         ];
         for variant in &variants {
@@ -422,7 +422,7 @@ mod tests {
                 AuthType::Ghcr => {}
                 AuthType::Anonymous => {}
                 AuthType::Basic => {}
-                AuthType::Token => {}
+                AuthType::StaticToken => {}
                 AuthType::DockerConfig => {}
             }
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -162,8 +162,23 @@ pub(crate) async fn build_registry_client(
             let auth = StaticTokenAuth::new(tok);
             RegistryClient::builder(url).auth(auth)
         }
-        Some(AuthType::DockerConfig | AuthType::Ghcr | AuthType::Gcr | AuthType::Acr) => {
-            // User explicitly requested docker config auth — error if config can't load.
+        Some(AuthType::Ghcr | AuthType::Gcr | AuthType::Acr) => {
+            // These registries will eventually have native providers (OAuth2, GITHUB_TOKEN).
+            // For now, resolve credentials from docker config — covers PATs and helper-stored creds.
+            tracing::debug!(
+                registry = bare_host,
+                auth_type = ?auth_type,
+                "using docker config credential resolution for registry provider"
+            );
+            let docker_config = DockerConfig::load_default().map_err(|e| {
+                CliError::Input(format!(
+                    "failed to load docker config for '{bare_host}': {e}"
+                ))
+            })?;
+            let auth = DockerConfigAuth::new(bare_host, &docker_config, http)?;
+            RegistryClient::builder(url).auth(auth)
+        }
+        Some(AuthType::DockerConfig) => {
             let docker_config = DockerConfig::load_default().map_err(|e| {
                 CliError::Input(format!(
                     "failed to load docker config for '{bare_host}': {e}"
@@ -177,7 +192,10 @@ pub(crate) async fn build_registry_client(
             RegistryClient::builder(url).auth(auth)
         }
         None => {
-            // Auto-detect: ECR by hostname, otherwise anonymous.
+            // Interim credential resolution: ECR by hostname, docker config for
+            // everything else, anonymous as final fallback. Native providers for
+            // GCR/ACR/GHCR will be inserted between ECR and docker config when
+            // implemented.
             if let Some(ProviderKind::Ecr | ProviderKind::EcrPublic) =
                 detect_provider_kind(bare_host)
             {
@@ -186,8 +204,27 @@ pub(crate) async fn build_registry_client(
                 })?;
                 RegistryClient::builder(url).auth(auth)
             } else {
-                let auth = AnonymousAuth::new(bare_host, http);
-                RegistryClient::builder(url).auth(auth)
+                // Try docker config — falls back to anonymous exchange if no creds found.
+                match DockerConfig::load_default() {
+                    Ok(config) => {
+                        let auth =
+                            DockerConfigAuth::new(bare_host, &config, http).map_err(|e| {
+                                CliError::Input(format!(
+                                    "docker config credential resolution for '{bare_host}': {e}"
+                                ))
+                            })?;
+                        RegistryClient::builder(url).auth(auth)
+                    }
+                    Err(_) => {
+                        // No docker config file — use anonymous.
+                        tracing::debug!(
+                            registry = bare_host,
+                            "no docker config found, using anonymous auth"
+                        );
+                        let auth = AnonymousAuth::new(bare_host, http);
+                        RegistryClient::builder(url).auth(auth)
+                    }
+                }
             }
         }
     };

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -171,7 +171,7 @@ pub(crate) async fn build_registry_client(
                 );
                 DockerConfig::default()
             });
-            let auth = DockerConfigAuth::new(bare_host, config);
+            let auth = DockerConfigAuth::new(bare_host, config, http);
             RegistryClient::builder(url).auth(auth)
         }
         Some(AuthType::Anonymous) | None => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,9 +7,13 @@ pub(crate) mod progress;
 pub(crate) mod shutdown;
 
 use ocync_distribution::RegistryClient;
+use ocync_distribution::auth::Credentials;
 use ocync_distribution::auth::anonymous::AnonymousAuth;
+use ocync_distribution::auth::basic::BasicAuth;
 use ocync_distribution::auth::detect::{ProviderKind, detect_provider_kind};
+use ocync_distribution::auth::docker::{DockerConfig, DockerConfigAuth};
 use ocync_distribution::auth::ecr::EcrAuth;
+use ocync_distribution::auth::static_token::StaticTokenAuth;
 use tracing_subscriber::{EnvFilter, fmt};
 use url::Url;
 
@@ -109,10 +113,16 @@ pub(crate) fn bare_hostname(s: &str) -> &str {
 ///
 /// When `max_concurrent` is `Some`, the per-registry aggregate concurrency
 /// cap is set to that value; otherwise the client default applies.
+///
+/// The `credentials` and `token` parameters supply auth material for
+/// `Basic` and `Token` auth types respectively. Config validation ensures
+/// these are present when the corresponding `auth_type` is set.
 pub(crate) async fn build_registry_client(
     hostname: &str,
     auth_type: Option<&AuthType>,
     max_concurrent: Option<usize>,
+    credentials: Option<&config::CredentialsConfig>,
+    token: Option<&str>,
 ) -> Result<RegistryClient, CliError> {
     let base_url = if hostname.starts_with("http://") || hostname.starts_with("https://") {
         hostname.to_string()
@@ -124,32 +134,65 @@ pub(crate) async fn build_registry_client(
         .map_err(|e| CliError::Input(format!("invalid registry URL '{base_url}': {e}")))?;
 
     let bare_host = bare_hostname(hostname);
+    let http = reqwest::Client::new();
 
-    let provider_kind = match auth_type {
-        Some(AuthType::Ecr) => Some(ProviderKind::Ecr),
-        Some(AuthType::Anonymous) => None,
-        Some(unsupported) => {
-            tracing::warn!(
-                auth_type = ?unsupported,
-                registry = bare_host,
-                "auth type not yet implemented, falling back to anonymous auth"
-            );
-            None
-        }
-        None => detect_provider_kind(bare_host),
-    };
-
-    let mut builder = match provider_kind {
-        Some(ProviderKind::Ecr | ProviderKind::EcrPublic) => {
+    let mut builder = match auth_type {
+        Some(AuthType::Ecr) => {
             let auth = EcrAuth::new(bare_host)
                 .await
                 .map_err(|e| CliError::Input(format!("ECR auth setup for '{bare_host}': {e}")))?;
             RegistryClient::builder(url).auth(auth)
         }
-        _ => {
-            let http = reqwest::Client::new();
-            let auth = AnonymousAuth::new(bare_host, http);
+        Some(AuthType::Basic) => {
+            // Config validation ensures credentials are present for Basic auth.
+            let creds = credentials.expect("basic auth requires credentials (validated)");
+            let auth = BasicAuth::new(
+                bare_host,
+                http,
+                Credentials::Basic {
+                    username: creds.username.clone(),
+                    password: creds.password.clone(),
+                },
+            );
             RegistryClient::builder(url).auth(auth)
+        }
+        Some(AuthType::Token) => {
+            // Config validation ensures token is present for Token auth.
+            let tok = token.expect("token auth requires token field (validated)");
+            let auth = StaticTokenAuth::new(tok);
+            RegistryClient::builder(url).auth(auth)
+        }
+        Some(AuthType::DockerConfig | AuthType::Ghcr | AuthType::Gcr | AuthType::Acr) => {
+            let config = DockerConfig::load_default().unwrap_or_else(|e| {
+                tracing::debug!(
+                    registry = bare_host,
+                    error = %e,
+                    "failed to load docker config, using anonymous auth"
+                );
+                DockerConfig::default()
+            });
+            let auth = DockerConfigAuth::new(bare_host, config);
+            RegistryClient::builder(url).auth(auth)
+        }
+        Some(AuthType::Anonymous) | None => {
+            // Explicit anonymous or no auth_type specified.
+            // For None, also try auto-detection for ECR.
+            if auth_type.is_none() {
+                if let Some(ProviderKind::Ecr | ProviderKind::EcrPublic) =
+                    detect_provider_kind(bare_host)
+                {
+                    let auth = EcrAuth::new(bare_host).await.map_err(|e| {
+                        CliError::Input(format!("ECR auth setup for '{bare_host}': {e}"))
+                    })?;
+                    RegistryClient::builder(url).auth(auth)
+                } else {
+                    let auth = AnonymousAuth::new(bare_host, http);
+                    RegistryClient::builder(url).auth(auth)
+                }
+            } else {
+                let auth = AnonymousAuth::new(bare_host, http);
+                RegistryClient::builder(url).auth(auth)
+            }
         }
     };
 
@@ -359,5 +402,33 @@ mod tests {
     #[test]
     fn bare_hostname_preserves_port() {
         assert_eq!(bare_hostname("localhost:5000"), "localhost:5000");
+    }
+
+    #[test]
+    fn all_auth_types_are_handled() {
+        // Exhaustive match ensures no AuthType variant is unhandled.
+        // If a new variant is added, this fails to compile.
+        let variants = [
+            AuthType::Ecr,
+            AuthType::Gcr,
+            AuthType::Acr,
+            AuthType::Ghcr,
+            AuthType::Anonymous,
+            AuthType::Basic,
+            AuthType::Token,
+            AuthType::DockerConfig,
+        ];
+        for variant in &variants {
+            match variant {
+                AuthType::Ecr => {}
+                AuthType::Gcr => {}
+                AuthType::Acr => {}
+                AuthType::Ghcr => {}
+                AuthType::Anonymous => {}
+                AuthType::Basic => {}
+                AuthType::Token => {}
+                AuthType::DockerConfig => {}
+            }
+        }
     }
 }

--- a/src/cli/progress.rs
+++ b/src/cli/progress.rs
@@ -435,6 +435,24 @@ mod tests {
     }
 
     #[test]
+    fn verbosity_1_prints_immutable_tag_skip() {
+        let (progress, stderr, _stdout) = test_progress(1);
+        let result = make_result(
+            ImageStatus::Skipped {
+                reason: SkipReason::ImmutableTag,
+            },
+            0,
+        );
+        progress.image_completed(&result);
+        let output = String::from_utf8(stderr.borrow().clone()).unwrap();
+        assert!(output.starts_with("skipped "), "should print skipped");
+        assert!(
+            output.contains("immutable tag"),
+            "should contain immutable tag reason"
+        );
+    }
+
+    #[test]
     fn run_completed_exact_format() {
         let (progress, _stderr, stdout) = test_progress(0);
         let report = SyncReport {

--- a/src/cli/progress.rs
+++ b/src/cli/progress.rs
@@ -69,8 +69,7 @@ impl TextProgress {
 
 impl ProgressReporter for TextProgress {
     fn image_started(&self, _source: &str, _target: &str) {
-        // No-op for text output. BarProgress (PR #21) will use this
-        // to create per-image progress bars.
+        // No-op for text output — only progress bar implementations need this.
     }
 
     fn image_completed(&self, result: &ImageResult) {


### PR DESCRIPTION
## Summary

- **Auth providers:** `BasicAuth` (token exchange with HTTP Basic credentials), `StaticTokenAuth` (static bearer token for PATs/CI tokens), `DockerConfigAuth` (wraps `~/.docker/config.json` resolution, delegates to BasicAuth or AnonymousAuth)
- **Config + CLI wiring:** `credentials` and `token` fields on `RegistryConfig` with validation (Basic requires credentials, Token requires token field). All `AuthType` variants wired in `build_registry_client()` — no more fallback-to-anonymous warning
- **ECR immutable tag:** HTTP 400 `ImageTagAlreadyExistsException` → `Skipped { reason: ImmutableTag }` instead of `Failed`

## Test plan

- [ ] `cargo fmt --check && cargo clippy -- -D warnings && cargo test && cargo deny check`
- [ ] BasicAuth: wiremock tests verify Authorization header, scope caching, invalidation, missing WWW-Authenticate error
- [ ] StaticTokenAuth: returns configured token, survives invalidate, redacts in Debug
- [ ] DockerConfigAuth: inline creds → Basic auth flow, no creds → anonymous fallback
- [ ] Config validation: `auth_type: basic` without credentials → error, `auth_type: token` without token → error
- [ ] ECR immutable tag: `is_immutable_tag_error()` detects only HTTP 400 + `ImageTagAlreadyExistsException`
- [ ] All secret fields redacted in Debug output (no Option presence leak)