### PR TITLE
feat: /readyz endpoint and TTY progress bars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,6 +620,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +747,12 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -1254,6 +1272,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "web-time",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,12 +1436,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "ocync"
 version = "0.1.0"
 dependencies = [
  "anstyle",
  "clap",
  "http 1.4.0",
+ "indicatif",
  "ocync-distribution",
  "ocync-sync",
  "reqwest",
@@ -1514,6 +1551,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "postcard"
@@ -2594,6 +2637,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -1111,16 +1111,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1347,9 +1346,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1691,9 +1690,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1838,9 +1837,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -1875,9 +1874,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2213,9 +2212,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ aws-lc-rs = { version = "1", default-features = false, features = ["aws-lc-sys"]
 bytes = { version = "1", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 http = { version = "1", default-features = false }
+indicatif = { version = "0.17", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
 thiserror = { version = "2", default-features = false }
@@ -53,6 +54,7 @@ workspace = true
 anstyle = { version = "1", default-features = false }
 clap = { version = "4", default-features = false, features = ["derive", "std", "help", "usage", "error-context", "color"] }
 http.workspace = true
+indicatif.workspace = true
 ocync-distribution.workspace = true
 ocync-sync.workspace = true
 serde.workspace = true

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -459,12 +459,12 @@ impl SyncEngine {
                     };
 
                     let staging_ref = Rc::clone(&staging);
-                    let source_display = format!("{} -> {}", item.source, item.target_name);
-                    let target_display = item.target.to_string();
+                    let source_str = item.source.to_string();
+                    let target_str = item.target.to_string();
 
                     execution_futures.push(Box::pin(async move {
                         let _permit = sem.acquire().await.unwrap();
-                        progress.image_started(&source_display, &target_display);
+                        progress.image_started(&source_str, &target_str);
                         execute_item(item, &cache_ref, &staging_ref, &freq_counts, &retry).await
                     }));
                 }

--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,11 @@
 [advisories]
 version = 2
+ignore = [
+  # number_prefix is unmaintained but is a transitive dep of indicatif
+  # (used only for byte-count formatting in progress bars, which we don't use —
+  # our bars are spinners). No security impact, just an unmaintained notice.
+  "RUSTSEC-2025-0119",
+]
 
 [licenses]
 version = 2

--- a/deny.toml
+++ b/deny.toml
@@ -5,6 +5,11 @@ ignore = [
   # (used only for byte-count formatting in progress bars, which we don't use —
   # our bars are spinners). No security impact, just an unmaintained notice.
   "RUSTSEC-2025-0119",
+  # rustls name constraint vulnerabilities in transitive deps (via reqwest →
+  # hyper-rustls → rustls). Pre-existing on main, not introduced by this PR.
+  # Fix: upgrade rustls when a patched version is available.
+  "RUSTSEC-2026-0098",
+  "RUSTSEC-2026-0099",
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -5,11 +5,6 @@ ignore = [
   # (used only for byte-count formatting in progress bars, which we don't use —
   # our bars are spinners). No security impact, just an unmaintained notice.
   "RUSTSEC-2025-0119",
-  # rustls name constraint vulnerabilities in transitive deps (via reqwest →
-  # hyper-rustls → rustls). Pre-existing on main, not introduced by this PR.
-  # Fix: upgrade rustls when a patched version is available.
-  "RUSTSEC-2026-0098",
-  "RUSTSEC-2026-0099",
 ]
 
 [licenses]

--- a/src/cli/health.rs
+++ b/src/cli/health.rs
@@ -112,7 +112,7 @@ mod tests {
     fn healthz_returns_200_before_first_sync() {
         let state = HealthState::new(Duration::from_secs(60));
         let resp = handle_request("/healthz", &state);
-        assert!(resp.contains("200 OK"));
+        assert!(resp.starts_with("HTTP/1.1 200 OK\r\n"));
         assert!(resp.ends_with("ok\n"));
     }
 
@@ -121,7 +121,7 @@ mod tests {
         let mut state = HealthState::new(Duration::from_secs(60));
         state.record_success();
         let resp = handle_request("/healthz", &state);
-        assert!(resp.contains("200 OK"));
+        assert!(resp.starts_with("HTTP/1.1 200 OK\r\n"));
         assert!(resp.ends_with("ok\n"));
     }
 
@@ -131,7 +131,7 @@ mod tests {
         let mut state = HealthState::new(interval);
         state.last_success = Some(Instant::now() - interval * 3);
         let resp = handle_request("/healthz", &state);
-        assert!(resp.contains("200 OK"));
+        assert!(resp.starts_with("HTTP/1.1 200 OK\r\n"));
         assert!(resp.ends_with("ok\n"));
     }
 
@@ -139,7 +139,7 @@ mod tests {
     fn readyz_returns_503_before_first_sync() {
         let state = HealthState::new(Duration::from_secs(60));
         let resp = handle_request("/readyz", &state);
-        assert!(resp.contains("503 Service Unavailable"));
+        assert!(resp.starts_with("HTTP/1.1 503 Service Unavailable\r\n"));
         assert!(resp.ends_with("sync stale\n"));
     }
 
@@ -148,7 +148,7 @@ mod tests {
         let mut state = HealthState::new(Duration::from_secs(60));
         state.record_success();
         let resp = handle_request("/readyz", &state);
-        assert!(resp.contains("200 OK"));
+        assert!(resp.starts_with("HTTP/1.1 200 OK\r\n"));
         assert!(resp.ends_with("ok\n"));
     }
 
@@ -158,7 +158,7 @@ mod tests {
         let mut state = HealthState::new(interval);
         state.last_success = Some(Instant::now() - interval * 3);
         let resp = handle_request("/readyz", &state);
-        assert!(resp.contains("503 Service Unavailable"));
+        assert!(resp.starts_with("HTTP/1.1 503 Service Unavailable\r\n"));
         assert!(resp.ends_with("sync stale\n"));
     }
 
@@ -166,7 +166,7 @@ mod tests {
     fn unknown_path_returns_404() {
         let state = HealthState::new(Duration::from_secs(60));
         let resp = handle_request("/foo", &state);
-        assert!(resp.contains("404 Not Found"));
+        assert!(resp.starts_with("HTTP/1.1 404 Not Found\r\n"));
         assert!(resp.ends_with("not found\n"));
     }
 

--- a/src/cli/health.rs
+++ b/src/cli/health.rs
@@ -1,8 +1,8 @@
-//! Health endpoint for watch mode.
+//! Health and readiness endpoints for watch mode.
 //!
-//! Exposes `/healthz` for Kubernetes liveness probes. Returns 200 if
-//! the last successful sync completed within `2 * interval`, 503
-//! otherwise.
+//! Exposes `/healthz` (liveness — always 200) and `/readyz` (readiness —
+//! 200 if last sync within `2 * interval`, 503 otherwise) for Kubernetes
+//! probes.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -49,19 +49,24 @@ fn format_response(status: &str, body: &str) -> String {
     )
 }
 
-/// Route a request path to a formatted HTTP response string based on health state.
+/// Route a request path to a formatted HTTP response string.
+///
+/// - `/healthz` — liveness: always 200 (process is running).
+/// - `/readyz`  — readiness: 200 if last sync within `2 * interval`, 503 otherwise.
 fn handle_request(path: &str, state: &HealthState) -> String {
     match path {
-        "/healthz" if state.is_healthy() => format_response("200 OK", "ok\n"),
-        "/healthz" => format_response("503 Service Unavailable", "sync stale\n"),
+        "/healthz" => format_response("200 OK", "ok\n"),
+        "/readyz" if state.is_healthy() => format_response("200 OK", "ok\n"),
+        "/readyz" => format_response("503 Service Unavailable", "sync stale\n"),
         _ => format_response("404 Not Found", "not found\n"),
     }
 }
 
 /// Start the health server on a pre-bound listener.
 ///
-/// Serves `/healthz` until the task is cancelled. Must be called from
-/// within a `spawn_local` on the `current_thread` runtime.
+/// Serves `/healthz` (liveness) and `/readyz` (readiness) until the task
+/// is cancelled. Must be called from within a `spawn_local` on the
+/// `current_thread` runtime.
 ///
 /// Accepts a `TcpListener` rather than a port number so the caller
 /// controls binding (avoids TOCTOU races in tests and lets production
@@ -104,11 +109,11 @@ mod tests {
     // -- handler unit tests (no TCP, no port) --
 
     #[test]
-    fn healthz_returns_503_before_first_sync() {
+    fn healthz_returns_200_before_first_sync() {
         let state = HealthState::new(Duration::from_secs(60));
         let resp = handle_request("/healthz", &state);
-        assert!(resp.contains("503 Service Unavailable"));
-        assert!(resp.ends_with("sync stale\n"));
+        assert!(resp.contains("200 OK"));
+        assert!(resp.ends_with("ok\n"));
     }
 
     #[test]
@@ -121,11 +126,38 @@ mod tests {
     }
 
     #[test]
-    fn healthz_returns_503_when_stale() {
+    fn healthz_returns_200_when_stale() {
         let interval = Duration::from_millis(10);
         let mut state = HealthState::new(interval);
         state.last_success = Some(Instant::now() - interval * 3);
         let resp = handle_request("/healthz", &state);
+        assert!(resp.contains("200 OK"));
+        assert!(resp.ends_with("ok\n"));
+    }
+
+    #[test]
+    fn readyz_returns_503_before_first_sync() {
+        let state = HealthState::new(Duration::from_secs(60));
+        let resp = handle_request("/readyz", &state);
+        assert!(resp.contains("503 Service Unavailable"));
+        assert!(resp.ends_with("sync stale\n"));
+    }
+
+    #[test]
+    fn readyz_returns_200_after_successful_sync() {
+        let mut state = HealthState::new(Duration::from_secs(60));
+        state.record_success();
+        let resp = handle_request("/readyz", &state);
+        assert!(resp.contains("200 OK"));
+        assert!(resp.ends_with("ok\n"));
+    }
+
+    #[test]
+    fn readyz_returns_503_when_stale() {
+        let interval = Duration::from_millis(10);
+        let mut state = HealthState::new(interval);
+        state.last_success = Some(Instant::now() - interval * 3);
+        let resp = handle_request("/readyz", &state);
         assert!(resp.contains("503 Service Unavailable"));
         assert!(resp.ends_with("sync stale\n"));
     }
@@ -237,12 +269,12 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn serve_healthz_200() {
+    async fn serve_healthz_always_200() {
         let local = tokio::task::LocalSet::new();
         local
             .run_until(async {
+                // No record_success — /healthz should still return 200.
                 let state = Rc::new(RefCell::new(HealthState::new(Duration::from_secs(60))));
-                state.borrow_mut().record_success();
 
                 let resp =
                     serve_and_request(state, b"GET /healthz HTTP/1.1\r\nHost: localhost\r\n\r\n")
@@ -254,21 +286,37 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn serve_healthz_503() {
+    async fn serve_readyz_503_before_sync() {
         let local = tokio::task::LocalSet::new();
         local
             .run_until(async {
                 let state = Rc::new(RefCell::new(HealthState::new(Duration::from_secs(60))));
-                // No record_success — should return 503.
 
                 let resp =
-                    serve_and_request(state, b"GET /healthz HTTP/1.1\r\nHost: localhost\r\n\r\n")
+                    serve_and_request(state, b"GET /readyz HTTP/1.1\r\nHost: localhost\r\n\r\n")
                         .await;
                 assert!(
                     resp.starts_with("HTTP/1.1 503 Service Unavailable\r\n"),
                     "got: {resp}"
                 );
                 assert!(resp.ends_with("sync stale\n"), "got: {resp}");
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn serve_readyz_200_after_sync() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let state = Rc::new(RefCell::new(HealthState::new(Duration::from_secs(60))));
+                state.borrow_mut().record_success();
+
+                let resp =
+                    serve_and_request(state, b"GET /readyz HTTP/1.1\r\nHost: localhost\r\n\r\n")
+                        .await;
+                assert!(resp.starts_with("HTTP/1.1 200 OK\r\n"), "got: {resp}");
+                assert!(resp.ends_with("ok\n"), "got: {resp}");
             })
             .await;
     }

--- a/src/cli/health.rs
+++ b/src/cli/health.rs
@@ -170,6 +170,19 @@ mod tests {
         assert!(resp.ends_with("not found\n"));
     }
 
+    #[test]
+    fn healthz_200_while_readyz_503() {
+        // Core invariant: liveness is always 200 even when readiness is 503.
+        let state = HealthState::new(Duration::from_secs(60));
+        let liveness = handle_request("/healthz", &state);
+        let readiness = handle_request("/readyz", &state);
+        assert!(liveness.contains("200 OK"), "liveness: {liveness}");
+        assert!(
+            readiness.contains("503 Service Unavailable"),
+            "readiness: {readiness}"
+        );
+    }
+
     // -- state logic unit tests --
 
     #[test]

--- a/src/cli/health.rs
+++ b/src/cli/health.rs
@@ -8,6 +8,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
+use http::StatusCode;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
@@ -41,24 +42,26 @@ impl HealthState {
     }
 }
 
-/// Format a complete HTTP/1.1 response string with a text/plain body.
-fn format_response(status: &str, body: &str) -> String {
+/// Format a complete HTTP/1.1 response with a text/plain body.
+fn format_response(status: StatusCode, body: &str) -> String {
     format!(
-        "HTTP/1.1 {status}\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        "HTTP/1.1 {} {}\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        status.as_u16(),
+        status.canonical_reason().unwrap_or("Unknown"),
         body.len(),
     )
 }
 
-/// Route a request path to a formatted HTTP response string.
+/// Route a request path to a formatted HTTP response based on health state.
 ///
 /// - `/healthz` — liveness: always 200 (process is running).
 /// - `/readyz`  — readiness: 200 if last sync within `2 * interval`, 503 otherwise.
 fn handle_request(path: &str, state: &HealthState) -> String {
     match path {
-        "/healthz" => format_response("200 OK", "ok\n"),
-        "/readyz" if state.is_healthy() => format_response("200 OK", "ok\n"),
-        "/readyz" => format_response("503 Service Unavailable", "sync stale\n"),
-        _ => format_response("404 Not Found", "not found\n"),
+        "/healthz" => format_response(StatusCode::OK, "ok\n"),
+        "/readyz" if state.is_healthy() => format_response(StatusCode::OK, "ok\n"),
+        "/readyz" => format_response(StatusCode::SERVICE_UNAVAILABLE, "sync stale\n"),
+        _ => format_response(StatusCode::NOT_FOUND, "not found\n"),
     }
 }
 
@@ -229,7 +232,7 @@ mod tests {
     #[test]
     fn format_response_200() {
         assert_eq!(
-            format_response("200 OK", "ok\n"),
+            format_response(StatusCode::OK, "ok\n"),
             "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 3\r\nConnection: close\r\n\r\nok\n"
         );
     }
@@ -237,7 +240,7 @@ mod tests {
     #[test]
     fn format_response_503() {
         assert_eq!(
-            format_response("503 Service Unavailable", "sync stale\n"),
+            format_response(StatusCode::SERVICE_UNAVAILABLE, "sync stale\n"),
             "HTTP/1.1 503 Service Unavailable\r\nContent-Type: text/plain\r\nContent-Length: 11\r\nConnection: close\r\n\r\nsync stale\n"
         );
     }
@@ -245,7 +248,7 @@ mod tests {
     #[test]
     fn format_response_404() {
         assert_eq!(
-            format_response("404 Not Found", "not found\n"),
+            format_response(StatusCode::NOT_FOUND, "not found\n"),
             "HTTP/1.1 404 Not Found\r\nContent-Type: text/plain\r\nContent-Length: 10\r\nConnection: close\r\n\r\nnot found\n"
         );
     }

--- a/src/cli/health.rs
+++ b/src/cli/health.rs
@@ -32,9 +32,9 @@ impl HealthState {
         self.last_success = Some(Instant::now());
     }
 
-    /// Returns `true` if the sync loop is healthy: at least one success
-    /// within `2 * interval`.
-    fn is_healthy(&self) -> bool {
+    /// Returns `true` if the sync loop is ready: at least one success
+    /// within `2 * interval`. Used by the `/readyz` endpoint.
+    fn is_ready(&self) -> bool {
         match self.last_success {
             Some(last) => last.elapsed() < self.interval * 2,
             None => false,
@@ -59,7 +59,7 @@ fn format_response(status: StatusCode, body: &str) -> String {
 fn handle_request(path: &str, state: &HealthState) -> String {
     match path {
         "/healthz" => format_response(StatusCode::OK, "ok\n"),
-        "/readyz" if state.is_healthy() => format_response(StatusCode::OK, "ok\n"),
+        "/readyz" if state.is_ready() => format_response(StatusCode::OK, "ok\n"),
         "/readyz" => format_response(StatusCode::SERVICE_UNAVAILABLE, "sync stale\n"),
         _ => format_response(StatusCode::NOT_FOUND, "not found\n"),
     }
@@ -174,14 +174,25 @@ mod tests {
     }
 
     #[test]
+    fn empty_path_returns_404() {
+        let state = HealthState::new(Duration::from_secs(60));
+        let resp = handle_request("", &state);
+        assert!(resp.starts_with("HTTP/1.1 404 Not Found\r\n"));
+        assert!(resp.ends_with("not found\n"));
+    }
+
+    #[test]
     fn healthz_200_while_readyz_503() {
         // Core invariant: liveness is always 200 even when readiness is 503.
         let state = HealthState::new(Duration::from_secs(60));
         let liveness = handle_request("/healthz", &state);
         let readiness = handle_request("/readyz", &state);
-        assert!(liveness.contains("200 OK"), "liveness: {liveness}");
         assert!(
-            readiness.contains("503 Service Unavailable"),
+            liveness.starts_with("HTTP/1.1 200 OK\r\n"),
+            "liveness: {liveness}"
+        );
+        assert!(
+            readiness.starts_with("HTTP/1.1 503 Service Unavailable\r\n"),
             "readiness: {readiness}"
         );
     }
@@ -189,42 +200,42 @@ mod tests {
     // -- state logic unit tests --
 
     #[test]
-    fn health_state_no_success_is_unhealthy() {
+    fn health_state_no_success_is_not_ready() {
         let state = HealthState::new(Duration::from_secs(60));
-        assert!(!state.is_healthy());
+        assert!(!state.is_ready());
     }
 
     #[test]
-    fn health_state_recent_success_is_healthy() {
+    fn health_state_recent_success_is_ready() {
         let mut state = HealthState::new(Duration::from_secs(60));
         state.record_success();
-        assert!(state.is_healthy());
+        assert!(state.is_ready());
     }
 
     #[test]
-    fn health_state_stale_success_is_unhealthy() {
+    fn health_state_stale_success_is_not_ready() {
         let interval = Duration::from_millis(10);
         let mut state = HealthState::new(interval);
         state.last_success = Some(Instant::now() - interval * 3);
-        assert!(!state.is_healthy());
+        assert!(!state.is_ready());
     }
 
     #[test]
     fn health_state_boundary_just_inside_threshold() {
-        // At exactly 2 * interval - epsilon, should still be healthy.
+        // At exactly 2 * interval - epsilon, should still be ready.
         let interval = Duration::from_secs(60);
         let mut state = HealthState::new(interval);
         state.last_success = Some(Instant::now() - interval - Duration::from_secs(59));
-        assert!(state.is_healthy());
+        assert!(state.is_ready());
     }
 
     #[test]
     fn health_state_boundary_just_outside_threshold() {
-        // At exactly 2 * interval + epsilon, should be unhealthy.
+        // At exactly 2 * interval + epsilon, should not be ready.
         let interval = Duration::from_millis(50);
         let mut state = HealthState::new(interval);
         state.last_success = Some(Instant::now() - Duration::from_millis(101));
-        assert!(!state.is_healthy());
+        assert!(!state.is_ready());
     }
 
     // -- response formatting --
@@ -333,6 +344,27 @@ mod tests {
                         .await;
                 assert!(resp.starts_with("HTTP/1.1 200 OK\r\n"), "got: {resp}");
                 assert!(resp.ends_with("ok\n"), "got: {resp}");
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn serve_readyz_503_when_stale() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let interval = Duration::from_millis(10);
+                let state = Rc::new(RefCell::new(HealthState::new(interval)));
+                state.borrow_mut().last_success = Some(Instant::now() - interval * 3);
+
+                let resp =
+                    serve_and_request(state, b"GET /readyz HTTP/1.1\r\nHost: localhost\r\n\r\n")
+                        .await;
+                assert!(
+                    resp.starts_with("HTTP/1.1 503 Service Unavailable\r\n"),
+                    "got: {resp}"
+                );
+                assert!(resp.ends_with("sync stale\n"), "got: {resp}");
             })
             .await;
     }

--- a/src/cli/progress.rs
+++ b/src/cli/progress.rs
@@ -1,12 +1,86 @@
-//! Verbosity-aware text progress reporter.
+//! Verbosity-aware progress reporters for sync output.
+//!
+//! [`TextProgress`] writes plain status lines to stderr (non-TTY).
+//! [`BarProgress`] shows `indicatif` spinners on stderr (TTY).
+//! Both write the run summary to stdout.
 
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::io::{self, Write};
+use std::time::Duration;
 
+#[cfg(test)]
+use indicatif::ProgressDrawTarget;
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use ocync_sync::progress::ProgressReporter;
 use ocync_sync::{ImageResult, ImageStatus, SyncReport};
 
 use crate::cli::output::{format_bytes, format_duration};
+
+/// Format a per-image status line, or `None` if the status should be silent
+/// at the given verbosity level.
+///
+/// Failed images always produce a line. Synced/skipped images produce a
+/// line only at verbosity >= 1.
+fn format_image_line(result: &ImageResult, verbosity: u8) -> Option<String> {
+    match &result.status {
+        ImageStatus::Failed { kind, error, .. } => Some(format!(
+            "FAILED  {} -> {}  ({kind}: {error})",
+            result.source, result.target,
+        )),
+        ImageStatus::Synced if verbosity >= 1 => Some(format!(
+            "synced  {} -> {}  ({}, {})",
+            result.source,
+            result.target,
+            format_bytes(result.bytes_transferred),
+            format_duration(result.duration),
+        )),
+        ImageStatus::Skipped { reason } if verbosity >= 1 => Some(format!(
+            "skipped {} -> {}  ({reason})",
+            result.source, result.target,
+        )),
+        _ => None,
+    }
+}
+
+/// Write the run summary to `stdout`, or do nothing if `suppress_summary`
+/// is true or the report contains no images.
+fn write_run_summary(
+    stdout: &RefCell<Box<dyn Write>>,
+    report: &SyncReport,
+    suppress_summary: bool,
+) {
+    if suppress_summary {
+        return;
+    }
+    if report.images.is_empty() {
+        return;
+    }
+    let s = &report.stats;
+    let discovery = if s.discovery_cache_hits > 0 || s.discovery_cache_misses > 0 {
+        format!(
+            " | discovery: {} cached, {} pulled",
+            s.discovery_cache_hits, s.discovery_cache_misses,
+        )
+    } else {
+        String::new()
+    };
+    if let Err(e) = writeln!(
+        stdout.borrow_mut(),
+        "sync complete: {} synced, {} skipped, {} failed | blobs: {} transferred, {} skipped, {} mounted | {} in {}{}",
+        s.images_synced,
+        s.images_skipped,
+        s.images_failed,
+        s.blobs_transferred,
+        s.blobs_skipped,
+        s.blobs_mounted,
+        format_bytes(s.bytes_transferred),
+        format_duration(report.duration),
+        discovery,
+    ) {
+        tracing::warn!(error = %e, "failed to write progress summary to stdout");
+    }
+}
 
 /// Text progress reporter with configurable verbosity.
 ///
@@ -67,80 +141,115 @@ impl TextProgress {
     }
 }
 
+/// TTY progress reporter using `indicatif` spinners.
+///
+/// Shows a spinner per in-flight image on stderr. When an image completes,
+/// the spinner is replaced with a final status line (failures always shown,
+/// synced/skipped shown at verbosity >= 1, silently cleared at verbosity 0).
+///
+/// Falls back to [`TextProgress`] when stderr is not a terminal — the
+/// selection is made in `main.rs`, not here.
+pub(crate) struct BarProgress {
+    multi: MultiProgress,
+    bars: RefCell<HashMap<String, ProgressBar>>,
+    verbosity: u8,
+    suppress_summary: bool,
+    stdout: RefCell<Box<dyn Write>>,
+}
+
+impl std::fmt::Debug for BarProgress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BarProgress")
+            .field("verbosity", &self.verbosity)
+            .field("suppress_summary", &self.suppress_summary)
+            .field("active_bars", &self.bars.borrow().len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl BarProgress {
+    /// Create a new bar progress reporter writing spinners to stderr
+    /// and the run summary to stdout.
+    pub(crate) fn new(verbosity: u8, suppress_summary: bool) -> Self {
+        Self {
+            multi: MultiProgress::new(),
+            bars: RefCell::new(HashMap::new()),
+            verbosity,
+            suppress_summary,
+            stdout: RefCell::new(Box::new(io::stdout())),
+        }
+    }
+
+    /// Create a bar progress reporter with a hidden draw target and
+    /// custom stdout writer (for testing).
+    #[cfg(test)]
+    fn with_writers(verbosity: u8, suppress_summary: bool, stdout: Box<dyn Write>) -> Self {
+        Self {
+            multi: MultiProgress::with_draw_target(ProgressDrawTarget::hidden()),
+            bars: RefCell::new(HashMap::new()),
+            verbosity,
+            suppress_summary,
+            stdout: RefCell::new(stdout),
+        }
+    }
+
+    /// Build the map key for an image.
+    fn bar_key(source: &str, target: &str) -> String {
+        format!("{source} -> {target}")
+    }
+}
+
+impl ProgressReporter for BarProgress {
+    fn image_started(&self, source: &str, target: &str) {
+        let style = ProgressStyle::with_template("{spinner:.cyan} {msg}")
+            .expect("hardcoded template is valid");
+        let pb = self.multi.add(ProgressBar::new_spinner());
+        pb.set_style(style);
+        pb.set_message(format!("syncing {source} -> {target}"));
+        pb.enable_steady_tick(Duration::from_millis(100));
+        self.bars
+            .borrow_mut()
+            .insert(Self::bar_key(source, target), pb);
+    }
+
+    fn image_completed(&self, result: &ImageResult) {
+        let key = Self::bar_key(&result.source, &result.target);
+        let mut bars = self.bars.borrow_mut();
+        let Some(pb) = bars.remove(&key) else {
+            tracing::warn!(
+                source = %result.source,
+                target = %result.target,
+                "image_completed called without matching image_started"
+            );
+            return;
+        };
+
+        match format_image_line(result, self.verbosity) {
+            Some(line) => pb.finish_with_message(line),
+            None => pb.finish_and_clear(),
+        }
+    }
+
+    fn run_completed(&self, report: &SyncReport) {
+        write_run_summary(&self.stdout, report, self.suppress_summary);
+    }
+}
+
 impl ProgressReporter for TextProgress {
     fn image_started(&self, _source: &str, _target: &str) {
         // No-op for text output — only progress bar implementations need this.
     }
 
     fn image_completed(&self, result: &ImageResult) {
-        match &result.status {
-            ImageStatus::Failed { kind, error, .. } => {
-                if let Err(e) = writeln!(
-                    self.stderr.borrow_mut(),
-                    "FAILED  {} -> {}  ({kind}: {error})",
-                    result.source,
-                    result.target,
-                ) {
-                    tracing::warn!(error = %e, "failed to write progress to stderr");
-                }
+        if let Some(line) = format_image_line(result, self.verbosity) {
+            if let Err(e) = writeln!(self.stderr.borrow_mut(), "{line}") {
+                tracing::warn!(error = %e, "failed to write progress to stderr");
             }
-            ImageStatus::Synced if self.verbosity >= 1 => {
-                if let Err(e) = writeln!(
-                    self.stderr.borrow_mut(),
-                    "synced  {} -> {}  ({}, {})",
-                    result.source,
-                    result.target,
-                    format_bytes(result.bytes_transferred),
-                    format_duration(result.duration),
-                ) {
-                    tracing::warn!(error = %e, "failed to write progress to stderr");
-                }
-            }
-            ImageStatus::Skipped { reason } if self.verbosity >= 1 => {
-                if let Err(e) = writeln!(
-                    self.stderr.borrow_mut(),
-                    "skipped {} -> {}  ({reason})",
-                    result.source,
-                    result.target,
-                ) {
-                    tracing::warn!(error = %e, "failed to write progress to stderr");
-                }
-            }
-            _ => {}
         }
     }
 
     fn run_completed(&self, report: &SyncReport) {
-        if self.suppress_summary {
-            return;
-        }
-        if report.images.is_empty() {
-            return;
-        }
-        let s = &report.stats;
-        let discovery = if s.discovery_cache_hits > 0 || s.discovery_cache_misses > 0 {
-            format!(
-                " | discovery: {} cached, {} pulled",
-                s.discovery_cache_hits, s.discovery_cache_misses,
-            )
-        } else {
-            String::new()
-        };
-        if let Err(e) = writeln!(
-            self.stdout.borrow_mut(),
-            "sync complete: {} synced, {} skipped, {} failed | blobs: {} transferred, {} skipped, {} mounted | {} in {}{}",
-            s.images_synced,
-            s.images_skipped,
-            s.images_failed,
-            s.blobs_transferred,
-            s.blobs_skipped,
-            s.blobs_mounted,
-            format_bytes(s.bytes_transferred),
-            format_duration(report.duration),
-            discovery,
-        ) {
-            tracing::warn!(error = %e, "failed to write progress summary to stdout");
-        }
+        write_run_summary(&self.stdout, report, self.suppress_summary);
     }
 }
 
@@ -561,6 +670,180 @@ mod tests {
         assert!(
             stdout.borrow().is_empty(),
             "suppress_summary should not write to stdout on image_completed"
+        );
+    }
+
+    // -- BarProgress tests --
+
+    fn test_bar_progress(verbosity: u8) -> (BarProgress, Buf) {
+        test_bar_progress_with_suppress(verbosity, false)
+    }
+
+    fn test_bar_progress_with_suppress(
+        verbosity: u8,
+        suppress_summary: bool,
+    ) -> (BarProgress, Buf) {
+        let stdout_buf = Rc::new(RefCell::new(Vec::new()));
+        let progress = BarProgress::with_writers(
+            verbosity,
+            suppress_summary,
+            Box::new(RcWriter(Rc::clone(&stdout_buf))),
+        );
+        (progress, stdout_buf)
+    }
+
+    #[test]
+    fn bar_image_started_creates_bar() {
+        let (progress, _stdout) = test_bar_progress(0);
+        progress.image_started("source/repo:v1", "target/repo:v1");
+        assert_eq!(progress.bars.borrow().len(), 1);
+    }
+
+    #[test]
+    fn bar_image_started_multiple_images() {
+        let (progress, _stdout) = test_bar_progress(0);
+        progress.image_started("source/a:v1", "target/a:v1");
+        progress.image_started("source/b:v1", "target/b:v1");
+        assert_eq!(progress.bars.borrow().len(), 2);
+    }
+
+    #[test]
+    fn bar_image_completed_removes_bar() {
+        let (progress, _stdout) = test_bar_progress(0);
+        progress.image_started("source/repo:v1", "target/repo:v1");
+        let result = make_result(ImageStatus::Synced, 1024);
+        progress.image_completed(&result);
+        assert!(progress.bars.borrow().is_empty());
+    }
+
+    #[test]
+    fn bar_image_completed_failed_always_finishes_with_message() {
+        let (progress, _stdout) = test_bar_progress(0);
+        progress.image_started("source/repo:v1", "target/repo:v1");
+        let result = make_result(
+            ImageStatus::Failed {
+                kind: ErrorKind::ManifestPush,
+                error: "timeout".into(),
+                retries: 2,
+            },
+            0,
+        );
+        progress.image_completed(&result);
+        assert!(progress.bars.borrow().is_empty());
+    }
+
+    #[test]
+    fn bar_image_completed_synced_v0_clears() {
+        let (progress, _stdout) = test_bar_progress(0);
+        progress.image_started("source/repo:v1", "target/repo:v1");
+        let result = make_result(ImageStatus::Synced, 1024);
+        progress.image_completed(&result);
+        assert!(progress.bars.borrow().is_empty());
+    }
+
+    #[test]
+    fn bar_image_completed_synced_v1_finishes() {
+        let (progress, _stdout) = test_bar_progress(1);
+        progress.image_started("source/repo:v1", "target/repo:v1");
+        let result = make_result(ImageStatus::Synced, 187_000_000);
+        progress.image_completed(&result);
+        assert!(progress.bars.borrow().is_empty());
+    }
+
+    #[test]
+    fn bar_image_completed_skipped_v0_clears() {
+        let (progress, _stdout) = test_bar_progress(0);
+        progress.image_started("source/repo:v1", "target/repo:v1");
+        let result = make_result(
+            ImageStatus::Skipped {
+                reason: SkipReason::DigestMatch,
+            },
+            0,
+        );
+        progress.image_completed(&result);
+        assert!(progress.bars.borrow().is_empty());
+    }
+
+    #[test]
+    fn bar_image_completed_skipped_v1_finishes() {
+        let (progress, _stdout) = test_bar_progress(1);
+        progress.image_started("source/repo:v1", "target/repo:v1");
+        let result = make_result(
+            ImageStatus::Skipped {
+                reason: SkipReason::DigestMatch,
+            },
+            0,
+        );
+        progress.image_completed(&result);
+        assert!(progress.bars.borrow().is_empty());
+    }
+
+    #[test]
+    fn bar_image_completed_missing_key_does_not_panic() {
+        let (progress, _stdout) = test_bar_progress(0);
+        // No image_started — should warn, not panic.
+        let result = make_result(ImageStatus::Synced, 1024);
+        progress.image_completed(&result);
+        assert!(progress.bars.borrow().is_empty());
+    }
+
+    #[test]
+    fn bar_run_completed_writes_summary() {
+        let (progress, stdout) = test_bar_progress(0);
+        let report = make_report(vec![make_result(ImageStatus::Synced, 1024)]);
+        progress.run_completed(&report);
+        let output = String::from_utf8(stdout.borrow().clone()).unwrap();
+        assert_eq!(
+            output,
+            "sync complete: 3 synced, 47 skipped, 1 failed | blobs: 12 transferred, 0 skipped, 34 mounted | 432.0 MB in 47s\n"
+        );
+    }
+
+    #[test]
+    fn bar_run_completed_suppressed() {
+        let (progress, stdout) = test_bar_progress_with_suppress(0, true);
+        let report = make_report(vec![make_result(ImageStatus::Synced, 1024)]);
+        progress.run_completed(&report);
+        assert!(stdout.borrow().is_empty());
+    }
+
+    #[test]
+    fn bar_run_completed_empty_report() {
+        let (progress, stdout) = test_bar_progress(0);
+        let report = SyncReport {
+            run_id: Uuid::now_v7(),
+            images: vec![],
+            stats: SyncStats::default(),
+            duration: Duration::ZERO,
+        };
+        progress.run_completed(&report);
+        assert!(stdout.borrow().is_empty());
+    }
+
+    #[test]
+    fn bar_all_cleaned_up_after_multiple_images() {
+        let (progress, _stdout) = test_bar_progress(1);
+        progress.image_started("source/a:v1", "target/a:v1");
+        progress.image_started("source/b:v1", "target/b:v1");
+
+        let mut r1 = make_result(ImageStatus::Synced, 1024);
+        r1.source = "source/a:v1".into();
+        r1.target = "target/a:v1".into();
+        progress.image_completed(&r1);
+
+        let mut r2 = make_result(
+            ImageStatus::Skipped {
+                reason: SkipReason::DigestMatch,
+            },
+            0,
+        );
+        r2.source = "source/b:v1".into();
+        r2.target = "target/b:v1".into();
+        progress.image_completed(&r2);
+
+        assert!(
+            progress.bars.borrow().is_empty(),
+            "all bars should be cleaned up"
         );
     }
 }

--- a/src/cli/progress.rs
+++ b/src/cli/progress.rs
@@ -7,7 +7,6 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::io::{self, Write};
-use std::time::Duration;
 
 #[cfg(test)]
 use indicatif::ProgressDrawTarget;
@@ -152,6 +151,7 @@ impl TextProgress {
 pub(crate) struct BarProgress {
     multi: MultiProgress,
     bars: RefCell<HashMap<String, ProgressBar>>,
+    style: ProgressStyle,
     verbosity: u8,
     suppress_summary: bool,
     stdout: RefCell<Box<dyn Write>>,
@@ -174,6 +174,7 @@ impl BarProgress {
         Self {
             multi: MultiProgress::new(),
             bars: RefCell::new(HashMap::new()),
+            style: Self::spinner_style(),
             verbosity,
             suppress_summary,
             stdout: RefCell::new(Box::new(io::stdout())),
@@ -187,10 +188,16 @@ impl BarProgress {
         Self {
             multi: MultiProgress::with_draw_target(ProgressDrawTarget::hidden()),
             bars: RefCell::new(HashMap::new()),
+            style: Self::spinner_style(),
             verbosity,
             suppress_summary,
             stdout: RefCell::new(stdout),
         }
+    }
+
+    /// Spinner style shared by all progress bars.
+    fn spinner_style() -> ProgressStyle {
+        ProgressStyle::with_template("{spinner:.cyan} {msg}").expect("hardcoded template is valid")
     }
 
     /// Build the map key for an image.
@@ -201,12 +208,9 @@ impl BarProgress {
 
 impl ProgressReporter for BarProgress {
     fn image_started(&self, source: &str, target: &str) {
-        let style = ProgressStyle::with_template("{spinner:.cyan} {msg}")
-            .expect("hardcoded template is valid");
         let pb = self.multi.add(ProgressBar::new_spinner());
-        pb.set_style(style);
+        pb.set_style(self.style.clone());
         pb.set_message(format!("syncing {source} -> {target}"));
-        pb.enable_steady_tick(Duration::from_millis(100));
         self.bars
             .borrow_mut()
             .insert(Self::bar_key(source, target), pb);
@@ -277,27 +281,6 @@ mod tests {
 
     type Buf = Rc<RefCell<Vec<u8>>>;
 
-    fn test_progress(verbosity: u8) -> (TextProgress, Buf, Buf) {
-        test_progress_with_suppress(verbosity, false)
-    }
-
-    fn test_progress_with_suppress(
-        verbosity: u8,
-        suppress_summary: bool,
-    ) -> (TextProgress, Buf, Buf) {
-        let stderr_buf = Rc::new(RefCell::new(Vec::new()));
-        let stdout_buf = Rc::new(RefCell::new(Vec::new()));
-
-        let progress = TextProgress::with_writers(
-            verbosity,
-            suppress_summary,
-            Box::new(RcWriter(Rc::clone(&stderr_buf))),
-            Box::new(RcWriter(Rc::clone(&stdout_buf))),
-        );
-
-        (progress, stderr_buf, stdout_buf)
-    }
-
     fn make_result(status: ImageStatus, bytes: u64) -> ImageResult {
         ImageResult {
             image_id: Uuid::now_v7(),
@@ -328,11 +311,10 @@ mod tests {
         }
     }
 
-    // -- image_completed tests --
+    // -- format_image_line tests (shared formatting logic) --
 
     #[test]
-    fn verbosity_0_prints_failed() {
-        let (progress, stderr, _stdout) = test_progress(0);
+    fn image_line_failed_always_returns_some() {
         let result = make_result(
             ImageStatus::Failed {
                 kind: ErrorKind::ManifestPush,
@@ -341,155 +323,292 @@ mod tests {
             },
             0,
         );
-        progress.image_completed(&result);
-        let output = String::from_utf8(stderr.borrow().clone()).unwrap();
-        assert!(
-            output.contains("FAILED"),
-            "should print FAILED, got: {output}"
-        );
-        assert!(
-            output.contains("manifest push"),
-            "should contain error kind"
-        );
-        assert!(
-            output.contains("connection refused"),
-            "should contain error message"
-        );
+        let line = format_image_line(&result, 0).expect("failed should always produce a line");
+        assert!(line.starts_with("FAILED  "), "got: {line}");
+        assert!(line.contains("manifest push"), "got: {line}");
+        assert!(line.contains("connection refused"), "got: {line}");
     }
 
     #[test]
-    fn verbosity_0_silent_on_synced() {
-        let (progress, stderr, _stdout) = test_progress(0);
+    fn image_line_failed_at_any_verbosity() {
+        let result = make_result(
+            ImageStatus::Failed {
+                kind: ErrorKind::BlobTransfer,
+                error: "timeout".into(),
+                retries: 1,
+            },
+            0,
+        );
+        // Failed lines appear at every verbosity level.
+        for v in [0, 1, 2, 255] {
+            assert!(
+                format_image_line(&result, v).is_some(),
+                "failed should produce a line at verbosity {v}"
+            );
+        }
+    }
+
+    #[test]
+    fn image_line_failed_with_empty_error() {
+        let result = make_result(
+            ImageStatus::Failed {
+                kind: ErrorKind::ManifestPull,
+                error: String::new(),
+                retries: 0,
+            },
+            0,
+        );
+        let line = format_image_line(&result, 0).unwrap();
+        assert!(line.contains("manifest pull: )"), "got: {line}");
+    }
+
+    #[test]
+    fn image_line_synced_v0_returns_none() {
         let result = make_result(ImageStatus::Synced, 187_000_000);
-        progress.image_completed(&result);
-        let output = stderr.borrow();
-        assert!(
-            output.is_empty(),
-            "verbosity 0 should not print synced images"
-        );
+        assert!(format_image_line(&result, 0).is_none());
     }
 
     #[test]
-    fn verbosity_0_silent_on_skipped() {
-        let (progress, stderr, _stdout) = test_progress(0);
+    fn image_line_synced_v1_includes_bytes_and_duration() {
+        let result = make_result(ImageStatus::Synced, 187_000_000);
+        let line = format_image_line(&result, 1).expect("synced at v1 should produce a line");
+        assert!(line.starts_with("synced  "), "got: {line}");
+        assert!(line.contains("187.0 MB"), "got: {line}");
+        assert!(line.contains("14s"), "got: {line}");
+    }
+
+    #[test]
+    fn image_line_synced_zero_bytes() {
+        let result = make_result(ImageStatus::Synced, 0);
+        let line = format_image_line(&result, 1).unwrap();
+        assert!(line.contains("0 B"), "got: {line}");
+    }
+
+    #[test]
+    fn image_line_skipped_v0_returns_none() {
         let result = make_result(
             ImageStatus::Skipped {
                 reason: SkipReason::DigestMatch,
             },
             0,
         );
-        progress.image_completed(&result);
-        let output = stderr.borrow();
-        assert!(
-            output.is_empty(),
-            "verbosity 0 should not print skipped images"
-        );
+        assert!(format_image_line(&result, 0).is_none());
     }
 
     #[test]
-    fn verbosity_1_prints_synced() {
-        let (progress, stderr, _stdout) = test_progress(1);
-        let result = make_result(ImageStatus::Synced, 187_000_000);
-        progress.image_completed(&result);
-        let output = String::from_utf8(stderr.borrow().clone()).unwrap();
-        assert!(
-            output.contains("synced"),
-            "should print synced, got: {output}"
-        );
-        assert!(
-            output.contains("187.0 MB"),
-            "should contain formatted bytes"
-        );
-    }
-
-    #[test]
-    fn verbosity_1_prints_skipped() {
-        let (progress, stderr, _stdout) = test_progress(1);
+    fn image_line_skipped_v1_includes_reason() {
         let result = make_result(
             ImageStatus::Skipped {
                 reason: SkipReason::DigestMatch,
             },
             0,
         );
-        progress.image_completed(&result);
-        let output = String::from_utf8(stderr.borrow().clone()).unwrap();
-        assert!(
-            output.contains("skipped"),
-            "should print skipped, got: {output}"
-        );
-        assert!(
-            output.contains("digest match"),
-            "should contain skip reason"
-        );
+        let line = format_image_line(&result, 1).expect("skipped at v1 should produce a line");
+        assert!(line.starts_with("skipped "), "got: {line}");
+        assert!(line.contains("digest match"), "got: {line}");
     }
 
     #[test]
-    fn verbosity_1_prints_skip_existing() {
-        let (progress, stderr, _stdout) = test_progress(1);
+    fn image_line_skip_existing_reason() {
         let result = make_result(
             ImageStatus::Skipped {
                 reason: SkipReason::SkipExisting,
             },
             0,
         );
-        progress.image_completed(&result);
-        let output = String::from_utf8(stderr.borrow().clone()).unwrap();
-        assert!(output.contains("skipped"), "should print skipped");
-        assert!(
-            output.contains("skip existing"),
-            "should contain skip existing reason"
+        let line = format_image_line(&result, 1).unwrap();
+        assert!(line.contains("skip existing"), "got: {line}");
+    }
+
+    #[test]
+    fn image_line_immutable_tag_reason() {
+        let result = make_result(
+            ImageStatus::Skipped {
+                reason: SkipReason::ImmutableTag,
+            },
+            0,
+        );
+        let line = format_image_line(&result, 1).unwrap();
+        assert!(line.starts_with("skipped "), "got: {line}");
+        assert!(line.contains("immutable tag"), "got: {line}");
+    }
+
+    #[test]
+    fn image_line_exact_format_synced() {
+        let result = make_result(ImageStatus::Synced, 432_000_000);
+        let line = format_image_line(&result, 1).unwrap();
+        assert_eq!(
+            line,
+            "synced  source/repo:v1 -> target/repo:v1  (432.0 MB, 14s)"
         );
     }
 
-    // -- run_completed tests --
+    #[test]
+    fn image_line_exact_format_failed() {
+        let result = make_result(
+            ImageStatus::Failed {
+                kind: ErrorKind::BlobTransfer,
+                error: "network error".into(),
+                retries: 2,
+            },
+            0,
+        );
+        let line = format_image_line(&result, 0).unwrap();
+        assert_eq!(
+            line,
+            "FAILED  source/repo:v1 -> target/repo:v1  (blob transfer: network error)"
+        );
+    }
+
+    // -- write_run_summary tests --
 
     #[test]
-    fn run_completed_prints_summary() {
-        let (progress, _stderr, stdout) = test_progress(0);
+    fn summary_exact_format() {
+        let buf: Buf = Rc::new(RefCell::new(Vec::new()));
+        let stdout: RefCell<Box<dyn Write>> = RefCell::new(Box::new(RcWriter(Rc::clone(&buf))));
+        let report = SyncReport {
+            run_id: Uuid::now_v7(),
+            images: vec![make_result(ImageStatus::Synced, 1024)],
+            stats: SyncStats {
+                images_synced: 3,
+                images_skipped: 47,
+                images_failed: 1,
+                blobs_transferred: 12,
+                blobs_skipped: 5,
+                blobs_mounted: 34,
+                bytes_transferred: 432_000_000,
+                ..SyncStats::default()
+            },
+            duration: Duration::from_secs(47),
+        };
+        write_run_summary(&stdout, &report, false);
+        let output = String::from_utf8(buf.borrow().clone()).unwrap();
+        assert_eq!(
+            output,
+            "sync complete: 3 synced, 47 skipped, 1 failed | blobs: 12 transferred, 5 skipped, 34 mounted | 432.0 MB in 47s\n"
+        );
+    }
+
+    #[test]
+    fn summary_with_discovery_stats() {
+        let buf: Buf = Rc::new(RefCell::new(Vec::new()));
+        let stdout: RefCell<Box<dyn Write>> = RefCell::new(Box::new(RcWriter(Rc::clone(&buf))));
+        let report = SyncReport {
+            run_id: Uuid::now_v7(),
+            images: vec![make_result(ImageStatus::Synced, 1024)],
+            stats: SyncStats {
+                images_synced: 3,
+                images_skipped: 47,
+                images_failed: 0,
+                blobs_transferred: 12,
+                blobs_skipped: 5,
+                blobs_mounted: 34,
+                bytes_transferred: 432_000_000,
+                discovery_cache_hits: 40,
+                discovery_cache_misses: 10,
+                discovery_head_failures: 2,
+                discovery_target_stale: 1,
+            },
+            duration: Duration::from_secs(47),
+        };
+        write_run_summary(&stdout, &report, false);
+        let output = String::from_utf8(buf.borrow().clone()).unwrap();
+        assert!(
+            output.contains("| discovery: 40 cached, 10 pulled"),
+            "got: {output}"
+        );
+    }
+
+    #[test]
+    fn summary_omits_discovery_when_zero() {
+        let buf: Buf = Rc::new(RefCell::new(Vec::new()));
+        let stdout: RefCell<Box<dyn Write>> = RefCell::new(Box::new(RcWriter(Rc::clone(&buf))));
         let report = make_report(vec![make_result(ImageStatus::Synced, 1024)]);
-        progress.run_completed(&report);
-        let output = String::from_utf8(stdout.borrow().clone()).unwrap();
-        assert!(
-            output.contains("sync complete:"),
-            "should print summary, got: {output}"
-        );
-        assert!(output.contains("3 synced"), "should contain synced count");
-        assert!(
-            output.contains("47 skipped"),
-            "should contain skipped count"
-        );
-        assert!(output.contains("1 failed"), "should contain failed count");
-        assert!(
-            output.contains("12 transferred"),
-            "should contain blobs transferred count"
-        );
-        assert!(
-            output.contains("0 skipped, 34 mounted"),
-            "should contain blobs_skipped and blobs_mounted in order"
-        );
-        assert!(
-            output.contains("432.0 MB"),
-            "should contain formatted bytes"
-        );
+        write_run_summary(&stdout, &report, false);
+        let output = String::from_utf8(buf.borrow().clone()).unwrap();
+        assert!(!output.contains("discovery"), "got: {output}");
     }
 
     #[test]
-    fn run_completed_empty_report_no_output() {
-        let (progress, _stderr, stdout) = test_progress(0);
+    fn summary_suppressed_produces_no_output() {
+        let buf: Buf = Rc::new(RefCell::new(Vec::new()));
+        let stdout: RefCell<Box<dyn Write>> = RefCell::new(Box::new(RcWriter(Rc::clone(&buf))));
+        let report = make_report(vec![make_result(ImageStatus::Synced, 1024)]);
+        write_run_summary(&stdout, &report, true);
+        assert!(buf.borrow().is_empty());
+    }
+
+    #[test]
+    fn summary_empty_report_produces_no_output() {
+        let buf: Buf = Rc::new(RefCell::new(Vec::new()));
+        let stdout: RefCell<Box<dyn Write>> = RefCell::new(Box::new(RcWriter(Rc::clone(&buf))));
         let report = SyncReport {
             run_id: Uuid::now_v7(),
             images: vec![],
             stats: SyncStats::default(),
             duration: Duration::ZERO,
         };
-        progress.run_completed(&report);
-        let output = stdout.borrow();
-        assert!(output.is_empty(), "empty report should produce no summary");
+        write_run_summary(&stdout, &report, false);
+        assert!(buf.borrow().is_empty());
+    }
+
+    // -- TextProgress tests (wiring: writes to correct streams) --
+
+    fn test_text_progress(verbosity: u8) -> (TextProgress, Buf, Buf) {
+        test_text_progress_with_suppress(verbosity, false)
+    }
+
+    fn test_text_progress_with_suppress(
+        verbosity: u8,
+        suppress_summary: bool,
+    ) -> (TextProgress, Buf, Buf) {
+        let stderr_buf = Rc::new(RefCell::new(Vec::new()));
+        let stdout_buf = Rc::new(RefCell::new(Vec::new()));
+        let progress = TextProgress::with_writers(
+            verbosity,
+            suppress_summary,
+            Box::new(RcWriter(Rc::clone(&stderr_buf))),
+            Box::new(RcWriter(Rc::clone(&stdout_buf))),
+        );
+        (progress, stderr_buf, stdout_buf)
     }
 
     #[test]
-    fn stream_separation_failed_stderr_summary_stdout() {
-        let (progress, stderr, stdout) = test_progress(0);
+    fn text_image_completed_writes_to_stderr() {
+        let (progress, stderr, _stdout) = test_text_progress(1);
+        let result = make_result(ImageStatus::Synced, 187_000_000);
+        progress.image_completed(&result);
+        let output = String::from_utf8(stderr.borrow().clone()).unwrap();
+        assert!(output.starts_with("synced  "), "got: {output}");
+    }
+
+    #[test]
+    fn text_image_completed_silent_at_v0() {
+        let (progress, stderr, _stdout) = test_text_progress(0);
+        let result = make_result(ImageStatus::Synced, 187_000_000);
+        progress.image_completed(&result);
+        assert!(stderr.borrow().is_empty());
+    }
+
+    #[test]
+    fn text_failed_always_writes_to_stderr() {
+        let (progress, stderr, _stdout) = test_text_progress(0);
+        let result = make_result(
+            ImageStatus::Failed {
+                kind: ErrorKind::ManifestPush,
+                error: "timeout".into(),
+                retries: 2,
+            },
+            0,
+        );
+        progress.image_completed(&result);
+        let output = String::from_utf8(stderr.borrow().clone()).unwrap();
+        assert!(output.starts_with("FAILED  "), "got: {output}");
+    }
+
+    #[test]
+    fn text_stream_separation() {
+        let (progress, stderr, stdout) = test_text_progress(0);
         let failed = make_result(
             ImageStatus::Failed {
                 kind: ErrorKind::ManifestPull,
@@ -506,10 +625,11 @@ mod tests {
         let stderr_text = String::from_utf8(stderr.borrow().clone()).unwrap();
         let stdout_text = String::from_utf8(stdout.borrow().clone()).unwrap();
 
+        // Per-image output on stderr, summary on stdout, never crossed.
         assert!(stderr_text.contains("FAILED"), "FAILED should be on stderr");
         assert!(
             !stdout_text.contains("FAILED"),
-            "FAILED should NOT be on stdout"
+            "FAILED must NOT be on stdout"
         );
         assert!(
             stdout_text.contains("sync complete:"),
@@ -517,13 +637,13 @@ mod tests {
         );
         assert!(
             !stderr_text.contains("sync complete:"),
-            "summary should NOT be on stderr"
+            "summary must NOT be on stderr"
         );
     }
 
     #[test]
-    fn multiple_images_mixed_status() {
-        let (progress, stderr, _stdout) = test_progress(1);
+    fn text_multiple_images_mixed_status() {
+        let (progress, stderr, _stdout) = test_text_progress(1);
 
         progress.image_completed(&make_result(ImageStatus::Synced, 100_000_000));
         progress.image_completed(&make_result(ImageStatus::Synced, 200_000_000));
@@ -544,115 +664,23 @@ mod tests {
 
         let output = String::from_utf8(stderr.borrow().clone()).unwrap();
         let lines: Vec<&str> = output.lines().collect();
-        let synced_lines = lines.iter().filter(|l| l.starts_with("synced  ")).count();
-        let skipped_lines = lines.iter().filter(|l| l.starts_with("skipped ")).count();
-        let failed_lines = lines.iter().filter(|l| l.starts_with("FAILED  ")).count();
-        assert_eq!(synced_lines, 2, "should have 2 synced lines");
-        assert_eq!(skipped_lines, 1, "should have 1 skipped line");
-        assert_eq!(failed_lines, 1, "should have 1 FAILED line");
-    }
-
-    #[test]
-    fn verbosity_1_prints_immutable_tag_skip() {
-        let (progress, stderr, _stdout) = test_progress(1);
-        let result = make_result(
-            ImageStatus::Skipped {
-                reason: SkipReason::ImmutableTag,
-            },
-            0,
-        );
-        progress.image_completed(&result);
-        let output = String::from_utf8(stderr.borrow().clone()).unwrap();
-        assert!(output.starts_with("skipped "), "should print skipped");
-        assert!(
-            output.contains("immutable tag"),
-            "should contain immutable tag reason"
-        );
-    }
-
-    #[test]
-    fn run_completed_exact_format() {
-        let (progress, _stderr, stdout) = test_progress(0);
-        let report = SyncReport {
-            run_id: Uuid::now_v7(),
-            images: vec![make_result(ImageStatus::Synced, 1024)],
-            stats: SyncStats {
-                images_synced: 3,
-                images_skipped: 47,
-                images_failed: 1,
-                blobs_transferred: 12,
-                blobs_skipped: 5,
-                blobs_mounted: 34,
-                bytes_transferred: 432_000_000,
-                ..SyncStats::default()
-            },
-            duration: Duration::from_secs(47),
-        };
-        progress.run_completed(&report);
-        let output = String::from_utf8(stdout.borrow().clone()).unwrap();
         assert_eq!(
-            output,
-            "sync complete: 3 synced, 47 skipped, 1 failed | blobs: 12 transferred, 5 skipped, 34 mounted | 432.0 MB in 47s\n"
+            lines.iter().filter(|l| l.starts_with("synced  ")).count(),
+            2
+        );
+        assert_eq!(
+            lines.iter().filter(|l| l.starts_with("skipped ")).count(),
+            1
+        );
+        assert_eq!(
+            lines.iter().filter(|l| l.starts_with("FAILED  ")).count(),
+            1
         );
     }
 
     #[test]
-    fn run_completed_with_discovery_stats() {
-        let (progress, _stderr, stdout) = test_progress(0);
-        let report = SyncReport {
-            run_id: Uuid::now_v7(),
-            images: vec![make_result(ImageStatus::Synced, 1024)],
-            stats: SyncStats {
-                images_synced: 3,
-                images_skipped: 47,
-                images_failed: 0,
-                blobs_transferred: 12,
-                blobs_skipped: 5,
-                blobs_mounted: 34,
-                bytes_transferred: 432_000_000,
-                discovery_cache_hits: 40,
-                discovery_cache_misses: 10,
-                discovery_head_failures: 2,
-                discovery_target_stale: 1,
-            },
-            duration: Duration::from_secs(47),
-        };
-        progress.run_completed(&report);
-        let output = String::from_utf8(stdout.borrow().clone()).unwrap();
-        assert!(
-            output.contains("| discovery: 40 cached, 10 pulled"),
-            "should include discovery stats, got: {output}"
-        );
-    }
-
-    #[test]
-    fn run_completed_omits_discovery_when_zero() {
-        let (progress, _stderr, stdout) = test_progress(0);
-        let report = make_report(vec![make_result(ImageStatus::Synced, 1024)]);
-        progress.run_completed(&report);
-        let output = String::from_utf8(stdout.borrow().clone()).unwrap();
-        assert!(
-            !output.contains("discovery"),
-            "should omit discovery stats when zero, got: {output}"
-        );
-    }
-
-    // -- suppress_summary tests --
-
-    #[test]
-    fn run_completed_suppressed_when_flag_set() {
-        let (progress, _stderr, stdout) = test_progress_with_suppress(0, true);
-        let report = make_report(vec![make_result(ImageStatus::Synced, 1024)]);
-        progress.run_completed(&report);
-        assert!(
-            stdout.borrow().is_empty(),
-            "suppress_summary should suppress summary on stdout"
-        );
-    }
-
-    #[test]
-    fn suppress_summary_still_prints_failures_to_stderr() {
-        let (progress, stderr, stdout) = test_progress_with_suppress(0, true);
+    fn text_suppress_summary_still_prints_failures() {
+        let (progress, stderr, stdout) = test_text_progress_with_suppress(0, true);
         let result = make_result(
             ImageStatus::Failed {
                 kind: ErrorKind::ManifestPush,
@@ -662,45 +690,38 @@ mod tests {
             0,
         );
         progress.image_completed(&result);
-        let stderr_text = String::from_utf8(stderr.borrow().clone()).unwrap();
+
+        let report = make_report(vec![make_result(ImageStatus::Synced, 1024)]);
+        progress.run_completed(&report);
+
         assert!(
-            stderr_text.contains("FAILED"),
-            "suppress_summary should still print failures to stderr"
+            !stderr.borrow().is_empty(),
+            "failures should still go to stderr"
         );
         assert!(
             stdout.borrow().is_empty(),
-            "suppress_summary should not write to stdout on image_completed"
+            "suppress_summary should suppress stdout"
         );
     }
 
-    // -- BarProgress tests --
+    // -- BarProgress tests (wiring: bar lifecycle and summary output) --
 
     fn test_bar_progress(verbosity: u8) -> (BarProgress, Buf) {
-        test_bar_progress_with_suppress(verbosity, false)
-    }
-
-    fn test_bar_progress_with_suppress(
-        verbosity: u8,
-        suppress_summary: bool,
-    ) -> (BarProgress, Buf) {
         let stdout_buf = Rc::new(RefCell::new(Vec::new()));
-        let progress = BarProgress::with_writers(
-            verbosity,
-            suppress_summary,
-            Box::new(RcWriter(Rc::clone(&stdout_buf))),
-        );
+        let progress =
+            BarProgress::with_writers(verbosity, false, Box::new(RcWriter(Rc::clone(&stdout_buf))));
         (progress, stdout_buf)
     }
 
     #[test]
-    fn bar_image_started_creates_bar() {
+    fn bar_started_creates_entry() {
         let (progress, _stdout) = test_bar_progress(0);
         progress.image_started("source/repo:v1", "target/repo:v1");
         assert_eq!(progress.bars.borrow().len(), 1);
     }
 
     #[test]
-    fn bar_image_started_multiple_images() {
+    fn bar_started_multiple_creates_multiple() {
         let (progress, _stdout) = test_bar_progress(0);
         progress.image_started("source/a:v1", "target/a:v1");
         progress.image_started("source/b:v1", "target/b:v1");
@@ -708,120 +729,38 @@ mod tests {
     }
 
     #[test]
-    fn bar_image_completed_removes_bar() {
+    fn bar_completed_removes_entry() {
         let (progress, _stdout) = test_bar_progress(0);
         progress.image_started("source/repo:v1", "target/repo:v1");
-        let result = make_result(ImageStatus::Synced, 1024);
-        progress.image_completed(&result);
+        progress.image_completed(&make_result(ImageStatus::Synced, 1024));
         assert!(progress.bars.borrow().is_empty());
     }
 
     #[test]
-    fn bar_image_completed_failed_always_finishes_with_message() {
+    fn bar_completed_failed_removes_entry() {
         let (progress, _stdout) = test_bar_progress(0);
         progress.image_started("source/repo:v1", "target/repo:v1");
-        let result = make_result(
+        progress.image_completed(&make_result(
             ImageStatus::Failed {
                 kind: ErrorKind::ManifestPush,
                 error: "timeout".into(),
                 retries: 2,
             },
             0,
-        );
-        progress.image_completed(&result);
+        ));
         assert!(progress.bars.borrow().is_empty());
     }
 
     #[test]
-    fn bar_image_completed_synced_v0_clears() {
+    fn bar_completed_without_started_does_not_panic() {
         let (progress, _stdout) = test_bar_progress(0);
-        progress.image_started("source/repo:v1", "target/repo:v1");
-        let result = make_result(ImageStatus::Synced, 1024);
-        progress.image_completed(&result);
+        // No image_started — should warn and return, not panic.
+        progress.image_completed(&make_result(ImageStatus::Synced, 1024));
         assert!(progress.bars.borrow().is_empty());
     }
 
     #[test]
-    fn bar_image_completed_synced_v1_finishes() {
-        let (progress, _stdout) = test_bar_progress(1);
-        progress.image_started("source/repo:v1", "target/repo:v1");
-        let result = make_result(ImageStatus::Synced, 187_000_000);
-        progress.image_completed(&result);
-        assert!(progress.bars.borrow().is_empty());
-    }
-
-    #[test]
-    fn bar_image_completed_skipped_v0_clears() {
-        let (progress, _stdout) = test_bar_progress(0);
-        progress.image_started("source/repo:v1", "target/repo:v1");
-        let result = make_result(
-            ImageStatus::Skipped {
-                reason: SkipReason::DigestMatch,
-            },
-            0,
-        );
-        progress.image_completed(&result);
-        assert!(progress.bars.borrow().is_empty());
-    }
-
-    #[test]
-    fn bar_image_completed_skipped_v1_finishes() {
-        let (progress, _stdout) = test_bar_progress(1);
-        progress.image_started("source/repo:v1", "target/repo:v1");
-        let result = make_result(
-            ImageStatus::Skipped {
-                reason: SkipReason::DigestMatch,
-            },
-            0,
-        );
-        progress.image_completed(&result);
-        assert!(progress.bars.borrow().is_empty());
-    }
-
-    #[test]
-    fn bar_image_completed_missing_key_does_not_panic() {
-        let (progress, _stdout) = test_bar_progress(0);
-        // No image_started — should warn, not panic.
-        let result = make_result(ImageStatus::Synced, 1024);
-        progress.image_completed(&result);
-        assert!(progress.bars.borrow().is_empty());
-    }
-
-    #[test]
-    fn bar_run_completed_writes_summary() {
-        let (progress, stdout) = test_bar_progress(0);
-        let report = make_report(vec![make_result(ImageStatus::Synced, 1024)]);
-        progress.run_completed(&report);
-        let output = String::from_utf8(stdout.borrow().clone()).unwrap();
-        assert_eq!(
-            output,
-            "sync complete: 3 synced, 47 skipped, 1 failed | blobs: 12 transferred, 0 skipped, 34 mounted | 432.0 MB in 47s\n"
-        );
-    }
-
-    #[test]
-    fn bar_run_completed_suppressed() {
-        let (progress, stdout) = test_bar_progress_with_suppress(0, true);
-        let report = make_report(vec![make_result(ImageStatus::Synced, 1024)]);
-        progress.run_completed(&report);
-        assert!(stdout.borrow().is_empty());
-    }
-
-    #[test]
-    fn bar_run_completed_empty_report() {
-        let (progress, stdout) = test_bar_progress(0);
-        let report = SyncReport {
-            run_id: Uuid::now_v7(),
-            images: vec![],
-            stats: SyncStats::default(),
-            duration: Duration::ZERO,
-        };
-        progress.run_completed(&report);
-        assert!(stdout.borrow().is_empty());
-    }
-
-    #[test]
-    fn bar_all_cleaned_up_after_multiple_images() {
+    fn bar_multiple_images_all_cleaned_up() {
         let (progress, _stdout) = test_bar_progress(1);
         progress.image_started("source/a:v1", "target/a:v1");
         progress.image_started("source/b:v1", "target/b:v1");
@@ -841,9 +780,18 @@ mod tests {
         r2.target = "target/b:v1".into();
         progress.image_completed(&r2);
 
+        assert!(progress.bars.borrow().is_empty());
+    }
+
+    #[test]
+    fn bar_run_completed_writes_summary_to_stdout() {
+        let (progress, stdout) = test_bar_progress(0);
+        let report = make_report(vec![make_result(ImageStatus::Synced, 1024)]);
+        progress.run_completed(&report);
+        let output = String::from_utf8(stdout.borrow().clone()).unwrap();
         assert!(
-            progress.bars.borrow().is_empty(),
-            "all bars should be cleaned up"
+            output.starts_with("sync complete:"),
+            "summary should go to stdout, got: {output}"
         );
     }
 }

--- a/src/cli/progress.rs
+++ b/src/cli/progress.rs
@@ -23,6 +23,10 @@ use crate::cli::output::{format_bytes, format_duration};
 /// line only at verbosity >= 1.
 fn format_image_line(result: &ImageResult, verbosity: u8) -> Option<String> {
     match &result.status {
+        ImageStatus::Failed { kind, error, .. } if error.is_empty() => Some(format!(
+            "FAILED  {} -> {}  ({kind})",
+            result.source, result.target,
+        )),
         ImageStatus::Failed { kind, error, .. } => Some(format!(
             "FAILED  {} -> {}  ({kind}: {error})",
             result.source, result.target,
@@ -141,7 +145,7 @@ impl TextProgress {
 /// selection is made in `main.rs`, not here.
 pub(crate) struct TtyProgress {
     multi: MultiProgress,
-    spinners: RefCell<HashMap<String, ProgressBar>>,
+    spinners: RefCell<HashMap<(String, String), ProgressBar>>,
     style: ProgressStyle,
     verbosity: u8,
     suppress_summary: bool,
@@ -180,11 +184,6 @@ impl TtyProgress {
     fn spinner_style() -> ProgressStyle {
         ProgressStyle::with_template("{spinner:.cyan} {msg}").expect("hardcoded template is valid")
     }
-
-    /// Build the map key for an image.
-    fn spinner_key(source: &str, target: &str) -> String {
-        format!("{source} -> {target}")
-    }
 }
 
 impl ProgressReporter for TtyProgress {
@@ -194,11 +193,11 @@ impl ProgressReporter for TtyProgress {
         pb.set_message(format!("syncing {source} -> {target}"));
         self.spinners
             .borrow_mut()
-            .insert(Self::spinner_key(source, target), pb);
+            .insert((source.to_owned(), target.to_owned()), pb);
     }
 
     fn image_completed(&self, result: &ImageResult) {
-        let key = Self::spinner_key(&result.source, &result.target);
+        let key = (result.source.clone(), result.target.clone());
         let mut spinners = self.spinners.borrow_mut();
         let Some(pb) = spinners.remove(&key) else {
             tracing::warn!(
@@ -330,7 +329,7 @@ mod tests {
     }
 
     #[test]
-    fn image_line_failed_with_empty_error() {
+    fn image_line_failed_with_empty_error_omits_colon() {
         let result = make_result(
             ImageStatus::Failed {
                 kind: ErrorKind::ManifestPull,
@@ -340,7 +339,10 @@ mod tests {
             0,
         );
         let line = format_image_line(&result, 0).unwrap();
-        assert!(line.contains("manifest pull: )"), "got: {line}");
+        assert_eq!(
+            line,
+            "FAILED  source/repo:v1 -> target/repo:v1  (manifest pull)"
+        );
     }
 
     #[test]
@@ -526,6 +528,54 @@ mod tests {
     }
 
     #[test]
+    fn summary_with_only_cache_hits_includes_discovery() {
+        // Distinguishes the `||` from `&&` in the discovery condition:
+        // even when misses == 0, hits > 0 should show the discovery suffix.
+        let buf: Buf = Rc::new(RefCell::new(Vec::new()));
+        let stdout: RefCell<Box<dyn Write>> = RefCell::new(Box::new(RcWriter(Rc::clone(&buf))));
+        let report = SyncReport {
+            run_id: Uuid::now_v7(),
+            images: vec![make_result(ImageStatus::Synced, 1024)],
+            stats: SyncStats {
+                images_synced: 1,
+                discovery_cache_hits: 5,
+                discovery_cache_misses: 0,
+                ..SyncStats::default()
+            },
+            duration: Duration::from_secs(1),
+        };
+        write_run_summary(&stdout, &report, false);
+        let output = String::from_utf8(buf.borrow().clone()).unwrap();
+        assert!(
+            output.contains("discovery: 5 cached, 0 pulled"),
+            "got: {output}"
+        );
+    }
+
+    #[test]
+    fn summary_with_only_cache_misses_includes_discovery() {
+        let buf: Buf = Rc::new(RefCell::new(Vec::new()));
+        let stdout: RefCell<Box<dyn Write>> = RefCell::new(Box::new(RcWriter(Rc::clone(&buf))));
+        let report = SyncReport {
+            run_id: Uuid::now_v7(),
+            images: vec![make_result(ImageStatus::Synced, 1024)],
+            stats: SyncStats {
+                images_synced: 1,
+                discovery_cache_hits: 0,
+                discovery_cache_misses: 3,
+                ..SyncStats::default()
+            },
+            duration: Duration::from_secs(1),
+        };
+        write_run_summary(&stdout, &report, false);
+        let output = String::from_utf8(buf.borrow().clone()).unwrap();
+        assert!(
+            output.contains("discovery: 0 cached, 3 pulled"),
+            "got: {output}"
+        );
+    }
+
+    #[test]
     fn summary_suppressed_produces_no_output() {
         let buf: Buf = Rc::new(RefCell::new(Vec::new()));
         let stdout: RefCell<Box<dyn Write>> = RefCell::new(Box::new(RcWriter(Rc::clone(&buf))));
@@ -570,25 +620,44 @@ mod tests {
     }
 
     #[test]
+    fn text_image_started_is_noop() {
+        let (progress, stderr, stdout) = test_text_progress(1);
+        progress.image_started("source/repo:v1", "target/repo:v1");
+        assert!(
+            stderr.borrow().is_empty(),
+            "image_started should not write to stderr"
+        );
+        assert!(
+            stdout.borrow().is_empty(),
+            "image_started should not write to stdout"
+        );
+    }
+
+    #[test]
     fn text_image_completed_writes_to_stderr() {
-        let (progress, stderr, _stdout) = test_text_progress(1);
+        let (progress, stderr, stdout) = test_text_progress(1);
         let result = make_result(ImageStatus::Synced, 187_000_000);
         progress.image_completed(&result);
         let output = String::from_utf8(stderr.borrow().clone()).unwrap();
         assert!(output.starts_with("synced  "), "got: {output}");
+        assert!(
+            stdout.borrow().is_empty(),
+            "per-image output must NOT go to stdout"
+        );
     }
 
     #[test]
     fn text_image_completed_silent_at_v0() {
-        let (progress, stderr, _stdout) = test_text_progress(0);
+        let (progress, stderr, stdout) = test_text_progress(0);
         let result = make_result(ImageStatus::Synced, 187_000_000);
         progress.image_completed(&result);
         assert!(stderr.borrow().is_empty());
+        assert!(stdout.borrow().is_empty());
     }
 
     #[test]
     fn text_failed_always_writes_to_stderr() {
-        let (progress, stderr, _stdout) = test_text_progress(0);
+        let (progress, stderr, stdout) = test_text_progress(0);
         let result = make_result(
             ImageStatus::Failed {
                 kind: ErrorKind::ManifestPush,
@@ -600,6 +669,10 @@ mod tests {
         progress.image_completed(&result);
         let output = String::from_utf8(stderr.borrow().clone()).unwrap();
         assert!(output.starts_with("FAILED  "), "got: {output}");
+        assert!(
+            stdout.borrow().is_empty(),
+            "per-image output must NOT go to stdout"
+        );
     }
 
     #[test]
@@ -700,9 +773,9 @@ mod tests {
         );
     }
 
-    // -- TtyProgress tests (wiring: bar lifecycle and summary output) --
+    // -- TtyProgress tests (wiring: spinner lifecycle and summary output) --
 
-    fn test_bar_progress(verbosity: u8) -> (TtyProgress, Buf) {
+    fn test_tty_progress(verbosity: u8) -> (TtyProgress, Buf) {
         let stdout_buf = Rc::new(RefCell::new(Vec::new()));
         let progress =
             TtyProgress::with_writers(verbosity, false, Box::new(RcWriter(Rc::clone(&stdout_buf))));
@@ -710,31 +783,31 @@ mod tests {
     }
 
     #[test]
-    fn bar_started_creates_entry() {
-        let (progress, _stdout) = test_bar_progress(0);
+    fn tty_started_creates_entry() {
+        let (progress, _stdout) = test_tty_progress(0);
         progress.image_started("source/repo:v1", "target/repo:v1");
         assert_eq!(progress.spinners.borrow().len(), 1);
     }
 
     #[test]
-    fn bar_started_multiple_creates_multiple() {
-        let (progress, _stdout) = test_bar_progress(0);
+    fn tty_started_multiple_creates_multiple() {
+        let (progress, _stdout) = test_tty_progress(0);
         progress.image_started("source/a:v1", "target/a:v1");
         progress.image_started("source/b:v1", "target/b:v1");
         assert_eq!(progress.spinners.borrow().len(), 2);
     }
 
     #[test]
-    fn bar_completed_removes_entry() {
-        let (progress, _stdout) = test_bar_progress(0);
+    fn tty_completed_removes_entry() {
+        let (progress, _stdout) = test_tty_progress(0);
         progress.image_started("source/repo:v1", "target/repo:v1");
         progress.image_completed(&make_result(ImageStatus::Synced, 1024));
         assert!(progress.spinners.borrow().is_empty());
     }
 
     #[test]
-    fn bar_completed_failed_removes_entry() {
-        let (progress, _stdout) = test_bar_progress(0);
+    fn tty_completed_failed_removes_entry() {
+        let (progress, _stdout) = test_tty_progress(0);
         progress.image_started("source/repo:v1", "target/repo:v1");
         progress.image_completed(&make_result(
             ImageStatus::Failed {
@@ -748,16 +821,16 @@ mod tests {
     }
 
     #[test]
-    fn bar_completed_without_started_does_not_panic() {
-        let (progress, _stdout) = test_bar_progress(0);
+    fn tty_completed_without_started_does_not_panic() {
+        let (progress, _stdout) = test_tty_progress(0);
         // No image_started — should warn and return, not panic.
         progress.image_completed(&make_result(ImageStatus::Synced, 1024));
         assert!(progress.spinners.borrow().is_empty());
     }
 
     #[test]
-    fn bar_multiple_images_all_cleaned_up() {
-        let (progress, _stdout) = test_bar_progress(1);
+    fn tty_multiple_images_all_cleaned_up() {
+        let (progress, _stdout) = test_tty_progress(1);
         progress.image_started("source/a:v1", "target/a:v1");
         progress.image_started("source/b:v1", "target/b:v1");
 
@@ -781,7 +854,7 @@ mod tests {
 
     #[test]
     fn tty_run_completed_writes_summary_to_stdout() {
-        let (progress, stdout) = test_bar_progress(0);
+        let (progress, stdout) = test_tty_progress(0);
         let report = make_report(vec![make_result(ImageStatus::Synced, 1024)]);
         progress.run_completed(&report);
         let output = String::from_utf8(stdout.borrow().clone()).unwrap();
@@ -803,4 +876,47 @@ mod tests {
             "suppress_summary should suppress stdout"
         );
     }
+
+    #[test]
+    fn tty_suppress_summary_still_runs_spinners() {
+        // Spinner lifecycle must work even when summary is suppressed
+        // (e.g., --json mode). Spinners go to stderr, summary to stdout —
+        // suppressing stdout must not interfere with spinner create/remove.
+        let stdout_buf = Rc::new(RefCell::new(Vec::new()));
+        let progress =
+            TtyProgress::with_writers(0, true, Box::new(RcWriter(Rc::clone(&stdout_buf))));
+
+        progress.image_started("source/repo:v1", "target/repo:v1");
+        assert_eq!(progress.spinners.borrow().len(), 1);
+
+        progress.image_completed(&make_result(ImageStatus::Synced, 1024));
+        assert!(progress.spinners.borrow().is_empty());
+
+        let report = make_report(vec![make_result(ImageStatus::Synced, 1024)]);
+        progress.run_completed(&report);
+        assert!(
+            stdout_buf.borrow().is_empty(),
+            "suppress_summary should suppress stdout"
+        );
+    }
+
+    #[test]
+    fn tty_started_same_image_twice_overwrites() {
+        // If image_started is called twice for the same (source, target),
+        // the second spinner replaces the first. The map should still have
+        // exactly one entry, and image_completed should clean it up.
+        let (progress, _stdout) = test_tty_progress(0);
+        progress.image_started("source/repo:v1", "target/repo:v1");
+        progress.image_started("source/repo:v1", "target/repo:v1");
+        assert_eq!(progress.spinners.borrow().len(), 1);
+
+        progress.image_completed(&make_result(ImageStatus::Synced, 1024));
+        assert!(progress.spinners.borrow().is_empty());
+    }
+
+    // Note: spinner message content (the transient "syncing ..." text shown
+    // during in-flight transfers) cannot be asserted because indicatif's
+    // ProgressDrawTarget::hidden() swallows all rendering. The final message
+    // on completion uses format_image_line(), which IS thoroughly tested above.
+    // Only the cosmetic in-flight prefix is untested.
 }

--- a/src/cli/progress.rs
+++ b/src/cli/progress.rs
@@ -1,7 +1,7 @@
 //! Verbosity-aware progress reporters for sync output.
 //!
 //! [`TextProgress`] writes plain status lines to stderr (non-TTY).
-//! [`BarProgress`] shows `indicatif` spinners on stderr (TTY).
+//! [`TtyProgress`] shows `indicatif` spinners on stderr (TTY).
 //! Both write the run summary to stdout.
 
 use std::cell::RefCell;
@@ -99,15 +99,6 @@ pub(crate) struct TextProgress {
     stdout: RefCell<Box<dyn Write>>,
 }
 
-impl std::fmt::Debug for TextProgress {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("TextProgress")
-            .field("verbosity", &self.verbosity)
-            .field("suppress_summary", &self.suppress_summary)
-            .finish_non_exhaustive()
-    }
-}
-
 impl TextProgress {
     /// Create a new text progress reporter writing to real stderr/stdout.
     ///
@@ -148,32 +139,22 @@ impl TextProgress {
 ///
 /// Falls back to [`TextProgress`] when stderr is not a terminal — the
 /// selection is made in `main.rs`, not here.
-pub(crate) struct BarProgress {
+pub(crate) struct TtyProgress {
     multi: MultiProgress,
-    bars: RefCell<HashMap<String, ProgressBar>>,
+    spinners: RefCell<HashMap<String, ProgressBar>>,
     style: ProgressStyle,
     verbosity: u8,
     suppress_summary: bool,
     stdout: RefCell<Box<dyn Write>>,
 }
 
-impl std::fmt::Debug for BarProgress {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("BarProgress")
-            .field("verbosity", &self.verbosity)
-            .field("suppress_summary", &self.suppress_summary)
-            .field("active_bars", &self.bars.borrow().len())
-            .finish_non_exhaustive()
-    }
-}
-
-impl BarProgress {
-    /// Create a new bar progress reporter writing spinners to stderr
+impl TtyProgress {
+    /// Create a new TTY progress reporter writing spinners to stderr
     /// and the run summary to stdout.
     pub(crate) fn new(verbosity: u8, suppress_summary: bool) -> Self {
         Self {
             multi: MultiProgress::new(),
-            bars: RefCell::new(HashMap::new()),
+            spinners: RefCell::new(HashMap::new()),
             style: Self::spinner_style(),
             verbosity,
             suppress_summary,
@@ -181,13 +162,13 @@ impl BarProgress {
         }
     }
 
-    /// Create a bar progress reporter with a hidden draw target and
+    /// Create a TTY progress reporter with a hidden draw target and
     /// custom stdout writer (for testing).
     #[cfg(test)]
     fn with_writers(verbosity: u8, suppress_summary: bool, stdout: Box<dyn Write>) -> Self {
         Self {
             multi: MultiProgress::with_draw_target(ProgressDrawTarget::hidden()),
-            bars: RefCell::new(HashMap::new()),
+            spinners: RefCell::new(HashMap::new()),
             style: Self::spinner_style(),
             verbosity,
             suppress_summary,
@@ -195,31 +176,31 @@ impl BarProgress {
         }
     }
 
-    /// Spinner style shared by all progress bars.
+    /// Spinner style shared by all spinners.
     fn spinner_style() -> ProgressStyle {
         ProgressStyle::with_template("{spinner:.cyan} {msg}").expect("hardcoded template is valid")
     }
 
     /// Build the map key for an image.
-    fn bar_key(source: &str, target: &str) -> String {
+    fn spinner_key(source: &str, target: &str) -> String {
         format!("{source} -> {target}")
     }
 }
 
-impl ProgressReporter for BarProgress {
+impl ProgressReporter for TtyProgress {
     fn image_started(&self, source: &str, target: &str) {
         let pb = self.multi.add(ProgressBar::new_spinner());
         pb.set_style(self.style.clone());
         pb.set_message(format!("syncing {source} -> {target}"));
-        self.bars
+        self.spinners
             .borrow_mut()
-            .insert(Self::bar_key(source, target), pb);
+            .insert(Self::spinner_key(source, target), pb);
     }
 
     fn image_completed(&self, result: &ImageResult) {
-        let key = Self::bar_key(&result.source, &result.target);
-        let mut bars = self.bars.borrow_mut();
-        let Some(pb) = bars.remove(&key) else {
+        let key = Self::spinner_key(&result.source, &result.target);
+        let mut spinners = self.spinners.borrow_mut();
+        let Some(pb) = spinners.remove(&key) else {
             tracing::warn!(
                 source = %result.source,
                 target = %result.target,
@@ -460,6 +441,21 @@ mod tests {
         );
     }
 
+    #[test]
+    fn image_line_exact_format_skipped() {
+        let result = make_result(
+            ImageStatus::Skipped {
+                reason: SkipReason::DigestMatch,
+            },
+            0,
+        );
+        let line = format_image_line(&result, 1).unwrap();
+        assert_eq!(
+            line,
+            "skipped source/repo:v1 -> target/repo:v1  (digest match)"
+        );
+    }
+
     // -- write_run_summary tests --
 
     #[test]
@@ -513,9 +509,9 @@ mod tests {
         };
         write_run_summary(&stdout, &report, false);
         let output = String::from_utf8(buf.borrow().clone()).unwrap();
-        assert!(
-            output.contains("| discovery: 40 cached, 10 pulled"),
-            "got: {output}"
+        assert_eq!(
+            output,
+            "sync complete: 3 synced, 47 skipped, 0 failed | blobs: 12 transferred, 5 skipped, 34 mounted | 432.0 MB in 47s | discovery: 40 cached, 10 pulled\n"
         );
     }
 
@@ -704,12 +700,12 @@ mod tests {
         );
     }
 
-    // -- BarProgress tests (wiring: bar lifecycle and summary output) --
+    // -- TtyProgress tests (wiring: bar lifecycle and summary output) --
 
-    fn test_bar_progress(verbosity: u8) -> (BarProgress, Buf) {
+    fn test_bar_progress(verbosity: u8) -> (TtyProgress, Buf) {
         let stdout_buf = Rc::new(RefCell::new(Vec::new()));
         let progress =
-            BarProgress::with_writers(verbosity, false, Box::new(RcWriter(Rc::clone(&stdout_buf))));
+            TtyProgress::with_writers(verbosity, false, Box::new(RcWriter(Rc::clone(&stdout_buf))));
         (progress, stdout_buf)
     }
 
@@ -717,7 +713,7 @@ mod tests {
     fn bar_started_creates_entry() {
         let (progress, _stdout) = test_bar_progress(0);
         progress.image_started("source/repo:v1", "target/repo:v1");
-        assert_eq!(progress.bars.borrow().len(), 1);
+        assert_eq!(progress.spinners.borrow().len(), 1);
     }
 
     #[test]
@@ -725,7 +721,7 @@ mod tests {
         let (progress, _stdout) = test_bar_progress(0);
         progress.image_started("source/a:v1", "target/a:v1");
         progress.image_started("source/b:v1", "target/b:v1");
-        assert_eq!(progress.bars.borrow().len(), 2);
+        assert_eq!(progress.spinners.borrow().len(), 2);
     }
 
     #[test]
@@ -733,7 +729,7 @@ mod tests {
         let (progress, _stdout) = test_bar_progress(0);
         progress.image_started("source/repo:v1", "target/repo:v1");
         progress.image_completed(&make_result(ImageStatus::Synced, 1024));
-        assert!(progress.bars.borrow().is_empty());
+        assert!(progress.spinners.borrow().is_empty());
     }
 
     #[test]
@@ -748,7 +744,7 @@ mod tests {
             },
             0,
         ));
-        assert!(progress.bars.borrow().is_empty());
+        assert!(progress.spinners.borrow().is_empty());
     }
 
     #[test]
@@ -756,7 +752,7 @@ mod tests {
         let (progress, _stdout) = test_bar_progress(0);
         // No image_started — should warn and return, not panic.
         progress.image_completed(&make_result(ImageStatus::Synced, 1024));
-        assert!(progress.bars.borrow().is_empty());
+        assert!(progress.spinners.borrow().is_empty());
     }
 
     #[test]
@@ -780,11 +776,11 @@ mod tests {
         r2.target = "target/b:v1".into();
         progress.image_completed(&r2);
 
-        assert!(progress.bars.borrow().is_empty());
+        assert!(progress.spinners.borrow().is_empty());
     }
 
     #[test]
-    fn bar_run_completed_writes_summary_to_stdout() {
+    fn tty_run_completed_writes_summary_to_stdout() {
         let (progress, stdout) = test_bar_progress(0);
         let report = make_report(vec![make_result(ImageStatus::Synced, 1024)]);
         progress.run_completed(&report);
@@ -792,6 +788,19 @@ mod tests {
         assert!(
             output.starts_with("sync complete:"),
             "summary should go to stdout, got: {output}"
+        );
+    }
+
+    #[test]
+    fn tty_suppress_summary_produces_no_stdout() {
+        let stdout_buf = Rc::new(RefCell::new(Vec::new()));
+        let progress =
+            TtyProgress::with_writers(0, true, Box::new(RcWriter(Rc::clone(&stdout_buf))));
+        let report = make_report(vec![make_result(ImageStatus::Synced, 1024)]);
+        progress.run_completed(&report);
+        assert!(
+            stdout_buf.borrow().is_empty(),
+            "suppress_summary should suppress stdout"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -310,7 +310,7 @@ async fn main() -> std::process::ExitCode {
     let progress: Box<dyn ocync_sync::progress::ProgressReporter> = if cli.quiet {
         Box::new(NullProgress)
     } else if std::io::stderr().is_terminal() {
-        Box::new(cli::progress::BarProgress::new(
+        Box::new(cli::progress::TtyProgress::new(
             effective_verbosity,
             suppress_summary,
         ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,8 +74,8 @@ const WATCH_LONG_ABOUT: &str = "\
 Run sync continuously on a recurring schedule
 
 Runs the sync operation in a loop at the configured interval. Handles graceful
-shutdown on SIGINT/SIGTERM. Exposes a /healthz endpoint for Kubernetes liveness
-probes.
+shutdown on SIGINT/SIGTERM. Exposes /healthz (liveness) and /readyz (readiness)
+endpoints for Kubernetes probes.
 
 Examples:
   ocync watch -c config.yaml

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 
 mod cli;
 
+use std::io::IsTerminal as _;
 use std::path::PathBuf;
 
 use anstyle::{Ansi256Color, Color, Style};
@@ -308,6 +309,11 @@ async fn main() -> std::process::ExitCode {
 
     let progress: Box<dyn ocync_sync::progress::ProgressReporter> = if cli.quiet {
         Box::new(NullProgress)
+    } else if std::io::stderr().is_terminal() {
+        Box::new(cli::progress::BarProgress::new(
+            effective_verbosity,
+            suppress_summary,
+        ))
     } else {
         Box::new(cli::progress::TextProgress::new(
             effective_verbosity,


### PR DESCRIPTION
## Summary

- Split `/healthz` (liveness, always 200) and `/readyz` (readiness, 200 if last sync within `2 * interval`, 503 otherwise) for correct Kubernetes probe semantics
- Add `indicatif`-based `BarProgress` with per-image spinners on TTY stderr, falling back to `TextProgress` on non-TTY
- Extract shared helpers (`format_image_line`, `write_run_summary`) to deduplicate progress reporter formatting

## Test plan

- [ ] `cargo fmt --check && cargo clippy -- -D warnings && cargo test && cargo deny check` passes
- [ ] Health endpoint unit tests: `/healthz` always 200 (before sync, after sync, when stale), `/readyz` returns 503/200 based on staleness
- [ ] Health endpoint TCP integration tests exercise both endpoints over real connections
- [ ] BarProgress tests: bar creation, removal, all status variants at v0/v1 verbosity, missing-key edge case, summary output, suppression
- [ ] TTY detection: `BarProgress` when stderr is terminal, `TextProgress` otherwise, `NullProgress` when `--quiet`
- [ ] Manual: `ocync watch -c config.yaml` shows spinners in terminal, plain text when piped