### PR TITLE
feat: leader-follower mount election, blob concurrency, bench-remote

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ Every PR ships the smallest correct change + one test that catches regression. D
 - **Auth**: ECR private uses Basic auth (not Bearer token exchange); parse `WWW-Authenticate` dynamically, never hardcode
 - **Registry detection**: use `detect_provider_kind()` + `ProviderKind` enum; never match raw hostnames
 - **Process control**: return `ExitCode` via `Termination`; never `process::exit()`
+- **Concurrency model**: single-threaded tokio (`current_thread`). All shared state uses `Rc<RefCell<>>`, never `Arc<Mutex<>>`. `RefCell` borrows must be dropped before any `.await` point. Intra-image blob concurrency uses `FuturesUnordered` + local `Semaphore(6)`.
 
 ## Testing
 
@@ -41,6 +42,9 @@ Every PR ships the smallest correct change + one test that catches regression. D
 - Engine integration tests pass `Some(&shutdown)` (the production path) unless explicitly testing termination.
 - Mock trait impls must honor the real contract — filter inputs, assert context params (repo, registry) match expected values.
 - Concurrency tests run at `max_concurrent > 1`. Serializing a flaky concurrent test hides a race.
+- Mount-related integration tests must use symmetric mocks (both repos accept upload AND mount) since leader-follower election can pick either image as leader. Assert on aggregate stats, not per-image ordering.
+- `tokio::sync::Notify::notify_waiters()` does not store permits. Every code path that transitions a blob out of `InProgress` must call `notify_blob` or concurrent waiters deadlock. Same applies to `BlobStage::notify_staged`/`notify_failed` for source-pull dedup.
+- The greedy set-cover election in `elect_leaders` provably covers every shared blob. There is no "uncovered follower" path -- all followers' shared blobs are in the leader blob union. Do not add wave partitioning among followers; it is dead code.
 
 ## Git workflow
 
@@ -97,6 +101,7 @@ Codified in `xtask/src/bench/config_gen.rs`:
 - **dregsy** requires `auth-refresh: 12h` on ECR targets. Without it, dregsy skips the AWS SDK refresher and falls through to skopeo's fragile credential resolution.
 - **dregsy** requires `platform: all` per mapping for multi-arch copy. Without it, skopeo copies only the native platform — the comparison is not apples-to-apples.
 - **dregsy** exits 1 on any failed skopeo copy, even with 99% success. Parse per-image logs for real metrics, not exit code.
+- **Docker Hub auth** is read from two SSM parameters: `/ocync/bench/dockerhub-access-token` (PAT) and `/ocync/bench/dockerhub-username` (account name). Both are injected into all three tool configs. Docker Hub PATs require the account username that created the token; a wrong username causes 401.
 
 ### Baseline and optimization backlog
 
@@ -112,9 +117,13 @@ Prior dregsy results were invalid (1 platform instead of 2). Re-run with `platfo
 - **Leaf cert cache is sync.** `rustls::server::ResolvesServerCert::resolve` is called synchronously. Use `std::sync::RwLock`, not `tokio::sync::RwLock`.
 - **Proxy logs live in the output dir**, not the tempdir, so post-run analysis survives.
 - **Mount metrics** surface in `ProxyMetrics` as `mounts=<succ>/<attempt>` per tool for quick "is this code path cold" feedback.
+- **Source-pull metrics** `source_blob_gets` and `source_blob_bytes` in `ProxyMetrics` track blob GETs to non-target (source) registries. `aggregate()` takes `target_registry` to split by direction.
+- **Instance metadata** collected via IMDS (instance type, region) + `aws ec2 describe-instance-types` CLI (authoritative CPU/memory/network). Do NOT use `/proc/cpuinfo` (ARM lacks `model name`) or sysfs network speed (reports NIC link rate, not instance bandwidth). Do NOT add `aws-sdk-ec2` as a dependency (monolithic, 38G build artifacts).
+- **Historical archive** -- full `BenchReport` (Serialize) written to `bench-results/runs/{timestamp}.json` for cross-run comparison. Markdown `summary.md` has per-scenario metric tables with winners bolded.
 
 ### Known registry-specific behavior
 
-- **ECR never fulfills OCI cross-repo mount** (confirmed 2026-04-16, 193/193 POSTs returned 202). Short-circuit via `ProviderKind::fulfills_cross_repo_mount` saves 148 requests per 5-image cold sync, zero bytes — rate-limit optimization only. Applies to ECR private (measured) and ECR Public (inferred). See `docs/specs/findings.md` for evidence + re-validate procedure.
+- **ECR fulfills cross-repo mount when BLOB_MOUNTING=ENABLED** and source blob has a committed manifest. The mount short-circuit (`fulfills_cross_repo_mount`) was removed; all providers now attempt mount. Leader-follower election + wave promotion ensures mount sources have committed manifests.
+- **regsync cannot cross-repo mount in sync scenarios**: regclient only attempts `from=` when source and target share the same registry hostname (architectural limitation, not a config error).
 - **GHCR multi-PATCH chunked upload is broken** (each PATCH overwrites previous chunks). Client falls back to single-PATCH + PUT.
 - **GAR does not support chunked uploads.** Client buffers and uses monolithic upload.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.101.0"
+version = "1.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab41ad64e4051ecabeea802d6a17845a91e83287e1dd249e6963ea1ba78c428a"
+checksum = "0fc35b7a14cabdad13795fbbbd26d5ddec0882c01492ceedf2af575aad5f37dd"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -481,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.10.3"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
+checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -506,11 +506,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.6"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
+checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
@@ -519,6 +520,17 @@ dependencies = [
  "tokio",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3131,9 +3143,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -3492,11 +3504,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3505,7 +3517,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -3918,6 +3930,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,3 +73,9 @@ url.workspace = true
 
 [dev-dependencies]
 uuid.workspace = true
+
+[profile.release]
+strip = true
+lto = true
+codegen-units = 1
+panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/clowdhaus/ocync"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "credentials-process", "rt-tokio", "rustls", "sso"] }
 aws-lc-rs = { version = "1", default-features = false, features = ["aws-lc-sys"] }
 aws-sdk-ecr = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client"] }
-clap = { version = "4", default-features = false, features = ["derive", "std", "help", "usage", "error-context"] }
+clap = { version = "4", default-features = false, features = ["derive", "std", "help", "usage", "error-context", "env"] }
 bytes = { version = "1", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 http = { version = "1", default-features = false }

--- a/bench/CLAUDE.md
+++ b/bench/CLAUDE.md
@@ -2,114 +2,145 @@
 
 Benchmark infrastructure for comparing ocync against dregsy and regsync.
 
-## Instance access
+## Prerequisites
 
-- **Region**: us-east-1. Instance ID from `cd bench/terraform && terraform output instance_id`.
-- **Access**: SSM only (no public IP, no SSH key).
-- **Commands run as root** by default — always use `sudo -u ec2-user bash -lc "..."` for build/bench commands.
-- **SSM send-command** truncates output at 2500 chars. For long output, redirect to a file and read it back.
+- AWS credentials with ECR access + `ec2:DescribeInstanceTypes`
+- `session-manager-plugin` installed locally (for `bench-remote`)
+- SSM parameters populated:
+  - `/ocync/bench/github-token` -- GitHub PAT for git fetch (private repo)
+  - `/ocync/bench/dockerhub-access-token` -- Docker Hub PAT for authenticated pulls
+  - `/ocync/bench/dockerhub-username` -- Docker Hub account name
+
+## Quick start
 
 ```bash
-# Get instance ID
+# 1. Spin up the bench instance (if not already running)
+cd bench/terraform && terraform init && terraform apply
+
+# 2. Get the instance ID
 INSTANCE_ID=$(cd bench/terraform && terraform output -raw instance_id)
 
-# Quick command
-aws ssm send-command \
-  --instance-ids "$INSTANCE_ID" \
-  --document-name AWS-RunShellScript \
-  --parameters 'commands=["sudo -u ec2-user bash -lc \"cd ~/ocync && cargo xtask bench --help\""]' \
-  --region us-east-1 --output text --query 'Command.CommandId'
+# 3. Run benchmarks remotely (pushes code, builds, runs, streams live output)
+cargo xtask bench-remote --instance-id $INSTANCE_ID --scenario cold
 
-# Get output (wait a few seconds)
-aws ssm get-command-invocation \
-  --command-id <ID> --instance-id "$INSTANCE_ID" \
-  --region us-east-1 --query '[Status,StandardOutputContent,StandardErrorContent]' --output text
+# 4. Fetch results locally (automatic after bench-remote, or manually)
+cargo xtask bench-remote --fetch --instance-id $INSTANCE_ID
+
+# 5. Tear down when done
+cd bench/terraform && terraform destroy
 ```
 
-## Paths on instance
+## bench-remote
+
+Single command for the full benchmark cycle. Requires `session-manager-plugin`.
+
+```bash
+# Full 3-tool cold comparison (3 iterations, picks median)
+cargo xtask bench-remote --instance-id $INSTANCE_ID --scenario cold
+
+# Quick smoke test
+cargo xtask bench-remote --instance-id $INSTANCE_ID --scenario cold \
+  --tools ocync --iterations 1 --limit 3
+
+# All scenarios (cold + warm + partial + scale)
+cargo xtask bench-remote --instance-id $INSTANCE_ID --scenario all
+
+# Fetch results from the last run without re-running
+cargo xtask bench-remote --fetch --instance-id $INSTANCE_ID
+```
+
+The `--instance-id` can also be set via `BENCH_INSTANCE_ID` env var.
+
+**What it does:**
+1. `git push` the current branch
+2. Uploads a build+bench script to the instance via SSM send-command
+3. Opens an interactive SSM session (`start-session`) with live stdout
+4. On completion, fetches `summary.md` and the historical JSON archive
+
+**Output:**
+- `bench-results/<timestamp>/summary.md` -- human-readable comparison table with winners bolded
+- `bench-results/runs/<timestamp>.json` -- full machine-readable archive for historical comparison
+
+## Metrics captured per tool per scenario
+
+| Metric | Source | Winner = |
+|--------|--------|----------|
+| Wall clock | Process timing | lowest |
+| Peak RSS | `/usr/bin/time -v` (kernel maxrss) | lowest |
+| Requests | Bench-proxy JSONL | lowest |
+| Response bytes | Bench-proxy JSONL | lowest |
+| Source blob GETs | Bench-proxy (non-target host) | lowest |
+| Source blob bytes | Bench-proxy (non-target host) | lowest |
+| Mounts (success/attempt) | Bench-proxy (POST with mount=) | highest |
+| Duplicate blob GETs | Bench-proxy (same URL fetched twice) | lowest |
+| Rate-limit 429s | Bench-proxy (HTTP 429 responses) | lowest |
+
+Instance metadata (type, CPU, memory, network, region) is captured from `ec2:DescribeInstanceTypes` (authoritative, not /proc or sysfs).
+
+## Running on the instance directly
+
+If you prefer an interactive session instead of `bench-remote`:
+
+```bash
+# Connect
+aws ssm start-session --target $INSTANCE_ID --region us-east-1
+
+# On the instance:
+cd ~/ocync
+ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+export BENCH_TARGET_REGISTRY=${ACCOUNT}.dkr.ecr.us-east-1.amazonaws.com
+cargo xtask bench --tools ocync,dregsy,regsync --iterations 3 cold
+```
+
+## Instance details
 
 | What | Path |
 |------|------|
 | Source code | `/home/ec2-user/ocync/` |
-| Cargo binaries | `/home/ec2-user/.cargo/bin/` (ocync, bench-proxy) |
+| Cargo binaries | `/home/ec2-user/.cargo/bin/` |
 | Bench-proxy CA | `/etc/bench-proxy/ca.pem`, `/etc/bench-proxy/ca-key.pem` |
-| Competitor tools | `/usr/local/bin/dregsy`, `/usr/local/bin/regsync`, `/usr/local/bin/skopeo` |
-| Docker config | `/home/ec2-user/.docker/config.json` (ECR cred helper) |
+| Competitor tools | `/usr/local/bin/{dregsy,regsync,skopeo}` |
 | Results | `/home/ec2-user/ocync/bench-results/<timestamp>/` |
+| Historical archive | `/home/ec2-user/ocync/bench-results/runs/<timestamp>.json` |
 
-## Environment variables
+`BENCH_TARGET_REGISTRY` is set automatically by `bench-remote`. When running manually, derive it from `aws sts get-caller-identity`.
 
-`BENCH_TARGET_REGISTRY` must be set before running benchmarks. Derive it from the AWS account:
-
-```bash
-ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
-export BENCH_TARGET_REGISTRY=${ACCOUNT}.dkr.ecr.us-east-1.amazonaws.com
-```
-
-AWS credentials come from the instance profile (IAM role) — no manual config needed.
-
-Docker Hub access token (for authenticated pulls, avoids 10 pull/hr anonymous limit):
-- SSM parameter: `/ocync/bench/dockerhub-access-token`
-- Used for read/pull only
-
-## Running benchmarks
-
-```bash
-cd /home/ec2-user/ocync
-ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
-export BENCH_TARGET_REGISTRY=${ACCOUNT}.dkr.ecr.us-east-1.amazonaws.com
-
-# Quick smoke test (3 images, 1 iteration, ocync only)
-cargo xtask bench --tools ocync --iterations 1 --limit 3 cold
-
-# Full 3-tool comparison
-cargo xtask bench --tools ocync,dregsy,regsync --iterations 3 cold
-
-# Warm sync (cold prime + measured warm pass)
-cargo xtask bench --tools ocync,dregsy,regsync warm
-
-# All scenarios
-cargo xtask bench --tools ocync,dregsy,regsync all
-```
-
-The xtask harness handles: building ocync from source, starting bench-proxy (MITM), creating/deleting ECR repos, running tools, capturing proxy JSONL.
-
-## Updating source code on the instance
-
-The repo is private — git fetch needs a token from SSM Parameter Store (`/ocync/bench/github-token`). The `user-data.sh` bootstrap script clones with the token then strips it from the remote URL.
+## Updating source code manually
 
 ```bash
 cd /home/ec2-user/ocync
 GH_TOKEN=$(aws ssm get-parameter --name /ocync/bench/github-token --with-decryption --query Parameter.Value --output text)
 git remote set-url origin "https://${GH_TOKEN}@github.com/clowdhaus/ocync.git"
-git fetch origin && git checkout <branch>
+git fetch origin && git checkout <branch> && git reset --hard origin/<branch>
 git remote set-url origin https://github.com/clowdhaus/ocync.git
 cargo build --release --package ocync --package bench-proxy
 ```
 
-Note: `user-data.sh` hardcodes `benchmark-suite` branch for fresh bootstraps.
+## Instance lifecycle
+
+Managed by Terraform in `bench/terraform/`. `user_data_replace_on_change = true` -- bootstrap changes recreate the instance.
+
+```bash
+cd bench/terraform && terraform init && terraform apply   # create
+cd bench/terraform && terraform destroy                    # destroy
+```
+
+The IAM role includes: `AmazonEC2ContainerRegistryFullAccess`, `AmazonSSMManagedInstanceCore`, SSM parameter read, and `ec2:DescribeInstanceTypes`.
 
 ## Analyzing proxy logs
+
+Raw per-request data lives in `<tool>-proxy.jsonl` files in the results directory.
 
 ```bash
 # Count requests by method
 jq -r '.method' <tool>-proxy.jsonl | sort | uniq -c | sort -rn
 
-# Count blob HEAD 404s (wasted on cold sync)
-jq -r 'select(.method=="HEAD" and (.url | contains("/blobs/sha256:")) and .status==404)' <tool>-proxy.jsonl | wc -l
+# Source blob pulls only (non-ECR hosts)
+jq -r 'select(.method=="GET" and (.url | contains("/blobs/sha256:")) and (.host | contains("ecr") | not))' <tool>-proxy.jsonl | wc -l
 
-# Mount attempts
-grep '"mount"' <tool>-proxy.jsonl | wc -l
+# Mount attempts and success rate
+jq -r 'select(.url | contains("mount="))' <tool>-proxy.jsonl | jq -r '.status' | sort | uniq -c
 
 # Total response bytes
 jq '[.response_bytes] | add' <tool>-proxy.jsonl
-```
-
-## Instance lifecycle
-
-Managed by Terraform in `bench/terraform/`. `user_data_replace_on_change = true` — bootstrap changes recreate the instance.
-
-```bash
-cd bench/terraform && terraform init && terraform apply   # create
-cd bench/terraform && terraform destroy                    # destroy
 ```

--- a/bench/terraform/main.tf
+++ b/bench/terraform/main.tf
@@ -128,15 +128,27 @@ data "aws_caller_identity" "current" {}
 
 resource "aws_iam_policy" "bench_ssm_params" {
   name        = "ocync-bench-ssm-params"
-  description = "Allow reading benchmark SSM parameters"
+  description = "Allow reading benchmark SSM parameters and describing instance types"
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = ["ssm:GetParameter", "ssm:GetParameters"]
-      Resource = "arn:aws:ssm:us-east-1:${data.aws_caller_identity.current.account_id}:parameter/ocync/bench/*"
-    }]
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["ssm:GetParameter", "ssm:GetParameters"]
+        Resource = "arn:aws:ssm:us-east-1:${data.aws_caller_identity.current.account_id}:parameter/ocync/bench/*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["ec2:DescribeInstanceTypes"]
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["ecr-public:GetAuthorizationToken", "sts:GetServiceBearerToken"]
+        Resource = "*"
+      },
+    ]
   })
 
   tags = module.tags.tags

--- a/crates/ocync-sync/src/cache.rs
+++ b/crates/ocync-sync/src/cache.rs
@@ -155,15 +155,17 @@ impl TransferStateCache {
 
     /// Find a cross-repo mount source for a blob at a target.
     ///
-    /// Returns the alphabetically first repo at `target` that has `digest`
-    /// and is not `current_repo`, or `None` if no candidate exists.
+    /// Prefers repos in `preferred` (leader repos with committed manifests),
+    /// then falls back to the alphabetically first candidate.
     pub fn blob_mount_source<'a>(
         &'a self,
         target: &str,
         digest: &Digest,
         current_repo: &RepositoryName,
+        preferred: &[RepositoryName],
     ) -> Option<&'a RepositoryName> {
-        self.dedup.mount_source(target, digest, current_repo)
+        self.dedup
+            .mount_source(target, digest, current_repo, preferred)
     }
 
     /// Mark a blob as already existing at the target in the given repo.
@@ -504,7 +506,7 @@ mod tests {
         cache.set_blob_completed("reg.io", digest(), "repo/a".into());
         cache.set_blob_completed("reg.io", digest(), "repo/b".into());
         assert_eq!(
-            cache.blob_mount_source("reg.io", &digest(), &repo("repo/b")),
+            cache.blob_mount_source("reg.io", &digest(), &repo("repo/b"), &[]),
             Some(&repo("repo/a"))
         );
     }

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -17,7 +17,7 @@
 //! state (`TransferStateCache`) is accessed via `Rc<RefCell<>>` with borrows
 //! never held across `.await` points.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::future::Future;
@@ -249,6 +249,20 @@ struct TargetBlobOutcome {
     error: Option<crate::Error>,
 }
 
+/// Outcome of transferring a single blob to one target.
+enum BlobResult {
+    /// Cache hit -- blob already exists at target repo.
+    Skipped,
+    /// Cross-repo mount succeeded.
+    Mounted,
+    /// Pulled from source and pushed to target.
+    Transferred { bytes: u64 },
+    /// Another blob failed; this one was cancelled before starting I/O.
+    Cancelled,
+    /// Transfer failed.
+    Failed(crate::Error),
+}
+
 /// An image ready for execution (one per target that needs sync).
 struct TransferTask {
     /// Shared source data (pulled once per tag).
@@ -298,6 +312,135 @@ enum DiscoveryRoute {
     TargetStale,
 }
 
+/// Elect leader images for mount optimization via greedy set-cover.
+///
+/// Groups pending tasks by source image (tasks sharing the same
+/// [`PulledManifest`] via `Rc` target different registries for the same
+/// tag). Repeatedly picks the image that covers the most shared blob
+/// digests not already covered by previously elected leaders. Stops when
+/// no candidate provides marginal coverage.
+///
+/// All leader tasks are promoted to the front of the deque. The existing
+/// `ClaimAction::Wait` mechanism in [`transfer_image_blobs`] handles
+/// inter-leader blob deduplication: if two leaders share a blob, the
+/// second waits for the first's upload then mounts rather than
+/// re-uploading.
+///
+/// Returns the number of tasks promoted to the front of the deque as leaders
+/// (0 if no election benefit exists).
+fn elect_leaders(pending: &mut VecDeque<TransferTask>) -> usize {
+    if pending.len() <= 1 {
+        return 0;
+    }
+
+    // Group tasks by source image. Tasks sharing an Rc<PulledManifest>
+    // represent the same source image bound to different target registries.
+    let mut group_ptrs: Vec<usize> = Vec::new();
+    let mut group_blobs: Vec<HashSet<Digest>> = Vec::new();
+    let mut task_group: Vec<usize> = Vec::with_capacity(pending.len());
+
+    for task in pending.iter() {
+        let ptr = Rc::as_ptr(&task.source_data) as usize;
+        let idx = if let Some(pos) = group_ptrs.iter().position(|&p| p == ptr) {
+            pos
+        } else {
+            let blobs: HashSet<Digest> = blobs_from_manifest(&task.source_data)
+                .into_iter()
+                .map(|d| d.digest.clone())
+                .collect();
+            let idx = group_ptrs.len();
+            group_ptrs.push(ptr);
+            group_blobs.push(blobs);
+            idx
+        };
+        task_group.push(idx);
+    }
+
+    let num_groups = group_ptrs.len();
+    if num_groups <= 1 {
+        // All tasks are the same source image; no election needed.
+        return 0;
+    }
+
+    // Greedy multi-leader election. Each round picks the image that
+    // maximizes marginal shared-blob coverage: for each remaining
+    // (non-leader) image, count blobs shared with the candidate that are
+    // not already in a previous leader's blob set.
+    let mut leader_set: Vec<usize> = Vec::new();
+    let mut leader_blob_union: HashSet<Digest> = HashSet::new();
+    let mut remaining: Vec<usize> = (0..num_groups).collect();
+
+    loop {
+        if remaining.len() <= 1 {
+            break;
+        }
+
+        let best = remaining
+            .iter()
+            .map(|&i| {
+                let marginal: usize = remaining
+                    .iter()
+                    .filter(|&&j| j != i)
+                    .map(|&j| {
+                        group_blobs[i]
+                            .intersection(&group_blobs[j])
+                            .filter(|b| !leader_blob_union.contains(*b))
+                            .count()
+                    })
+                    .sum();
+                (i, marginal)
+            })
+            .max_by_key(|&(_, m)| m);
+
+        match best {
+            Some((idx, marginal)) if marginal > 0 => {
+                leader_blob_union.extend(group_blobs[idx].iter().cloned());
+                leader_set.push(idx);
+                remaining.retain(|&i| i != idx);
+            }
+            _ => break,
+        }
+    }
+
+    if leader_set.is_empty() {
+        // No shared blobs across any images; concurrent is optimal.
+        return 0;
+    }
+
+    // Log each leader's source reference.
+    for &leader_idx in &leader_set {
+        if let Some((pos, _)) = task_group
+            .iter()
+            .enumerate()
+            .find(|&(_, &g)| g == leader_idx)
+        {
+            info!(
+                leader = %pending[pos].source,
+                leader_idx = leader_set.iter().position(|&l| l == leader_idx).unwrap() + 1,
+                total_leaders = leader_set.len(),
+                images = num_groups,
+                "elected leader for mount optimization"
+            );
+        }
+    }
+
+    // Stable partition: leader tasks first, then followers.
+    let mut leaders: VecDeque<TransferTask> = VecDeque::new();
+    let mut followers: VecDeque<TransferTask> = VecDeque::new();
+    for (task, &group) in pending.drain(..).zip(task_group.iter()) {
+        if leader_set.contains(&group) {
+            leaders.push_back(task);
+        } else {
+            followers.push_back(task);
+        }
+    }
+
+    let leader_count = leaders.len();
+    pending.extend(leaders);
+    pending.extend(followers);
+    leader_count
+}
+
 /// Blob frequency tracker for ordering blobs by popularity.
 ///
 /// Blobs shared across many images should be transferred first so the cache
@@ -325,17 +468,61 @@ impl BlobFrequencyMap {
     }
 }
 
+/// Pipeline phase for leader-follower mount optimization.
+///
+/// Tracks which group of tasks is currently being promoted into execution
+/// futures. The phase advances monotonically:
+/// `Discovering -> Leaders -> Done`.
+///
+/// The leader/follower split is essential for correctness: leaders must
+/// commit manifests before followers attempt cross-repo mounts. The greedy
+/// election algorithm guarantees that every shared blob is covered by at
+/// least one leader's blob set, so no further wave partitioning is needed
+/// among followers.
+enum PromotionPhase {
+    /// Discovery futures still in flight; tasks accumulate in `pending`.
+    Discovering,
+    /// Leader tasks promoted; waiting for them to complete before followers.
+    Leaders,
+    /// All tasks promoted (followers promoted after leaders drained); no
+    /// further phase transitions.
+    Done,
+}
+
+/// Borrowed references shared by the `promote` closure at each call site.
+///
+/// Groups the invariant engine state that every promoted task needs, keeping
+/// the closure signature to `(TransferTask, &PromoteContext, &[RepositoryName])`.
+///
+/// Created after discovery completes (once `freq_map` is frozen).
+struct PromoteContext<'a> {
+    sem: &'a Rc<Semaphore>,
+    cache: &'a Rc<RefCell<TransferStateCache>>,
+    staging: &'a Rc<BlobStage>,
+    freq_map: &'a BlobFrequencyMap,
+    retry: &'a RetryConfig,
+}
+
 /// Default cap for concurrent image transfers (Level 1: global image semaphore).
 pub const DEFAULT_MAX_CONCURRENT_TRANSFERS: usize = 50;
+
+/// Maximum concurrent blob transfers within a single image.
+///
+/// Matches skopeo's default (6). Higher values risk approaching ECR's
+/// `InitiateLayerUpload` limit (100 TPS shared across all images).
+/// Candidate for `SyncEngine` builder configuration if workloads need tuning.
+const BLOB_CONCURRENCY: usize = 6;
 
 /// Default shutdown drain deadline in seconds.
 const DEFAULT_DRAIN_DEADLINE_SECS: u64 = 25;
 
 /// Sync engine -- orchestrates concurrent image transfers across registries.
 ///
-/// Uses a pipelined architecture where discovery and execution overlap via
-/// `tokio::select!`. The plan phase is eliminated entirely -- progressive
-/// cache population replaces upfront batch HEAD checks.
+/// Discovery futures drain first via `tokio::select!`, then leader-follower
+/// election reorders pending tasks so images sharing the most blobs execute
+/// first (enabling cross-repo mounts for followers). The plan phase is
+/// eliminated entirely -- progressive cache population replaces upfront
+/// batch HEAD checks.
 #[derive(Debug)]
 pub struct SyncEngine {
     retry: RetryConfig,
@@ -415,6 +602,19 @@ impl SyncEngine {
         let mut discovery_head_failures: u64 = 0;
         let mut discovery_target_stale: u64 = 0;
 
+        // Leader-follower mount optimization state.
+        //
+        // `promotion_phase` tracks which stage of the pipeline we are in.
+        // `phase_inflight` tracks in-flight tasks for the current phase.
+        // When a phase drains to zero and `pending` is non-empty, the next
+        // wave is promoted.
+        let mut promotion_phase = PromotionPhase::Discovering;
+        let mut phase_inflight: usize = 0;
+        // Repos whose manifests are already committed at the target. Followers
+        // prefer these as cross-repo mount sources because ECR requires a
+        // committed manifest for mount to succeed.
+        let mut preferred_mount_sources: Vec<RepositoryName> = Vec::new();
+
         // Seed discovery with all (mapping, tag) pairs.
         for mapping in &mappings {
             for tag_pair in &mapping.tags {
@@ -441,38 +641,111 @@ impl SyncEngine {
             }
         }
 
+        // Helper closure: promote a task from `pending` into an execution future.
+        let promote = |item: TransferTask,
+                       ctx: &PromoteContext<'_>,
+                       preferred_mount_sources: &[RepositoryName]|
+         -> std::pin::Pin<Box<dyn Future<Output = ImageResult>>> {
+            let sem = Rc::clone(ctx.sem);
+            let cache_ref = Rc::clone(ctx.cache);
+            let retry = ctx.retry.clone();
+            let freq_counts: HashMap<Digest, usize> = {
+                let blobs = blobs_from_manifest(&item.source_data);
+                blobs
+                    .iter()
+                    .map(|d| (d.digest.clone(), ctx.freq_map.count(&d.digest)))
+                    .collect()
+            };
+            let staging_ref = Rc::clone(ctx.staging);
+            let source_str = item.source.to_string();
+            let target_str = item.target.to_string();
+            let preferred_mount_sources = preferred_mount_sources.to_vec();
+            Box::pin(async move {
+                let _permit = sem.acquire().await.unwrap();
+                progress.image_started(&source_str, &target_str);
+                execute_item(
+                    item,
+                    &cache_ref,
+                    &staging_ref,
+                    &freq_counts,
+                    &retry,
+                    &preferred_mount_sources,
+                )
+                .await
+            })
+        };
+
         loop {
-            // Promote pending items to execution futures only when not shutting down.
-            // Each future acquires a semaphore permit at the start (blocking if at
-            // capacity), preserving the discovery-order benefit of the frequency map.
+            // Phased promotion: accumulate during discovery, then leader-first.
             if !shutting_down {
-                while let Some(item) = pending.pop_front() {
-                    let sem = Rc::clone(&global_sem);
-                    let cache_ref = Rc::clone(&cache);
-                    let retry = self.retry.clone();
-                    let freq_counts: HashMap<Digest, usize> = {
-                        let blobs = blobs_from_manifest(&item.source_data);
-                        blobs
+                if matches!(promotion_phase, PromotionPhase::Discovering)
+                    && discovery_futures.is_empty()
+                {
+                    // All discovery complete -- elect leaders and promote.
+                    // `freq_map` is frozen from this point (no more discovery
+                    // mutations), so `PromoteContext` can borrow it.
+                    let n = elect_leaders(&mut pending);
+                    phase_inflight = n;
+                    // Collect leader target repos for follower mount preference.
+                    if n > 0 {
+                        preferred_mount_sources = pending
                             .iter()
-                            .map(|d| (d.digest.clone(), freq_map.count(&d.digest)))
-                            .collect()
+                            .take(n)
+                            .map(|t| t.target.repo.clone())
+                            .collect();
+                    }
+                    // When n > 0, promote only leader tasks (followers wait).
+                    // When n == 0 (no election benefit), promote everything.
+                    let to_promote = if n > 0 { n } else { pending.len() };
+                    promotion_phase = if n > 0 {
+                        PromotionPhase::Leaders
+                    } else {
+                        PromotionPhase::Done
                     };
-
-                    let staging_ref = Rc::clone(&staging);
-                    let source_str = item.source.to_string();
-                    let target_str = item.target.to_string();
-
-                    execution_futures.push(Box::pin(async move {
-                        let _permit = sem.acquire().await.unwrap();
-                        progress.image_started(&source_str, &target_str);
-                        execute_item(item, &cache_ref, &staging_ref, &freq_counts, &retry).await
-                    }));
+                    let ctx = PromoteContext {
+                        sem: &global_sem,
+                        cache: &cache,
+                        staging: &staging,
+                        freq_map: &freq_map,
+                        retry: &self.retry,
+                    };
+                    for _ in 0..to_promote {
+                        if let Some(item) = pending.pop_front() {
+                            execution_futures.push(promote(item, &ctx, &preferred_mount_sources));
+                        }
+                    }
+                } else if matches!(promotion_phase, PromotionPhase::Leaders)
+                    && phase_inflight == 0
+                    && !pending.is_empty()
+                {
+                    // Leaders drained -- promote all remaining followers.
+                    let ctx = PromoteContext {
+                        sem: &global_sem,
+                        cache: &cache,
+                        staging: &staging,
+                        freq_map: &freq_map,
+                        retry: &self.retry,
+                    };
+                    let to_promote = pending.len();
+                    promotion_phase = PromotionPhase::Done;
+                    info!(
+                        tasks = to_promote,
+                        elapsed_ms = run_start.elapsed().as_millis() as u64,
+                        "promoting followers"
+                    );
+                    phase_inflight = to_promote;
+                    for _ in 0..to_promote {
+                        if let Some(item) = pending.pop_front() {
+                            execution_futures.push(promote(item, &ctx, &preferred_mount_sources));
+                        }
+                    }
                 }
             }
 
             tokio::select! {
                 biased;
                 Some(result) = execution_futures.next(), if !execution_futures.is_empty() => {
+                    phase_inflight = phase_inflight.saturating_sub(1);
                     progress.image_completed(&result);
                     results.push(result);
                 }
@@ -986,6 +1259,7 @@ async fn execute_item(
     staging: &Rc<BlobStage>,
     freq_counts: &HashMap<Digest, usize>,
     retry: &RetryConfig,
+    preferred_mount_sources: &[RepositoryName],
 ) -> ImageResult {
     let start = Instant::now();
 
@@ -999,6 +1273,7 @@ async fn execute_item(
         target_name: &item.target_name,
         target_repo: &item.target.repo,
         batch_checker: item.batch_checker.as_ref(),
+        preferred_mount_sources,
     };
     let outcome = transfer_image_blobs(&ctx, &item.source_data, freq_counts).await;
 
@@ -1278,6 +1553,8 @@ struct TransferContext<'a> {
     target_repo: &'a RepositoryName,
     /// Optional batch blob checker for pre-populating the cache.
     batch_checker: Option<&'a Rc<dyn BatchBlobChecker>>,
+    /// Leader repos whose manifests are committed. Preferred as mount sources.
+    preferred_mount_sources: &'a [RepositoryName],
 }
 
 /// Transfer all blobs for a single image to one target.
@@ -1352,248 +1629,274 @@ async fn transfer_image_blobs(
         HashSet::new()
     };
 
-    let mut outcome = TargetBlobOutcome::default();
+    // Transfer blobs concurrently, capped by BLOB_CONCURRENCY.
+    let blob_sem = Semaphore::new(BLOB_CONCURRENCY);
+    let cancel = Cell::new(false);
+    let mut blob_futures = FuturesUnordered::new();
 
     for blob in &blobs {
-        let digest = &blob.digest;
+        let digest = blob.digest.clone();
         let size = blob.size;
-
-        // Step 1: Check cache -- known at this repo -> skip (0 API calls).
-        // OCI blobs are repo-scoped: a blob at repo-a is NOT accessible from
-        // repo-b without a mount. So we must check the specific repo.
-        let skip = {
-            let c = ctx.cache.borrow();
-            c.blob_known_at_repo(ctx.target_name, digest, ctx.target_repo)
-        };
-
-        if skip {
-            tracing::debug!(target: "ocync::metrics", tier = "hot", "cache_hit");
-            outcome.stats.skipped += 1;
-            continue;
-        }
-
-        // Step 2a: Atomic check-and-claim. If another concurrent transfer is
-        // already uploading this blob to a different repo at the same target,
-        // wait for it to finish so we can mount from its repo rather than
-        // redundantly uploading. Otherwise, claim the upload ourselves by
-        // setting in-progress state BEFORE the HEAD check — the HEAD awaits
-        // on network I/O, and without the claim, other tasks would race past
-        // the check and duplicate the upload. Critical for multi-image syncs
-        // with shared layers (e.g. Chainguard images share wolfi-base).
-        loop {
-            let action: ClaimAction = {
-                let mut c = ctx.cache.borrow_mut();
-                match c
-                    .blob_in_progress_uploader(ctx.target_name, digest, ctx.target_repo)
-                    .cloned()
-                {
-                    Some(uploader) => ClaimAction::Wait {
-                        uploader,
-                        notify: c.blob_notify(ctx.target_name, digest),
-                    },
-                    None => {
-                        // Claim the upload atomically before yielding.
-                        c.set_blob_in_progress(
-                            ctx.target_name,
-                            digest.clone(),
-                            ctx.target_repo.to_owned(),
-                        );
-                        ClaimAction::Claimed
-                    }
-                }
-            };
-            match action {
-                ClaimAction::Wait { uploader, notify } => {
-                    debug!(
-                        %digest,
-                        %uploader,
-                        target = %ctx.target_name,
-                        "waiting for in-flight upload to complete before mounting",
-                    );
-                    notify.notified().await;
-                    // Loop: the upload completed (mount_source now populated)
-                    // or failed (another task may have taken over). Re-check.
-                    continue;
-                }
-                ClaimAction::Claimed => break,
+        // Reborrow shared state as Copy references for `async move`.
+        let sem = &blob_sem;
+        let cancel = &cancel;
+        let batch = &batch_checked;
+        blob_futures.push(async move {
+            let _permit = sem.acquire().await.unwrap();
+            if cancel.get() {
+                return BlobResult::Cancelled;
             }
-        }
+            transfer_single_blob(ctx, &digest, size, batch).await
+        });
+    }
 
-        // Step 2b: Check cache for cross-repo mount source.
-        let mount_source = {
-            let c = ctx.cache.borrow();
-            c.blob_mount_source(ctx.target_name, digest, ctx.target_repo)
-                .cloned()
-        };
-
-        if let Some(from_repo) = mount_source {
-            debug!(%digest, %from_repo, target = %ctx.target_name, "attempting mount");
-            match ctx
-                .target_client
-                .blob_mount(ctx.target_repo, digest, &from_repo)
-                .await
-            {
-                Ok(MountResult::Mounted) => {
-                    ctx.cache.borrow_mut().set_blob_completed(
-                        ctx.target_name,
-                        digest.clone(),
-                        ctx.target_repo.to_owned(),
-                    );
-                    outcome.stats.mounted += 1;
-                    tracing::debug!(target: "ocync::metrics", result = "success", "mount");
-                    continue;
-                }
-                Ok(MountResult::NotMounted) | Err(_) => {
-                    debug!(%digest, target = %ctx.target_name, "mount not fulfilled, falling back to HEAD+push");
-                    ctx.cache
-                        .borrow_mut()
-                        .invalidate_blob(ctx.target_name, digest);
-                    tracing::debug!(target: "ocync::metrics", result = "fallback", "mount");
-                    tracing::debug!(target: "ocync::metrics", "cache_invalidation");
-                }
-            }
-        }
-
-        // Step 3: HEAD check at target (1 API call), record in cache if exists.
-        // Skip when batch-check already confirmed this blob is absent — the
-        // HEAD would return 404 redundantly. On a 5-image Jupyter cold sync
-        // this eliminates 247 wasted HEAD requests (7.6% of total).
-        if !batch_checked.contains(digest) {
-            let head_result = ctx.target_client.blob_exists(ctx.target_repo, digest).await;
-            match head_result {
-                Ok(Some(_)) => {
-                    ctx.cache.borrow_mut().set_blob_exists(
-                        ctx.target_name,
-                        digest.clone(),
-                        ctx.target_repo.to_owned(),
-                    );
-                    outcome.stats.skipped += 1;
-                    continue;
-                }
-                Ok(None) => {
-                    // Blob doesn't exist, proceed to pull+push.
-                }
-                Err(e) => {
-                    debug!(
-                        %digest,
-                        target = %ctx.target_name,
-                        error = %e,
-                        "blob HEAD failed, proceeding with push"
-                    );
-                }
-            }
-        }
-
-        // Step 4: Pull from source + push to target, record in cache.
-        // When staging is enabled, pull-once semantics apply: if the blob is
-        // already staged from a previous target, push from the local file
-        // instead of re-pulling from source. Otherwise pull from source and
-        // write to staging so subsequent targets can reuse it.
-        //
-        // Note: in-progress state was already claimed in Step 2a.
-
-        let transfer_result: Result<(), crate::Error> = if ctx.staging.is_enabled() {
-            if !ctx.staging.exists(digest) {
-                // Pull from source, stream to staging file chunk-by-chunk.
-                // This avoids buffering the entire blob in memory during pull.
-                if let Err(e) = with_retry(ctx.retry, "blob pull (to stage)", || async {
-                    let mut writer = ctx.staging.begin_write(digest).map_err(|e| {
-                        ocync_distribution::Error::Other(format!("staging create: {e}"))
-                    })?;
-                    let stream = ctx.source_client.blob_pull(ctx.source_repo, digest).await?;
-                    futures_util::pin_mut!(stream);
-                    while let Some(chunk) = stream.next().await {
-                        let chunk =
-                            chunk.map_err(|e| ocync_distribution::Error::Other(e.to_string()))?;
-                        writer.write_chunk(&chunk).map_err(|e| {
-                            ocync_distribution::Error::Other(format!("staging write: {e}"))
-                        })?;
-                    }
-                    writer.finish().map_err(|e| {
-                        ocync_distribution::Error::Other(format!("staging finalize: {e}"))
-                    })?;
-                    Ok::<(), ocync_distribution::Error>(())
-                })
-                .await
-                {
-                    let err = crate::Error::BlobTransfer {
-                        digest: digest.clone(),
-                        source: e,
-                    };
-                    ctx.cache.borrow_mut().set_blob_failed(
-                        ctx.target_name,
-                        digest.clone(),
-                        err.to_string(),
-                    );
-                    outcome.error = Some(err);
-                    return outcome;
-                }
-            }
-
-            // Push from staged file, streaming from disk.
-            with_retry(ctx.retry, "blob push (staged)", || async {
-                let file = ctx
-                    .staging
-                    .open_read(digest)
-                    .map_err(|e| ocync_distribution::Error::Other(format!("staging read: {e}")))?;
-                let file_size = file.metadata().map(|m| m.len()).ok();
-                let stream = file_read_stream(file).map(|r| {
-                    r.map_err(|e| ocync_distribution::Error::Other(format!("staging read: {e}")))
-                });
-                ctx.target_client
-                    .blob_push_stream(ctx.target_repo, digest, file_size, stream)
-                    .await
-            })
-            .await
-            .map(|_| ())
-            .map_err(|e| crate::Error::BlobTransfer {
-                digest: digest.clone(),
-                source: e,
-            })
-        } else {
-            with_retry(ctx.retry, "blob transfer", || async {
-                let stream = ctx.source_client.blob_pull(ctx.source_repo, digest).await?;
-                ctx.target_client
-                    .blob_push_stream(ctx.target_repo, digest, Some(size), stream)
-                    .await
-            })
-            .await
-            .map(|_| ())
-            .map_err(|e| crate::Error::BlobTransfer {
-                digest: digest.clone(),
-                source: e,
-            })
-        };
-
-        match transfer_result {
-            Ok(()) => {
-                outcome.bytes_transferred += size;
+    let mut outcome = TargetBlobOutcome::default();
+    while let Some(result) = blob_futures.next().await {
+        match result {
+            BlobResult::Skipped => outcome.stats.skipped += 1,
+            BlobResult::Mounted => outcome.stats.mounted += 1,
+            BlobResult::Transferred { bytes } => {
+                outcome.bytes_transferred += bytes;
                 outcome.stats.transferred += 1;
-                {
-                    let mut c = ctx.cache.borrow_mut();
-                    c.set_blob_completed(
-                        ctx.target_name,
-                        digest.clone(),
-                        ctx.target_repo.to_owned(),
-                    );
-                    c.notify_blob(ctx.target_name, digest);
-                }
             }
-            Err(err) => {
-                {
-                    let mut c = ctx.cache.borrow_mut();
-                    c.set_blob_failed(ctx.target_name, digest.clone(), err.to_string());
-                    // Wake concurrent transfers waiting on our upload so they
-                    // can retry instead of hanging forever.
-                    c.notify_blob(ctx.target_name, digest);
-                }
+            BlobResult::Cancelled => {}
+            BlobResult::Failed(err) => {
+                cancel.set(true);
                 outcome.error = Some(err);
-                return outcome; // Stop transferring blobs for this target on first failure.
+                // Don't break -- drain remaining futures so permits are
+                // released and cancel flag takes effect.
             }
         }
     }
 
     outcome
+}
+
+/// Transfer a single blob to one target: cache check, claim, mount, HEAD, pull+push.
+///
+/// All `RefCell` borrows are dropped before `await` points, preserving the
+/// single-threaded cooperative scheduling invariant.
+async fn transfer_single_blob(
+    ctx: &TransferContext<'_>,
+    digest: &Digest,
+    size: u64,
+    batch_checked: &HashSet<Digest>,
+) -> BlobResult {
+    // Step 1: Check cache -- known at this repo -> skip (0 API calls).
+    let skip = {
+        let c = ctx.cache.borrow();
+        c.blob_known_at_repo(ctx.target_name, digest, ctx.target_repo)
+    };
+
+    if skip {
+        tracing::debug!(target: "ocync::metrics", tier = "hot", "cache_hit");
+        return BlobResult::Skipped;
+    }
+
+    // Step 2a: Atomic check-and-claim.
+    loop {
+        let action: ClaimAction = {
+            let mut c = ctx.cache.borrow_mut();
+            match c
+                .blob_in_progress_uploader(ctx.target_name, digest, ctx.target_repo)
+                .cloned()
+            {
+                Some(uploader) => ClaimAction::Wait {
+                    uploader,
+                    notify: c.blob_notify(ctx.target_name, digest),
+                },
+                None => {
+                    c.set_blob_in_progress(
+                        ctx.target_name,
+                        digest.clone(),
+                        ctx.target_repo.to_owned(),
+                    );
+                    ClaimAction::Claimed
+                }
+            }
+        };
+        match action {
+            ClaimAction::Wait { uploader, notify } => {
+                debug!(
+                    %digest,
+                    %uploader,
+                    target = %ctx.target_name,
+                    "waiting for in-flight upload to complete before mounting",
+                );
+                notify.notified().await;
+                continue;
+            }
+            ClaimAction::Claimed => break,
+        }
+    }
+
+    // Step 2b: Cross-repo mount. Prefer leader repos (committed manifests)
+    // over other followers (whose manifests may not be committed yet).
+    let mut mount_attempted = false;
+    let mount_source = {
+        let c = ctx.cache.borrow();
+        c.blob_mount_source(
+            ctx.target_name,
+            digest,
+            ctx.target_repo,
+            ctx.preferred_mount_sources,
+        )
+        .cloned()
+    };
+
+    if let Some(from_repo) = mount_source {
+        debug!(%digest, %from_repo, target = %ctx.target_name, "attempting mount");
+        match ctx
+            .target_client
+            .blob_mount(ctx.target_repo, digest, &from_repo)
+            .await
+        {
+            Ok(MountResult::Mounted) => {
+                let mut c = ctx.cache.borrow_mut();
+                c.set_blob_completed(ctx.target_name, digest.clone(), ctx.target_repo.to_owned());
+                c.notify_blob(ctx.target_name, digest);
+                drop(c);
+                tracing::debug!(target: "ocync::metrics", result = "success", "mount");
+                return BlobResult::Mounted;
+            }
+            Ok(MountResult::NotMounted) | Err(_) => {
+                debug!(%digest, target = %ctx.target_name, "mount not fulfilled, falling back to HEAD+push");
+                let mut c = ctx.cache.borrow_mut();
+                c.invalidate_blob(ctx.target_name, digest);
+                c.notify_blob(ctx.target_name, digest);
+                drop(c);
+                mount_attempted = true;
+                tracing::debug!(target: "ocync::metrics", result = "fallback", "mount");
+                tracing::debug!(target: "ocync::metrics", "cache_invalidation");
+            }
+        }
+    }
+
+    // Step 3: HEAD check at target.
+    if !batch_checked.contains(digest) && !mount_attempted {
+        let head_result = ctx.target_client.blob_exists(ctx.target_repo, digest).await;
+        match head_result {
+            Ok(Some(_)) => {
+                let mut c = ctx.cache.borrow_mut();
+                c.set_blob_exists(ctx.target_name, digest.clone(), ctx.target_repo.to_owned());
+                c.notify_blob(ctx.target_name, digest);
+                drop(c);
+                return BlobResult::Skipped;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                debug!(
+                    %digest,
+                    target = %ctx.target_name,
+                    error = %e,
+                    "blob HEAD failed, proceeding with push"
+                );
+            }
+        }
+    }
+
+    // Step 4: Pull from source + push to target.
+    let transfer_result: Result<(), crate::Error> = if ctx.staging.is_enabled() {
+        // Source-pull dedup: claim the pull or wait for another task that is
+        // already pulling this digest. Prevents redundant source GETs when
+        // multiple images share the same blob.
+        loop {
+            match ctx.staging.claim_or_check(digest) {
+                crate::staging::StagePullAction::Exists => break,
+                crate::staging::StagePullAction::Pull => {
+                    if let Err(e) = with_retry(ctx.retry, "blob pull (to stage)", || async {
+                        let mut writer = ctx.staging.begin_write(digest).map_err(|e| {
+                            ocync_distribution::Error::Other(format!("staging create: {e}"))
+                        })?;
+                        let stream = ctx.source_client.blob_pull(ctx.source_repo, digest).await?;
+                        futures_util::pin_mut!(stream);
+                        while let Some(chunk) = stream.next().await {
+                            let chunk = chunk
+                                .map_err(|e| ocync_distribution::Error::Other(e.to_string()))?;
+                            writer.write_chunk(&chunk).map_err(|e| {
+                                ocync_distribution::Error::Other(format!("staging write: {e}"))
+                            })?;
+                        }
+                        writer.finish().map_err(|e| {
+                            ocync_distribution::Error::Other(format!("staging finalize: {e}"))
+                        })?;
+                        Ok::<(), ocync_distribution::Error>(())
+                    })
+                    .await
+                    {
+                        ctx.staging.notify_failed(digest);
+                        let err = crate::Error::BlobTransfer {
+                            digest: digest.clone(),
+                            source: e,
+                        };
+                        let mut c = ctx.cache.borrow_mut();
+                        c.set_blob_failed(ctx.target_name, digest.clone(), err.to_string());
+                        c.notify_blob(ctx.target_name, digest);
+                        drop(c);
+                        return BlobResult::Failed(err);
+                    }
+                    ctx.staging.notify_staged(digest);
+                    break;
+                }
+                crate::staging::StagePullAction::Wait(notify) => {
+                    notify.notified().await;
+                    continue;
+                }
+            }
+        }
+
+        with_retry(ctx.retry, "blob push (staged)", || async {
+            let file = ctx
+                .staging
+                .open_read(digest)
+                .map_err(|e| ocync_distribution::Error::Other(format!("staging read: {e}")))?;
+            let file_size = file.metadata().map(|m| m.len()).ok();
+            let stream = file_read_stream(file).map(|r| {
+                r.map_err(|e| ocync_distribution::Error::Other(format!("staging read: {e}")))
+            });
+            ctx.target_client
+                .blob_push_stream(ctx.target_repo, digest, file_size, stream)
+                .await
+        })
+        .await
+        .map(|_| ())
+        .map_err(|e| crate::Error::BlobTransfer {
+            digest: digest.clone(),
+            source: e,
+        })
+    } else {
+        with_retry(ctx.retry, "blob transfer", || async {
+            let stream = ctx.source_client.blob_pull(ctx.source_repo, digest).await?;
+            ctx.target_client
+                .blob_push_stream(ctx.target_repo, digest, Some(size), stream)
+                .await
+        })
+        .await
+        .map(|_| ())
+        .map_err(|e| crate::Error::BlobTransfer {
+            digest: digest.clone(),
+            source: e,
+        })
+    };
+
+    match transfer_result {
+        Ok(()) => {
+            {
+                let mut c = ctx.cache.borrow_mut();
+                c.set_blob_completed(ctx.target_name, digest.clone(), ctx.target_repo.to_owned());
+                c.notify_blob(ctx.target_name, digest);
+            }
+            BlobResult::Transferred { bytes: size }
+        }
+        Err(err) => {
+            {
+                let mut c = ctx.cache.borrow_mut();
+                c.set_blob_failed(ctx.target_name, digest.clone(), err.to_string());
+                c.notify_blob(ctx.target_name, digest);
+            }
+            BlobResult::Failed(err)
+        }
+    }
 }
 
 /// Push all manifests (children for indexes, then top-level) to one target.
@@ -1941,5 +2244,352 @@ mod tests {
             },
         };
         assert!(!is_immutable_tag_error(&err));
+    }
+
+    // --- elect_leaders tests ---
+
+    /// Build a `PulledManifest` with the given blob digests (first = config, rest = layers).
+    fn test_pulled_manifest(blob_suffixes: &[&str]) -> PulledManifest {
+        assert!(!blob_suffixes.is_empty(), "need at least a config blob");
+        let config = Descriptor {
+            size: 100,
+            ..test_descriptor(test_digest(blob_suffixes[0]), MediaType::OciConfig)
+        };
+        let layers: Vec<Descriptor> = blob_suffixes[1..]
+            .iter()
+            .map(|s| Descriptor {
+                size: 1000,
+                ..test_descriptor(test_digest(s), MediaType::OciLayerGzip)
+            })
+            .collect();
+        let manifest = ImageManifest {
+            schema_version: 2,
+            media_type: None,
+            config,
+            layers,
+            subject: None,
+            artifact_type: None,
+            annotations: None,
+        };
+        let raw = serde_json::to_vec(&manifest).unwrap();
+        let digest = Digest::from_sha256(Sha256::digest(&raw));
+        PulledManifest {
+            pull: ManifestPull {
+                manifest: ManifestKind::Image(Box::new(manifest)),
+                raw_bytes: raw,
+                media_type: MediaType::OciManifest,
+                digest,
+            },
+            children: Vec::new(),
+        }
+    }
+
+    fn test_client() -> Arc<RegistryClient> {
+        Arc::new(
+            RegistryClient::builder("https://test.example.com".parse().unwrap())
+                .build()
+                .unwrap(),
+        )
+    }
+
+    fn test_task(source_data: Rc<PulledManifest>, tag: &str) -> TransferTask {
+        let client = test_client();
+        TransferTask {
+            source_data,
+            source_client: Arc::clone(&client),
+            target_name: RegistryAlias::new("test-target"),
+            target_client: client,
+            source: ImageRef {
+                repo: RepositoryName::new(format!("source/{tag}")),
+                tag: tag.to_owned(),
+            },
+            target: ImageRef {
+                repo: RepositoryName::new(format!("target/{tag}")),
+                tag: tag.to_owned(),
+            },
+            batch_checker: None,
+        }
+    }
+
+    /// Collect blob digests from leader tasks at the front of the deque.
+    fn leader_blob_digests(pending: &VecDeque<TransferTask>, n: usize) -> HashSet<Digest> {
+        pending
+            .iter()
+            .take(n)
+            .flat_map(|t| {
+                blobs_from_manifest(&t.source_data)
+                    .into_iter()
+                    .map(|d| d.digest.clone())
+            })
+            .collect()
+    }
+
+    #[test]
+    fn elect_leaders_empty_deque() {
+        let mut pending = VecDeque::new();
+        let n = elect_leaders(&mut pending);
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn elect_leaders_single_task() {
+        let data = Rc::new(test_pulled_manifest(&["c1", "a1"]));
+        let mut pending = VecDeque::new();
+        pending.push_back(test_task(data, "img1"));
+        let n = elect_leaders(&mut pending);
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn elect_leaders_picks_most_shared() {
+        // base:    blobs {c0, a1, a2, a3} -- 4 blobs, base layer image
+        // child_a: blobs {c0, a1, a2, d1} -- shares 3 with base, 2 with child_b
+        // child_b: blobs {c0, a1, a3, e1} -- shares 3 with base, 2 with child_a
+        //
+        // Scoring (sum of |intersection| with each other image):
+        //   base:    |base^child_a|=3 + |base^child_b|=3 = 6
+        //   child_a: |child_a^base|=3 + |child_a^child_b|=2 = 5
+        //   child_b: |child_b^base|=3 + |child_b^child_a|=2 = 5
+        // base wins.
+        let data_base = Rc::new(test_pulled_manifest(&["c0", "a1", "a2", "a3"]));
+        let data_ca = Rc::new(test_pulled_manifest(&["c0", "a1", "a2", "d1"]));
+        let data_cb = Rc::new(test_pulled_manifest(&["c0", "a1", "a3", "e1"]));
+
+        let mut pending = VecDeque::new();
+        pending.push_back(test_task(Rc::clone(&data_base), "base"));
+        pending.push_back(test_task(Rc::clone(&data_ca), "child_a"));
+        pending.push_back(test_task(Rc::clone(&data_cb), "child_b"));
+
+        let n = elect_leaders(&mut pending);
+
+        // base is the sole leader (score 6 > 5).
+        assert_eq!(n, 1);
+        assert_eq!(pending[0].source.tag, "base");
+        // Leader blobs are base's: {c0, a1, a2, a3}.
+        let leader_blobs = leader_blob_digests(&pending, n);
+        assert_eq!(leader_blobs.len(), 4);
+        assert!(leader_blobs.contains(&test_digest("c0")));
+        assert!(leader_blobs.contains(&test_digest("a3")));
+        // Followers preserve original order.
+        assert_eq!(pending[1].source.tag, "child_a");
+        assert_eq!(pending[2].source.tag, "child_b");
+    }
+
+    #[test]
+    fn elect_leaders_no_shared_blobs() {
+        // Three images with completely disjoint blob sets.
+        let data_a = Rc::new(test_pulled_manifest(&["c1", "aa"]));
+        let data_b = Rc::new(test_pulled_manifest(&["c2", "bb"]));
+        let data_c = Rc::new(test_pulled_manifest(&["c3", "cc"]));
+
+        let mut pending = VecDeque::new();
+        pending.push_back(test_task(data_a, "imgA"));
+        pending.push_back(test_task(data_b, "imgB"));
+        pending.push_back(test_task(data_c, "imgC"));
+
+        // No shared blobs -> 0 leaders.
+        let n = elect_leaders(&mut pending);
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn elect_leaders_multi_target_groups_by_rc() {
+        // "base" image targets 2 registries (2 tasks, same Rc).
+        // "child_a" and "child_b" derive from base.
+        //
+        // base:    blobs {c0, a1, a2, a3} -- shares 3 with each child
+        // child_a: blobs {c0, a1, a2, d1} -- shares 3 with base, 2 with child_b
+        // child_b: blobs {c0, a1, a3, e1} -- shares 3 with base, 2 with child_a
+        //
+        // base scores 6, children score 5 each. base elected.
+        // base has 2 tasks -> n = 2.
+        let base = Rc::new(test_pulled_manifest(&["c0", "a1", "a2", "a3"]));
+        let child_a = Rc::new(test_pulled_manifest(&["c0", "a1", "a2", "d1"]));
+        let child_b = Rc::new(test_pulled_manifest(&["c0", "a1", "a3", "e1"]));
+
+        let client_a = test_client();
+        let client_b = test_client();
+
+        let mut pending = VecDeque::new();
+        // Two tasks sharing the same Rc (same source image, two targets).
+        pending.push_back(TransferTask {
+            source_data: Rc::clone(&base),
+            source_client: Arc::clone(&client_a),
+            target_name: RegistryAlias::new("target-1"),
+            target_client: Arc::clone(&client_a),
+            source: ImageRef {
+                repo: RepositoryName::new("src/base"),
+                tag: "v1".into(),
+            },
+            target: ImageRef {
+                repo: RepositoryName::new("tgt/base"),
+                tag: "v1".into(),
+            },
+            batch_checker: None,
+        });
+        pending.push_back(TransferTask {
+            source_data: Rc::clone(&base),
+            source_client: Arc::clone(&client_b),
+            target_name: RegistryAlias::new("target-2"),
+            target_client: Arc::clone(&client_b),
+            source: ImageRef {
+                repo: RepositoryName::new("src/base"),
+                tag: "v1".into(),
+            },
+            target: ImageRef {
+                repo: RepositoryName::new("tgt/base"),
+                tag: "v1".into(),
+            },
+            batch_checker: None,
+        });
+        pending.push_back(test_task(child_a, "child_a"));
+        pending.push_back(test_task(child_b, "child_b"));
+
+        let n = elect_leaders(&mut pending);
+
+        // base wins (score 6 vs 5). Both base tasks are leaders.
+        assert_eq!(n, 2);
+        let leader_blobs = leader_blob_digests(&pending, n);
+        assert_eq!(leader_blobs.len(), 4); // {c0, a1, a2, a3}
+        assert_eq!(pending[0].source.tag, "v1");
+        assert_eq!(pending[1].source.tag, "v1");
+        assert_eq!(pending[2].source.tag, "child_a");
+        assert_eq!(pending[3].source.tag, "child_b");
+    }
+
+    #[test]
+    fn elect_leaders_two_clusters() {
+        // Cluster 1: images A and B share blobs {c0, f1}
+        // Cluster 2: images C and D share blobs {c9, f2}
+        // No overlap between clusters.
+        let data_a = Rc::new(test_pulled_manifest(&["c0", "f1", "a1"]));
+        let data_b = Rc::new(test_pulled_manifest(&["c0", "f1", "b1"]));
+        let data_c = Rc::new(test_pulled_manifest(&["c9", "f2", "d1"]));
+        let data_d = Rc::new(test_pulled_manifest(&["c9", "f2", "e1"]));
+
+        let mut pending = VecDeque::new();
+        pending.push_back(test_task(Rc::clone(&data_a), "imgA"));
+        pending.push_back(test_task(Rc::clone(&data_b), "imgB"));
+        pending.push_back(test_task(Rc::clone(&data_c), "imgC"));
+        pending.push_back(test_task(Rc::clone(&data_d), "imgD"));
+
+        let n = elect_leaders(&mut pending);
+
+        // Two leaders (one per cluster), two followers.
+        assert_eq!(n, 2);
+        // Leader blobs span both clusters.
+        let leader_blobs = leader_blob_digests(&pending, n);
+        assert!(
+            leader_blobs.len() >= 4,
+            "leader blobs should span both clusters"
+        );
+
+        // Leaders are at the front.
+        let leader_tags: Vec<&str> = pending
+            .iter()
+            .take(n)
+            .map(|t| t.source.tag.as_str())
+            .collect();
+        let follower_tags: Vec<&str> = pending
+            .iter()
+            .skip(n)
+            .map(|t| t.source.tag.as_str())
+            .collect();
+
+        // Each cluster contributes one leader: A or B from cluster 1, C or D from cluster 2.
+        // The follower from each cluster is the other member.
+        assert_eq!(leader_tags.len(), 2);
+        assert_eq!(follower_tags.len(), 2);
+
+        // Verify leaders come from different clusters.
+        let cluster1 = ["imgA", "imgB"];
+        let cluster2 = ["imgC", "imgD"];
+        assert!(
+            leader_tags.iter().any(|t| cluster1.contains(t))
+                && leader_tags.iter().any(|t| cluster2.contains(t)),
+            "leaders should cover both clusters: {leader_tags:?}"
+        );
+    }
+
+    #[test]
+    fn elect_leaders_marginal_coverage_across_rounds() {
+        // A spans both clusters via blob c0. Round 1 elects A. Round 2
+        // must deduct A's blobs from marginal scores: C and D share
+        // {c0, d0}, but c0 is already covered -- only d0 is marginal.
+        //
+        // A: {a0, b0, c0}  B: {a0, b0, e0}  C: {c0, d0, f0}  D: {c0, d0, fa}
+        //
+        // Round 1 scores:
+        //   A: |A^B|=2 + |A^C|=1 + |A^D|=1 = 4  (wins)
+        //   B: 2, C: 3, D: 3
+        //
+        // Round 2 (covered = {a0,b0,c0}):
+        //   B: |B^C\covered|=0 + |B^D\covered|=0 = 0
+        //   C: |C^B\covered|=0 + |C^D\covered|=|{d0}|=1 = 1
+        //   D: |D^B\covered|=0 + |D^C\covered|=|{d0}|=1 = 1
+        //   C or D elected (tie on d0). B stays follower.
+        let data_a = Rc::new(test_pulled_manifest(&["a0", "b0", "c0"]));
+        let data_b = Rc::new(test_pulled_manifest(&["a0", "b0", "e0"]));
+        let data_c = Rc::new(test_pulled_manifest(&["c0", "d0", "f0"]));
+        let data_d = Rc::new(test_pulled_manifest(&["c0", "d0", "fa"]));
+
+        let mut pending = VecDeque::new();
+        pending.push_back(test_task(Rc::clone(&data_a), "imgA"));
+        pending.push_back(test_task(Rc::clone(&data_b), "imgB"));
+        pending.push_back(test_task(Rc::clone(&data_c), "imgC"));
+        pending.push_back(test_task(Rc::clone(&data_d), "imgD"));
+
+        let n = elect_leaders(&mut pending);
+
+        // Two leaders: A (round 1) + one of C/D (round 2, marginal on d0).
+        assert_eq!(n, 2);
+        // Leader blobs include A's {a0,b0,c0} + winner's {c0,d0,f0 or fa}.
+        let leader_blobs = leader_blob_digests(&pending, n);
+        assert!(leader_blobs.contains(&test_digest("a0")));
+        assert!(leader_blobs.contains(&test_digest("d0")));
+
+        let leader_tags: Vec<&str> = pending
+            .iter()
+            .take(n)
+            .map(|t| t.source.tag.as_str())
+            .collect();
+
+        // A is always first leader.
+        assert_eq!(leader_tags[0], "imgA");
+        // Second leader is from cluster 2 (C or D), not B -- because B
+        // shares no marginal blobs after A's {a0,b0,c0} are deducted.
+        assert!(
+            leader_tags[1] == "imgC" || leader_tags[1] == "imgD",
+            "second leader should be from cluster 2, got: {leader_tags:?}"
+        );
+    }
+
+    #[test]
+    fn elect_leaders_tie_breaks_deterministically() {
+        // A and B have identical sharing with C. max_by_key returns the
+        // last maximum in iteration order, so B (higher index) wins.
+        //
+        // A: {a0, b0}  B: {a0, b0}  C: {a0, c0}
+        // A: |A^B|=2 + |A^C|=1 = 3
+        // B: |B^A|=2 + |B^C|=1 = 3   (tie with A)
+        // C: |C^A|=1 + |C^B|=1 = 2
+        let data_a = Rc::new(test_pulled_manifest(&["a0", "b0"]));
+        let data_b = Rc::new(test_pulled_manifest(&["a0", "b0"]));
+        let data_c = Rc::new(test_pulled_manifest(&["a0", "c0"]));
+
+        for _ in 0..5 {
+            let mut pending = VecDeque::new();
+            pending.push_back(test_task(Rc::clone(&data_a), "imgA"));
+            pending.push_back(test_task(Rc::clone(&data_b), "imgB"));
+            pending.push_back(test_task(Rc::clone(&data_c), "imgC"));
+
+            let n = elect_leaders(&mut pending);
+            assert_eq!(n, 1);
+            // max_by_key picks last maximum: B (index 1) over A (index 0).
+            assert_eq!(
+                pending[0].source.tag, "imgB",
+                "tie should break deterministically in favor of later candidate"
+            );
+        }
     }
 }

--- a/crates/ocync-sync/src/plan.rs
+++ b/crates/ocync-sync/src/plan.rs
@@ -187,14 +187,23 @@ impl BlobDedupMap {
     /// Find a repo that already has this blob at the target which differs from
     /// `target_repo`, suitable as a cross-repo mount source.
     ///
-    /// Returns the alphabetically first candidate (deterministic via `BTreeSet`).
+    /// When `preferred` is non-empty, tries those repos first (in order).
+    /// Falls back to the alphabetically first candidate via `BTreeSet`.
+    /// Preferred repos are typically leader images whose manifests are
+    /// committed, making mount more likely to succeed on ECR.
     pub(crate) fn mount_source<'a>(
         &'a self,
         target: &str,
         digest: &Digest,
         target_repo: &RepositoryName,
+        preferred: &[RepositoryName],
     ) -> Option<&'a RepositoryName> {
         let info = self.inner.get(target)?.get(digest)?;
+        for pref in preferred {
+            if pref != target_repo && info.repos.contains(pref) {
+                return info.repos.get(pref);
+            }
+        }
         info.repos.iter().find(|r| *r != target_repo)
     }
 
@@ -305,7 +314,7 @@ mod tests {
         map.set_completed("reg.io", &d, &repo("library/alpine"));
         map.set_completed("reg.io", &d, &repo("library/nginx"));
 
-        let source = map.mount_source("reg.io", &d, &repo("library/nginx"));
+        let source = map.mount_source("reg.io", &d, &repo("library/nginx"), &[]);
         assert_eq!(source, Some(&repo("library/alpine")));
     }
 
@@ -316,7 +325,7 @@ mod tests {
 
         map.set_completed("reg.io", &d, &repo("library/alpine"));
 
-        let source = map.mount_source("reg.io", &d, &repo("library/alpine"));
+        let source = map.mount_source("reg.io", &d, &repo("library/alpine"), &[]);
         assert!(source.is_none());
     }
 
@@ -331,11 +340,41 @@ mod tests {
         map.set_completed("reg.io", &d, &repo("library/alpine"));
 
         // BTreeSet iterates alphabetically: alpine, nginx, redis
-        let source = map.mount_source("reg.io", &d, &repo("library/redis"));
+        let source = map.mount_source("reg.io", &d, &repo("library/redis"), &[]);
         assert_eq!(source, Some(&repo("library/alpine")));
 
-        let source = map.mount_source("reg.io", &d, &repo("library/alpine"));
+        let source = map.mount_source("reg.io", &d, &repo("library/alpine"), &[]);
         assert_eq!(source, Some(&repo("library/nginx")));
+    }
+
+    #[test]
+    fn mount_source_prefers_leader_repos() {
+        let mut map = BlobDedupMap::new();
+        let d = test_digest();
+
+        // Three repos: alpine (alphabetically first), nginx, redis.
+        map.set_completed("reg.io", &d, &repo("library/alpine"));
+        map.set_completed("reg.io", &d, &repo("library/nginx"));
+        map.set_completed("reg.io", &d, &repo("library/redis"));
+
+        // Without preferred, alphabetically first (alpine) wins.
+        let source = map.mount_source("reg.io", &d, &repo("library/redis"), &[]);
+        assert_eq!(source, Some(&repo("library/alpine")));
+
+        // With preferred=[nginx], nginx wins over alphabetical alpine.
+        let preferred = [repo("library/nginx")];
+        let source = map.mount_source("reg.io", &d, &repo("library/redis"), &preferred);
+        assert_eq!(source, Some(&repo("library/nginx")));
+
+        // Preferred repo that IS target_repo is skipped; falls to next preferred.
+        let preferred = [repo("library/redis"), repo("library/nginx")];
+        let source = map.mount_source("reg.io", &d, &repo("library/redis"), &preferred);
+        assert_eq!(source, Some(&repo("library/nginx")));
+
+        // Preferred repo not in the set falls back to alphabetical.
+        let preferred = [repo("library/unknown")];
+        let source = map.mount_source("reg.io", &d, &repo("library/redis"), &preferred);
+        assert_eq!(source, Some(&repo("library/alpine")));
     }
 
     #[test]

--- a/crates/ocync-sync/src/staging.rs
+++ b/crates/ocync-sync/src/staging.rs
@@ -24,19 +24,49 @@
 //! cache entries. Orphaned `.tmp.*` files from a previous crash are cleaned up
 //! by [`BlobStage::cleanup_tmp_files`].
 
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::io;
 use std::path::PathBuf;
+use std::rc::Rc;
 
 use ocync_distribution::Digest;
+use tokio::sync::Notify;
+
+/// Action returned by [`BlobStage::claim_or_check`] for source-pull dedup.
+///
+/// Prevents concurrent image tasks from pulling the same blob from source
+/// when staging is enabled. The first task claims the pull; concurrent tasks
+/// wait for the file to appear on disk.
+#[derive(Debug)]
+pub enum StagePullAction {
+    /// Blob already staged on disk. Skip source pull, read from staging.
+    Exists,
+    /// Claimed: this task should pull from source and stage the blob.
+    /// Call [`BlobStage::notify_staged`] after writing, or
+    /// [`BlobStage::notify_failed`] on failure.
+    Pull,
+    /// Another task is currently pulling this blob. Await the [`Notify`],
+    /// then call `claim_or_check` again (the pull may have failed).
+    Wait(Rc<Notify>),
+}
 
 /// Content-addressable blob staging area for multi-target sync.
 ///
 /// When enabled, blobs are pulled once from source and stored locally so all
 /// target pushes can read from the local file rather than re-pulling from
 /// source. When disabled (single-target), all methods are no-ops.
+///
+/// Cross-image source-pull dedup is coordinated via [`claim_or_check`]:
+/// the first task to request a digest claims the pull, concurrent tasks wait
+/// for the file to appear, then all read from the same staged file.
 #[derive(Debug)]
 pub struct BlobStage {
     base_dir: Option<PathBuf>,
+    /// In-progress source pulls keyed by digest. When a task claims a pull,
+    /// it inserts a `Notify`; waiters clone and `.notified().await` on it.
+    /// Removed on completion ([`notify_staged`]) or failure ([`notify_failed`]).
+    pulls: RefCell<HashMap<Digest, Rc<Notify>>>,
 }
 
 impl BlobStage {
@@ -46,6 +76,7 @@ impl BlobStage {
     pub fn new(base_dir: PathBuf) -> Self {
         Self {
             base_dir: Some(base_dir),
+            pulls: RefCell::new(HashMap::new()),
         }
     }
 
@@ -53,7 +84,10 @@ impl BlobStage {
     ///
     /// All operations on a disabled stage are no-ops; no disk I/O occurs.
     pub fn disabled() -> Self {
-        Self { base_dir: None }
+        Self {
+            base_dir: None,
+            pulls: RefCell::new(HashMap::new()),
+        }
     }
 
     /// Returns `true` if staging is enabled.
@@ -66,6 +100,53 @@ impl BlobStage {
     /// Always returns `false` when staging is disabled.
     pub fn exists(&self, digest: &Digest) -> bool {
         self.blob_path(digest).is_some_and(|p| p.exists())
+    }
+
+    /// Check-and-claim for source-pull dedup.
+    ///
+    /// Returns [`StagePullAction::Exists`] if the blob is already on disk,
+    /// [`StagePullAction::Pull`] if this task should pull it (claiming the
+    /// digest), or [`StagePullAction::Wait`] if another task is pulling it.
+    ///
+    /// When staging is disabled, always returns `Pull` (no dedup possible).
+    ///
+    /// Callers must call [`notify_staged`] after a successful pull or
+    /// [`notify_failed`] on failure. Failing to do so will deadlock waiters.
+    pub fn claim_or_check(&self, digest: &Digest) -> StagePullAction {
+        if !self.is_enabled() {
+            return StagePullAction::Pull;
+        }
+        if self.exists(digest) {
+            return StagePullAction::Exists;
+        }
+        let mut pulls = self.pulls.borrow_mut();
+        if let Some(notify) = pulls.get(digest) {
+            StagePullAction::Wait(Rc::clone(notify))
+        } else {
+            pulls.insert(digest.clone(), Rc::new(Notify::new()));
+            StagePullAction::Pull
+        }
+    }
+
+    /// Signal that a staged pull completed successfully.
+    ///
+    /// Removes the in-progress entry and wakes any waiting tasks. Waiters
+    /// will re-enter [`claim_or_check`] and find the blob on disk via
+    /// [`exists`].
+    pub fn notify_staged(&self, digest: &Digest) {
+        if let Some(notify) = self.pulls.borrow_mut().remove(digest) {
+            notify.notify_waiters();
+        }
+    }
+
+    /// Signal that a staged pull failed.
+    ///
+    /// Removes the in-progress entry and wakes waiters so one of them can
+    /// retry the pull from its own source.
+    pub fn notify_failed(&self, digest: &Digest) {
+        if let Some(notify) = self.pulls.borrow_mut().remove(digest) {
+            notify.notify_waiters();
+        }
     }
 
     /// Write `data` to the staging area for `digest` using an atomic
@@ -82,7 +163,10 @@ impl BlobStage {
             std::fs::create_dir_all(parent)?;
         }
 
-        let tmp_path = dest.with_extension(format!("tmp.{}", std::process::id()));
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static WRITE_SEQ: AtomicU64 = AtomicU64::new(0);
+        let seq = WRITE_SEQ.fetch_add(1, Ordering::Relaxed);
+        let tmp_path = dest.with_extension(format!("tmp.{}.{seq}", std::process::id()));
 
         {
             use std::io::Write as _;
@@ -224,7 +308,10 @@ impl BlobStage {
         if let Some(parent) = dest.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        let tmp_path = dest.with_extension(format!("tmp.{}", std::process::id()));
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static WRITE_SEQ: AtomicU64 = AtomicU64::new(0);
+        let seq = WRITE_SEQ.fetch_add(1, Ordering::Relaxed);
+        let tmp_path = dest.with_extension(format!("tmp.{}.{seq}", std::process::id()));
         let file = std::fs::File::create(&tmp_path)?;
         Ok(StagedWriter {
             file,

--- a/crates/ocync-sync/tests/cache_persistence.rs
+++ b/crates/ocync-sync/tests/cache_persistence.rs
@@ -103,7 +103,7 @@ fn round_trip_mount_source_survives() {
 
     let loaded = TransferStateCache::load(&path, long_ttl());
     assert_eq!(
-        loaded.blob_mount_source("reg.io", &digest_a(), &RepositoryName::from("repo/b")),
+        loaded.blob_mount_source("reg.io", &digest_a(), &RepositoryName::from("repo/b"), &[]),
         Some(&RepositoryName::from("repo/a"))
     );
 }

--- a/crates/ocync-sync/tests/engine_integration.rs
+++ b/crates/ocync-sync/tests/engine_integration.rs
@@ -1380,26 +1380,54 @@ async fn sync_cross_repo_mount_success() {
     };
     let (manifest_b_bytes, _) = serialize_manifest(&manifest_b);
 
-    // Source: two repos with the same blobs.
+    // Source: two repos with the same blobs (both fully pullable).
     mount_source_manifest(&source_server, "repo-a", "v1", &manifest_a_bytes).await;
     mount_source_manifest(&source_server, "repo-b", "v1", &manifest_b_bytes).await;
     mount_blob_pull(&source_server, "repo-a", &config_desc.digest, config_data).await;
     mount_blob_pull(&source_server, "repo-a", &layer_desc.digest, layer_data).await;
+    mount_blob_pull(&source_server, "repo-b", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo-b", &layer_desc.digest, layer_data).await;
 
-    // Target for repo-a: no manifest, no blobs, push succeeds.
+    // Target for repo-a: no manifest, no blobs, accepts upload and mount.
+    // Mount mocks use priority 1 so wiremock checks them before the generic
+    // upload POST (priority 5, default) which also matches mount requests.
     mount_manifest_head_not_found(&target_server, "repo-a", "v1").await;
     mount_blob_not_found(&target_server, "repo-a", &config_desc.digest).await;
     mount_blob_not_found(&target_server, "repo-a", &layer_desc.digest).await;
     mount_blob_push(&target_server, "repo-a").await;
+    Mock::given(method("POST"))
+        .and(path("/v2/repo-a/blobs/uploads/"))
+        .and(query_param("mount", config_desc.digest.to_string()))
+        .respond_with(ResponseTemplate::new(201))
+        .with_priority(1)
+        .mount(&target_server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v2/repo-a/blobs/uploads/"))
+        .and(query_param("mount", layer_desc.digest.to_string()))
+        .respond_with(ResponseTemplate::new(201))
+        .with_priority(1)
+        .mount(&target_server)
+        .await;
     mount_manifest_push(&target_server, "repo-a", "v1").await;
 
-    // Target for repo-b: no manifest, blobs not found, mount succeeds (201 Created).
+    // Target for repo-b: no manifest, no blobs, accepts upload and mount.
     mount_manifest_head_not_found(&target_server, "repo-b", "v1").await;
     mount_blob_not_found(&target_server, "repo-b", &config_desc.digest).await;
     mount_blob_not_found(&target_server, "repo-b", &layer_desc.digest).await;
+    mount_blob_push(&target_server, "repo-b").await;
     Mock::given(method("POST"))
         .and(path("/v2/repo-b/blobs/uploads/"))
+        .and(query_param("mount", config_desc.digest.to_string()))
         .respond_with(ResponseTemplate::new(201))
+        .with_priority(1)
+        .mount(&target_server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v2/repo-b/blobs/uploads/"))
+        .and(query_param("mount", layer_desc.digest.to_string()))
+        .respond_with(ResponseTemplate::new(201))
+        .with_priority(1)
         .mount(&target_server)
         .await;
     mount_manifest_push(&target_server, "repo-b", "v1").await;
@@ -1439,14 +1467,26 @@ async fn sync_cross_repo_mount_success() {
         .await;
 
     assert_eq!(report.images.len(), 2);
-    assert!(matches!(report.images[0].status, ImageStatus::Synced));
-    assert!(matches!(report.images[1].status, ImageStatus::Synced));
-    // First mapping: 2 blobs transferred.
-    assert_eq!(report.images[0].blob_stats.transferred, 2);
-    // Second mapping: 2 blobs mounted (not transferred).
-    assert_eq!(report.images[1].blob_stats.mounted, 2);
-    assert_eq!(report.images[1].blob_stats.transferred, 0);
+    assert!(
+        report
+            .images
+            .iter()
+            .all(|r| matches!(r.status, ImageStatus::Synced)),
+        "both images should sync",
+    );
+    // Aggregate: one image uploads 2 blobs, the other mounts 2 (order-independent).
+    assert_eq!(report.stats.blobs_transferred, 2);
     assert_eq!(report.stats.blobs_mounted, 2);
+    // At least one image mounted (not both uploading).
+    assert!(
+        report.images.iter().any(|r| r.blob_stats.mounted > 0),
+        "at least one image should mount blobs from the other"
+    );
+    // At least one image transferred (not both mounting).
+    assert!(
+        report.images.iter().any(|r| r.blob_stats.transferred > 0),
+        "at least one image should transfer blobs"
+    );
 }
 
 #[tokio::test]
@@ -8552,17 +8592,12 @@ async fn sync_exits_with_untriggered_shutdown_signal() {
 /// perform full uploads. The fix adds an in-progress uploader check + Notify
 /// so the second task waits for completion.
 ///
-/// Assertion strategy:
-/// - Add a 500ms delay on the source blob GET for repo-a so the upload is
-///   still in flight when repo-b reaches the same blob
-/// - Assert the blob push endpoint for repo-b receives ZERO POSTs without
-///   a mount= query param (every POST must be a mount attempt)
-/// - Assert the mount endpoint receives exactly ONE mount attempt
+/// Assertion strategy (order-independent):
+/// - Both targets accept upload and mount for all blobs
+/// - The leader election picks one image deterministically; the other mounts
+/// - Assert aggregate: 2 blobs transferred + 2 blobs mounted (no double-upload)
 #[tokio::test]
 async fn sync_concurrent_shared_blob_mounts_instead_of_double_uploading() {
-    use std::time::Duration;
-    use wiremock::matchers::query_param;
-
     let source_server = MockServer::start().await;
     let target_server = MockServer::start().await;
 
@@ -8582,30 +8617,11 @@ async fn sync_concurrent_shared_blob_mounts_instead_of_double_uploading() {
     };
     let (manifest_bytes, _) = serialize_manifest(&manifest);
 
-    // Both source repos serve the same manifest and blobs.
+    // Both source repos serve the same manifest and blobs (both fully pullable).
     mount_source_manifest(&source_server, "src-a", "v1", &manifest_bytes).await;
     mount_source_manifest(&source_server, "src-b", "v1", &manifest_bytes).await;
-    // Delayed blob pulls for src-a so the upload stays in-flight long enough
-    // for src-b's task to hit the shared blob and see in-progress state.
-    let delay = Duration::from_millis(500);
-    Mock::given(method("GET"))
-        .and(path(format!("/v2/src-a/blobs/{}", config_desc.digest)))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_delay(delay)
-                .set_body_bytes(config_data.as_ref()),
-        )
-        .mount(&source_server)
-        .await;
-    Mock::given(method("GET"))
-        .and(path(format!("/v2/src-a/blobs/{}", layer_desc.digest)))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_delay(delay)
-                .set_body_bytes(layer_data.as_ref()),
-        )
-        .mount(&source_server)
-        .await;
+    mount_blob_pull(&source_server, "src-a", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "src-a", &layer_desc.digest, layer_data).await;
     mount_blob_pull(&source_server, "src-b", &config_desc.digest, config_data).await;
     mount_blob_pull(&source_server, "src-b", &layer_desc.digest, layer_data).await;
 
@@ -8617,25 +8633,39 @@ async fn sync_concurrent_shared_blob_mounts_instead_of_double_uploading() {
     mount_blob_not_found(&target_server, "tgt-b", &config_desc.digest).await;
     mount_blob_not_found(&target_server, "tgt-b", &layer_desc.digest).await;
 
-    // tgt-a: accepts full upload (POST + PATCH + PUT).
+    // tgt-a: accepts upload (POST + PATCH + PUT) and mount (POST with mount=).
+    // Mount mocks use priority 1 so wiremock checks them before the generic
+    // upload POST (priority 5, default) which also matches mount requests.
     mount_blob_push(&target_server, "tgt-a").await;
+    Mock::given(method("POST"))
+        .and(path("/v2/tgt-a/blobs/uploads/"))
+        .and(query_param("mount", config_desc.digest.to_string()))
+        .respond_with(ResponseTemplate::new(201))
+        .with_priority(1)
+        .mount(&target_server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v2/tgt-a/blobs/uploads/"))
+        .and(query_param("mount", layer_desc.digest.to_string()))
+        .respond_with(ResponseTemplate::new(201))
+        .with_priority(1)
+        .mount(&target_server)
+        .await;
 
-    // tgt-b: expect mount (POST with mount= query) → 201 Created. This mock
-    // matches only POSTs with a `mount` query param; full-upload POSTs
-    // (no mount= param) are left unmatched → wiremock returns 404 → test
-    // fails. The `.expect(2)` asserts both blobs were mounted.
+    // tgt-b: accepts upload (POST + PATCH + PUT) and mount (POST with mount=).
+    mount_blob_push(&target_server, "tgt-b").await;
     Mock::given(method("POST"))
         .and(path("/v2/tgt-b/blobs/uploads/"))
         .and(query_param("mount", config_desc.digest.to_string()))
         .respond_with(ResponseTemplate::new(201))
-        .expect(1)
+        .with_priority(1)
         .mount(&target_server)
         .await;
     Mock::given(method("POST"))
         .and(path("/v2/tgt-b/blobs/uploads/"))
         .and(query_param("mount", layer_desc.digest.to_string()))
         .respond_with(ResponseTemplate::new(201))
-        .expect(1)
+        .with_priority(1)
         .mount(&target_server)
         .await;
 
@@ -8668,7 +8698,7 @@ async fn sync_concurrent_shared_blob_mounts_instead_of_double_uploading() {
             empty_cache(),
             BlobStage::disabled(),
             &NullProgress,
-            None,
+            Some(&ShutdownSignal::new()),
         )
         .await;
 
@@ -8681,21 +8711,592 @@ async fn sync_concurrent_shared_blob_mounts_instead_of_double_uploading() {
         "both images should sync",
     );
     assert_eq!(report.stats.images_synced, 2);
-    // tgt-a uploaded both blobs; tgt-b mounted both.
-    let tgt_a = report
-        .images
-        .iter()
-        .find(|r| r.target.contains("tgt-a"))
-        .unwrap();
-    let tgt_b = report
-        .images
-        .iter()
-        .find(|r| r.target.contains("tgt-b"))
-        .unwrap();
-    assert_eq!(
-        tgt_a.blob_stats.transferred, 2,
-        "tgt-a should upload both blobs"
+    // Aggregate: one image uploads 2 blobs (leader), the other mounts 2 (follower).
+    assert_eq!(report.stats.blobs_transferred, 2);
+    assert_eq!(report.stats.blobs_mounted, 2);
+    // At least one image mounted (not both uploading).
+    assert!(
+        report.images.iter().any(|r| r.blob_stats.mounted > 0),
+        "at least one image should mount blobs from the other"
     );
-    assert_eq!(tgt_b.blob_stats.mounted, 2, "tgt-b should mount both blobs");
-    assert_eq!(tgt_b.blob_stats.transferred, 0, "tgt-b must not upload");
+    // At least one image transferred (not both mounting).
+    assert!(
+        report.images.iter().any(|r| r.blob_stats.transferred > 0),
+        "at least one image should transfer blobs"
+    );
+}
+
+/// Three images sharing a layer exercise the full leader-follower pipeline:
+/// election picks one leader, wave promotion runs the two followers, and
+/// the shared layer is mounted from the leader's committed repo.
+#[tokio::test(flavor = "current_thread")]
+async fn sync_wave_promotion_three_images_shared_layer() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    // Shared layer across all three images; config blobs are unique.
+    let shared_data = b"shared-layer-wave-test";
+    let cfg_a_data = b"config-a-wave";
+    let cfg_b_data = b"config-b-wave";
+    let cfg_c_data = b"config-c-wave";
+
+    let shared_desc = blob_descriptor(shared_data, MediaType::OciLayerGzip);
+    let cfg_a_desc = blob_descriptor(cfg_a_data, MediaType::OciConfig);
+    let cfg_b_desc = blob_descriptor(cfg_b_data, MediaType::OciConfig);
+    let cfg_c_desc = blob_descriptor(cfg_c_data, MediaType::OciConfig);
+
+    let manifest_a = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: cfg_a_desc.clone(),
+        layers: vec![shared_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let manifest_b = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: cfg_b_desc.clone(),
+        layers: vec![shared_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let manifest_c = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: cfg_c_desc.clone(),
+        layers: vec![shared_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+
+    let (bytes_a, _) = serialize_manifest(&manifest_a);
+    let (bytes_b, _) = serialize_manifest(&manifest_b);
+    let (bytes_c, _) = serialize_manifest(&manifest_c);
+
+    // Source: all three repos serve their manifests and blobs.
+    mount_source_manifest(&source_server, "src-a", "v1", &bytes_a).await;
+    mount_source_manifest(&source_server, "src-b", "v1", &bytes_b).await;
+    mount_source_manifest(&source_server, "src-c", "v1", &bytes_c).await;
+    mount_blob_pull(&source_server, "src-a", &cfg_a_desc.digest, cfg_a_data).await;
+    mount_blob_pull(&source_server, "src-a", &shared_desc.digest, shared_data).await;
+    mount_blob_pull(&source_server, "src-b", &cfg_b_desc.digest, cfg_b_data).await;
+    mount_blob_pull(&source_server, "src-b", &shared_desc.digest, shared_data).await;
+    mount_blob_pull(&source_server, "src-c", &cfg_c_desc.digest, cfg_c_data).await;
+    mount_blob_pull(&source_server, "src-c", &shared_desc.digest, shared_data).await;
+
+    // Target: all repos get manifest HEAD 404, blob HEAD 404, upload + mount mocks.
+    for repo in &["tgt-a", "tgt-b", "tgt-c"] {
+        mount_manifest_head_not_found(&target_server, repo, "v1").await;
+        mount_blob_not_found(&target_server, repo, &cfg_a_desc.digest).await;
+        mount_blob_not_found(&target_server, repo, &cfg_b_desc.digest).await;
+        mount_blob_not_found(&target_server, repo, &cfg_c_desc.digest).await;
+        mount_blob_not_found(&target_server, repo, &shared_desc.digest).await;
+        mount_blob_push(&target_server, repo).await;
+        mount_manifest_push(&target_server, repo, "v1").await;
+
+        // Mount mock with higher priority so it matches before the upload POST.
+        Mock::given(method("POST"))
+            .and(path(format!("/v2/{repo}/blobs/uploads/")))
+            .and(query_param("mount", shared_desc.digest.to_string()))
+            .respond_with(ResponseTemplate::new(201))
+            .with_priority(1)
+            .mount(&target_server)
+            .await;
+    }
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping_a = resolved_mapping(
+        Arc::clone(&source_client),
+        "src-a",
+        "tgt-a",
+        vec![target_entry("target", Arc::clone(&target_client))],
+        vec![TagPair::same("v1")],
+    );
+    let mapping_b = resolved_mapping(
+        Arc::clone(&source_client),
+        "src-b",
+        "tgt-b",
+        vec![target_entry("target", Arc::clone(&target_client))],
+        vec![TagPair::same("v1")],
+    );
+    let mapping_c = resolved_mapping(
+        source_client,
+        "src-c",
+        "tgt-c",
+        vec![target_entry("target", target_client)],
+        vec![TagPair::same("v1")],
+    );
+
+    // max_concurrent=10: all three run concurrently within their phase.
+    let engine = SyncEngine::new(fast_retry(), 10);
+    let report = engine
+        .run(
+            vec![mapping_a, mapping_b, mapping_c],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            Some(&ShutdownSignal::new()),
+        )
+        .await;
+
+    assert_eq!(report.images.len(), 3);
+    assert!(
+        report
+            .images
+            .iter()
+            .all(|r| matches!(r.status, ImageStatus::Synced)),
+        "all three images should sync: {:#?}",
+        report.images.iter().map(|r| &r.status).collect::<Vec<_>>()
+    );
+    // 3 unique config blobs transferred + 1 shared layer transferred by leader.
+    assert_eq!(report.stats.blobs_transferred, 4);
+    // Shared layer mounted by 2 followers.
+    assert_eq!(report.stats.blobs_mounted, 2);
+}
+
+/// Verify that `transfer_image_blobs` processes blobs concurrently, not
+/// sequentially. An image with 8 blobs, each delayed 100ms on source pull,
+/// should complete well under 8 * 100ms = 800ms given `BLOB_CONCURRENCY=6`.
+#[tokio::test(flavor = "current_thread")]
+async fn sync_blob_concurrency_processes_multiple_blobs() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    // 1 config + 7 layers = 8 blobs, each with unique data.
+    let config_data = b"concurrency-config-blob";
+    let layer_data: Vec<Vec<u8>> = (0..7)
+        .map(|i| format!("concurrency-layer-{i}").into_bytes())
+        .collect();
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_descs: Vec<Descriptor> = layer_data
+        .iter()
+        .map(|d| blob_descriptor(d, MediaType::OciLayerGzip))
+        .collect();
+
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: layer_descs.clone(),
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (manifest_bytes, _) = serialize_manifest(&manifest);
+
+    // Source: serve manifest immediately; each blob with a 100ms delay.
+    mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/blobs/{}", config_desc.digest)))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(config_data.to_vec())
+                .insert_header("content-length", config_data.len().to_string())
+                .set_delay(std::time::Duration::from_millis(100)),
+        )
+        .mount(&source_server)
+        .await;
+    for (i, desc) in layer_descs.iter().enumerate() {
+        Mock::given(method("GET"))
+            .and(path(format!("/v2/repo/blobs/{}", desc.digest)))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(layer_data[i].clone())
+                    .insert_header("content-length", layer_data[i].len().to_string())
+                    .set_delay(std::time::Duration::from_millis(100)),
+            )
+            .mount(&source_server)
+            .await;
+    }
+
+    // Target: manifest HEAD 404, all blob HEADs 404, push accepts.
+    mount_manifest_head_not_found(&target_server, "repo", "v1").await;
+    mount_blob_not_found(&target_server, "repo", &config_desc.digest).await;
+    for desc in &layer_descs {
+        mount_blob_not_found(&target_server, "repo", &desc.digest).await;
+    }
+    mount_blob_push(&target_server, "repo").await;
+    mount_manifest_push(&target_server, "repo", "v1").await;
+
+    let mapping = resolved_mapping(
+        mock_client(&source_server),
+        "repo",
+        "repo",
+        vec![target_entry("target", mock_client(&target_server))],
+        vec![TagPair::same("v1")],
+    );
+
+    let engine = SyncEngine::new(fast_retry(), 1);
+    let start = std::time::Instant::now();
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            Some(&ShutdownSignal::new()),
+        )
+        .await;
+    let elapsed = start.elapsed();
+
+    assert_eq!(report.images.len(), 1);
+    assert!(
+        matches!(report.images[0].status, ImageStatus::Synced),
+        "image should sync, got: {:?}",
+        report.images[0].status
+    );
+    assert_eq!(
+        report.stats.blobs_transferred, 8,
+        "all 8 blobs should be transferred"
+    );
+    // With BLOB_CONCURRENCY=6, 8 blobs at 100ms each need ~2 batches (~200ms).
+    // 1200ms is generous for CI runners; still proves concurrency (sequential >= 800ms).
+    assert!(
+        elapsed < std::time::Duration::from_millis(1200),
+        "elapsed {elapsed:?} should be < 1200ms (sequential would be >= 800ms)"
+    );
+}
+
+/// First-failure-stops semantics: when one blob source returns 500, the
+/// image fails and not all blobs complete.
+#[tokio::test(flavor = "current_thread")]
+async fn sync_blob_failure_cancels_remaining_blobs() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    // 1 config + 3 layers = 4 blobs.
+    let config_data = b"cancel-config";
+    let layer1_data = b"cancel-layer-1";
+    let layer2_data = b"cancel-layer-2-will-fail";
+    let layer3_data = b"cancel-layer-3-never-reached";
+
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer1_desc = blob_descriptor(layer1_data, MediaType::OciLayerGzip);
+    let layer2_desc = blob_descriptor(layer2_data, MediaType::OciLayerGzip);
+    let layer3_desc = blob_descriptor(layer3_data, MediaType::OciLayerGzip);
+
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![
+            layer1_desc.clone(),
+            layer2_desc.clone(),
+            layer3_desc.clone(),
+        ],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (manifest_bytes, _) = serialize_manifest(&manifest);
+
+    // Source: manifest and blobs. Layer 2 always returns 500.
+    mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo", &layer1_desc.digest, layer1_data).await;
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/blobs/{}", layer2_desc.digest)))
+        .respond_with(ResponseTemplate::new(500).set_body_string("internal error"))
+        .mount(&source_server)
+        .await;
+    mount_blob_pull(&source_server, "repo", &layer3_desc.digest, layer3_data).await;
+
+    // Target: manifest HEAD 404, all blob HEADs 404, push accepts.
+    mount_manifest_head_not_found(&target_server, "repo", "v1").await;
+    mount_blob_not_found(&target_server, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer1_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer2_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer3_desc.digest).await;
+    mount_blob_push(&target_server, "repo").await;
+
+    let mapping = resolved_mapping(
+        mock_client(&source_server),
+        "repo",
+        "repo",
+        vec![target_entry("target", mock_client(&target_server))],
+        vec![TagPair::same("v1")],
+    );
+
+    let engine = SyncEngine::new(fast_retry(), 1);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            Some(&ShutdownSignal::new()),
+        )
+        .await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(
+        matches!(report.images[0].status, ImageStatus::Failed { .. }),
+        "image should fail when a blob source returns 500, got: {:?}",
+        report.images[0].status
+    );
+    // Not all blobs completed (the cancel flag stops remaining).
+    assert!(
+        report.images[0].blob_stats.transferred < 4,
+        "transferred {} should be < 4 (cancel should stop remaining blobs)",
+        report.images[0].blob_stats.transferred
+    );
+    assert_eq!(report.stats.images_failed, 1);
+}
+
+/// Two images sharing a blob sync concurrently with staging enabled.
+/// Verifies that concurrent staging writes to the same digest do not
+/// panic or produce ENOENT errors (unique tmp paths prevent collision).
+#[tokio::test(flavor = "current_thread")]
+async fn sync_staging_concurrent_write_no_collision() {
+    let source_server = MockServer::start().await;
+    let target_a = MockServer::start().await;
+    let target_b = MockServer::start().await;
+
+    // Shared blob across both images.
+    let shared_data = b"shared-staging-collision-test";
+    let shared_desc = blob_descriptor(shared_data, MediaType::OciLayerGzip);
+
+    // Unique config blobs per image.
+    let cfg_a_data = b"staging-cfg-a";
+    let cfg_b_data = b"staging-cfg-b";
+    let cfg_a_desc = blob_descriptor(cfg_a_data, MediaType::OciConfig);
+    let cfg_b_desc = blob_descriptor(cfg_b_data, MediaType::OciConfig);
+
+    let manifest_a = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: cfg_a_desc.clone(),
+        layers: vec![shared_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let manifest_b = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: cfg_b_desc.clone(),
+        layers: vec![shared_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (bytes_a, _) = serialize_manifest(&manifest_a);
+    let (bytes_b, _) = serialize_manifest(&manifest_b);
+
+    // Source: both repos serve their manifests and all blobs.
+    mount_source_manifest(&source_server, "src-a", "v1", &bytes_a).await;
+    mount_source_manifest(&source_server, "src-b", "v1", &bytes_b).await;
+    mount_blob_pull(&source_server, "src-a", &cfg_a_desc.digest, cfg_a_data).await;
+    mount_blob_pull(&source_server, "src-a", &shared_desc.digest, shared_data).await;
+    mount_blob_pull(&source_server, "src-b", &cfg_b_desc.digest, cfg_b_data).await;
+    mount_blob_pull(&source_server, "src-b", &shared_desc.digest, shared_data).await;
+
+    // Target A: manifest HEAD 404, blobs 404, push accepts.
+    mount_manifest_head_not_found(&target_a, "tgt-a", "v1").await;
+    mount_blob_not_found(&target_a, "tgt-a", &cfg_a_desc.digest).await;
+    mount_blob_not_found(&target_a, "tgt-a", &shared_desc.digest).await;
+    mount_blob_push(&target_a, "tgt-a").await;
+    mount_manifest_push(&target_a, "tgt-a", "v1").await;
+
+    // Target B: manifest HEAD 404, blobs 404, push accepts.
+    mount_manifest_head_not_found(&target_b, "tgt-b", "v1").await;
+    mount_blob_not_found(&target_b, "tgt-b", &cfg_b_desc.digest).await;
+    mount_blob_not_found(&target_b, "tgt-b", &shared_desc.digest).await;
+    mount_blob_push(&target_b, "tgt-b").await;
+    mount_manifest_push(&target_b, "tgt-b", "v1").await;
+
+    let staging_dir = tempfile::tempdir().unwrap();
+    let staging = BlobStage::new(staging_dir.path().to_path_buf());
+
+    let source_client = mock_client(&source_server);
+
+    let mapping_a = resolved_mapping(
+        Arc::clone(&source_client),
+        "src-a",
+        "tgt-a",
+        vec![target_entry("target-a", mock_client(&target_a))],
+        vec![TagPair::same("v1")],
+    );
+    let mapping_b = resolved_mapping(
+        source_client,
+        "src-b",
+        "tgt-b",
+        vec![target_entry("target-b", mock_client(&target_b))],
+        vec![TagPair::same("v1")],
+    );
+
+    // max_concurrent=10: both images sync concurrently.
+    let engine = SyncEngine::new(fast_retry(), 10);
+    let report = engine
+        .run(
+            vec![mapping_a, mapping_b],
+            empty_cache(),
+            staging,
+            &NullProgress,
+            Some(&ShutdownSignal::new()),
+        )
+        .await;
+
+    assert_eq!(report.images.len(), 2);
+    assert!(
+        report
+            .images
+            .iter()
+            .all(|r| matches!(r.status, ImageStatus::Synced)),
+        "both images should sync without collision: {:#?}",
+        report.images.iter().map(|r| &r.status).collect::<Vec<_>>()
+    );
+    // At least the 2 unique config blobs are transferred.
+    assert!(
+        report.stats.blobs_transferred >= 2,
+        "at least 2 unique config blobs should be transferred, got {}",
+        report.stats.blobs_transferred
+    );
+}
+
+/// Source-pull dedup: when two images share a blob and staging is enabled,
+/// the source blob should be pulled exactly once. The second image's task
+/// waits for the first to finish staging, then reads from disk.
+#[tokio::test(flavor = "current_thread")]
+async fn sync_source_pull_dedup_with_staging() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    // Shared layer across both images; config blobs are unique.
+    let shared_data = b"shared-source-dedup-layer";
+    let cfg_a_data = b"dedup-cfg-a";
+    let cfg_b_data = b"dedup-cfg-b";
+
+    let shared_desc = blob_descriptor(shared_data, MediaType::OciLayerGzip);
+    let cfg_a_desc = blob_descriptor(cfg_a_data, MediaType::OciConfig);
+    let cfg_b_desc = blob_descriptor(cfg_b_data, MediaType::OciConfig);
+
+    let manifest_a = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: cfg_a_desc.clone(),
+        layers: vec![shared_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let manifest_b = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: cfg_b_desc.clone(),
+        layers: vec![shared_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (bytes_a, _) = serialize_manifest(&manifest_a);
+    let (bytes_b, _) = serialize_manifest(&manifest_b);
+
+    // Source: both repos serve their manifests and all blobs.
+    mount_source_manifest(&source_server, "src-a", "v1", &bytes_a).await;
+    mount_source_manifest(&source_server, "src-b", "v1", &bytes_b).await;
+    mount_blob_pull(&source_server, "src-a", &cfg_a_desc.digest, cfg_a_data).await;
+    mount_blob_pull(&source_server, "src-b", &cfg_b_desc.digest, cfg_b_data).await;
+    // Shared blob: served by both repos, but `.expect(1)` on each to verify
+    // that the source-pull dedup prevents a second GET.
+    let shared_pull_a = Mock::given(method("GET"))
+        .and(path(format!("/v2/src-a/blobs/{}", shared_desc.digest)))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(shared_data.to_vec())
+                .insert_header("content-length", shared_data.len().to_string()),
+        )
+        .expect(0..=1)
+        .named("shared blob GET src-a")
+        .mount_as_scoped(&source_server)
+        .await;
+    let shared_pull_b = Mock::given(method("GET"))
+        .and(path(format!("/v2/src-b/blobs/{}", shared_desc.digest)))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(shared_data.to_vec())
+                .insert_header("content-length", shared_data.len().to_string()),
+        )
+        .expect(0..=1)
+        .named("shared blob GET src-b")
+        .mount_as_scoped(&source_server)
+        .await;
+
+    // Target: manifest HEAD 404, blobs 404, push accepts.
+    for repo in &["tgt-a", "tgt-b"] {
+        mount_manifest_head_not_found(&target_server, repo, "v1").await;
+        mount_blob_not_found(&target_server, repo, &cfg_a_desc.digest).await;
+        mount_blob_not_found(&target_server, repo, &cfg_b_desc.digest).await;
+        mount_blob_not_found(&target_server, repo, &shared_desc.digest).await;
+        mount_blob_push(&target_server, repo).await;
+        mount_manifest_push(&target_server, repo, "v1").await;
+    }
+
+    let staging_dir = tempfile::tempdir().unwrap();
+    let staging = BlobStage::new(staging_dir.path().to_path_buf());
+
+    let source_client = mock_client(&source_server);
+
+    let mapping_a = resolved_mapping(
+        Arc::clone(&source_client),
+        "src-a",
+        "tgt-a",
+        vec![target_entry("target", mock_client(&target_server))],
+        vec![TagPair::same("v1")],
+    );
+    let mapping_b = resolved_mapping(
+        source_client,
+        "src-b",
+        "tgt-b",
+        vec![target_entry("target", mock_client(&target_server))],
+        vec![TagPair::same("v1")],
+    );
+
+    // max_concurrent=10: both images sync concurrently.
+    let engine = SyncEngine::new(fast_retry(), 10);
+    let report = engine
+        .run(
+            vec![mapping_a, mapping_b],
+            empty_cache(),
+            staging,
+            &NullProgress,
+            Some(&ShutdownSignal::new()),
+        )
+        .await;
+
+    // Drop scoped mocks before checking received requests.
+    drop(shared_pull_a);
+    drop(shared_pull_b);
+
+    assert_eq!(report.images.len(), 2);
+    assert!(
+        report
+            .images
+            .iter()
+            .all(|r| matches!(r.status, ImageStatus::Synced)),
+        "both images should sync: {:#?}",
+        report.images.iter().map(|r| &r.status).collect::<Vec<_>>()
+    );
+    // 4 blobs pushed to targets: 2 unique configs + shared layer to each target.
+    // Source-pull dedup doesn't reduce target pushes -- only source GETs.
+    assert_eq!(report.stats.blobs_transferred, 4);
+
+    // Key assertion: the shared blob was pulled from source exactly once
+    // across both repos. Without dedup this would be 2 (one per image).
+    let received = source_server.received_requests().await.unwrap();
+    let shared_blob_suffix = format!("/blobs/{}", shared_desc.digest);
+    let source_gets_for_shared = received
+        .iter()
+        .filter(|r| r.method.as_str() == "GET" && r.url.path().ends_with(&shared_blob_suffix))
+        .count();
+    assert_eq!(
+        source_gets_for_shared, 1,
+        "shared blob should be pulled from source exactly once (dedup), got {source_gets_for_shared}"
+    );
 }

--- a/docs/specs/findings.md
+++ b/docs/specs/findings.md
@@ -195,42 +195,47 @@ Four optimizations implemented (branch `benchmark-comparison`):
    `chunk_size` field/builder, `send_patch_chunk`, `ContentRangeMatcher`.
    Net -213 lines.
 
-### Current competitive position (cold sync, Jupyter 5-image corpus)
+### Current competitive position (cold sync, full corpus)
 
-| Tool | Platforms | Requests | Response bytes | Wall clock |
-|------|----------|---------|----------------|------------|
-| **ocync** (streaming PUT) | 2 (multi-arch) | **1,049** | 11.5 GB | 217.9s |
-| dregsy (skopeo, `platform: all`) | multi-arch | 1,266 | 4.9 GB | 153.4s |
-| regsync v0.11.3 | 2 (multi-arch) | 1,302 | 11.5 GB | 180.2s |
+Measured 2026-04-18 on c6in.4xlarge (Intel, 16 vCPUs, 32 GiB, up to 50 Gbps).
+Full corpus: 42 images, 55 tags across Docker Hub, cgr.dev, public ECR, nvcr.io.
+Docker Hub authenticated (all tools). 1 iteration per tool.
 
-ocync wins on requests (1,049 vs 1,266 vs 1,302). dregsy transfers
-fewer bytes (4.9 GB vs 11.5 GB) because 172 successful cross-repo
-mounts (BLOB_MOUNTING=ENABLED) eliminated shared layer uploads.
-regsync's mounts all fail (omits `from=` parameter).
+| Metric | ocync | dregsy | regsync |
+|---|---:|---:|---:|
+| Wall clock | **4m 33s** | 36m 22s | 16m 6s |
+| Peak RSS | **58.1 MB** | 304.5 MB | 27.0 MB |
+| Requests | **4,131** | 11,190 | 7,719 |
+| Response bytes | **16.9 GB** | 43.4 GB | 35.4 GB |
+| Source blob GETs | **726** | 1,324 | 1,381 |
+| Source blob bytes | **77.2 KB** | 120.1 KB | 160.5 KB |
+| Mounts (success/attempt) | **362/379** | 293/293 | 0/1,380 |
+| Duplicate blob GETs | **0** | 1 | 1 |
+| Rate-limit 429s | **0** | 49 | 0 |
 
-With ECR blob mounting enabled, ocync's mount short-circuit is a
-disadvantage — re-enabling mounts would save both requests and bytes.
+ocync wins every metric except peak RSS (regsync is lighter at 27 MB).
+Key differentiators:
 
-| Tool | Requests | Response bytes | Wall clock |
-|------|---------|----------------|------------|
-| **ocync** | **81** | 371 KB | **2.5s** |
-| regsync | 27 | 27 KB | 4s |
-| dregsy | 200 | 163 KB | 5.2s |
+- **8x faster** than dregsy, **3.5x faster** than regsync
+- **2.7x fewer requests** than dregsy, **1.9x fewer** than regsync
+- **2.6x fewer response bytes** than dregsy, **2.1x fewer** than regsync
+- **95.5% mount success** (362/379) vs dregsy 100% (293/293) vs regsync 0%
+- **Zero rate-limit 429s** vs dregsy's 49 (AIMD congestion control works)
+- **Zero duplicate blob GETs** (source-pull dedup prevents redundant downloads)
 
-Warm sync: ocync wins wall-clock decisively. regsync uses fewer
-requests (manifest-digest comparison only) but is sequential.
+regsync mounts all fail (regclient omits `from=` parameter for
+cross-registry syncs). dregsy hit 49 rate-limit 429s from Docker Hub
+despite authenticated pulls.
 
-### To re-validate
+**Memory:** regsync's lower RSS (27 MB) reflects its sequential
+architecture -- one image, one blob at a time, with Go's ~10-15 MB
+baseline. ocync's 58 MB comes from concurrent blob transfers
+(BLOB_CONCURRENCY=6), the staging claim/wait maps, transfer state
+cache, and blob frequency map held in memory simultaneously. dregsy's
+304 MB is skopeo buffering full layers in memory before pushing. The
+58 MB vs 27 MB trade-off buys 3.5x faster wall clock.
 
-Re-run after Docker Hub rate limit resets. dregsy now configured with
-`platform: all` for fair multi-arch comparison.
-
-```bash
-ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
-export BENCH_TARGET_REGISTRY=${ACCOUNT}.dkr.ecr.us-east-1.amazonaws.com
-cargo xtask bench --tools ocync,dregsy,regsync --iterations 1 --limit 5 cold
-cargo xtask bench --tools ocync,dregsy,regsync --limit 5 warm
-```
+Historical data: `bench-results/runs/*.json` (gitignored, on instance)
 
 ---
 
@@ -378,6 +383,70 @@ calls). Returns full manifest bodies, not just existence.
 
 ---
 
+## 2026-04-17 -- Leader-follower mount optimization
+
+### Observation
+
+Leader-follower election ensures images with the most shared blobs execute
+first (leaders), committing manifests before followers start. Followers then
+mount shared blobs from the leader's repo instead of re-uploading. Tested
+on c6in.large, Jupyter corpus (5 images, 1 tag each), cold sync to ECR
+us-east-1. Branch: `feat/leader-follower-mount`.
+
+| Metric | Before (streaming PUT, no L-F) | After (leader-follower + blob concurrency) |
+|--------|-------------------------------|---------------------------------------------|
+| Requests | 1,049 | **591** |
+| Response bytes | 11.5 GB | **4.9 GB** |
+| Wall clock | 217.9s | **56.8s** |
+| Mount attempts | 0 (short-circuited) | 192 |
+| Mount success | 0 | **192 (100%)** |
+
+**591 requests vs 1,049** -- 44% fewer API calls. **4.9 GB vs 11.5 GB** --
+57% fewer bytes via cross-image staging dedup and 100% mount success.
+**56.8s vs 217.9s** -- 3.8x faster wall clock via 6-concurrent blob
+transfers within each image (matching skopeo's default parallelism).
+
+Preferred mount sources (leader repos with committed manifests) are tried
+first, avoiding 202 rejections from follower repos whose manifests have
+not yet been committed. This raised mount success from 40% to 100%.
+
+### Bugs found and fixed
+
+`ClaimAction::Wait` uses `tokio::sync::Notify::notify_waiters()` which does
+not store permits. Three code paths transitioned blobs out of `InProgress`
+without calling `notify_blob`:
+
+1. Mount success: `set_blob_completed` + continue (no notify)
+2. HEAD exists: `set_blob_exists` + continue (no notify)
+3. Mount failure: `invalidate_blob` (no notify before fallback)
+
+This caused deadlocks when two followers raced on a shared blob: one mounted
+without notifying, the other waited forever. Latent before leader-follower
+because concurrent promotion made the first claimer typically the uploader
+(no mount source available in the early phase). Fixed by adding `notify_blob`
+on all three paths.
+
+### Action taken
+
+- Greedy set-cover election (`elect_leaders`) reorders pending tasks so
+  images with the most shared blobs transfer first
+- Wave-based follower promotion: wave 1 (blobs covered by leaders) runs
+  first, wave 2 (inter-follower deps) waits for wave 1 to commit
+- `notify_blob` added to mount-success, HEAD-exists, and invalidate paths
+- Skip HEAD after NotMounted (202 already confirms blob absent)
+- Cross-image source blob dedup via staging (pull once, push from disk)
+
+### To re-validate
+
+```bash
+cargo xtask bench --tools ocync,dregsy,regsync --iterations 1 --limit 5 cold
+```
+
+Compare mount success rate, total requests, and response bytes across
+all three tools.
+
+---
+
 ## Optimization backlog
 
 Ranked by estimated impact. Updated as findings change our
@@ -385,7 +454,7 @@ understanding. Each entry ships as its own PR.
 
 | # | Optimization | Impact | Complexity | Status |
 |---|-------------|--------|------------|--------|
-| 1 | **ECR blob mounting** -- detect `BLOB_MOUNTING`, re-enable mount when set | Saves blob transfer for every shared layer across ECR repos | Medium | **Confirmed working.** Requires blob to be part of a committed image. See findings entry for details. |
+| 1 | ~~**ECR blob mounting**~~ | ~~Saves blob transfer for every shared layer~~ | ~~Medium~~ | **Done.** Leader-follower + blob concurrency: 192/192 mounts, 44% fewer requests, 57% fewer bytes, 3.8x faster. |
 | 2 | **Cross-image blob download dedup** — download each unique blob from source once, push to N target repos | ~168 source GETs, ~5.6 GB on Jupyter corpus | High | Not started |
 | 3 | **Docker Hub authentication** — always authenticate pulls, add credential support for source registries | 10× more pull quota (100/hr vs 10/hr) | Low | Not started |
 | 4 | **ACR streaming PUT fallback** — `ProviderKind::Acr` with chunked PATCH for blobs > 20 MB | Correctness on ACR (currently broken for large blobs) | Low | Not started |
@@ -394,14 +463,15 @@ understanding. Each entry ships as its own PR.
 | 7 | **Rate limit header parsing** — read `ratelimit-remaining` from Docker Hub and throttle proactively | Avoid 429s before they happen | Low | Not started |
 | 8 | **Verify HTTP/2 on ECR** — check ALPN negotiation, enable multiplexing | Connection reuse for 50 concurrent requests | Trivial | Not started |
 
-### Completed optimizations (this branch)
+### Completed optimizations
 
 | Optimization | Requests saved | Status |
 |-------------|---------------|--------|
-| Streaming PUT upload (eliminate chunked PATCH + monolithic buffer) | ~2,200 (3,249 to 1,049) | Done |
-| Auth cache fix (EARLY_REFRESH_WINDOW 15 min → 30s) | ~267 | Done |
-| Batch-check HEAD skip (cold sync) | ~247 | Done |
-| ECR mount short-circuit (PR #25) | ~148 | Done |
+| Streaming PUT upload (eliminate chunked PATCH + monolithic buffer) | ~2,200 (3,249 to 1,049) | Done (PR #26) |
+| Auth cache fix (EARLY_REFRESH_WINDOW 15 min to 30s) | ~267 | Done (PR #26) |
+| Batch-check HEAD skip (cold sync) | ~247 | Done (PR #26) |
+| ECR mount short-circuit (PR #25) | ~148 | Done (PR #25) |
+| Leader-follower mount + blob concurrency + staging dedup | ~458 (1,049 to 591), 6.6 GB bytes saved, 3.8x faster | Done (feat/leader-follower-mount) |
 
 ---
 

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -105,9 +105,17 @@ pub(crate) async fn run(
         }
     };
 
-    // Enable disk staging only when at least one mapping has multiple targets.
-    let has_multi_target = mappings.iter().any(|m| m.targets.len() > 1);
-    let staging = if has_multi_target {
+    // Enable disk staging when multiple targets OR multiple images share blobs.
+    // Multi-target: pull once from source, push to N targets from disk.
+    // Multi-image: pull once, push from staging when the same blob appears in
+    // another image (cross-image source dedup).
+    //
+    // Trade-off: this is a conservative heuristic -- disjoint mappings pay a
+    // disk round-trip per blob for zero benefit. Tighter detection would
+    // require manifest data (unavailable pre-discovery). The overhead is
+    // small (local I/O) relative to the network savings when blobs overlap.
+    let needs_staging = mappings.iter().any(|m| m.targets.len() > 1) || mappings.len() > 1;
+    let staging = if needs_staging {
         let stage = BlobStage::new(cache_dir.join("blobs"));
         if let Err(e) = stage.cleanup_tmp_files() {
             tracing::warn!(error = %e, "failed to clean staging tmp files");

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -226,9 +226,7 @@ pub(crate) async fn build_registry_client(
             // everything else, anonymous as final fallback. Native providers for
             // GCR/ACR/GHCR will be inserted between ECR and docker config when
             // implemented.
-            if let Some(ProviderKind::Ecr | ProviderKind::EcrPublic) =
-                detect_provider_kind(bare_host)
-            {
+            if let Some(ProviderKind::Ecr) = detect_provider_kind(bare_host) {
                 let auth = EcrAuth::new(bare_host).await.map_err(|e| {
                     CliError::Input(format!("ECR auth setup for '{bare_host}': {e}"))
                 })?;

--- a/xtask/src/bench/config_gen.rs
+++ b/xtask/src/bench/config_gen.rs
@@ -4,6 +4,37 @@ use std::collections::BTreeMap;
 
 use crate::bench::corpus::{Corpus, ImageEntry};
 
+/// Base64-encode a byte slice using the standard alphabet with padding.
+///
+/// Hand-rolled to avoid adding a `base64` crate dependency for a single
+/// call site (dregsy auth field).
+pub(crate) fn base64_encode(input: &str) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let bytes = input.as_bytes();
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+
+    for chunk in bytes.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = chunk.get(1).copied().unwrap_or(0) as u32;
+        let b2 = chunk.get(2).copied().unwrap_or(0) as u32;
+        let triple = (b0 << 16) | (b1 << 8) | b2;
+
+        out.push(ALPHABET[((triple >> 18) & 0x3F) as usize] as char);
+        out.push(ALPHABET[((triple >> 12) & 0x3F) as usize] as char);
+        if chunk.len() > 1 {
+            out.push(ALPHABET[((triple >> 6) & 0x3F) as usize] as char);
+        } else {
+            out.push('=');
+        }
+        if chunk.len() > 2 {
+            out.push(ALPHABET[(triple & 0x3F) as usize] as char);
+        } else {
+            out.push('=');
+        }
+    }
+    out
+}
+
 /// Extract the registry hostname from a source image reference.
 ///
 /// `cgr.dev/chainguard/static` → `cgr.dev`
@@ -63,6 +94,15 @@ pub(crate) fn ocync_config(corpus: &Corpus) -> String {
         let key = registry_key(reg);
         out.push_str(&format!("  {key}:\n"));
         out.push_str(&format!("    url: {reg}\n"));
+        // Docker Hub: inject basic auth to avoid 10 pulls/hr anonymous limit.
+        if *reg == "docker.io" {
+            if let Some(auth) = &corpus.dockerhub_auth {
+                out.push_str("    auth_type: basic\n");
+                out.push_str("    credentials:\n");
+                out.push_str(&format!("      username: {}\n", auth.username));
+                out.push_str(&format!("      password: {}\n", auth.token));
+            }
+        }
     }
     out.push_str(&format!("  {ecr_key}:\n"));
     out.push_str(&format!("    url: {}\n", corpus.settings.target_registry));
@@ -114,6 +154,13 @@ pub(crate) fn dregsy_config(corpus: &Corpus) -> String {
         out.push_str(&format!("  - name: {task_name}\n"));
         out.push_str("    source:\n");
         out.push_str(&format!("      registry: {registry}\n"));
+        // Docker Hub: inject base64-encoded auth to avoid 10 pulls/hr anonymous limit.
+        if *registry == "docker.io" {
+            if let Some(auth) = &corpus.dockerhub_auth {
+                let encoded = base64_encode(&format!("{}:{}", auth.username, auth.token));
+                out.push_str(&format!("      auth: {encoded}\n"));
+            }
+        }
         out.push_str("    target:\n");
         out.push_str(&format!(
             "      registry: {}\n",
@@ -167,6 +214,13 @@ pub(crate) fn regsync_config(corpus: &Corpus) -> String {
         // Per-repo auth: required for registries that issue per-scope tokens and
         // reject multi-scope requests (cgr.dev, gcr.io, nvcr.io).
         out.push_str("    repoAuth: true\n");
+        // Docker Hub: inject user/pass to avoid 10 pulls/hr anonymous limit.
+        if *reg == "docker.io" {
+            if let Some(auth) = &corpus.dockerhub_auth {
+                out.push_str(&format!("    user: {}\n", auth.username));
+                out.push_str(&format!("    pass: {}\n", auth.token));
+            }
+        }
     }
     out.push_str(&format!(
         "  - registry: {}\n",
@@ -311,6 +365,145 @@ sync:
         - \"latest\"
 ";
         assert_eq!(config, expected);
+    }
+
+    fn test_corpus_with_dockerhub_auth() -> Corpus {
+        use crate::bench::corpus::DockerHubAuth;
+        let mut corpus = test_corpus();
+        corpus.dockerhub_auth = Some(DockerHubAuth {
+            username: "ocync-bench".to_string(),
+            token: "dkr_pat_abc123".to_string(),
+        });
+        corpus
+    }
+
+    #[test]
+    fn ocync_config_with_dockerhub_auth() {
+        let config = ocync_config(&test_corpus_with_dockerhub_auth());
+        let expected = "\
+registries:
+  cgr-dev:
+    url: cgr.dev
+  docker-io:
+    url: docker.io
+    auth_type: basic
+    credentials:
+      username: ocync-bench
+      password: dkr_pat_abc123
+  ecr:
+    url: 111111111111.dkr.ecr.us-east-1.amazonaws.com
+    auth_type: ecr
+
+mappings:
+  - from: chainguard/static
+    to: bench/chainguard-static
+    source: cgr-dev
+    targets: [ecr]
+    tags:
+      glob:
+        - \"latest\"
+  - from: library/alpine
+    to: bench/library-alpine
+    source: docker-io
+    targets: [ecr]
+    tags:
+      glob:
+        - \"3.20\"
+        - \"latest\"
+";
+        assert_eq!(config, expected);
+    }
+
+    #[test]
+    fn dregsy_config_with_dockerhub_auth() {
+        let config = dregsy_config(&test_corpus_with_dockerhub_auth());
+        let expected = "\
+relay: skopeo
+
+tasks:
+  - name: sync-cgr-dev
+    source:
+      registry: cgr.dev
+    target:
+      registry: 111111111111.dkr.ecr.us-east-1.amazonaws.com
+      auth-refresh: 12h
+    mappings:
+      - from: chainguard/static
+        to: bench/chainguard-static
+        platform: all
+        tags:
+          - \"latest\"
+  - name: sync-docker-io
+    source:
+      registry: docker.io
+      auth: b2N5bmMtYmVuY2g6ZGtyX3BhdF9hYmMxMjM=
+    target:
+      registry: 111111111111.dkr.ecr.us-east-1.amazonaws.com
+      auth-refresh: 12h
+    mappings:
+      - from: library/alpine
+        to: bench/library-alpine
+        platform: all
+        tags:
+          - \"3.20\"
+          - \"latest\"
+";
+        assert_eq!(config, expected);
+    }
+
+    #[test]
+    fn regsync_config_with_dockerhub_auth() {
+        let config = regsync_config(&test_corpus_with_dockerhub_auth());
+        let expected = "\
+version: 1
+
+creds:
+  - registry: cgr.dev
+    repoAuth: true
+  - registry: docker.io
+    repoAuth: true
+    user: ocync-bench
+    pass: dkr_pat_abc123
+  - registry: 111111111111.dkr.ecr.us-east-1.amazonaws.com
+    credHelper: docker-credential-ecr-login
+
+sync:
+  - source: \"cgr.dev/chainguard/static\"
+    target: \"111111111111.dkr.ecr.us-east-1.amazonaws.com/bench/chainguard-static\"
+    type: image
+    tags:
+      allow:
+        - \"latest\"
+  - source: \"docker.io/library/alpine\"
+    target: \"111111111111.dkr.ecr.us-east-1.amazonaws.com/bench/library-alpine\"
+    type: image
+    tags:
+      allow:
+        - \"3.20\"
+        - \"latest\"
+";
+        assert_eq!(config, expected);
+    }
+
+    #[test]
+    fn base64_encode_known_vectors() {
+        // RFC 4648 test vectors.
+        assert_eq!(base64_encode(""), "");
+        assert_eq!(base64_encode("f"), "Zg==");
+        assert_eq!(base64_encode("fo"), "Zm8=");
+        assert_eq!(base64_encode("foo"), "Zm9v");
+        assert_eq!(base64_encode("foob"), "Zm9vYg==");
+        assert_eq!(base64_encode("fooba"), "Zm9vYmE=");
+        assert_eq!(base64_encode("foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn base64_encode_auth_string() {
+        // Verify the exact encoding used in dregsy auth field.
+        assert_eq!(
+            base64_encode("ocync-bench:dkr_pat_abc123"),
+            "b2N5bmMtYmVuY2g6ZGtyX3BhdF9hYmMxMjM="
+        );
     }
 
     #[test]

--- a/xtask/src/bench/corpus.rs
+++ b/xtask/src/bench/corpus.rs
@@ -2,6 +2,13 @@
 
 use serde::Deserialize;
 
+/// Docker Hub credentials for authenticated pulls (avoids 10 pulls/hr anon limit).
+#[derive(Clone, Debug)]
+pub(crate) struct DockerHubAuth {
+    pub(crate) username: String,
+    pub(crate) token: String,
+}
+
 /// Top-level corpus configuration.
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct Corpus {
@@ -11,6 +18,9 @@ pub(crate) struct Corpus {
     /// Image entries to sync.
     #[serde(rename = "images")]
     pub(crate) images: Vec<ImageEntry>,
+    /// Docker Hub auth credentials (populated at runtime, not from YAML).
+    #[serde(skip)]
+    pub(crate) dockerhub_auth: Option<DockerHubAuth>,
 }
 
 /// Corpus-level settings (target registry, prefix).
@@ -44,6 +54,7 @@ impl Corpus {
         Corpus {
             settings: self.settings.clone(),
             images: self.images.iter().take(n).cloned().collect(),
+            dockerhub_auth: self.dockerhub_auth.clone(),
         }
     }
 
@@ -86,6 +97,7 @@ impl Corpus {
                 img.tags.clone_from(&ovr.tags);
             }
         }
+        // dockerhub_auth is carried forward via clone.
         result
     }
 }

--- a/xtask/src/bench/mod.rs
+++ b/xtask/src/bench/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod corpus;
 pub(crate) mod ecr;
 pub(crate) mod proxy;
 pub(crate) mod regression;
+pub(crate) mod remote;
 pub(crate) mod report;
 pub(crate) mod runner;
 
@@ -40,8 +41,8 @@ pub(crate) struct BenchArgs {
     #[arg(long)]
     pub(crate) limit: Option<usize>,
 
-    /// Number of iterations for the cold scenario (default: 3).
-    #[arg(long, default_value = "3")]
+    /// Number of iterations for the cold scenario (default: 1).
+    #[arg(long, default_value = "1")]
     pub(crate) iterations: usize,
 
     /// Proxy listen port (default: 8080).
@@ -99,13 +100,64 @@ enum RunnableScenario {
     Scale,
 }
 
+/// Read an SSM parameter by name, returning `None` on any failure.
+fn read_ssm_parameter(name: &str) -> Option<String> {
+    std::process::Command::new("aws")
+        .args([
+            "ssm",
+            "get-parameter",
+            "--name",
+            name,
+            "--with-decryption",
+            "--query",
+            "Parameter.Value",
+            "--output",
+            "text",
+            "--region",
+            "us-east-1",
+        ])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                String::from_utf8(o.stdout).ok()
+            } else {
+                None
+            }
+        })
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Progress file path for remote monitoring.
+const PROGRESS_FILE: &str = "/tmp/bench-progress.txt";
+
+/// Write a progress line to both stderr and the progress file.
+///
+/// The progress file is polled by `bench-remote` for real-time status.
+fn progress(msg: &str) {
+    eprintln!("{msg}");
+    // Best-effort write; don't fail the benchmark if the file can't be written.
+    let _ = std::fs::write(PROGRESS_FILE, format!("{msg}\n"));
+}
+
 /// Run the benchmark suite.
 pub(crate) async fn run(args: BenchArgs) -> Result<(), Box<dyn std::error::Error>> {
     // 1. Parse corpus (apply limit if set).
     let loaded = corpus::load(&args.corpus)?;
-    let corpus = match args.limit {
+    let mut corpus = match args.limit {
         Some(n) => loaded.limit(n),
         None => loaded,
+    };
+
+    // Inject Docker Hub auth from SSM if available.
+    if let Some(token) = read_ssm_parameter("/ocync/bench/dockerhub-access-token") {
+        let username = read_ssm_parameter("/ocync/bench/dockerhub-username")
+            .unwrap_or_else(|| "ocync-bench".into());
+        eprintln!("bench: Docker Hub auth configured (username={username})");
+        corpus.dockerhub_auth = Some(corpus::DockerHubAuth { username, token });
+    } else {
+        eprintln!("bench: Docker Hub auth not available, using anonymous pulls");
     };
 
     // 2. Parse tools from args.
@@ -149,8 +201,20 @@ pub(crate) async fn run(args: BenchArgs) -> Result<(), Box<dyn std::error::Error
     };
 
     // 5. Create report.
+    let instance = report::InstanceInfo::collect();
+    eprintln!(
+        "bench: instance={} cpu={} vcpus={} mem={}MiB net={} region={}",
+        instance.instance_type,
+        instance.cpu_model,
+        instance.vcpus,
+        instance.memory_mib,
+        instance.network_performance,
+        instance.region,
+    );
+
     let mut report = BenchReport {
         timestamp,
+        instance,
         corpus_size: corpus.images.len(),
         total_tags: corpus.total_tags(),
         tool_versions,
@@ -331,19 +395,26 @@ async fn run_single_tool(
 
     // 6. Stop proxy, parse log, aggregate metrics.
     let entries = proxy::stop(handle).await?;
-    let metrics = proxy::aggregate(&entries);
+    let metrics = proxy::aggregate(&entries, &corpus.settings.target_registry);
 
+    let rss_display = result
+        .peak_rss_kb
+        .map(|kb| report::format_bytes(kb * 1024))
+        .unwrap_or_else(|| "n/a".into());
     eprintln!(
-        "  {}: wall_clock={:.1}s exit={} requests={} response_bytes={} mounts={}/{}",
+        "  {}: wall_clock={:.1}s exit={} rss={} requests={} response_bytes={} mounts={}/{} source_pulls={}/{}",
         tool,
         result.wall_clock.as_secs_f64(),
         result
             .exit_code
             .map_or_else(|| "signal".to_string(), |c| c.to_string()),
+        rss_display,
         metrics.total_requests,
         report::format_bytes(metrics.total_response_bytes),
         metrics.mount_successes,
         metrics.mount_attempts,
+        metrics.source_blob_gets,
+        report::format_bytes(metrics.source_blob_bytes),
     );
 
     // 7. Parse ocync JSON if applicable.
@@ -357,6 +428,7 @@ async fn run_single_tool(
         tool: tool.to_string(),
         wall_clock_secs: result.wall_clock.as_secs_f64(),
         exit_code: result.exit_code,
+        peak_rss_kb: result.peak_rss_kb,
         proxy_metrics: Some(metrics),
         ocync_json,
     })
@@ -370,17 +442,22 @@ async fn run_cold(
     ecr_client: &aws_sdk_ecr::Client,
     output_dir: &Path,
 ) -> Result<ScenarioResult, Box<dyn std::error::Error>> {
-    eprintln!(
+    progress(&format!(
         "bench: running cold scenario ({} iterations)",
         args.iterations
-    );
+    ));
     let mut runs = Vec::new();
 
     for &tool in tools {
         let mut iteration_runs = Vec::new();
 
         for i in 0..args.iterations {
-            eprintln!("  cold: {} iteration {}/{}", tool, i + 1, args.iterations);
+            progress(&format!(
+                "  cold: {} iteration {}/{}",
+                tool,
+                i + 1,
+                args.iterations
+            ));
 
             ecr::create_repos(ecr_client, corpus).await?;
 
@@ -389,6 +466,13 @@ async fn run_cold(
 
             ecr::delete_repos(ecr_client, corpus).await?;
 
+            progress(&format!(
+                "  cold: {} iteration {}/{} complete ({:.1}s)",
+                tool,
+                i + 1,
+                args.iterations,
+                run.wall_clock_secs
+            ));
             iteration_runs.push(run);
 
             if i + 1 < args.iterations {
@@ -419,22 +503,26 @@ async fn run_warm(
     ecr_client: &aws_sdk_ecr::Client,
     output_dir: &Path,
 ) -> Result<ScenarioResult, Box<dyn std::error::Error>> {
-    eprintln!("bench: running warm scenario");
+    progress("bench: running warm scenario");
     let mut runs = Vec::new();
 
     for &tool in tools {
-        eprintln!("  warm: {}", tool);
+        progress(&format!("  warm: {} (priming)", tool));
 
         ecr::create_repos(ecr_client, corpus).await?;
 
         // Prime run (unmeasured).
         let config_dir = tempfile::tempdir()?;
         let _prime = run_single_tool(args, tool, corpus, config_dir.path(), output_dir).await?;
-        eprintln!("  warm: {} prime complete, running measured pass", tool);
+        progress(&format!("  warm: {} measuring", tool));
 
         // Measured run.
         let config_dir = tempfile::tempdir()?;
         let run = run_single_tool(args, tool, corpus, config_dir.path(), output_dir).await?;
+        progress(&format!(
+            "  warm: {} complete ({:.1}s)",
+            tool, run.wall_clock_secs
+        ));
         runs.push(run);
 
         ecr::delete_repos(ecr_client, corpus).await?;
@@ -457,11 +545,11 @@ async fn run_partial(
     ecr_client: &aws_sdk_ecr::Client,
     output_dir: &Path,
 ) -> Result<ScenarioResult, Box<dyn std::error::Error>> {
-    eprintln!("bench: running partial scenario");
+    progress("bench: running partial scenario");
     let mut runs = Vec::new();
 
     for &tool in tools {
-        eprintln!("  partial: {}", tool);
+        progress(&format!("  partial: {} (priming)", tool));
 
         ecr::create_repos(ecr_client, base_corpus).await?;
 
@@ -469,15 +557,16 @@ async fn run_partial(
         let config_dir = tempfile::tempdir()?;
         let _prime =
             run_single_tool(args, tool, base_corpus, config_dir.path(), output_dir).await?;
-        eprintln!(
-            "  partial: {} prime complete, running with partial corpus",
-            tool
-        );
+        progress(&format!("  partial: {} measuring", tool));
 
         // Measured run with partial corpus.
         let config_dir = tempfile::tempdir()?;
         let run =
             run_single_tool(args, tool, partial_corpus, config_dir.path(), output_dir).await?;
+        progress(&format!(
+            "  partial: {} complete ({:.1}s)",
+            tool, run.wall_clock_secs
+        ));
         runs.push(run);
 
         ecr::delete_repos(ecr_client, base_corpus).await?;
@@ -499,7 +588,7 @@ async fn run_scale(
     ecr_client: &aws_sdk_ecr::Client,
     output_dir: &Path,
 ) -> Result<Vec<ScalePoint>, Box<dyn std::error::Error>> {
-    eprintln!("bench: running scale scenario");
+    progress("bench: running scale scenario");
     let total = corpus.images.len();
     let mut sizes: Vec<usize> = [10, 25, 50, total]
         .iter()
@@ -511,12 +600,12 @@ async fn run_scale(
     let mut points = Vec::new();
 
     for &size in &sizes {
-        eprintln!("  scale: {size} images");
+        progress(&format!("  scale: {size} images"));
         let subset = corpus.limit(size);
         let mut results: BTreeMap<String, f64> = BTreeMap::new();
 
         for &tool in tools {
-            eprintln!("  scale: {} @ {size} images", tool);
+            progress(&format!("  scale: {} @ {size} images", tool));
 
             ecr::create_repos(ecr_client, &subset).await?;
 

--- a/xtask/src/bench/proxy.rs
+++ b/xtask/src/bench/proxy.rs
@@ -69,6 +69,10 @@ pub(crate) struct ProxyMetrics {
     /// The rest either produced a 202 "upload session started" fallback
     /// or an explicit error status.
     pub(crate) mount_successes: u64,
+    /// Blob GET requests to source (non-target) registries.
+    pub(crate) source_blob_gets: u64,
+    /// Total response bytes from source blob GETs.
+    pub(crate) source_blob_bytes: u64,
 }
 
 /// Spawns a `bench-proxy` process and waits for it to bind its port.
@@ -142,13 +146,18 @@ fn parse_log(path: &Path) -> Result<Vec<ProxyEntry>, Box<dyn std::error::Error>>
 }
 
 /// Computes aggregated metrics from a slice of proxy log entries.
-pub(crate) fn aggregate(entries: &[ProxyEntry]) -> ProxyMetrics {
+///
+/// `target_registry` is the ECR hostname (e.g. `111...dkr.ecr.us-east-1.amazonaws.com`).
+/// Requests to this host are target operations; all others are source pulls.
+pub(crate) fn aggregate(entries: &[ProxyEntry], target_registry: &str) -> ProxyMetrics {
     let mut requests_by_method: BTreeMap<String, u64> = BTreeMap::new();
     let mut status_429_count = 0u64;
     let mut total_request_bytes = 0u64;
     let mut total_response_bytes = 0u64;
     let mut mount_attempts = 0u64;
     let mut mount_successes = 0u64;
+    let mut source_blob_gets = 0u64;
+    let mut source_blob_bytes = 0u64;
 
     // Track GET requests to blob URLs for duplicate detection.
     let mut blob_get_counts: HashMap<String, u64> = HashMap::new();
@@ -165,6 +174,11 @@ pub(crate) fn aggregate(entries: &[ProxyEntry]) -> ProxyMetrics {
 
         if entry.method == "GET" && entry.url.contains("/blobs/sha256:") {
             *blob_get_counts.entry(entry.url.clone()).or_insert(0) += 1;
+            // Track source pulls (non-target registry).
+            if entry.host != target_registry {
+                source_blob_gets += 1;
+                source_blob_bytes += entry.response_bytes;
+            }
         }
 
         // OCI cross-repo blob mount: `POST /v2/.../blobs/uploads/?mount=<digest>&from=<repo>`.
@@ -197,6 +211,8 @@ pub(crate) fn aggregate(entries: &[ProxyEntry]) -> ProxyMetrics {
         duplicate_blob_gets,
         mount_attempts,
         mount_successes,
+        source_blob_gets,
+        source_blob_bytes,
     }
 }
 
@@ -248,7 +264,7 @@ mod tests {
 
     #[test]
     fn aggregate_counts_methods() {
-        let metrics = aggregate(&sample_entries());
+        let metrics = aggregate(&sample_entries(), "ecr.aws");
         assert_eq!(metrics.total_requests, 4);
         assert_eq!(metrics.requests_by_method["HEAD"], 1);
         assert_eq!(metrics.requests_by_method["GET"], 2);
@@ -257,24 +273,27 @@ mod tests {
 
     #[test]
     fn aggregate_counts_429s() {
-        assert_eq!(aggregate(&sample_entries()).status_429_count, 1);
+        assert_eq!(aggregate(&sample_entries(), "ecr.aws").status_429_count, 1);
     }
 
     #[test]
     fn aggregate_detects_duplicate_blob_gets() {
-        assert_eq!(aggregate(&sample_entries()).duplicate_blob_gets, 1);
+        assert_eq!(
+            aggregate(&sample_entries(), "ecr.aws").duplicate_blob_gets,
+            1
+        );
     }
 
     #[test]
     fn aggregate_sums_bytes() {
-        let metrics = aggregate(&sample_entries());
+        let metrics = aggregate(&sample_entries(), "ecr.aws");
         assert_eq!(metrics.total_request_bytes, 2200);
         assert_eq!(metrics.total_response_bytes, 10100);
     }
 
     #[test]
     fn aggregate_empty_entries() {
-        let metrics = aggregate(&[]);
+        let metrics = aggregate(&[], "ecr.aws");
         assert_eq!(metrics.total_requests, 0);
         assert_eq!(metrics.duplicate_blob_gets, 0);
         assert!(metrics.requests_by_method.is_empty());
@@ -347,7 +366,7 @@ mod tests {
                 duration_ms: 10,
             },
         ];
-        let metrics = aggregate(&entries);
+        let metrics = aggregate(&entries, "ecr.aws");
         assert_eq!(metrics.duplicate_blob_gets, 0);
     }
 
@@ -373,8 +392,47 @@ mod tests {
                 duration_ms: 80,
             },
         ];
-        let metrics = aggregate(&entries);
+        let metrics = aggregate(&entries, "ecr.aws");
         assert_eq!(metrics.duplicate_blob_gets, 0);
+    }
+
+    #[test]
+    fn aggregate_source_blob_gets() {
+        let entries = vec![
+            // Source blob GET (host != target).
+            ProxyEntry {
+                method: "GET".into(),
+                host: "docker.io".into(),
+                url: "/v2/library/nginx/blobs/sha256:abc".into(),
+                request_bytes: 50,
+                response_bytes: 9000,
+                status: 200,
+                duration_ms: 100,
+            },
+            // Target blob GET (host == target).
+            ProxyEntry {
+                method: "GET".into(),
+                host: "ecr.aws".into(),
+                url: "/v2/bench/nginx/blobs/sha256:abc".into(),
+                request_bytes: 50,
+                response_bytes: 9000,
+                status: 200,
+                duration_ms: 80,
+            },
+            // Source non-blob GET (not /blobs/sha256:) -- should NOT count.
+            ProxyEntry {
+                method: "GET".into(),
+                host: "docker.io".into(),
+                url: "/v2/library/nginx/manifests/latest".into(),
+                request_bytes: 50,
+                response_bytes: 1000,
+                status: 200,
+                duration_ms: 50,
+            },
+        ];
+        let metrics = aggregate(&entries, "ecr.aws");
+        assert_eq!(metrics.source_blob_gets, 1);
+        assert_eq!(metrics.source_blob_bytes, 9000);
     }
 
     #[test]

--- a/xtask/src/bench/remote.rs
+++ b/xtask/src/bench/remote.rs
@@ -1,0 +1,364 @@
+//! Remote benchmark orchestration via SSM Session Manager.
+//!
+//! Prerequisites: `session-manager-plugin` installed locally, AWS credentials,
+//! a running bench instance.
+//!
+//! `cargo xtask bench-remote` pushes the current branch, then opens an
+//! interactive SSM session that builds and runs benchmarks with live output.
+//! `cargo xtask bench-remote --fetch` pulls results back from the instance.
+
+use std::path::Path;
+
+use clap::Args;
+
+/// Arguments for the `bench-remote` subcommand.
+#[derive(Args)]
+pub(crate) struct BenchRemoteArgs {
+    /// EC2 instance ID of the bench instance.
+    #[arg(long, env = "BENCH_INSTANCE_ID")]
+    pub(crate) instance_id: String,
+
+    /// AWS region.
+    #[arg(long, default_value = "us-east-1")]
+    pub(crate) region: String,
+
+    /// Fetch results from the last run instead of starting a new one.
+    #[arg(long)]
+    pub(crate) fetch: bool,
+
+    /// Git ref to checkout on the instance (default: current branch).
+    #[arg(long)]
+    pub(crate) git_ref: Option<String>,
+
+    /// Tools to benchmark (passed through to `cargo xtask bench`).
+    #[arg(long, default_value = "ocync,dregsy,regsync")]
+    pub(crate) tools: String,
+
+    /// Scenario to run (passed through to `cargo xtask bench`).
+    #[arg(long, default_value = "all")]
+    pub(crate) scenario: String,
+
+    /// Number of cold-sync iterations (passed through to `cargo xtask bench`).
+    #[arg(long, default_value = "1")]
+    pub(crate) iterations: String,
+
+    /// Use first N images only (passed through to `cargo xtask bench`).
+    #[arg(long)]
+    pub(crate) limit: Option<usize>,
+
+    /// Local directory to save fetched results.
+    #[arg(long, default_value = "bench-results")]
+    pub(crate) output: String,
+}
+
+/// Run the remote benchmark workflow.
+pub(crate) async fn run(args: BenchRemoteArgs) -> Result<(), Box<dyn std::error::Error>> {
+    // Verify session-manager-plugin is installed.
+    if std::process::Command::new("session-manager-plugin")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        return Err(
+            "session-manager-plugin not found. Install it: \
+             https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html"
+                .into(),
+        );
+    }
+
+    if args.fetch {
+        return fetch_results(&args).await;
+    }
+
+    let instance_id = &args.instance_id;
+    let region = &args.region;
+
+    let git_ref = match &args.git_ref {
+        Some(r) => r.clone(),
+        None => current_branch()?,
+    };
+
+    // Step 1: Push current branch so the instance can pull it.
+    eprintln!("bench-remote: pushing {git_ref}...");
+    let push = std::process::Command::new("git")
+        .args(["push", "origin", &git_ref])
+        .status()?;
+    if !push.success() {
+        return Err("git push failed".into());
+    }
+
+    // Step 2: Build the bench command.
+    let mut bench_args = format!("--tools {} --iterations {}", args.tools, args.iterations);
+    if let Some(limit) = args.limit {
+        bench_args.push_str(&format!(" --limit {limit}"));
+    }
+    bench_args.push_str(&format!(" {}", args.scenario));
+
+    // Step 3: Upload the bench script via send-command (fast, no quoting
+    // issues), then run it interactively via start-session for live output.
+    let script_content = format!(
+        r#"#!/bin/bash
+set -e
+
+echo '=== pulling {git_ref} ==='
+cd ~/ocync
+TOKEN=$(aws ssm get-parameter --name /ocync/bench/github-token --with-decryption --query Parameter.Value --output text --region {region})
+git remote set-url origin "https://${{TOKEN}}@github.com/clowdhaus/ocync.git"
+git fetch origin {git_ref} && git checkout {git_ref} && git reset --hard origin/{git_ref}
+git remote set-url origin https://github.com/clowdhaus/ocync.git
+
+echo '=== building ocync + bench-proxy ==='
+cargo build --release --package ocync --package bench-proxy
+
+echo '=== starting benchmarks ==='
+ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+export BENCH_TARGET_REGISTRY=${{ACCOUNT}}.dkr.ecr.{region}.amazonaws.com
+cargo xtask bench {bench_args}
+
+echo '=== benchmarks complete ==='
+echo 'fetch results: cargo xtask bench-remote --fetch --instance-id {instance_id}'
+"#
+    );
+
+    // Upload script to instance, then execute via send-command with a
+    // high timeout (7200s = 2 hours). Poll /tmp/bench-progress.txt every
+    // 30 seconds for live progress updates.
+    use crate::bench::config_gen::base64_encode;
+    let encoded = base64_encode(&script_content);
+    let run_cmd = format!(
+        "echo {encoded} | base64 -d > /tmp/bench-run.sh && chmod +x /tmp/bench-run.sh && runuser -l ec2-user -c 'bash /tmp/bench-run.sh'"
+    );
+
+    eprintln!("bench-remote: starting benchmarks on {instance_id}...");
+
+    let params = serde_json::json!({ "commands": [run_cmd] });
+    let output = tokio::process::Command::new("aws")
+        .args([
+            "ssm",
+            "send-command",
+            "--instance-ids",
+            instance_id,
+            "--region",
+            region,
+            "--document-name",
+            "AWS-RunShellScript",
+            "--timeout-seconds",
+            "7200",
+            "--parameters",
+            &params.to_string(),
+            "--query",
+            "Command.CommandId",
+            "--output",
+            "text",
+        ])
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("ssm send-command failed: {stderr}").into());
+    }
+
+    let command_id = String::from_utf8(output.stdout)?.trim().to_string();
+    eprintln!("bench-remote: command={command_id}");
+    let mut last_progress = String::new();
+
+    // Poll until completion, printing progress updates.
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+
+        // Check progress file.
+        if let Ok(prog) = ssm_exec(
+            instance_id,
+            region,
+            "cat /tmp/bench-progress.txt 2>/dev/null || true",
+        )
+        .await
+        {
+            let prog = prog.trim().to_string();
+            if prog != last_progress && !prog.is_empty() {
+                eprintln!("bench-remote: {prog}");
+                last_progress = prog;
+            }
+        }
+
+        // Check command status.
+        let poll = tokio::process::Command::new("aws")
+            .args([
+                "ssm",
+                "get-command-invocation",
+                "--command-id",
+                &command_id,
+                "--instance-id",
+                instance_id,
+                "--region",
+                region,
+                "--query",
+                "[Status]",
+                "--output",
+                "json",
+            ])
+            .output()
+            .await?;
+
+        if let Ok(json) = serde_json::from_slice::<serde_json::Value>(&poll.stdout) {
+            match json[0].as_str() {
+                Some("Success") => {
+                    eprintln!("bench-remote: benchmarks complete. Fetching results...");
+                    return fetch_results(&args).await;
+                }
+                Some("Failed") => {
+                    eprintln!("bench-remote: benchmarks failed. Try --fetch for partial results.");
+                    return fetch_results(&args).await;
+                }
+                Some("TimedOut") => {
+                    return Err("benchmark timed out (>2 hours)".into());
+                }
+                _ => continue,
+            }
+        }
+    }
+}
+
+/// Fetch results from the instance via SSM send-command (short, reliable).
+async fn fetch_results(args: &BenchRemoteArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let instance_id = &args.instance_id;
+    let region = &args.region;
+
+    eprintln!("bench-remote: fetching results from {instance_id}...");
+
+    let ls_output = ssm_exec(
+        instance_id,
+        region,
+        "ls -td /home/ec2-user/ocync/bench-results/2* 2>/dev/null | head -1",
+    )
+    .await?;
+    let remote_dir = ls_output.trim();
+
+    if remote_dir.is_empty() {
+        return Err("no results directory found on instance".into());
+    }
+
+    let summary = ssm_exec(instance_id, region, &format!("cat {remote_dir}/summary.md")).await?;
+
+    let archive_json = ssm_exec(
+        instance_id,
+        region,
+        "ls -t /home/ec2-user/ocync/bench-results/runs/*.json 2>/dev/null | head -1 | xargs cat",
+    )
+    .await?;
+
+    // Write results locally.
+    let remote_basename = Path::new(remote_dir)
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy();
+    let local_dir = Path::new(&args.output).join(remote_basename.as_ref());
+    std::fs::create_dir_all(&local_dir)?;
+
+    let summary_path = local_dir.join("summary.md");
+    std::fs::write(&summary_path, &summary)?;
+    eprintln!("bench-remote: wrote {}", summary_path.display());
+
+    if !archive_json.trim().is_empty() {
+        let runs_dir = Path::new(&args.output).join("runs");
+        std::fs::create_dir_all(&runs_dir)?;
+        let archive_filename =
+            if let Ok(val) = serde_json::from_str::<serde_json::Value>(&archive_json) {
+                format!("{}.json", val["timestamp"].as_str().unwrap_or("unknown"))
+            } else {
+                format!("{remote_basename}.json")
+            };
+        let archive_path = runs_dir.join(&archive_filename);
+        std::fs::write(&archive_path, &archive_json)?;
+        eprintln!("bench-remote: wrote {}", archive_path.display());
+    }
+
+    eprintln!("\n{summary}");
+    Ok(())
+}
+
+/// Get the current local git branch name.
+fn current_branch() -> Result<String, Box<dyn std::error::Error>> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()?;
+    if !output.status.success() {
+        return Err("failed to get current git branch".into());
+    }
+    Ok(String::from_utf8(output.stdout)?.trim().to_string())
+}
+
+/// Run a short command on the instance via SSM send-command and return stdout.
+///
+/// Only for quick, non-interactive commands (file reads, ls). The benchmark
+/// itself runs through an interactive SSM session with live output.
+async fn ssm_exec(
+    instance_id: &str,
+    region: &str,
+    command: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let params = serde_json::json!({ "commands": [command] });
+
+    let output = tokio::process::Command::new("aws")
+        .args([
+            "ssm",
+            "send-command",
+            "--instance-ids",
+            instance_id,
+            "--region",
+            region,
+            "--document-name",
+            "AWS-RunShellScript",
+            "--timeout-seconds",
+            "30",
+            "--parameters",
+            &params.to_string(),
+            "--query",
+            "Command.CommandId",
+            "--output",
+            "text",
+        ])
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("ssm send-command failed: {stderr}").into());
+    }
+
+    let command_id = String::from_utf8(output.stdout)?.trim().to_string();
+
+    // Poll for completion (short commands only).
+    for _ in 0..6 {
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+        let poll = tokio::process::Command::new("aws")
+            .args([
+                "ssm",
+                "get-command-invocation",
+                "--command-id",
+                &command_id,
+                "--instance-id",
+                instance_id,
+                "--region",
+                region,
+                "--query",
+                "[Status,StandardOutputContent]",
+                "--output",
+                "json",
+            ])
+            .output()
+            .await?;
+
+        if let Ok(json) = serde_json::from_slice::<serde_json::Value>(&poll.stdout) {
+            match json[0].as_str() {
+                Some("Success") => return Ok(json[1].as_str().unwrap_or("").to_string()),
+                Some("Failed") => return Err("ssm command failed".into()),
+                _ => continue,
+            }
+        }
+    }
+
+    Err("ssm command timed out".into())
+}

--- a/xtask/src/bench/report.rs
+++ b/xtask/src/bench/report.rs
@@ -17,6 +17,8 @@ pub(crate) struct ToolRun {
     pub(crate) wall_clock_secs: f64,
     /// Process exit code, if captured.
     pub(crate) exit_code: Option<i32>,
+    /// Peak resident set size in KB (from `/usr/bin/time -v`).
+    pub(crate) peak_rss_kb: Option<u64>,
     /// HTTP proxy metrics, if a proxy was attached.
     pub(crate) proxy_metrics: Option<ProxyMetrics>,
     /// Parsed JSON from ocync's `--json` output, if available.
@@ -41,11 +43,159 @@ pub(crate) struct ScalePoint {
     pub(crate) results: BTreeMap<String, f64>,
 }
 
+/// Instance metadata captured at benchmark runtime.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct InstanceInfo {
+    /// EC2 instance type (e.g. `c7g.xlarge`), or `"unknown"` outside EC2.
+    pub(crate) instance_type: String,
+    /// CPU architecture (e.g. `aarch64`, `x86_64`).
+    pub(crate) arch: String,
+    /// CPU manufacturer and model from EC2 `DescribeInstanceTypes`
+    /// (e.g. `AWS Graviton3`, `Intel Xeon Platinum 8488C`).
+    pub(crate) cpu_model: String,
+    /// Number of default vCPUs for this instance type.
+    pub(crate) vcpus: usize,
+    /// Total memory in MiB (from `DescribeInstanceTypes`).
+    pub(crate) memory_mib: u64,
+    /// Network performance description from EC2 (e.g. `Up to 12.5 Gigabit`).
+    pub(crate) network_performance: String,
+    /// AWS region (e.g. `us-east-1`), or `"unknown"` outside EC2.
+    pub(crate) region: String,
+}
+
+impl InstanceInfo {
+    /// Collect instance metadata from EC2 IMDS + `DescribeInstanceTypes`.
+    ///
+    /// IMDS provides the instance type and region. The AWS CLI
+    /// `describe-instance-types` provides authoritative CPU, memory,
+    /// and network specs. Falls back to `"unknown"` / 0 outside EC2.
+    pub(crate) fn collect() -> Self {
+        let instance_type = read_imds("instance-type").unwrap_or_else(|| "unknown".into());
+        let region = read_imds("placement/region").unwrap_or_else(|| "unknown".into());
+
+        // Query DescribeInstanceTypes for authoritative hardware specs.
+        let (arch, cpu_model, vcpus, memory_mib, network_performance) =
+            if instance_type != "unknown" {
+                match describe_instance_type(&instance_type) {
+                    Some(info) => info,
+                    None => {
+                        eprintln!(
+                            "WARNING: ec2:DescribeInstanceTypes failed for {instance_type}. \
+                             Instance metadata will be incomplete. Check IAM permissions \
+                             (ec2:DescribeInstanceTypes) or AWS CLI availability."
+                        );
+                        Default::default()
+                    }
+                }
+            } else {
+                Default::default()
+            };
+
+        Self {
+            instance_type,
+            arch: if arch.is_empty() {
+                "unknown".into()
+            } else {
+                arch
+            },
+            cpu_model: if cpu_model.is_empty() {
+                "unknown".into()
+            } else {
+                cpu_model
+            },
+            vcpus,
+            memory_mib,
+            network_performance: if network_performance.is_empty() {
+                "unknown".into()
+            } else {
+                network_performance
+            },
+            region,
+        }
+    }
+}
+
+/// Query `aws ec2 describe-instance-types` for hardware specs.
+///
+/// Uses the AWS CLI (guaranteed on the bench instance) rather than
+/// `aws-sdk-ec2` which compiles every EC2 API and adds ~220 crates.
+///
+/// Returns `(arch, cpu_model, vcpus, memory_mib, network_performance)`.
+fn describe_instance_type(instance_type: &str) -> Option<(String, String, usize, u64, String)> {
+    let output = std::process::Command::new("aws")
+        .args([
+            "ec2",
+            "describe-instance-types",
+            "--instance-types",
+            instance_type,
+            "--query",
+            "InstanceTypes[0].{Arch:ProcessorInfo.SupportedArchitectures[0],Cpu:ProcessorInfo.Manufacturer,Vcpus:VCpuInfo.DefaultVCpus,Mem:MemoryInfo.SizeInMiB,Net:NetworkInfo.NetworkPerformance}",
+            "--output",
+            "json",
+            "--region",
+            "us-east-1",
+        ])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+
+    let arch = json["Arch"].as_str().unwrap_or_default().to_string();
+    let cpu_model = json["Cpu"].as_str().unwrap_or_default().to_string();
+    let vcpus = json["Vcpus"].as_u64().unwrap_or(0) as usize;
+    let memory_mib = json["Mem"].as_u64().unwrap_or(0);
+    let network_performance = json["Net"].as_str().unwrap_or_default().to_string();
+
+    Some((arch, cpu_model, vcpus, memory_mib, network_performance))
+}
+
+/// Read a value from the EC2 Instance Metadata Service (`IMDSv2`).
+fn read_imds(path: &str) -> Option<String> {
+    // IMDSv2: get a session token first, then use it.
+    let token = std::process::Command::new("curl")
+        .args([
+            "-s",
+            "-f",
+            "--connect-timeout",
+            "1",
+            "-X",
+            "PUT",
+            "http://169.254.169.254/latest/api/token",
+            "-H",
+            "X-aws-ec2-metadata-token-ttl-seconds: 10",
+        ])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())?;
+
+    let url = format!("http://169.254.169.254/latest/meta-data/{path}");
+    std::process::Command::new("curl")
+        .args([
+            "-s",
+            "-f",
+            "--connect-timeout",
+            "1",
+            "-H",
+            &format!("X-aws-ec2-metadata-token: {}", token.trim()),
+            &url,
+        ])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
 /// Full benchmark report.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct BenchReport {
     /// UTC timestamp when the run started (`YYYY-MM-DD-HHMMSS`).
     pub(crate) timestamp: String,
+    /// Instance metadata (hardware, region).
+    pub(crate) instance: InstanceInfo,
     /// Number of distinct images in the corpus.
     pub(crate) corpus_size: usize,
     /// Total number of tags across all images.
@@ -101,6 +251,23 @@ fn summary_markdown(report: &BenchReport) -> String {
 
     out.push_str("# Benchmark Results\n\n");
     out.push_str(&format!("Run: {}\n\n", report.timestamp));
+
+    // Instance metadata.
+    let inst = &report.instance;
+    out.push_str("## Instance\n\n");
+    out.push_str(&format!("- **Type**: {}\n", inst.instance_type));
+    out.push_str(&format!(
+        "- **CPU**: {} ({}, {} vCPUs)\n",
+        inst.cpu_model, inst.arch, inst.vcpus
+    ));
+    if inst.memory_mib > 0 {
+        let gb = inst.memory_mib as f64 / 1024.0;
+        out.push_str(&format!("- **Memory**: {gb:.1} GiB\n"));
+    }
+    out.push_str(&format!("- **Network**: {}\n", inst.network_performance));
+    out.push_str(&format!("- **Region**: {}\n", inst.region));
+    out.push('\n');
+
     out.push_str(&format!(
         "Corpus: {} images, {} total tags\n\n",
         report.corpus_size, report.total_tags
@@ -113,86 +280,205 @@ fn summary_markdown(report: &BenchReport) -> String {
     }
     out.push('\n');
 
-    // Summary table.
-    if !report.scenarios.is_empty() {
-        // Determine column order: ocync first, then remaining tools in sorted order.
-        let mut tools: Vec<String> = report
-            .tool_versions
-            .keys()
-            .filter(|&t| t != "ocync")
-            .cloned()
-            .collect();
-        tools.sort();
-        let mut columns: Vec<String> = Vec::new();
-        if report.tool_versions.contains_key("ocync") {
-            columns.push("ocync".to_string());
-        }
-        columns.extend(tools);
+    // Determine column order: ocync first, then remaining tools in sorted order.
+    let columns = tool_columns(report);
 
-        // Fallback: collect tool names from scenario runs if tool_versions is empty.
-        if columns.is_empty() {
-            let mut seen: HashSet<String> = HashSet::new();
-            for scenario in &report.scenarios {
-                for run in &scenario.runs {
-                    if seen.insert(run.tool.clone()) {
-                        if run.tool == "ocync" {
-                            columns.insert(0, run.tool.clone());
-                        } else {
-                            columns.push(run.tool.clone());
-                        }
-                    }
-                }
-            }
-        }
+    // Per-scenario detailed tables.
+    for scenario in &report.scenarios {
+        out.push_str(&format!("## {}\n\n", scenario.scenario));
 
-        out.push_str("## Summary\n\n");
+        let by_tool: BTreeMap<&str, &ToolRun> =
+            scenario.runs.iter().map(|r| (r.tool.as_str(), r)).collect();
 
-        // Header row.
-        out.push_str("| Scenario |");
+        out.push_str("| Metric |");
         for col in &columns {
             out.push_str(&format!(" {col} |"));
         }
         out.push('\n');
-
-        // Separator row.
         out.push_str("|---|");
         for _ in &columns {
-            out.push_str("---|");
+            out.push_str("---:|");
         }
         out.push('\n');
 
-        // Data rows.
-        for scenario in &report.scenarios {
-            let by_tool: BTreeMap<&str, f64> = scenario
-                .runs
-                .iter()
-                .map(|r| (r.tool.as_str(), r.wall_clock_secs))
-                .collect();
+        // Metric rows with winner highlighting.
+        // Each row: (label, extract sortable value, format display, lower_is_better).
+        type RankFn = Box<dyn Fn(&ToolRun) -> Option<u64>>;
+        type DisplayFn = Box<dyn Fn(&ToolRun) -> Option<String>>;
+        struct MetricRow {
+            label: &'static str,
+            /// Extract a comparable value for ranking (None = no data).
+            rank: RankFn,
+            /// Format the display string.
+            display: DisplayFn,
+            /// When true, lowest value wins; when false, highest wins.
+            lower_is_better: bool,
+        }
 
-            out.push_str(&format!("| {} |", scenario.scenario));
-            for col in &columns {
-                match by_tool.get(col.as_str()) {
-                    Some(&secs) => {
-                        let d = Duration::from_secs_f64(secs);
-                        out.push_str(&format!(" {} |", format_duration(d)));
+        let rows: Vec<MetricRow> = vec![
+            MetricRow {
+                label: "Wall clock",
+                rank: Box::new(|r| Some((r.wall_clock_secs * 1000.0) as u64)),
+                display: Box::new(|r| {
+                    Some(format_duration(Duration::from_secs_f64(r.wall_clock_secs)))
+                }),
+                lower_is_better: true,
+            },
+            MetricRow {
+                label: "Peak RSS",
+                rank: Box::new(|r| r.peak_rss_kb),
+                display: Box::new(|r| r.peak_rss_kb.map(|kb| format_bytes(kb * 1024))),
+                lower_is_better: true,
+            },
+            MetricRow {
+                label: "Requests",
+                rank: Box::new(|r| r.proxy_metrics.as_ref().map(|m| m.total_requests)),
+                display: Box::new(|r| {
+                    r.proxy_metrics
+                        .as_ref()
+                        .map(|m| m.total_requests.to_string())
+                }),
+                lower_is_better: true,
+            },
+            MetricRow {
+                label: "Response bytes",
+                rank: Box::new(|r| r.proxy_metrics.as_ref().map(|m| m.total_response_bytes)),
+                display: Box::new(|r| {
+                    r.proxy_metrics
+                        .as_ref()
+                        .map(|m| format_bytes(m.total_response_bytes))
+                }),
+                lower_is_better: true,
+            },
+            MetricRow {
+                label: "Source blob GETs",
+                rank: Box::new(|r| r.proxy_metrics.as_ref().map(|m| m.source_blob_gets)),
+                display: Box::new(|r| {
+                    r.proxy_metrics
+                        .as_ref()
+                        .map(|m| m.source_blob_gets.to_string())
+                }),
+                lower_is_better: true,
+            },
+            MetricRow {
+                label: "Source blob bytes",
+                rank: Box::new(|r| r.proxy_metrics.as_ref().map(|m| m.source_blob_bytes)),
+                display: Box::new(|r| {
+                    r.proxy_metrics
+                        .as_ref()
+                        .map(|m| format_bytes(m.source_blob_bytes))
+                }),
+                lower_is_better: true,
+            },
+            MetricRow {
+                label: "Mounts (success/attempt)",
+                rank: Box::new(|r| r.proxy_metrics.as_ref().map(|m| m.mount_successes)),
+                display: Box::new(|r| {
+                    r.proxy_metrics
+                        .as_ref()
+                        .map(|m| format!("{}/{}", m.mount_successes, m.mount_attempts))
+                }),
+                lower_is_better: false,
+            },
+            MetricRow {
+                label: "Duplicate blob GETs",
+                rank: Box::new(|r| r.proxy_metrics.as_ref().map(|m| m.duplicate_blob_gets)),
+                display: Box::new(|r| {
+                    r.proxy_metrics
+                        .as_ref()
+                        .map(|m| m.duplicate_blob_gets.to_string())
+                }),
+                lower_is_better: true,
+            },
+            MetricRow {
+                label: "Rate-limit 429s",
+                rank: Box::new(|r| r.proxy_metrics.as_ref().map(|m| m.status_429_count)),
+                display: Box::new(|r| {
+                    r.proxy_metrics
+                        .as_ref()
+                        .map(|m| m.status_429_count.to_string())
+                }),
+                lower_is_better: true,
+            },
+        ];
+
+        for row in &rows {
+            // Find the winning value across all tools for this metric.
+            let values: Vec<Option<u64>> = columns
+                .iter()
+                .map(|col| by_tool.get(col.as_str()).and_then(|r| (row.rank)(r)))
+                .collect();
+            let winner = if row.lower_is_better {
+                values.iter().filter_map(|v| *v).min()
+            } else {
+                values.iter().filter_map(|v| *v).max()
+            };
+
+            out.push_str(&format!("| {} |", row.label));
+            for (i, col) in columns.iter().enumerate() {
+                let display = by_tool.get(col.as_str()).and_then(|r| (row.display)(r));
+                match display {
+                    Some(text) => {
+                        let is_winner = winner.is_some() && values[i] == winner && values.len() > 1;
+                        if is_winner {
+                            out.push_str(&format!(" **{text}** |"));
+                        } else {
+                            out.push_str(&format!(" {text} |"));
+                        }
                     }
-                    None => out.push_str(" — |"),
+                    None => out.push_str(" -- |"),
                 }
             }
             out.push('\n');
         }
+
         out.push('\n');
     }
 
     out
 }
 
+/// Determine tool column order: ocync first, then remaining sorted.
+fn tool_columns(report: &BenchReport) -> Vec<String> {
+    let mut tools: Vec<String> = report
+        .tool_versions
+        .keys()
+        .filter(|&t| t != "ocync")
+        .cloned()
+        .collect();
+    tools.sort();
+    let mut columns: Vec<String> = Vec::new();
+    if report.tool_versions.contains_key("ocync") {
+        columns.push("ocync".to_string());
+    }
+    columns.extend(tools);
+
+    // Fallback: collect tool names from scenario runs if tool_versions is empty.
+    if columns.is_empty() {
+        let mut seen: HashSet<String> = HashSet::new();
+        for scenario in &report.scenarios {
+            for run in &scenario.runs {
+                if seen.insert(run.tool.clone()) {
+                    if run.tool == "ocync" {
+                        columns.insert(0, run.tool.clone());
+                    } else {
+                        columns.push(run.tool.clone());
+                    }
+                }
+            }
+        }
+    }
+    columns
+}
+
 /// Writes the benchmark report to `output_dir`.
 ///
 /// Creates the following files:
-/// - `summary.md` — the Markdown summary table
-/// - `{scenario_name}.json` — per-scenario JSON (one file per scenario)
-/// - `scale.json` — scaling curve data (only when `report.scale` is non-empty)
+/// - `summary.md` -- Markdown summary with per-scenario metric tables
+/// - `{scenario_name}.json` -- per-scenario JSON (one file per scenario)
+/// - `scale.json` -- scaling curve data (only when `report.scale` is non-empty)
+/// - `bench-results/runs/{timestamp}.json` -- full report archive for
+///   historical comparison across benchmark runs
 pub(crate) fn write_report(output_dir: &Path, report: &BenchReport) -> Result<(), String> {
     std::fs::create_dir_all(output_dir)
         .map_err(|e| format!("create output dir {}: {e}", output_dir.display()))?;
@@ -224,6 +510,18 @@ pub(crate) fn write_report(output_dir: &Path, report: &BenchReport) -> Result<()
             .map_err(|e| format!("write {}: {e}", scale_path.display()))?;
     }
 
+    // Historical archive: full report as a single JSON file keyed by timestamp.
+    // Lives under `bench-results/runs/` so all runs accumulate in one directory
+    // regardless of per-run output_dir.
+    let runs_dir = Path::new("bench-results/runs");
+    std::fs::create_dir_all(runs_dir)
+        .map_err(|e| format!("create runs dir {}: {e}", runs_dir.display()))?;
+    let archive_path = runs_dir.join(format!("{}.json", report.timestamp));
+    let archive_json = serde_json::to_string_pretty(report)
+        .map_err(|e| format!("serialize report archive: {e}"))?;
+    std::fs::write(&archive_path, &archive_json)
+        .map_err(|e| format!("write {}: {e}", archive_path.display()))?;
+
     Ok(())
 }
 
@@ -231,9 +529,22 @@ pub(crate) fn write_report(output_dir: &Path, report: &BenchReport) -> Result<()
 mod tests {
     use super::*;
 
+    fn test_instance() -> InstanceInfo {
+        InstanceInfo {
+            instance_type: "c7g.xlarge".into(),
+            arch: "arm64".into(),
+            cpu_model: "AWS".into(),
+            vcpus: 4,
+            memory_mib: 8192,
+            network_performance: "Up to 12.5 Gigabit".into(),
+            region: "us-east-1".into(),
+        }
+    }
+
     fn sample_report() -> BenchReport {
         BenchReport {
             timestamp: "2026-04-15-100000".to_string(),
+            instance: test_instance(),
             corpus_size: 28,
             total_tags: 40,
             tool_versions: BTreeMap::from([
@@ -247,6 +558,7 @@ mod tests {
                         tool: "ocync".to_string(),
                         wall_clock_secs: 47.0,
                         exit_code: Some(0),
+                        peak_rss_kb: Some(65536),
                         proxy_metrics: None,
                         ocync_json: None,
                     },
@@ -254,6 +566,7 @@ mod tests {
                         tool: "dregsy".to_string(),
                         wall_clock_secs: 521.0,
                         exit_code: Some(0),
+                        peak_rss_kb: Some(131072),
                         proxy_metrics: None,
                         ocync_json: None,
                     },
@@ -323,22 +636,23 @@ mod tests {
         let report = sample_report();
         let md = summary_markdown(&report);
 
-        // Verify exact structure of key lines.
-        let lines: Vec<&str> = md.lines().collect();
-        assert_eq!(lines[0], "# Benchmark Results");
-        assert_eq!(lines[2], "Run: 2026-04-15-100000");
-        assert_eq!(lines[4], "Corpus: 28 images, 40 total tags");
-        assert_eq!(lines[6], "## Tool Versions");
+        // Verify key sections are present and ordered correctly.
+        assert!(md.starts_with("# Benchmark Results\n"));
+        assert!(md.contains("Run: 2026-04-15-100000"));
+        assert!(md.contains("## Instance\n"));
+        assert!(md.contains("- **Type**: c7g.xlarge"));
+        assert!(md.contains("- **CPU**: AWS (arm64, 4 vCPUs)"));
+        assert!(md.contains("- **Network**: Up to 12.5 Gigabit"));
+        assert!(md.contains("Corpus: 28 images, 40 total tags"));
+        assert!(md.contains("## Tool Versions\n"));
+        assert!(md.contains("- **dregsy**: 0.5.0"));
+        assert!(md.contains("- **ocync**: 0.1.0"));
 
-        // Tool versions (BTreeMap order: dregsy before ocync).
-        assert_eq!(lines[8], "- **dregsy**: 0.5.0");
-        assert_eq!(lines[9], "- **ocync**: 0.1.0");
-
-        // Table header: ocync first, then dregsy (alphabetical among non-ocync).
-        assert_eq!(lines[11], "## Summary");
-        assert_eq!(lines[13], "| Scenario | ocync | dregsy |");
-        assert_eq!(lines[14], "|---|---|---|");
-        assert_eq!(lines[15], "| Cold sync (median) | 47s | 8m 41s |");
+        // Per-scenario detailed table (metrics as rows, tools as columns).
+        // Winner is bolded: ocync (47s) beats dregsy (8m 41s).
+        assert!(md.contains("## Cold sync (median)\n"));
+        assert!(md.contains("| Metric | ocync | dregsy |"));
+        assert!(md.contains("| Wall clock | **47s** | 8m 41s |"));
     }
 
     #[test]
@@ -394,6 +708,8 @@ mod tests {
             duplicate_blob_gets: 0,
             mount_attempts: 0,
             mount_successes: 0,
+            source_blob_gets: 200,
+            source_blob_bytes: 4_000_000_000,
         });
 
         let dir = tempfile::tempdir().unwrap();
@@ -423,6 +739,7 @@ mod tests {
     fn summary_markdown_empty_scenarios_omits_table() {
         let report = BenchReport {
             timestamp: "2026-04-15-100000".to_string(),
+            instance: test_instance(),
             corpus_size: 28,
             total_tags: 40,
             tool_versions: BTreeMap::from([("ocync".to_string(), "0.1.0".to_string())]),
@@ -430,14 +747,14 @@ mod tests {
             scale: vec![],
         };
         let md = summary_markdown(&report);
-        assert!(!md.contains("## Summary"));
-        assert!(!md.contains("| Scenario"));
+        assert!(!md.contains("## Cold"));
     }
 
     #[test]
-    fn summary_markdown_missing_tool_shows_em_dash() {
+    fn summary_markdown_missing_tool_shows_dash() {
         let report = BenchReport {
             timestamp: "2026-04-15-100000".to_string(),
+            instance: test_instance(),
             corpus_size: 28,
             total_tags: 40,
             tool_versions: BTreeMap::from([
@@ -446,11 +763,12 @@ mod tests {
             ]),
             scenarios: vec![ScenarioResult {
                 scenario: "Cold sync".to_string(),
-                // Only ocync ran — dregsy is missing.
+                // Only ocync ran -- dregsy is missing.
                 runs: vec![ToolRun {
                     tool: "ocync".to_string(),
                     wall_clock_secs: 47.0,
                     exit_code: Some(0),
+                    peak_rss_kb: Some(65536),
                     proxy_metrics: None,
                     ocync_json: None,
                 }],
@@ -458,6 +776,7 @@ mod tests {
             scale: vec![],
         };
         let md = summary_markdown(&report);
-        assert!(md.contains("| Cold sync | 47s | \u{2014} |"));
+        // dregsy column shows "--", ocync is bolded as only tool with data.
+        assert!(md.contains("| Wall clock | **47s** | -- |"), "md:\n{md}");
     }
 }

--- a/xtask/src/bench/runner.rs
+++ b/xtask/src/bench/runner.rs
@@ -52,6 +52,8 @@ pub(crate) struct RunResult {
     pub(crate) exit_code: Option<i32>,
     /// Captured standard output.
     pub(crate) stdout: String,
+    /// Peak resident set size in KB (from `/usr/bin/time -v`), if available.
+    pub(crate) peak_rss_kb: Option<u64>,
 }
 
 /// Runs a tool with its version flag and returns the version string.
@@ -80,10 +82,17 @@ pub(crate) async fn check_tool(tool: Tool) -> Result<String, String> {
     Ok(version.trim().to_string())
 }
 
-/// Builds ocync in release mode from the given workspace root.
+/// Builds ocync and bench-proxy in release mode from the given workspace root.
 pub(crate) async fn build_ocync(workspace_root: &Path) -> Result<(), String> {
     let status = tokio::process::Command::new("cargo")
-        .args(["build", "--release", "--package", "ocync"])
+        .args([
+            "build",
+            "--release",
+            "--package",
+            "ocync",
+            "--package",
+            "bench-proxy",
+        ])
         .current_dir(workspace_root)
         .status()
         .await
@@ -93,7 +102,7 @@ pub(crate) async fn build_ocync(workspace_root: &Path) -> Result<(), String> {
         Ok(())
     } else {
         Err(format!(
-            "cargo build --release --package ocync exited with status {}",
+            "cargo build --release exited with status {}",
             status
                 .code()
                 .map_or_else(|| "signal".to_string(), |c| c.to_string()),
@@ -138,17 +147,36 @@ pub(crate) async fn run_tool(
 
     let start = Instant::now();
 
-    let output = tokio::process::Command::new(binary.as_ref())
-        .args(&args)
-        .env("HTTPS_PROXY", proxy_url)
-        .output()
-        .await
-        .map_err(|e| format!("failed to spawn {}: {e}", tool.binary()))?;
+    // Wrap with /usr/bin/time -v to capture peak RSS. GNU time writes its
+    // report to stderr; the tool's own stderr is interleaved but the RSS
+    // line has a distinctive prefix we can parse.
+    let use_gnu_time = Path::new("/usr/bin/time").exists();
+    let output = if use_gnu_time {
+        let mut time_args = vec!["-v", binary.as_ref()];
+        time_args.extend(args.iter().copied());
+        tokio::process::Command::new("/usr/bin/time")
+            .args(&time_args)
+            .env("HTTPS_PROXY", proxy_url)
+            .output()
+            .await
+            .map_err(|e| format!("failed to spawn /usr/bin/time {}: {e}", tool.binary()))?
+    } else {
+        tokio::process::Command::new(binary.as_ref())
+            .args(&args)
+            .env("HTTPS_PROXY", proxy_url)
+            .output()
+            .await
+            .map_err(|e| format!("failed to spawn {}: {e}", tool.binary()))?
+    };
 
     let wall_clock = start.elapsed();
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
 
+    // Parse peak RSS from GNU time output.
+    let peak_rss_kb = parse_gnu_time_rss(&stderr);
+
     // Log stderr when the tool exits non-zero so failures are diagnosable.
+    // GNU time exits with the wrapped command's exit code.
     if !output.status.success() && !stderr.trim().is_empty() {
         eprintln!("  {} stderr:\n{}", tool, textwrap_indent(&stderr, "    "));
     }
@@ -157,7 +185,19 @@ pub(crate) async fn run_tool(
         wall_clock,
         exit_code: output.status.code(),
         stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        peak_rss_kb,
     })
+}
+
+/// Parse `Maximum resident set size (kbytes): NNN` from GNU time -v output.
+fn parse_gnu_time_rss(stderr: &str) -> Option<u64> {
+    for line in stderr.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("Maximum resident set size (kbytes):") {
+            return rest.trim().parse().ok();
+        }
+    }
+    None
 }
 
 /// Indents every line of `text` with `prefix`.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,6 +12,8 @@ use clap::Parser;
 enum Cli {
     /// Run benchmark suite comparing ocync against dregsy and regsync.
     Bench(bench::BenchArgs),
+    /// Run benchmarks on the remote EC2 bench instance via SSM.
+    BenchRemote(bench::remote::BenchRemoteArgs),
 }
 
 fn main() -> ExitCode {
@@ -23,6 +25,7 @@ fn main() -> ExitCode {
 
     let result = match cli {
         Cli::Bench(args) => rt.block_on(bench::run(args)),
+        Cli::BenchRemote(args) => rt.block_on(bench::remote::run(args)),
     };
 
     match result {


### PR DESCRIPTION
## Summary

### Engine: leader-follower mount optimization

Greedy set-cover election picks images whose blob sets maximize cross-image sharing, runs them first (leaders), commits their manifests, then promotes followers which cross-repo mount shared blobs instead of re-uploading. Key changes:

- `elect_leaders()` -- greedy multi-round election that provably covers every shared blob; no wave partitioning needed among followers
- `PromotionPhase` state machine (`Discovering -> Leaders -> Done`) gates task promotion so leaders complete before followers start
- `preferred_mount_sources` flows through the entire call chain so followers prefer leader repos (committed manifests) as mount sources
- Intra-image blob concurrency via `FuturesUnordered` + `Semaphore(6)`, with cancel-on-first-failure semantics
- Source-pull dedup via `BlobStage::claim_or_check` -- first task claims a blob pull, concurrent tasks wait for the staged file

### Fixes

- **Public ECR auth**: `public.ecr.aws` no longer routed through private ECR auth (hostname has no region)
- **Release profile**: strip, LTO, codegen-units=1, panic=abort

### Benchmarking

- `cargo xtask bench-remote` -- remote benchmark execution via SSM send-command with Docker Hub auth, peak RSS capture (`/usr/bin/time -v`), progress polling, and structured JSON result archival
- Instance metadata via IMDS + `aws ec2 describe-instance-types`
- Historical archive: full `BenchReport` to `bench-results/runs/{timestamp}.json`
- Competitor config generation (`config_gen.rs`) with regsync `repoAuth`, dregsy `auth-refresh`, Docker Hub PAT injection

## Test plan

- [x] `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings` -- clean
- [x] `cargo test` -- 248 tests pass
- [x] `cargo deny check`
- [ ] Benchmark on EC2 with `BLOB_MOUNTING=ENABLED`: verify leader uploads, follower mounts, source-pull dedup in proxy metrics