### PR TITLE
fix: update benchmark git_ref to rebase-merged SHA

### DIFF
--- a/bench/results/ecr.json
+++ b/bench/results/ecr.json
@@ -1,7 +1,7 @@
 [
   {
     "timestamp": "2026-04-19-194331",
-    "git_ref": "4035fa8",
+    "git_ref": "8ed9619",
     "machine": {
       "provider": "aws",
       "instance_type": "c6in.4xlarge",


### PR DESCRIPTION
## Summary

- Update `bench/results/ecr.json` git_ref from pre-merge SHA to the actual rebase-merged commit on main (`8ed9619`)

## Test plan

- [ ] Verify `git log --oneline 8ed9619` resolves on main