### PR TITLE
fix: align doc-shell padding with site header

### DIFF
--- a/crates/ocync-distribution/src/auth/detect.rs
+++ b/crates/ocync-distribution/src/auth/detect.rs
@@ -46,7 +46,7 @@ impl ProviderKind {
     /// is disabled by default; when disabled, mount POSTs return 202 (the
     /// fallback path pushes normally). We always attempt mount on ECR because
     /// the 202 fallback is cheap (~100ms) and successful mounts save entire
-    /// blob uploads. See `docs/registries/ecr.md` for details.
+    /// blob uploads. See `docs/src/content/registries/ecr.md` for details.
     ///
     /// Uses an exhaustive `match` so adding a new [`ProviderKind`] variant
     /// forces a compile-time decision here.

--- a/crates/ocync-distribution/tests/registry2_mount.rs
+++ b/crates/ocync-distribution/tests/registry2_mount.rs
@@ -4,7 +4,7 @@
 //! Pins the protocol-compliant baseline for `blob_mount`: a committed
 //! source blob returns [`MountResult::Mounted`], a missing source returns
 //! [`MountResult::NotMounted`]. Real-ECR behavior is deliberately not
-//! covered here (see `docs/registries/ecr.md` -- ECR requires `BLOB_MOUNTING`,
+//! covered here (see `docs/src/content/registries/ecr.md` -- ECR requires `BLOB_MOUNTING`,
 //! so the client short-circuits and the engine integration test pins
 //! that end-to-end).
 //!

--- a/docs/src/content/design/benchmark.md
+++ b/docs/src/content/design/benchmark.md
@@ -57,7 +57,7 @@ against the registry we target?
   deterministic, runs in CI on every PR.
 - Registry-specific quirks that cannot be exercised against
   `registry:2` (e.g. ECR's "never fulfills mount" behavior) are
-  captured as evidence in the findings log and pinned by engine-level
+  captured as evidence in the per-registry documentation and pinned by engine-level
   integration tests asserting the adapted code path.
 
 **Hard rule:** every `ocync` optimization that claims bytes/requests

--- a/docs/src/layouts/DocLayout.astro
+++ b/docs/src/layouts/DocLayout.astro
@@ -178,6 +178,7 @@ const jsonLd = {
     grid-template-columns: var(--sidebar-width) 1fr 12rem;
     max-inline-size: var(--content-max);
     margin-inline: auto;
+    padding-inline: var(--space-6);
     min-block-size: calc(100dvh - 8rem);
   }
 
@@ -325,6 +326,7 @@ const jsonLd = {
   @media (width < 48rem) {
     .doc-shell {
       grid-template-columns: 1fr;
+      padding-inline: var(--space-4);
     }
 
     .doc-sidebar {

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -226,8 +226,7 @@
     font-weight: 600;
     color: var(--color-text-muted);
     cursor: pointer;
-    opacity: 0;
-    transition: opacity 0.15s, background-color 0.15s, color 0.15s;
+    transition: background-color 0.15s, color 0.15s;
 
     &:hover {
       background-color: color-mix(in srgb, var(--color-text) 20%, transparent);
@@ -239,8 +238,15 @@
     }
   }
 
-  pre:hover .copy-btn {
-    opacity: 1;
+  @media (hover: hover) {
+    .copy-btn {
+      opacity: 0;
+      transition: opacity 0.15s, background-color 0.15s, color 0.15s;
+    }
+
+    pre:hover .copy-btn {
+      opacity: 1;
+    }
   }
 
   /* Shiki dual-theme: switch dark vars when data-theme="dark" */


### PR DESCRIPTION
## Summary
- Add `padding-inline` to `.doc-shell` matching the site header's padding so the three-column grid aligns with the nav buttons
- Match mobile breakpoint padding (`--space-4`) with header's mobile override
- Fix 3 dangling cross-references to deleted `findings.md`

## Test plan
- [x] Verified visually in dev server across Docs, Registries, and Design sections