### PR TITLE
fix: harden auth, retry, and transfer reliability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ Every PR ships the smallest correct change + one test that catches regression. D
 ## Git workflow
 
 - One PR at a time, merge to main, then next. No stacked PRs ever.
+- When dispatching parallel worktree agents, each MUST create its own branch from `main` (`git checkout -b feat/xxx main`). Never push to an existing branch from a worktree agent.
 - Never include `Co-Authored-By: Claude` or Anthropic attribution
 - Run the CI gate locally before push: `cargo fmt --check && cargo clippy -- -D warnings && cargo test && cargo deny check`
 - During rebase conflicts on `Cargo.lock`, regenerate with `git checkout --theirs Cargo.lock && cargo generate-lockfile`
@@ -60,6 +61,7 @@ Every PR ships the smallest correct change + one test that catches regression. D
 - `docs/src/content/design/benchmark.md` - layered benchmark plan (protocol / throughput / cross-tool)
 - `docs/src/content/design/watch-mode.md` - watch mode, discovery optimization, platform filtering
 - `docs/superpowers/plans/` (gitignored) - in-flight implementation plans
+- Unimplemented features are marked with `> **Status: Planned.**` or `> **Status: Partially implemented.**` in design docs. Update these markers when implementing.
 
 When a benchmark or probe run changes our understanding of a registry's behavior, update the relevant per-registry doc in `docs/src/content/registries/` in the same PR as the behavior change.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ reqwest = { version = "0.12", default-features = false, features = ["system-prox
 url = { version = "2", default-features = false }
 uuid = { version = "1", default-features = false, features = ["v7", "serde"] }
 ocync-distribution = { path = "crates/ocync-distribution", default-features = false }
-ocync-sync = { path = "crates/ocync-sync" }
+ocync-sync = { path = "crates/ocync-sync", default-features = false }
 
 [workspace.lints.rust]
 missing_debug_implementations = "warn"

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Full documentation at [clowdhaus.github.io/ocync](https://clowdhaus.github.io/oc
 | Registry | Auth | Blob mount | Notes |
 |---|---|---|---|
 | Amazon ECR (private) | IAM (automatic) | Yes (opt-in) | Batch APIs, per-action rate limits |
-| Amazon ECR Public | IAM (automatic) | Yes | Separate auth from private ECR |
+| Amazon ECR Public | IAM (automatic) | No | Separate auth from private ECR |
 | Chainguard | Token exchange | N/A (source) | No rate limits |
 | Docker Hub | Docker config / static | Yes | 100/6hr authenticated manifest GETs; HEADs free |
 | GitHub Container Registry | Docker config | Yes | Single-PATCH upload fallback |

--- a/bench/proxy/src/ca.rs
+++ b/bench/proxy/src/ca.rs
@@ -37,6 +37,15 @@ pub(crate) enum Error {
         /// Human-readable parse failure reason.
         reason: String,
     },
+    /// SNI hostname could not be parsed as a valid DNS name for leaf
+    /// certificate generation.
+    #[error("invalid SNI hostname {host}: {reason}")]
+    InvalidSni {
+        /// The SNI value that failed parsing.
+        host: String,
+        /// Human-readable parse failure reason.
+        reason: String,
+    },
     /// rustls signer construction failed (unsupported key type).
     #[error("rustls signer: {0}")]
     Signer(String),
@@ -141,12 +150,11 @@ pub(crate) async fn load_ca(cert_path: &Path, key_path: &Path) -> Result<CaSigne
 fn generate_leaf(issuer: &Issuer<'static, KeyPair>, sni_host: &str) -> Result<CertifiedKey, Error> {
     let san = match Ia5String::try_from(sni_host.to_owned()) {
         Ok(s) => SanType::DnsName(s),
-        // Fall back to IP-address SAN if the hostname isn't a valid DNS
-        // IA5 string (e.g. an IP literal). Registries almost always hit
-        // this via DNS, but the fallback keeps the code robust.
+        // IP addresses are not supported as SANs; return an error.
+        // Registries always connect via DNS hostnames in practice.
         Err(_) => {
-            return Err(Error::Pem {
-                path: sni_host.to_owned(),
+            return Err(Error::InvalidSni {
+                host: sni_host.to_owned(),
                 reason: "SNI host is not a valid IA5 DNS name".into(),
             });
         }

--- a/bench/proxy/src/proxy.rs
+++ b/bench/proxy/src/proxy.rs
@@ -144,7 +144,13 @@ pub(crate) async fn serve(
     loop {
         tokio::select! {
             accept = listener.accept() => {
-                let (stream, peer) = accept?;
+                let (stream, peer) = match accept {
+                    Ok(conn) => conn,
+                    Err(e) => {
+                        warn!(error = %e, "accept failed, skipping connection");
+                        continue;
+                    }
+                };
                 let ca = ca.clone();
                 let log = log.clone();
                 let upstream = upstream.clone();
@@ -421,19 +427,21 @@ async fn handle_request(
             let host = host_for_log.clone();
             let url = url_for_log.clone();
             let status_code = status.as_u16();
-            tokio::spawn(async move {
-                let entry = ProxyEntry {
-                    timestamp: now_iso8601(),
-                    method: &method,
-                    host: &host,
-                    url: &url,
-                    request_bytes,
-                    response_bytes: entry_bytes,
-                    status: status_code,
-                    duration_ms: elapsed.as_millis() as u64,
-                };
-                log.write_entry(&entry).await;
-            });
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                handle.spawn(async move {
+                    let entry = ProxyEntry {
+                        timestamp: now_iso8601(),
+                        method: &method,
+                        host: &host,
+                        url: &url,
+                        request_bytes,
+                        response_bytes: entry_bytes,
+                        status: status_code,
+                        duration_ms: elapsed.as_millis() as u64,
+                    };
+                    log.write_entry(&entry).await;
+                });
+            }
         })),
     };
     let body = StreamBody::new(logging_stream).boxed_unsync();

--- a/charts/ocync/values.yaml
+++ b/charts/ocync/values.yaml
@@ -32,15 +32,18 @@ serviceAccount:
 ##   config:
 ##     registries:
 ##       source:
-##         hostname: cgr.dev
+##         url: cgr.dev
 ##       target:
-##         hostname: 123456789012.dkr.ecr.us-east-1.amazonaws.com
-##         auth: ecr
+##         url: 123456789012.dkr.ecr.us-east-1.amazonaws.com
+##     defaults:
+##       source: source
+##       targets: target
+##       tags:
+##         sort: semver
+##         latest: 5
 ##     mappings:
-##       - source: { registry: source, repository: chainguard/static }
-##         targets:
-##           - { registry: target, repository: chainguard/static }
-##         tags: { latest: 5 }
+##       - from: chainguard/static
+##         to: chainguard/static
 config: {}
 
 watch:

--- a/crates/ocync-distribution/CLAUDE.md
+++ b/crates/ocync-distribution/CLAUDE.md
@@ -35,7 +35,7 @@ OCI Distribution Specification client library - registry auth, blob/manifest tra
 
 - ECR fulfills mount when `BLOB_MOUNTING=ENABLED` account setting + source blob has a committed manifest.
 - Mount POST returns 201 (success) or 202 (not fulfilled, upload session started).
-- Mount is attempted on all providers unconditionally. `ProviderKind::fulfills_cross_repo_mount()` exists but is currently dead code (returns `true` for all variants, zero callers).
+- Mount is attempted on all providers unconditionally; the 202 fallback is cheap (~100ms).
 
 ## Dependencies
 

--- a/crates/ocync-distribution/Cargo.toml
+++ b/crates/ocync-distribution/Cargo.toml
@@ -18,25 +18,23 @@ workspace = true
 [dependencies]
 aws-config.workspace = true
 aws-lc-rs = { workspace = true }
-aws-sdk-ecr = { version = "1", default-features = false }
+aws-sdk-ecr = { workspace = true }
 base64 = { version = "0.22", default-features = false, features = ["alloc"] }
 bytes.workspace = true
 futures-util = { version = "0.3", default-features = false }
 http.workspace = true
 hex.workspace = true
 regex-lite = { version = "0.1", default-features = false }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots-no-provider", "stream", "json", "system-proxy"] }
+reqwest = { workspace = true, features = ["rustls-tls-native-roots-no-provider", "stream", "json"] }
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync", "time"] }
 tracing.workspace = true
-url = { version = "2", default-features = false }
+url = { workspace = true }
 
 [dev-dependencies]
-aws-config.workspace = true
-aws-sdk-ecr.workspace = true
 testcontainers = { version = "0.27", default-features = false }
 tokio = { workspace = true, features = ["sync", "time", "test-util", "macros", "rt-multi-thread"] }
-wiremock = "0.6"
+wiremock = { version = "0.6", default-features = false }

--- a/crates/ocync-distribution/README.md
+++ b/crates/ocync-distribution/README.md
@@ -46,7 +46,7 @@ let client = RegistryClient::builder(
     .build()
     .unwrap();
 
-let repo = ocync_distribution::spec::RepositoryName::new("library/nginx");
+let repo = ocync_distribution::spec::RepositoryName::new("library/nginx").unwrap();
 let manifest = client
     .manifest_pull(&repo, "latest")
     .await

--- a/crates/ocync-distribution/src/auth/anonymous.rs
+++ b/crates/ocync-distribution/src/auth/anonymous.rs
@@ -77,10 +77,17 @@ impl AuthProvider for AnonymousAuth {
             let mut cache = self.cache.lock().await;
 
             if let Some(token) = cache.get(&key).filter(|t| t.is_valid()) {
+                tracing::debug!(base_url = %self.base_url, scope = %key, "token cache hit");
                 return Ok(token.clone());
             }
 
-            let token = token_exchange::exchange(&self.http, &self.base_url, &scopes, None).await?;
+            tracing::debug!(base_url = %self.base_url, scope = %key, "token cache miss, exchanging");
+            let token = token_exchange::exchange(&self.http, &self.base_url, &scopes, None)
+                .await
+                .map_err(|e| {
+                    tracing::warn!(base_url = %self.base_url, scope = %key, error = %e, "token exchange failed");
+                    e
+                })?;
             cache.insert(key, token.clone());
 
             Ok(token)
@@ -90,6 +97,7 @@ impl AuthProvider for AnonymousAuth {
     fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
             let mut cache = self.cache.lock().await;
+            tracing::debug!(base_url = %self.base_url, entries = cache.len(), "invalidating token cache");
             cache.clear();
         })
     }

--- a/crates/ocync-distribution/src/auth/basic.rs
+++ b/crates/ocync-distribution/src/auth/basic.rs
@@ -62,8 +62,7 @@ impl BasicAuth {
     /// Create a new Basic auth provider with an explicit base URL.
     ///
     /// Use this for registries that don't use HTTPS (e.g. `http://localhost:5000`).
-    #[cfg(test)]
-    fn with_base_url(
+    pub fn with_base_url(
         base_url: impl Into<String>,
         http: reqwest::Client,
         credentials: Credentials,
@@ -94,16 +93,22 @@ impl AuthProvider for BasicAuth {
             let mut cache = self.cache.lock().await;
 
             if let Some(token) = cache.get(&key).filter(|t| t.is_valid()) {
+                tracing::debug!(base_url = %self.base_url, scope = %key, "token cache hit");
                 return Ok(token.clone());
             }
 
+            tracing::debug!(base_url = %self.base_url, scope = %key, "token cache miss, exchanging");
             let token = token_exchange::exchange(
                 &self.http,
                 &self.base_url,
                 &scopes,
                 Some(&self.credentials),
             )
-            .await?;
+            .await
+            .map_err(|e| {
+                tracing::warn!(base_url = %self.base_url, scope = %key, error = %e, "token exchange failed");
+                e
+            })?;
             cache.insert(key, token.clone());
 
             Ok(token)
@@ -113,6 +118,7 @@ impl AuthProvider for BasicAuth {
     fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
             let mut cache = self.cache.lock().await;
+            tracing::debug!(base_url = %self.base_url, entries = cache.len(), "invalidating token cache");
             cache.clear();
         })
     }

--- a/crates/ocync-distribution/src/auth/basic.rs
+++ b/crates/ocync-distribution/src/auth/basic.rs
@@ -267,7 +267,7 @@ mod tests {
         let auth =
             BasicAuth::with_base_url(server.uri(), crate::test_http_client(), test_credentials());
         let err = auth.get_token(&[Scope::pull("repo")]).await.unwrap_err();
-        assert!(matches!(err, Error::Http(_)));
+        assert!(matches!(err, Error::AuthFailed { .. }));
     }
 
     #[tokio::test]

--- a/crates/ocync-distribution/src/auth/detect.rs
+++ b/crates/ocync-distribution/src/auth/detect.rs
@@ -33,37 +33,6 @@ pub enum ProviderKind {
     Chainguard,
 }
 
-impl ProviderKind {
-    /// Whether this provider is known to fulfill OCI cross-repo blob mount.
-    ///
-    /// Returns `false` for providers observed to never return `201 Created`
-    /// to a mount POST. When `false`,
-    /// [`crate::blob::RegistryClient::blob_mount`] short-circuits without
-    /// issuing a network request.
-    ///
-    /// ECR fulfills mount when the `BLOB_MOUNTING` account setting is enabled
-    /// AND the source blob is referenced by a committed manifest. The setting
-    /// is disabled by default; when disabled, mount POSTs return 202 (the
-    /// fallback path pushes normally). We always attempt mount on ECR because
-    /// the 202 fallback is cheap (~100ms) and successful mounts save entire
-    /// blob uploads. See `docs/src/content/registries/ecr.md` for details.
-    ///
-    /// Uses an exhaustive `match` so adding a new [`ProviderKind`] variant
-    /// forces a compile-time decision here.
-    pub fn fulfills_cross_repo_mount(&self) -> bool {
-        match self {
-            Self::Ecr
-            | Self::EcrPublic
-            | Self::Gcr
-            | Self::Gar
-            | Self::Acr
-            | Self::Ghcr
-            | Self::DockerHub
-            | Self::Chainguard => true,
-        }
-    }
-}
-
 /// Compiled regex for ECR private registry hostnames.
 ///
 /// Pattern: `<12-digit-account>.dkr[.-]ecr[-fips].<region>.<partition-domain>`

--- a/crates/ocync-distribution/src/auth/docker.rs
+++ b/crates/ocync-distribution/src/auth/docker.rs
@@ -5,7 +5,6 @@ use std::fmt;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::process::Command;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
@@ -90,7 +89,7 @@ impl DockerConfig {
 ///
 /// Checks `auths` first (static credentials), then `credHelpers`, then the
 /// default `credsStore`. Handles Docker Hub hostname normalization.
-pub fn resolve_from_docker_config(
+pub async fn resolve_from_docker_config(
     config: &DockerConfig,
     registry: &str,
 ) -> Result<Option<Credentials>, Error> {
@@ -101,13 +100,13 @@ pub fn resolve_from_docker_config(
 
     // Try credential helpers.
     if let Some(helper) = lookup_cred_helper(config, registry) {
-        let creds = run_credential_helper(&helper, registry)?;
+        let creds = run_credential_helper(&helper, registry).await?;
         return Ok(Some(creds));
     }
 
     // Try default credential store.
     if let Some(ref store) = config.creds_store {
-        match run_credential_helper(store, registry) {
+        match run_credential_helper(store, registry).await {
             Ok(creds) => return Ok(Some(creds)),
             Err(_) => {
                 // Default store may not have creds for this registry -- not an error.
@@ -127,7 +126,7 @@ pub fn resolve_from_docker_config(
 fn lookup_auths(config: &DockerConfig, registry: &str) -> Result<Option<Credentials>, Error> {
     // Direct match.
     if let Some(entry) = config.auths.get(registry) {
-        if let Some(creds) = entry_to_credentials(entry)? {
+        if let Some(creds) = entry_to_credentials(entry, registry)? {
             return Ok(Some(creds));
         }
     }
@@ -135,7 +134,7 @@ fn lookup_auths(config: &DockerConfig, registry: &str) -> Result<Option<Credenti
     // Try with/without https:// prefix.
     let with_scheme = format!("https://{registry}");
     if let Some(entry) = config.auths.get(&with_scheme) {
-        if let Some(creds) = entry_to_credentials(entry)? {
+        if let Some(creds) = entry_to_credentials(entry, registry)? {
             return Ok(Some(creds));
         }
     }
@@ -145,7 +144,7 @@ fn lookup_auths(config: &DockerConfig, registry: &str) -> Result<Option<Credenti
     if is_docker_hub(registry) {
         for alias in DOCKER_HUB_ALIASES {
             if let Some(entry) = config.auths.get(*alias) {
-                if let Some(creds) = entry_to_credentials(entry)? {
+                if let Some(creds) = entry_to_credentials(entry, registry)? {
                     return Ok(Some(creds));
                 }
             }
@@ -174,11 +173,11 @@ fn lookup_cred_helper(config: &DockerConfig, registry: &str) -> Option<String> {
 }
 
 /// Convert an `AuthEntry` to `Credentials`.
-fn entry_to_credentials(entry: &AuthEntry) -> Result<Option<Credentials>, Error> {
+fn entry_to_credentials(entry: &AuthEntry, registry: &str) -> Result<Option<Credentials>, Error> {
     // Prefer the `auth` field (base64 encoded).
     if let Some(ref encoded) = entry.auth {
         if !encoded.is_empty() {
-            let (username, password) = decode_auth(encoded)?;
+            let (username, password) = decode_auth(encoded, registry)?;
             return Ok(Some(Credentials::Basic { username, password }));
         }
     }
@@ -195,19 +194,19 @@ fn entry_to_credentials(entry: &AuthEntry) -> Result<Option<Credentials>, Error>
 }
 
 /// Decode a base64-encoded `username:password` string.
-fn decode_auth(encoded: &str) -> Result<(String, String), Error> {
+fn decode_auth(encoded: &str, registry: &str) -> Result<(String, String), Error> {
     let decoded = BASE64.decode(encoded).map_err(|e| Error::AuthFailed {
-        registry: String::new(),
+        registry: registry.to_owned(),
         reason: format!("invalid base64 in auth field: {e}"),
     })?;
 
     let text = String::from_utf8(decoded).map_err(|e| Error::AuthFailed {
-        registry: String::new(),
+        registry: registry.to_owned(),
         reason: format!("auth field is not valid UTF-8: {e}"),
     })?;
 
     let (username, password) = text.split_once(':').ok_or_else(|| Error::AuthFailed {
-        registry: String::new(),
+        registry: registry.to_owned(),
         reason: "auth field does not contain ':'".into(),
     })?;
 
@@ -217,29 +216,75 @@ fn decode_auth(encoded: &str) -> Result<(String, String), Error> {
 /// Execute a Docker credential helper and return the credentials.
 ///
 /// Runs `docker-credential-{helper} get` with the registry on stdin.
-fn run_credential_helper(helper: &str, registry: &str) -> Result<Credentials, Error> {
+/// Uses `tokio::process::Command` to avoid blocking the single-threaded
+/// tokio runtime.
+async fn run_credential_helper(helper: &str, registry: &str) -> Result<Credentials, Error> {
+    // Validate helper name to prevent command injection via crafted
+    // `credsStore` / `credHelpers` values in Docker config.json.
+    if !helper
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-')
+    {
+        return Err(Error::CredentialHelperFailed {
+            helper: helper.to_owned(),
+            reason: format!(
+                "invalid credential helper name: {helper:?} \
+                 (must be alphanumeric and hyphens only)"
+            ),
+        });
+    }
+
     let program = format!("docker-credential-{helper}");
 
-    let output = Command::new(&program)
+    let mut child = tokio::process::Command::new(&program)
         .arg("get")
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
-        .and_then(|mut child| {
-            use std::io::Write;
-            if let Some(ref mut stdin) = child.stdin {
-                stdin.write_all(registry.as_bytes())?;
+        .map_err(|e| {
+            tracing::warn!(helper = %program, registry, error = %e, "credential helper failed to execute");
+            Error::CredentialHelperFailed {
+                helper: program.clone(),
+                reason: format!("failed to execute: {e}"),
             }
-            child.wait_with_output()
-        })
-        .map_err(|e| Error::CredentialHelperFailed {
+        })?;
+
+    // Write registry name to stdin, then drop to signal EOF.
+    if let Some(mut stdin) = child.stdin.take() {
+        use tokio::io::AsyncWriteExt;
+        stdin
+            .write_all(registry.as_bytes())
+            .await
+            .map_err(|e| Error::CredentialHelperFailed {
+                helper: program.clone(),
+                reason: format!("failed to write to stdin: {e}"),
+            })?;
+    }
+
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        child.wait_with_output(),
+    )
+    .await
+    .map_err(|_| {
+        tracing::warn!(helper = %program, registry, "credential helper timed out after 30s");
+        Error::CredentialHelperFailed {
+            helper: program.clone(),
+            reason: "timed out after 30s (helper may be waiting for interactive input)".into(),
+        }
+    })?
+    .map_err(|e| {
+        tracing::warn!(helper = %program, registry, error = %e, "credential helper failed to execute");
+        Error::CredentialHelperFailed {
             helper: program.clone(),
             reason: format!("failed to execute: {e}"),
-        })?;
+        }
+    })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        tracing::warn!(helper = %program, registry, status = %output.status, "credential helper exited with error");
         return Err(Error::CredentialHelperFailed {
             helper: program,
             reason: format!("exited with {}: {}", output.status, stderr.trim()),
@@ -296,14 +341,14 @@ impl fmt::Debug for DockerConfigAuth {
 impl DockerConfigAuth {
     /// Create a new Docker config auth provider for the given hostname.
     ///
-    /// Resolves credentials from `config` immediately. Uses HTTPS by default.
-    pub fn new(
+    /// Resolves credentials from `config`. Uses HTTPS by default.
+    pub async fn new(
         registry: impl Into<String>,
         config: &DockerConfig,
         http: reqwest::Client,
     ) -> Result<Self, Error> {
         let registry = registry.into();
-        let credentials = resolve_from_docker_config(config, &registry)?;
+        let credentials = resolve_from_docker_config(config, &registry).await?;
         if credentials.is_some() {
             tracing::debug!(registry = %registry, "docker config: resolved credentials");
         } else {
@@ -349,16 +394,22 @@ impl AuthProvider for DockerConfigAuth {
             let mut cache = self.cache.lock().await;
 
             if let Some(token) = cache.get(&key).filter(|t| t.is_valid()) {
+                tracing::debug!(base_url = %self.base_url, scope = %key, "token cache hit");
                 return Ok(token.clone());
             }
 
+            tracing::debug!(base_url = %self.base_url, scope = %key, "token cache miss, exchanging");
             let token = token_exchange::exchange(
                 &self.http,
                 &self.base_url,
                 &scopes,
                 self.credentials.as_ref(),
             )
-            .await?;
+            .await
+            .map_err(|e| {
+                tracing::warn!(base_url = %self.base_url, scope = %key, error = %e, "token exchange failed");
+                e
+            })?;
             cache.insert(key, token.clone());
 
             Ok(token)
@@ -368,6 +419,7 @@ impl AuthProvider for DockerConfigAuth {
     fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
             let mut cache = self.cache.lock().await;
+            tracing::debug!(base_url = %self.base_url, entries = cache.len(), "invalidating token cache");
             cache.clear();
         })
     }
@@ -413,7 +465,7 @@ mod tests {
     #[test]
     fn decode_auth_valid() {
         // "user:pass" base64-encoded
-        let (user, pass) = decode_auth("dXNlcjpwYXNz").unwrap();
+        let (user, pass) = decode_auth("dXNlcjpwYXNz", "test.io").unwrap();
         assert_eq!(user, "user");
         assert_eq!(pass, "pass");
     }
@@ -422,14 +474,14 @@ mod tests {
     fn decode_auth_with_colon_in_password() {
         // "user:pa:ss" base64-encoded
         let encoded = BASE64.encode("user:pa:ss");
-        let (user, pass) = decode_auth(&encoded).unwrap();
+        let (user, pass) = decode_auth(&encoded, "test.io").unwrap();
         assert_eq!(user, "user");
         assert_eq!(pass, "pa:ss");
     }
 
     #[test]
     fn decode_auth_invalid_base64() {
-        let result = decode_auth("not-valid-base64!!!");
+        let result = decode_auth("not-valid-base64!!!", "test.io");
         assert!(result.is_err());
     }
 
@@ -437,12 +489,22 @@ mod tests {
     fn decode_auth_no_colon() {
         // "userpass" (no colon) base64-encoded
         let encoded = BASE64.encode("userpass");
-        let result = decode_auth(&encoded);
+        let result = decode_auth(&encoded, "test.io");
         assert!(result.is_err());
     }
 
     #[test]
-    fn lookup_exact_match() {
+    fn decode_auth_error_includes_registry() {
+        let result = decode_auth("not-valid-base64!!!", "ghcr.io");
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("ghcr.io"),
+            "error should include registry name: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn lookup_exact_match() {
         let json = r#"{
             "auths": {
                 "ghcr.io": { "auth": "dXNlcjpwYXNz" }
@@ -450,6 +512,7 @@ mod tests {
         }"#;
         let config: DockerConfig = serde_json::from_str(json).unwrap();
         let creds = resolve_from_docker_config(&config, "ghcr.io")
+            .await
             .unwrap()
             .unwrap();
         assert!(
@@ -457,8 +520,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn lookup_with_scheme_prefix() {
+    #[tokio::test]
+    async fn lookup_with_scheme_prefix() {
         let json = r#"{
             "auths": {
                 "https://ghcr.io": { "auth": "dXNlcjpwYXNz" }
@@ -466,25 +529,28 @@ mod tests {
         }"#;
         let config: DockerConfig = serde_json::from_str(json).unwrap();
         let creds = resolve_from_docker_config(&config, "ghcr.io")
+            .await
             .unwrap()
             .unwrap();
         assert!(matches!(creds, Credentials::Basic { .. }));
     }
 
-    #[test]
-    fn lookup_not_found() {
+    #[tokio::test]
+    async fn lookup_not_found() {
         let json = r#"{
             "auths": {
                 "ghcr.io": { "auth": "dXNlcjpwYXNz" }
             }
         }"#;
         let config: DockerConfig = serde_json::from_str(json).unwrap();
-        let result = resolve_from_docker_config(&config, "quay.io").unwrap();
+        let result = resolve_from_docker_config(&config, "quay.io")
+            .await
+            .unwrap();
         assert!(result.is_none());
     }
 
-    #[test]
-    fn lookup_docker_hub_alias() {
+    #[tokio::test]
+    async fn lookup_docker_hub_alias() {
         let json = r#"{
             "auths": {
                 "https://index.docker.io/v1/": { "auth": "ZG9ja2VyOnNlY3JldA==" }
@@ -494,12 +560,14 @@ mod tests {
 
         // Look up via "docker.io" -- should find the creds stored under the full URL alias.
         let creds = resolve_from_docker_config(&config, "docker.io")
+            .await
             .unwrap()
             .unwrap();
         assert!(matches!(&creds, Credentials::Basic { username, .. } if username == "docker"));
 
         // Also via "registry-1.docker.io".
         let creds = resolve_from_docker_config(&config, "registry-1.docker.io")
+            .await
             .unwrap()
             .unwrap();
         assert!(matches!(creds, Credentials::Basic { .. }));
@@ -542,8 +610,8 @@ mod tests {
         assert!(config.creds_store.is_none());
     }
 
-    #[test]
-    fn entry_with_separate_username_password() {
+    #[tokio::test]
+    async fn entry_with_separate_username_password() {
         let json = r#"{
             "auths": {
                 "custom.io": {
@@ -554,6 +622,7 @@ mod tests {
         }"#;
         let config: DockerConfig = serde_json::from_str(json).unwrap();
         let creds = resolve_from_docker_config(&config, "custom.io")
+            .await
             .unwrap()
             .unwrap();
         assert!(
@@ -571,34 +640,38 @@ mod tests {
         assert!(!is_docker_hub("quay.io"));
     }
 
-    #[test]
-    fn empty_auth_field_returns_none() {
+    #[tokio::test]
+    async fn empty_auth_field_returns_none() {
         let json = r#"{
             "auths": {
                 "ghcr.io": { "auth": "" }
             }
         }"#;
         let config: DockerConfig = serde_json::from_str(json).unwrap();
-        let result = resolve_from_docker_config(&config, "ghcr.io").unwrap();
+        let result = resolve_from_docker_config(&config, "ghcr.io")
+            .await
+            .unwrap();
         assert!(result.is_none());
     }
 
-    #[test]
-    fn empty_auth_object_returns_none() {
+    #[tokio::test]
+    async fn empty_auth_object_returns_none() {
         let json = r#"{
             "auths": {
                 "ghcr.io": {}
             }
         }"#;
         let config: DockerConfig = serde_json::from_str(json).unwrap();
-        let result = resolve_from_docker_config(&config, "ghcr.io").unwrap();
+        let result = resolve_from_docker_config(&config, "ghcr.io")
+            .await
+            .unwrap();
         assert!(result.is_none());
     }
 
     #[test]
     fn decode_auth_empty_password() {
         let encoded = BASE64.encode("user:");
-        let (user, pass) = decode_auth(&encoded).unwrap();
+        let (user, pass) = decode_auth(&encoded, "test.io").unwrap();
         assert_eq!(user, "user");
         assert_eq!(pass, "");
     }
@@ -606,7 +679,7 @@ mod tests {
     #[test]
     fn decode_auth_empty_username() {
         let encoded = BASE64.encode(":password");
-        let (user, pass) = decode_auth(&encoded).unwrap();
+        let (user, pass) = decode_auth(&encoded, "test.io").unwrap();
         assert_eq!(user, "");
         assert_eq!(pass, "password");
     }
@@ -635,8 +708,8 @@ mod tests {
         assert_eq!(helper.as_deref(), Some("desktop"));
     }
 
-    #[test]
-    fn creds_store_not_checked_when_auths_match() {
+    #[tokio::test]
+    async fn creds_store_not_checked_when_auths_match() {
         let json = r#"{
             "auths": {
                 "ghcr.io": { "auth": "dXNlcjpwYXNz" }
@@ -645,6 +718,7 @@ mod tests {
         }"#;
         let config: DockerConfig = serde_json::from_str(json).unwrap();
         let creds = resolve_from_docker_config(&config, "ghcr.io")
+            .await
             .unwrap()
             .unwrap();
         assert!(matches!(creds, Credentials::Basic { username, .. } if username == "user"));
@@ -789,19 +863,20 @@ mod tests {
         // expect(2) proves cache was cleared.
     }
 
-    #[test]
-    fn docker_config_auth_name() {
+    #[tokio::test]
+    async fn docker_config_auth_name() {
         let auth = DockerConfigAuth::new(
             "example.com",
             &DockerConfig::default(),
             crate::test_http_client(),
         )
+        .await
         .unwrap();
         assert_eq!(auth.name(), "docker-config");
     }
 
-    #[test]
-    fn docker_config_auth_resolves_from_config() {
+    #[tokio::test]
+    async fn docker_config_auth_resolves_from_config() {
         let config = DockerConfig {
             auths: {
                 let mut m = HashMap::new();
@@ -818,14 +893,54 @@ mod tests {
             cred_helpers: HashMap::new(),
             creds_store: None,
         };
-        let auth = DockerConfigAuth::new("ghcr.io", &config, crate::test_http_client()).unwrap();
+        let auth = DockerConfigAuth::new("ghcr.io", &config, crate::test_http_client())
+            .await
+            .unwrap();
         // Verify credentials were resolved (has_credentials in Debug output).
         let debug = format!("{auth:?}");
         assert!(debug.contains("has_credentials: true"));
     }
 
-    #[test]
-    fn docker_config_auth_no_match_is_anonymous() {
+    #[tokio::test]
+    async fn credential_helper_rejects_path_traversal() {
+        let err = run_credential_helper("../../evil", "registry.example.com")
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("invalid credential helper name"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn credential_helper_rejects_shell_metacharacters() {
+        let err = run_credential_helper("helper;rm -rf /", "registry.example.com")
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("invalid credential helper name"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn credential_helper_accepts_valid_names() {
+        // These should pass validation but fail to execute (no such binary).
+        // Verify the error is CredentialHelperFailed with "failed to execute",
+        // NOT the name-validation error.
+        for name in ["gcloud", "ecr-login", "osxkeychain", "desktop"] {
+            let err = run_credential_helper(name, "registry.example.com")
+                .await
+                .unwrap_err();
+            assert!(
+                !err.to_string().contains("invalid credential helper name"),
+                "valid name {name:?} was rejected: {err}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn docker_config_auth_no_match_is_anonymous() {
         let config = DockerConfig {
             auths: {
                 let mut m = HashMap::new();
@@ -843,7 +958,9 @@ mod tests {
             creds_store: None,
         };
         // quay.io not in config -- should resolve as anonymous.
-        let auth = DockerConfigAuth::new("quay.io", &config, crate::test_http_client()).unwrap();
+        let auth = DockerConfigAuth::new("quay.io", &config, crate::test_http_client())
+            .await
+            .unwrap();
         let debug = format!("{auth:?}");
         assert!(debug.contains("has_credentials: false"));
     }

--- a/crates/ocync-distribution/src/auth/ecr.rs
+++ b/crates/ocync-distribution/src/auth/ecr.rs
@@ -215,6 +215,7 @@ impl EcrAuth {
         {
             let cached = self.cached_token.read().await;
             if let Some(token) = cached.as_ref().filter(|t| t.is_valid()) {
+                tracing::debug!(registry = %self.hostname, "token cache hit (read-lock fast path)");
                 return Ok(token.clone());
             }
         }
@@ -225,12 +226,18 @@ impl EcrAuth {
         // Double-check after acquiring write lock -- another task may have
         // already refreshed the token while we waited.
         if let Some(token) = cached.as_ref().filter(|t| t.is_valid()) {
+            tracing::debug!(registry = %self.hostname, "token cache hit (write-lock recheck)");
             return Ok(token.clone());
         }
 
-        let response = self.api.get_authorization_token().await?;
+        tracing::debug!(registry = %self.hostname, "token cache miss, calling GetAuthorizationToken");
+        let response = self.api.get_authorization_token().await.map_err(|e| {
+            tracing::warn!(registry = %self.hostname, error = %e, "ECR GetAuthorizationToken failed");
+            e
+        })?;
         validate_ecr_token(&response.encoded_token, &self.hostname)?;
         let ttl = response.expires_in.unwrap_or(ECR_DEFAULT_TOKEN_TTL);
+        tracing::debug!(registry = %self.hostname, ttl_secs = ttl.as_secs(), "ECR token refreshed");
         // ECR expects `Authorization: Basic <base64(AWS:password)>`. The encoded
         // token from GetAuthorizationToken is already in the right format.
         let token = Token::with_ttl(response.encoded_token, ttl).with_scheme(AuthScheme::Basic);
@@ -256,6 +263,7 @@ impl AuthProvider for EcrAuth {
     fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
             let mut cached = self.cached_token.write().await;
+            tracing::debug!(registry = %self.hostname, "invalidating cached ECR token");
             *cached = None;
         })
     }

--- a/crates/ocync-distribution/src/auth/mod.rs
+++ b/crates/ocync-distribution/src/auth/mod.rs
@@ -186,7 +186,8 @@ impl Token {
         match self.expires_at {
             Some(exp) => {
                 let now = Instant::now();
-                now >= exp || exp.duration_since(now) < EARLY_REFRESH_WINDOW
+                exp.checked_duration_since(now)
+                    .is_none_or(|remaining| remaining < EARLY_REFRESH_WINDOW)
             }
             None => false,
         }

--- a/crates/ocync-distribution/src/auth/static_token.rs
+++ b/crates/ocync-distribution/src/auth/static_token.rs
@@ -3,6 +3,7 @@
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use super::{AuthProvider, Scope, Token};
 use crate::error::Error;
@@ -13,26 +14,35 @@ use crate::error::Error;
 /// scenarios where the caller already has a valid bearer token
 /// that doesn't require a token-exchange flow.
 ///
-/// `invalidate()` is a no-op because there is no cached exchange
-/// to clear -- the token is the source of truth.
+/// When `invalidate()` is called (after a 401 from the registry),
+/// the token is marked as revoked and subsequent `get_token()` calls
+/// return an error, breaking the infinite retry loop.
 pub struct StaticTokenAuth {
     /// The bearer token value.
     token: String,
+    /// The registry this token authenticates against (for error messages).
+    registry: String,
+    /// Whether the token has been invalidated by a 401 response.
+    invalidated: AtomicBool,
 }
 
 impl fmt::Debug for StaticTokenAuth {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("StaticTokenAuth")
             .field("token", &"[REDACTED]")
+            .field("registry", &self.registry)
+            .field("invalidated", &self.invalidated.load(Ordering::Relaxed))
             .finish()
     }
 }
 
 impl StaticTokenAuth {
-    /// Create a new static token auth provider.
-    pub fn new(token: impl Into<String>) -> Self {
+    /// Create a new static token auth provider for the given registry.
+    pub fn new(registry: impl Into<String>, token: impl Into<String>) -> Self {
         Self {
             token: token.into(),
+            registry: registry.into(),
+            invalidated: AtomicBool::new(false),
         }
     }
 }
@@ -46,11 +56,26 @@ impl AuthProvider for StaticTokenAuth {
         &self,
         _scopes: &[Scope],
     ) -> Pin<Box<dyn Future<Output = Result<Token, Error>> + Send + '_>> {
-        Box::pin(async move { Ok(Token::new(&self.token)) })
+        Box::pin(async move {
+            if self.invalidated.load(Ordering::Acquire) {
+                return Err(Error::AuthFailed {
+                    registry: self.registry.clone(),
+                    reason: "static token was invalidated (rejected by registry)".into(),
+                });
+            }
+            tracing::trace!("using static token (no refresh possible)");
+            Ok(Token::new(&self.token))
+        })
     }
 
     fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        Box::pin(async {})
+        Box::pin(async {
+            tracing::warn!(
+                registry = %self.registry,
+                "static token invalidated; subsequent requests will fail"
+            );
+            self.invalidated.store(true, Ordering::Release);
+        })
     }
 }
 
@@ -61,7 +86,7 @@ mod tests {
 
     #[tokio::test]
     async fn static_token_returns_configured_value() {
-        let auth = StaticTokenAuth::new("my-pat-token-123");
+        let auth = StaticTokenAuth::new("ghcr.io", "my-pat-token-123");
         let scopes = [Scope::pull("library/nginx")];
         let token = auth.get_token(&scopes).await.unwrap();
         assert_eq!(token.value(), "my-pat-token-123");
@@ -69,7 +94,7 @@ mod tests {
 
     #[tokio::test]
     async fn static_token_ignores_scopes() {
-        let auth = StaticTokenAuth::new("token");
+        let auth = StaticTokenAuth::new("ghcr.io", "token");
         let t1 = auth.get_token(&[Scope::pull("repo-a")]).await.unwrap();
         let t2 = auth.get_token(&[Scope::pull_push("repo-b")]).await.unwrap();
         assert_eq!(t1.value(), "token");
@@ -77,22 +102,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn static_token_survives_invalidate() {
-        let auth = StaticTokenAuth::new("persistent");
+    async fn static_token_errors_after_invalidate() {
+        let auth = StaticTokenAuth::new("ghcr.io", "revoked-token");
         auth.invalidate().await;
-        let token = auth.get_token(&[Scope::pull("repo")]).await.unwrap();
-        assert_eq!(token.value(), "persistent");
+        let err = auth.get_token(&[Scope::pull("repo")]).await.unwrap_err();
+        assert!(err.to_string().contains("invalidated"), "error: {err}");
+        assert!(err.to_string().contains("ghcr.io"), "error: {err}");
     }
 
     #[test]
     fn static_token_name() {
-        let auth = StaticTokenAuth::new("t");
+        let auth = StaticTokenAuth::new("ghcr.io", "t");
         assert_eq!(auth.name(), "static-token");
     }
 
     #[test]
     fn static_token_debug_redacts() {
-        let auth = StaticTokenAuth::new("super-secret-token");
+        let auth = StaticTokenAuth::new("ghcr.io", "super-secret-token");
         let debug = format!("{auth:?}");
         assert!(!debug.contains("super-secret-token"));
         assert!(debug.contains("[REDACTED]"));

--- a/crates/ocync-distribution/src/auth/token_exchange.rs
+++ b/crates/ocync-distribution/src/auth/token_exchange.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
+use http::StatusCode;
 use http::header::WWW_AUTHENTICATE;
 use serde::Deserialize;
 
@@ -36,8 +37,20 @@ pub(crate) async fn exchange(
     let resp = http.get(&v2_url).send().await?;
 
     if resp.status().is_success() {
-        // No auth required -- return a dummy token.
+        tracing::debug!(base_url, "registry requires no auth, returning empty token");
         return Ok(Token::new(""));
+    }
+
+    // Only 401 carries a WWW-Authenticate challenge. Any other non-success
+    // status (403, 500, etc.) is a hard error -- don't fall through to header
+    // parsing with a misleading "missing WWW-Authenticate" message.
+    if resp.status() != StatusCode::UNAUTHORIZED {
+        let status = resp.status();
+        tracing::warn!(base_url, %status, "registry ping returned unexpected status");
+        return Err(Error::AuthFailed {
+            registry: base_url.to_owned(),
+            reason: format!("registry ping returned {status} (expected 401 challenge)"),
+        });
     }
 
     let www_auth = resp
@@ -75,24 +88,40 @@ pub(crate) async fn exchange(
         request = request.header("Authorization", basic_header_value(creds));
     }
 
-    let token_resp = request
-        .send()
-        .await?
-        .error_for_status()?
-        .json::<TokenResponse>()
-        .await?;
+    let resp = request.send().await?;
+    if resp.status().is_client_error() || resp.status().is_server_error() {
+        let status = resp.status();
+        tracing::warn!(base_url, %status, "token endpoint returned error");
+        return Err(Error::AuthFailed {
+            registry: base_url.to_owned(),
+            reason: format!("token endpoint returned {status}"),
+        });
+    }
+    let token_resp = resp.json::<TokenResponse>().await?;
 
     let token_value = token_resp
         .token
         .or(token_resp.access_token)
-        .ok_or_else(|| Error::AuthFailed {
-            registry: base_url.to_owned(),
-            reason: "token response missing both 'token' and 'access_token' fields".into(),
+        .ok_or_else(|| {
+            tracing::warn!(
+                base_url,
+                "token response missing both 'token' and 'access_token' fields"
+            );
+            Error::AuthFailed {
+                registry: base_url.to_owned(),
+                reason: "token response missing both 'token' and 'access_token' fields".into(),
+            }
         })?;
 
     let token = match token_resp.expires_in {
-        Some(secs) if secs > 0 => Token::with_ttl(token_value, Duration::from_secs(secs)),
-        _ => Token::new(token_value),
+        Some(secs) if secs > 0 => {
+            tracing::debug!(base_url, expires_in_secs = secs, "token exchange succeeded");
+            Token::with_ttl(token_value, Duration::from_secs(secs))
+        }
+        _ => {
+            tracing::debug!(base_url, "token exchange succeeded (no expiry)");
+            Token::new(token_value)
+        }
     };
 
     Ok(token)
@@ -157,20 +186,26 @@ impl WwwAuthenticate {
 }
 
 /// Split parameter string on commas, respecting quoted strings.
+///
+/// Handles backslash-escaped quotes (`\"`) inside quoted values so that
+/// a realm URL containing an escaped quote does not prematurely end the
+/// quoted region.
 fn split_params(s: &str) -> Vec<&str> {
     let mut parts = Vec::new();
     let mut start = 0;
     let mut in_quotes = false;
+    let mut prev_backslash = false;
 
     for (i, ch) in s.char_indices() {
         match ch {
-            '"' => in_quotes = !in_quotes,
+            '"' if !prev_backslash => in_quotes = !in_quotes,
             ',' if !in_quotes => {
                 parts.push(&s[start..i]);
                 start = i + 1;
             }
             _ => {}
         }
+        prev_backslash = ch == '\\' && !prev_backslash;
     }
     if start < s.len() {
         parts.push(&s[start..]);
@@ -254,6 +289,20 @@ mod tests {
         let parts = split_params(r#"realm="https://example.com/a,b",service="test""#);
         assert_eq!(parts.len(), 2);
         assert!(parts[0].contains("a,b"));
+    }
+
+    #[test]
+    fn split_params_with_escaped_quote() {
+        // A realm URL containing a backslash-escaped quote should not
+        // terminate the quoted region prematurely.
+        let input = r#"realm="https://example.com/path?q=\"val\"",service="test""#;
+        let parts = split_params(input);
+        assert_eq!(parts.len(), 2, "got parts: {parts:?}");
+        assert!(
+            parts[0].contains(r#"\"val\""#),
+            "escaped quotes missing: {}",
+            parts[0]
+        );
     }
 
     #[test]
@@ -413,7 +462,12 @@ mod tests {
         let err = exchange(&http, &mock.uri(), &[Scope::pull("repo")], None)
             .await
             .unwrap_err();
-        assert!(matches!(err, Error::Http(_)));
+        assert!(
+            matches!(err, Error::AuthFailed { .. }),
+            "expected AuthFailed, got: {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("403"), "expected 403 in error: {msg}");
     }
 
     #[tokio::test]
@@ -558,5 +612,56 @@ mod tests {
         assert_eq!(scope_params.len(), 2, "expected 2 scope params");
         assert!(scope_params.contains(&"repository:repo-a:pull".to_string()));
         assert!(scope_params.contains(&"repository:repo-b:pull,push".to_string()));
+    }
+
+    #[tokio::test]
+    async fn exchange_non_401_returns_clear_error() {
+        let mock = wiremock::MockServer::start().await;
+
+        // Return 403 instead of 401 -- should NOT produce a misleading
+        // "missing WWW-Authenticate" message.
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/"))
+            .respond_with(wiremock::ResponseTemplate::new(403))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let http = crate::test_http_client();
+        let err = exchange(&http, &mock.uri(), &[Scope::pull("repo")], None)
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("403") && msg.contains("expected 401 challenge"),
+            "unexpected error message: {msg}"
+        );
+        // Must NOT mention WWW-Authenticate.
+        assert!(
+            !msg.contains("WWW-Authenticate"),
+            "should not mention WWW-Authenticate for non-401: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn exchange_500_returns_clear_error() {
+        let mock = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/"))
+            .respond_with(wiremock::ResponseTemplate::new(500))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let http = crate::test_http_client();
+        let err = exchange(&http, &mock.uri(), &[Scope::pull("repo")], None)
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("500") && msg.contains("expected 401 challenge"),
+            "unexpected error message: {msg}"
+        );
     }
 }

--- a/crates/ocync-distribution/src/blob.rs
+++ b/crates/ocync-distribution/src/blob.rs
@@ -36,15 +36,27 @@ fn blob_path(digest: &Digest) -> String {
 
 /// Check an HTTP response status, returning an error with the response body
 /// if the status does not match `expected`.
+///
+/// Error messages include `registry/repository` context so operators can
+/// identify which endpoint failed, matching the format used by
+/// [`classify_response`](crate::client) for GET/HEAD errors.
 async fn expect_status(
     resp: reqwest::Response,
     expected: StatusCode,
+    base_url: &url::Url,
+    repository: &str,
 ) -> Result<reqwest::Response, Error> {
     let status = resp.status();
     if status == expected {
         Ok(resp)
     } else {
-        let message = resp.text().await.unwrap_or_default();
+        let registry = base_url.host_str().unwrap_or("unknown");
+        let body = resp.text().await.unwrap_or_default();
+        let message = if body.is_empty() {
+            format!("{registry}/{repository}")
+        } else {
+            format!("{registry}/{repository}: {body}")
+        };
         Err(Error::RegistryError { status, message })
     }
 }
@@ -74,6 +86,12 @@ impl RegistryClient {
     ///
     /// Issues a HEAD request to `/v2/{repository}/blobs/{digest}`.
     /// Returns `Some(size)` if the blob exists, `None` if not found.
+    ///
+    /// The size is extracted from the `Content-Length` header. If the header
+    /// is missing or unparseable, size defaults to `0`. Callers that only
+    /// need an existence check should use `is_some()`; callers that need the
+    /// actual byte count should treat `0` as "unknown" and fall back to a
+    /// GET-based size discovery if needed.
     pub async fn blob_exists(
         &self,
         repository: &RepositoryName,
@@ -147,7 +165,7 @@ impl RegistryClient {
             )
             .await?;
 
-        classify_mount_response(resp).await
+        classify_mount_response(resp, &self.base_url, repository).await
     }
 
     /// Push a blob to the given repository using a monolithic upload.
@@ -175,7 +193,7 @@ impl RegistryClient {
                 |headers| self.http.post(url.clone()).headers(headers),
             )
             .await?;
-        let resp = expect_status(resp, StatusCode::ACCEPTED).await?;
+        let resp = expect_status(resp, StatusCode::ACCEPTED, &self.base_url, repository).await?;
         let put_url = extract_location(&resp, &self.base_url)?;
 
         let digest_str = digest.to_string();
@@ -195,7 +213,7 @@ impl RegistryClient {
                 },
             )
             .await?;
-        expect_status(resp, StatusCode::CREATED).await?;
+        expect_status(resp, StatusCode::CREATED, &self.base_url, repository).await?;
 
         Ok(digest)
     }
@@ -246,7 +264,7 @@ impl RegistryClient {
         // gcr.io hosts support it fine, so only Gar triggers this path.
         if provider == Some(ProviderKind::Gar) {
             return self
-                .blob_push_stream_gar_fallback(repository, expected_digest, stream)
+                .blob_push_stream_gar_fallback(repository, expected_digest, known_size, stream)
                 .await;
         }
 
@@ -268,7 +286,7 @@ impl RegistryClient {
                 |headers| self.http.post(url.clone()).headers(headers),
             )
             .await?;
-        let resp = expect_status(resp, StatusCode::ACCEPTED).await?;
+        let resp = expect_status(resp, StatusCode::ACCEPTED, &self.base_url, repository).await?;
         let upload_url = extract_location(&resp, &self.base_url)?;
 
         // Streaming PUT - send the blob body through a single HTTP request.
@@ -295,7 +313,7 @@ impl RegistryClient {
             .map_err(Error::from);
         report_permit(permit, &result);
         let resp = result?;
-        expect_status(resp, StatusCode::CREATED).await?;
+        expect_status(resp, StatusCode::CREATED, &self.base_url, repository).await?;
 
         Ok(expected_digest.clone())
     }
@@ -310,6 +328,7 @@ impl RegistryClient {
         &self,
         repository: &RepositoryName,
         expected_digest: &Digest,
+        known_size: Option<u64>,
         stream: impl Stream<Item = Result<Bytes, Error>>,
     ) -> Result<Digest, Error> {
         warn!(
@@ -317,7 +336,7 @@ impl RegistryClient {
             host = self.base_url.host_str().unwrap_or("unknown"),
             "GAR does not support chunked uploads; buffering entire blob in memory"
         );
-        let body = buffer_stream(stream, None).await?;
+        let body = buffer_stream(stream, known_size).await?;
         let actual_digest = self.blob_push(repository, &body).await?;
 
         if &actual_digest != expected_digest {
@@ -359,11 +378,18 @@ impl RegistryClient {
                 |headers| self.http.post(url.clone()).headers(headers),
             )
             .await?;
-        let resp = expect_status(resp, StatusCode::ACCEPTED).await?;
+        let resp = expect_status(resp, StatusCode::ACCEPTED, &self.base_url, repository).await?;
         let upload_url = extract_location(&resp, &self.base_url)?;
 
-        // Buffer entire stream.
-        let body = Bytes::from(buffer_stream(stream, known_size).await?);
+        // Buffer entire stream and verify digest before uploading.
+        let raw = buffer_stream(stream, known_size).await?;
+        let actual_digest = Digest::from_sha256(Sha256::digest(&raw));
+        if &actual_digest != expected_digest {
+            return Err(Error::Other(format!(
+                "GHCR fallback: local digest {actual_digest} != expected {expected_digest}"
+            )));
+        }
+        let body = Bytes::from(raw);
         let body_len = body.len();
 
         // Single PATCH - no Content-Range header.
@@ -382,7 +408,7 @@ impl RegistryClient {
                 },
             )
             .await?;
-        let resp = expect_status(resp, StatusCode::ACCEPTED).await?;
+        let resp = expect_status(resp, StatusCode::ACCEPTED, &self.base_url, repository).await?;
         let finalize_url = extract_location(&resp, &self.base_url)?;
 
         // PUT to finalize with digest query param.
@@ -402,7 +428,7 @@ impl RegistryClient {
                 },
             )
             .await?;
-        expect_status(resp, StatusCode::CREATED).await?;
+        expect_status(resp, StatusCode::CREATED, &self.base_url, repository).await?;
 
         Ok(expected_digest.clone())
     }
@@ -432,13 +458,23 @@ fn extract_location(resp: &reqwest::Response, base_url: &url::Url) -> Result<Str
 /// in principle chain on; in practice it falls through to a fresh
 /// HEAD + push, so the URL is discarded and only the binary outcome
 /// is surfaced.
-async fn classify_mount_response(resp: reqwest::Response) -> Result<MountResult, Error> {
+async fn classify_mount_response(
+    resp: reqwest::Response,
+    base_url: &url::Url,
+    repository: &str,
+) -> Result<MountResult, Error> {
     let status = resp.status();
     match status {
         StatusCode::CREATED => Ok(MountResult::Mounted),
         StatusCode::ACCEPTED => Ok(MountResult::NotMounted),
         _ => {
-            let message = resp.text().await.unwrap_or_default();
+            let registry = base_url.host_str().unwrap_or("unknown");
+            let body = resp.text().await.unwrap_or_default();
+            let message = if body.is_empty() {
+                format!("{registry}/{repository}")
+            } else {
+                format!("{registry}/{repository}: {body}")
+            };
             Err(Error::RegistryError { status, message })
         }
     }
@@ -458,6 +494,38 @@ mod tests {
             blob_path(&digest),
             "blobs/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         );
+    }
+
+    #[tokio::test]
+    async fn expect_status_error_includes_registry_and_repo() {
+        let resp = http::Response::builder()
+            .status(500)
+            .body("internal error")
+            .unwrap();
+        let reqwest_resp = reqwest::Response::from(resp);
+        let base = url::Url::parse("https://ghcr.io").unwrap();
+        let err = expect_status(reqwest_resp, StatusCode::CREATED, &base, "myorg/myrepo")
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("ghcr.io"), "missing registry in error: {msg}");
+        assert!(msg.contains("myorg/myrepo"), "missing repo in error: {msg}");
+    }
+
+    #[tokio::test]
+    async fn classify_mount_error_includes_registry_and_repo() {
+        let resp = http::Response::builder()
+            .status(403)
+            .body("forbidden")
+            .unwrap();
+        let reqwest_resp = reqwest::Response::from(resp);
+        let base = url::Url::parse("https://ghcr.io").unwrap();
+        let err = classify_mount_response(reqwest_resp, &base, "myorg/myrepo")
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("ghcr.io"), "missing registry in error: {msg}");
+        assert!(msg.contains("myorg/myrepo"), "missing repo in error: {msg}");
     }
 
     #[test]
@@ -582,7 +650,7 @@ mod tests {
 
         let client = build_test_client("us-docker.pkg.dev", port);
 
-        let repo = RepositoryName::new("my-project/my-repo");
+        let repo = RepositoryName::new("my-project/my-repo").unwrap();
         let result = client
             .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
             .await
@@ -640,7 +708,7 @@ mod tests {
 
         // Pass None so the monolithic threshold does not intercept the call;
         // we are verifying the GHCR-specific single-PATCH path directly.
-        let repo = RepositoryName::new("my-org/my-image");
+        let repo = RepositoryName::new("my-org/my-image").unwrap();
         let result = client
             .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
             .await
@@ -691,7 +759,7 @@ mod tests {
         let client = build_test_client("ghcr.io", port);
 
         // No known_size - GHCR path still taken based on hostname alone.
-        let repo = RepositoryName::new("repo");
+        let repo = RepositoryName::new("repo").unwrap();
         let result = client
             .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
             .await
@@ -764,9 +832,9 @@ mod tests {
             let client = build_test_client(case.host, port);
             let result = client
                 .blob_mount(
-                    &RepositoryName::new("tgt/repo"),
+                    &RepositoryName::new("tgt/repo").unwrap(),
                     &test_digest(case.host.as_bytes()),
-                    &RepositoryName::new("src/repo"),
+                    &RepositoryName::new("src/repo").unwrap(),
                 )
                 .await
                 .unwrap();
@@ -823,7 +891,7 @@ mod tests {
 
         let client = build_test_client("registry.example.com", port);
 
-        let repo = RepositoryName::new("stream/repo");
+        let repo = RepositoryName::new("stream/repo").unwrap();
         let result = client
             .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
             .await

--- a/crates/ocync-distribution/src/client.rs
+++ b/crates/ocync-distribution/src/client.rs
@@ -328,6 +328,14 @@ fn build_v2_url(base: &Url) -> Result<Url, Error> {
 }
 
 /// Construct a URL for `/v2/{repository}/{path}`.
+///
+/// # Safety contract
+///
+/// `repository` is interpolated directly into the URL path without
+/// percent-encoding. Callers MUST pass validated repository names
+/// (e.g. via [`RepositoryName`] or a parsed [`Reference`](crate::Reference))
+/// which reject characters like `?`, `#`, and whitespace that would
+/// corrupt the URL structure.
 pub(crate) fn build_url(base: &Url, repository: &str, path: &str) -> Result<Url, Error> {
     let full_path = format!("/v2/{repository}/{path}");
     base.join(&full_path)
@@ -499,7 +507,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let repo = RepositoryName::new("repo");
+        let repo = RepositoryName::new("repo").unwrap();
         let _ = client
             .get(
                 &repo,

--- a/crates/ocync-distribution/src/digest.rs
+++ b/crates/ocync-distribution/src/digest.rs
@@ -75,18 +75,30 @@ impl FromStr for Digest {
             });
         }
 
-        // SHA-256 must be exactly 64 hex chars
-        if algorithm == SHA256_ALGO && hex_part.len() != 64 {
+        // SHA-256 must be exactly 64 hex chars (case-insensitive algorithm match).
+        if algorithm.eq_ignore_ascii_case(SHA256_ALGO) && hex_part.len() != 64 {
             return Err(Error::InvalidDigest {
                 digest: s.into(),
                 reason: format!("sha256 hex must be 64 characters, got {}", hex_part.len()),
             });
         }
 
-        Ok(Self {
-            raw: s.to_owned(),
-            algo_len,
-        })
+        // Normalize to lowercase so equality and hashing are case-insensitive.
+        // Fast path: skip allocation when already lowercase (common case).
+        let already_lower = !s.bytes().any(|b| b.is_ascii_uppercase());
+        if already_lower {
+            Ok(Self {
+                raw: s.to_owned(),
+                algo_len: algorithm.len(),
+            })
+        } else {
+            let algo_lower = algorithm.to_ascii_lowercase();
+            let raw = format!("{}:{}", algo_lower, hex_part.to_ascii_lowercase());
+            Ok(Self {
+                raw,
+                algo_len: algo_lower.len(),
+            })
+        }
     }
 }
 
@@ -212,7 +224,27 @@ mod tests {
         let hex = "A".repeat(64);
         let input = format!("sha256:{hex}");
         let d: Digest = input.parse().unwrap();
-        assert_eq!(d.hex(), hex);
+        // Parsing normalizes to lowercase.
+        assert_eq!(d.hex(), hex.to_ascii_lowercase());
+        // Upper and lower parse to the same value.
+        let lower_input = format!("sha256:{}", "a".repeat(64));
+        let d_lower: Digest = lower_input.parse().unwrap();
+        assert_eq!(d, d_lower);
+    }
+
+    #[test]
+    fn mixed_case_digests_are_equal() {
+        let lower: Digest =
+            "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+                .parse()
+                .unwrap();
+        let upper: Digest =
+            "sha256:ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890"
+                .parse()
+                .unwrap();
+        assert_eq!(lower, upper);
+        // Also verify the stored representation is lowercase.
+        assert!(upper.to_string().chars().all(|c| !c.is_ascii_uppercase()));
     }
 
     #[test]
@@ -222,15 +254,40 @@ mod tests {
     }
 
     #[test]
-    fn display_preserves_original() {
-        let input = TEST_DIGEST;
-        let d: Digest = input.parse().unwrap();
-        assert_eq!(d.to_string(), input);
+    fn display_is_normalized_lowercase() {
+        let d: Digest = TEST_DIGEST.parse().unwrap();
+        assert_eq!(d.to_string(), TEST_DIGEST);
+        // Uppercase input is normalized to lowercase on display.
+        let upper = format!("sha256:{}", "A".repeat(64));
+        let d2: Digest = upper.parse().unwrap();
+        assert_eq!(d2.to_string(), format!("sha256:{}", "a".repeat(64)));
     }
 
     #[test]
     fn deserialize_non_string_errors() {
         let result: Result<Digest, _> = serde_json::from_str("123");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn uppercase_algorithm_normalized() {
+        let hex = "a".repeat(64);
+        let input = format!("SHA256:{hex}");
+        let d: Digest = input.parse().unwrap();
+        assert_eq!(d.algorithm(), "sha256");
+        assert_eq!(d.to_string(), format!("sha256:{hex}"));
+
+        // Uppercase algorithm + lowercase hex matches lowercase algorithm + lowercase hex.
+        let lower_input = format!("sha256:{hex}");
+        let d_lower: Digest = lower_input.parse().unwrap();
+        assert_eq!(d, d_lower);
+    }
+
+    #[test]
+    fn mixed_case_algorithm_normalized() {
+        let hex = "b".repeat(64);
+        let input = format!("Sha256:{hex}");
+        let d: Digest = input.parse().unwrap();
+        assert_eq!(d.algorithm(), "sha256");
     }
 }

--- a/crates/ocync-distribution/src/ecr.rs
+++ b/crates/ocync-distribution/src/ecr.rs
@@ -507,7 +507,10 @@ mod tests {
         let checker = BatchChecker::with_api(mock);
 
         let result = checker
-            .check_blob_existence(&RepositoryName::new("my-repo"), &[d1.clone(), d2.clone()])
+            .check_blob_existence(
+                &RepositoryName::new("my-repo").unwrap(),
+                &[d1.clone(), d2.clone()],
+            )
             .await
             .unwrap();
 
@@ -535,7 +538,7 @@ mod tests {
 
         let result = checker
             .check_blob_existence(
-                &RepositoryName::new("my-repo"),
+                &RepositoryName::new("my-repo").unwrap(),
                 &[d1.clone(), d2.clone(), d3.clone()],
             )
             .await
@@ -576,7 +579,7 @@ mod tests {
         let checker = BatchChecker::with_api(mock);
 
         let result = checker
-            .check_blob_existence(&RepositoryName::new("my-repo"), &digests)
+            .check_blob_existence(&RepositoryName::new("my-repo").unwrap(), &digests)
             .await
             .unwrap();
 
@@ -600,7 +603,7 @@ mod tests {
         let checker = BatchChecker::with_api(mock);
 
         let result = checker
-            .check_blob_existence(&RepositoryName::new("my-repo"), &[])
+            .check_blob_existence(&RepositoryName::new("my-repo").unwrap(), &[])
             .await
             .unwrap();
 
@@ -616,7 +619,7 @@ mod tests {
         let checker = BatchChecker::with_api(mock);
 
         let result = checker
-            .check_blob_existence(&RepositoryName::new("my-repo"), &[test_digest(1)])
+            .check_blob_existence(&RepositoryName::new("my-repo").unwrap(), &[test_digest(1)])
             .await;
 
         assert!(result.is_err());
@@ -639,7 +642,7 @@ mod tests {
         let checker = BatchChecker::with_api(mock);
 
         let result = checker
-            .check_blob_existence(&RepositoryName::new("my-repo"), &[d1, d2])
+            .check_blob_existence(&RepositoryName::new("my-repo").unwrap(), &[d1, d2])
             .await
             .unwrap();
 
@@ -662,7 +665,10 @@ mod tests {
         let checker = BatchChecker::with_api(mock);
 
         let result = checker
-            .check_blob_existence(&RepositoryName::new("my-repo"), &[d1.clone(), d2.clone()])
+            .check_blob_existence(
+                &RepositoryName::new("my-repo").unwrap(),
+                &[d1.clone(), d2.clone()],
+            )
             .await
             .unwrap();
 
@@ -698,7 +704,7 @@ mod tests {
         let checker = BatchChecker::with_api(mock);
 
         let result = checker
-            .check_blob_existence(&RepositoryName::new("my-repo"), &digests)
+            .check_blob_existence(&RepositoryName::new("my-repo").unwrap(), &digests)
             .await
             .unwrap();
 

--- a/crates/ocync-distribution/src/lib.rs
+++ b/crates/ocync-distribution/src/lib.rs
@@ -39,6 +39,9 @@ pub fn install_crypto_provider() {
 /// Convenience for tests that need an HTTP client without going through
 /// [`RegistryClientBuilder`]. Production code should use
 /// [`install_crypto_provider`] at startup and construct clients directly.
+///
+/// This is a test utility; do not use in production code.
+#[doc(hidden)]
 pub fn test_http_client() -> reqwest::Client {
     install_crypto_provider();
     reqwest::Client::new()

--- a/crates/ocync-distribution/src/manifest.rs
+++ b/crates/ocync-distribution/src/manifest.rs
@@ -65,6 +65,10 @@ impl RegistryClient {
     /// Check whether a manifest exists and retrieve its metadata.
     ///
     /// Returns `None` if the manifest is not found (404).
+    ///
+    /// The `size` field in [`ManifestHead`] is extracted from `Content-Length`.
+    /// If the header is missing or unparseable, size defaults to `0`. Callers
+    /// that need the exact manifest size should treat `0` as "unknown".
     pub async fn manifest_head(
         &self,
         repository: &RepositoryName,
@@ -86,7 +90,11 @@ impl RegistryClient {
                 let digest_str = headers
                     .get(DOCKER_CONTENT_DIGEST)
                     .and_then(|v| v.to_str().ok())
-                    .unwrap_or_default();
+                    .ok_or_else(|| {
+                        Error::Other(
+                            "manifest HEAD response missing Docker-Content-Digest header".into(),
+                        )
+                    })?;
                 let digest: Digest = digest_str.parse().map_err(|_| {
                     Error::Other(format!(
                         "invalid digest in Docker-Content-Digest header: {digest_str}"

--- a/crates/ocync-distribution/src/reference.rs
+++ b/crates/ocync-distribution/src/reference.rs
@@ -129,6 +129,44 @@ impl FromStr for Reference {
             });
         }
 
+        // Reject characters that would corrupt URLs when interpolated into
+        // path segments. This is more permissive than the OCI spec (which
+        // requires lowercase) but catches the dangerous characters.
+        if let Some(bad) = repository
+            .chars()
+            .find(|c| !matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '.' | '_' | '/' | '-'))
+        {
+            return Err(Error::InvalidReference {
+                input: s.into(),
+                reason: format!(
+                    "repository name contains invalid character '{bad}'; \
+                     allowed: [a-zA-Z0-9._/-]"
+                ),
+            });
+        }
+
+        // Validate tag: must be 1-128 chars and match [a-zA-Z0-9_.-].
+        if let Some(ref t) = tag {
+            if t.len() > 128 {
+                return Err(Error::InvalidReference {
+                    input: s.into(),
+                    reason: format!("tag exceeds 128 characters ({})", t.len()),
+                });
+            }
+            if let Some(bad) = t
+                .chars()
+                .find(|c| !matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '.' | '-'))
+            {
+                return Err(Error::InvalidReference {
+                    input: s.into(),
+                    reason: format!(
+                        "tag contains invalid character '{bad}'; \
+                         allowed: [a-zA-Z0-9_.-]"
+                    ),
+                });
+            }
+        }
+
         Ok(Self {
             registry,
             repository,
@@ -149,7 +187,8 @@ fn split_name_tag(name_tag: &str) -> (&str, Option<String>) {
         let tag_start = after_slash + colon + 1;
         let tag = &name_tag[tag_start..];
         if tag.is_empty() {
-            (name_tag, None)
+            // Trailing colon with no tag (e.g. "ghcr.io/repo:") -- strip the colon.
+            (&name_tag[..after_slash + colon], None)
         } else {
             (&name_tag[..after_slash + colon], Some(tag.to_owned()))
         }
@@ -374,5 +413,64 @@ mod tests {
         assert_eq!(r.registry(), "docker.io");
         assert_eq!(r.repository(), "myuser/myrepo");
         assert_eq!(r.tag(), Some("latest"));
+    }
+
+    #[test]
+    fn repository_rejects_question_mark() {
+        let r = "ghcr.io/repo?evil:tag".parse::<Reference>();
+        assert!(r.is_err());
+        assert!(r.unwrap_err().to_string().contains("invalid character"));
+    }
+
+    #[test]
+    fn repository_rejects_hash() {
+        let r = "ghcr.io/repo#fragment:tag".parse::<Reference>();
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn repository_rejects_space() {
+        let r = "ghcr.io/repo name:tag".parse::<Reference>();
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn repository_rejects_control_chars() {
+        let r = "ghcr.io/repo\x01name:tag".parse::<Reference>();
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn repository_allows_valid_characters() {
+        // Uppercase, dots, underscores, hyphens, slashes are all valid.
+        let r: Reference = "ghcr.io/My-Org/my_repo.v2:tag".parse().unwrap();
+        assert_eq!(r.repository(), "My-Org/my_repo.v2");
+    }
+
+    #[test]
+    fn tag_rejects_invalid_chars() {
+        let err = "ghcr.io/repo:v1.0+build".parse::<Reference>().unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("tag") && msg.contains("invalid character"),
+            "error: {msg}"
+        );
+    }
+
+    #[test]
+    fn tag_rejects_overlength() {
+        let long_tag = "a".repeat(129);
+        let input = format!("ghcr.io/repo:{long_tag}");
+        let err = input.parse::<Reference>().unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("128"), "error: {msg}");
+    }
+
+    #[test]
+    fn tag_allows_128_chars() {
+        let tag = "a".repeat(128);
+        let input = format!("ghcr.io/repo:{tag}");
+        let r: Reference = input.parse().unwrap();
+        assert_eq!(r.tag().unwrap().len(), 128);
     }
 }

--- a/crates/ocync-distribution/src/spec.rs
+++ b/crates/ocync-distribution/src/spec.rs
@@ -262,9 +262,31 @@ impl fmt::Display for PlatformFilter {
 pub struct RepositoryName(String);
 
 impl RepositoryName {
-    /// Create a new repository name.
-    pub fn new(name: impl Into<String>) -> Self {
-        Self(name.into())
+    /// Create a new repository name after validating characters.
+    ///
+    /// Repository names must be non-empty and contain only `[a-zA-Z0-9._/-]`.
+    /// This matches the validation in [`Reference::from_str`](crate::Reference).
+    pub fn new(name: impl Into<String>) -> Result<Self, Error> {
+        let name = name.into();
+        if name.is_empty() {
+            return Err(Error::InvalidReference {
+                input: name,
+                reason: "repository name must be non-empty".into(),
+            });
+        }
+        if let Some(bad) = name
+            .chars()
+            .find(|c| !matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '.' | '_' | '/' | '-'))
+        {
+            return Err(Error::InvalidReference {
+                input: name,
+                reason: format!(
+                    "repository name contains invalid character '{bad}'; \
+                     allowed: [a-zA-Z0-9._/-]"
+                ),
+            });
+        }
+        Ok(Self(name))
     }
 
     /// Return the name as a string slice.
@@ -286,15 +308,10 @@ impl fmt::Display for RepositoryName {
     }
 }
 
-impl From<String> for RepositoryName {
-    fn from(s: String) -> Self {
-        Self(s)
-    }
-}
-
-impl From<&str> for RepositoryName {
-    fn from(s: &str) -> Self {
-        Self(s.to_owned())
+impl FromStr for RepositoryName {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
     }
 }
 
@@ -387,14 +404,28 @@ pub enum ManifestKind {
 
 impl ManifestKind {
     /// Deserialize a manifest from JSON bytes, using the media type to discriminate.
+    ///
+    /// Validates that `schemaVersion` is `2` as required by the OCI spec.
     pub fn from_json(media_type: &MediaType, bytes: &[u8]) -> Result<Self, Error> {
         match media_type {
             MediaType::OciManifest | MediaType::DockerManifestV2 => {
                 let m: ImageManifest = serde_json::from_slice(bytes)?;
+                if m.schema_version != 2 {
+                    return Err(Error::Other(format!(
+                        "unsupported schemaVersion {}, expected 2",
+                        m.schema_version
+                    )));
+                }
                 Ok(Self::Image(Box::new(m)))
             }
             MediaType::OciIndex | MediaType::DockerManifestList => {
                 let m: ImageIndex = serde_json::from_slice(bytes)?;
+                if m.schema_version != 2 {
+                    return Err(Error::Other(format!(
+                        "unsupported schemaVersion {}, expected 2",
+                        m.schema_version
+                    )));
+                }
                 Ok(Self::Index(Box::new(m)))
             }
             _ => Err(Error::UnsupportedMediaType {
@@ -844,5 +875,57 @@ mod tests {
             let parsed = MediaType::from(s);
             assert_eq!(&parsed, mt, "roundtrip failed for {s}");
         }
+    }
+
+    #[test]
+    fn manifest_from_json_rejects_schema_version_1() {
+        let json = serde_json::json!({
+            "schemaVersion": 1,
+            "config": test_descriptor(),
+            "layers": [test_layer_descriptor()]
+        });
+        let bytes = serde_json::to_vec(&json).unwrap();
+        let err = ManifestKind::from_json(&MediaType::OciManifest, &bytes).unwrap_err();
+        assert!(err.to_string().contains("schemaVersion"), "error: {err}");
+    }
+
+    #[test]
+    fn index_from_json_rejects_schema_version_1() {
+        let json = serde_json::json!({
+            "schemaVersion": 1,
+            "manifests": [{
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": TEST_DIGEST,
+                "size": 1000
+            }]
+        });
+        let bytes = serde_json::to_vec(&json).unwrap();
+        let err = ManifestKind::from_json(&MediaType::OciIndex, &bytes).unwrap_err();
+        assert!(err.to_string().contains("schemaVersion"), "error: {err}");
+    }
+
+    // --- RepositoryName validation tests ---
+
+    #[test]
+    fn repository_name_valid() {
+        assert!(RepositoryName::new("library/nginx").is_ok());
+        assert!(RepositoryName::new("My-Org/my_repo.v2").is_ok());
+    }
+
+    #[test]
+    fn repository_name_rejects_invalid_chars() {
+        let err = RepositoryName::new("repo?evil").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("invalid character"), "error: {msg}");
+        assert!(msg.contains('?'), "error: {msg}");
+
+        assert!(RepositoryName::new("repo name").is_err());
+        assert!(RepositoryName::new("repo#frag").is_err());
+    }
+
+    #[test]
+    fn repository_name_rejects_empty() {
+        let err = RepositoryName::new("").unwrap_err();
+        assert!(err.to_string().contains("non-empty"), "error: {err}");
     }
 }

--- a/crates/ocync-distribution/src/tags.rs
+++ b/crates/ocync-distribution/src/tags.rs
@@ -7,6 +7,10 @@ use crate::client::RegistryClient;
 use crate::error::Error;
 use crate::spec::RepositoryName;
 
+/// Maximum number of tag list pages to follow before treating the pagination
+/// as broken (e.g. a registry returning a self-referencing `Link: rel="next"`).
+const MAX_TAG_PAGES: usize = 10_000;
+
 /// Response body from the tag listing API.
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct TagListResponse {
@@ -30,20 +34,32 @@ where
 /// Parse a `Link` header to extract the URL for the `rel="next"` page.
 ///
 /// The OCI Distribution spec uses RFC 5988 Link headers for pagination:
-/// `<url>; rel="next"`.
+/// `<url>; rel="next"`. URLs are extracted from `<...>` delimiters first
+/// to avoid splitting on commas that may appear within the URL itself.
 pub(crate) fn parse_next_link(link_header: &str) -> Option<String> {
-    for part in link_header.split(',') {
-        let part = part.trim();
-        // Check if this link relation contains rel="next".
-        if !part.contains("rel=\"next\"") {
-            continue;
+    let mut remaining = link_header;
+    while !remaining.is_empty() {
+        // Find the next link-value: starts with '<', URL ends at '>'.
+        let Some(start) = remaining.find('<') else {
+            break;
+        };
+        let after_start = &remaining[start + 1..];
+        let Some(end) = after_start.find('>') else {
+            break;
+        };
+        let url = &after_start[..end];
+        let after_url = &after_start[end + 1..];
+
+        // Find the end of this link-value (next '<' that starts a new link).
+        let attrs_end = after_url.find('<').unwrap_or(after_url.len());
+        let attrs = &after_url[..attrs_end];
+
+        // Check if the attributes contain rel="next".
+        if attrs.contains("rel=\"next\"") {
+            return Some(url.to_owned());
         }
-        // Extract URL from angle brackets.
-        let start = part.find('<')?;
-        let end = part.find('>')?;
-        if start < end {
-            return Some(part[start + 1..end].to_owned());
-        }
+
+        remaining = &after_url[attrs_end..];
     }
     None
 }
@@ -55,8 +71,15 @@ impl RegistryClient {
     pub async fn list_tags(&self, repository: &RepositoryName) -> Result<Vec<String>, Error> {
         let mut all_tags = Vec::new();
         let mut path = "tags/list".to_owned();
+        let mut page_count: usize = 0;
 
         loop {
+            page_count += 1;
+            if page_count > MAX_TAG_PAGES {
+                return Err(Error::Other(format!(
+                    "tag listing exceeded {MAX_TAG_PAGES} pages; possible infinite loop from malformed Link headers"
+                )));
+            }
             let resp = self
                 .get(repository, &path, None, RegistryAction::TagList)
                 .await?;
@@ -180,5 +203,47 @@ mod tests {
         let header = r#"</v2/repo/tags/list?n=100&last=a>; rel="prev", </v2/repo/tags/list?n=100&last=z>; rel="next""#;
         let result = parse_next_link(header);
         assert_eq!(result, Some("/v2/repo/tags/list?n=100&last=z".to_owned()));
+    }
+
+    #[test]
+    fn parse_next_link_url_containing_comma() {
+        // A URL with a comma must not be split incorrectly.
+        let header = r#"</v2/repo/tags/list?filter=a,b&last=z>; rel="next""#;
+        let result = parse_next_link(header);
+        assert_eq!(
+            result,
+            Some("/v2/repo/tags/list?filter=a,b&last=z".to_owned())
+        );
+    }
+
+    /// A registry that always returns the same `Link: rel="next"` URL must be
+    /// stopped by the page-count guard, not loop forever.
+    #[tokio::test]
+    async fn tag_pagination_guard_fires() {
+        let server = wiremock::MockServer::start().await;
+
+        // Every request returns one tag and a self-referencing Link header.
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path_regex(r"/v2/repo/tags/list.*"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"name": "repo", "tags": ["t"]}))
+                    .append_header("link", r#"</v2/repo/tags/list?n=1&last=t>; rel="next""#),
+            )
+            .mount(&server)
+            .await;
+
+        let base_url = url::Url::parse(&server.uri()).unwrap();
+        let client = crate::client::RegistryClientBuilder::new(base_url)
+            .build()
+            .unwrap();
+
+        let repo = RepositoryName::new("repo").unwrap();
+        let err = client.list_tags(&repo).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("exceeded") && msg.contains("pages"),
+            "unexpected error: {msg}"
+        );
     }
 }

--- a/crates/ocync-distribution/tests/auth_anonymous.rs
+++ b/crates/ocync-distribution/tests/auth_anonymous.rs
@@ -162,7 +162,7 @@ async fn invalidate_clears_cache() {
     let _ = auth.get_token(&scopes).await.unwrap();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn concurrent_requests_coalesce() {
     let server = setup_auth_server().await;
 

--- a/crates/ocync-distribution/tests/blob_push_stream.rs
+++ b/crates/ocync-distribution/tests/blob_push_stream.rs
@@ -70,7 +70,7 @@ async fn happy_path() {
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("myrepo");
+    let repo = RepositoryName::new("myrepo").unwrap();
     let result = client
         .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
         .await
@@ -117,7 +117,7 @@ async fn multi_chunk_stream() {
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("repo");
+    let repo = RepositoryName::new("repo").unwrap();
     let result = client
         .blob_push_stream(&repo, &digest, None, data_stream(data, 2))
         .await
@@ -163,7 +163,7 @@ async fn single_chunk_stream() {
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("repo");
+    let repo = RepositoryName::new("repo").unwrap();
     let result = client
         .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
         .await
@@ -208,7 +208,7 @@ async fn empty_stream() {
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("repo");
+    let repo = RepositoryName::new("repo").unwrap();
     let result = client
         .blob_push_stream(&repo, &digest, None, data_stream(data, 1))
         .await
@@ -236,7 +236,7 @@ async fn post_initiation_rejected() {
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("repo");
+    let repo = RepositoryName::new("repo").unwrap();
     let err = client
         .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
         .await
@@ -278,7 +278,7 @@ async fn put_upload_failure() {
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("repo");
+    let repo = RepositoryName::new("repo").unwrap();
     let err = client
         .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
         .await
@@ -324,7 +324,7 @@ async fn put_rejected() {
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("repo");
+    let repo = RepositoryName::new("repo").unwrap();
     let err = client
         .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
         .await
@@ -366,7 +366,7 @@ async fn stream_error_propagates() {
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("repo");
+    let repo = RepositoryName::new("repo").unwrap();
     let result = client
         .blob_push_stream(&repo, &digest, None, error_stream)
         .await;
@@ -396,7 +396,7 @@ async fn post_returns_200_is_rejected() {
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("repo");
+    let repo = RepositoryName::new("repo").unwrap();
     let err = client
         .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
         .await
@@ -449,7 +449,7 @@ async fn small_blob_with_known_size() {
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("repo");
+    let repo = RepositoryName::new("repo").unwrap();
     let result = client
         .blob_push_stream(
             &repo,
@@ -497,7 +497,7 @@ async fn unknown_size_uses_streaming_put() {
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("repo");
+    let repo = RepositoryName::new("repo").unwrap();
     let result = client
         .blob_push_stream(&repo, &digest, None, data_stream(data, 4))
         .await
@@ -506,9 +506,12 @@ async fn unknown_size_uses_streaming_put() {
     assert_eq!(result, digest);
 }
 
-/// Verify GAR hostname detection matches the expected pattern.
+/// Verify GAR hostname detection uses the real `detect_provider_kind` function,
+/// not a hand-rolled `ends_with` check.
 #[test]
 fn gar_hostname_detection() {
+    use ocync_distribution::auth::{ProviderKind, detect_provider_kind};
+
     let gar_hosts = [
         "us-docker.pkg.dev",
         "europe-docker.pkg.dev",
@@ -516,24 +519,32 @@ fn gar_hostname_detection() {
         "us-central1-docker.pkg.dev",
     ];
     for host in gar_hosts {
-        assert!(
-            host.ends_with("-docker.pkg.dev"),
-            "{host} should match GAR pattern"
+        assert_eq!(
+            detect_provider_kind(host),
+            Some(ProviderKind::Gar),
+            "{host} should be detected as GAR"
         );
     }
+
+    // "docker.pkg.dev" without a region prefix must NOT match GAR.
+    assert_eq!(
+        detect_provider_kind("docker.pkg.dev"),
+        None,
+        "docker.pkg.dev (no region prefix) should not match GAR"
+    );
 
     let non_gar_hosts = [
         "docker.io",
         "ghcr.io",
         "registry-1.docker.io",
-        "docker.pkg.dev",
         "pkg.dev",
         "127.0.0.1",
     ];
     for host in non_gar_hosts {
-        assert!(
-            !host.ends_with("-docker.pkg.dev"),
-            "{host} should NOT match GAR pattern"
+        assert_ne!(
+            detect_provider_kind(host),
+            Some(ProviderKind::Gar),
+            "{host} should NOT be detected as GAR"
         );
     }
 }

--- a/crates/ocync-distribution/tests/client_integration.rs
+++ b/crates/ocync-distribution/tests/client_integration.rs
@@ -3,6 +3,7 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
 
 use http::StatusCode;
 use ocync_distribution::Error;
@@ -10,20 +11,58 @@ use ocync_distribution::RepositoryName;
 use ocync_distribution::auth::{AuthProvider, Scope, Token};
 use ocync_distribution::client::RegistryClientBuilder;
 use url::Url;
-use wiremock::matchers::{header_exists, method, path};
+use wiremock::matchers::{header_exists, method, path, path_regex, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-/// A mock auth provider that tracks token requests and invalidation calls.
+/// Shared state for [`MockAuth`], allowing assertions after the auth provider
+/// has been moved into the client.
+#[derive(Debug, Clone)]
+struct MockAuthState {
+    invalidate_count: Arc<AtomicU32>,
+    recorded_scopes: Arc<Mutex<Vec<Vec<Scope>>>>,
+}
+
+impl MockAuthState {
+    fn new() -> Self {
+        Self {
+            invalidate_count: Arc::new(AtomicU32::new(0)),
+            recorded_scopes: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Return the number of times `invalidate()` was called.
+    fn invalidate_count(&self) -> u32 {
+        self.invalidate_count.load(Ordering::SeqCst)
+    }
+
+    /// Return all scopes recorded across `get_token()` calls.
+    fn recorded_scopes(&self) -> Vec<Vec<Scope>> {
+        self.recorded_scopes.lock().unwrap().clone()
+    }
+}
+
+/// A mock auth provider that tracks token requests, scopes, and invalidation calls.
 struct MockAuth {
     token_value: String,
-    invalidate_count: AtomicU32,
+    state: MockAuthState,
 }
 
 impl MockAuth {
-    fn new(token: &str) -> Self {
+    fn new(token: &str) -> (Self, MockAuthState) {
+        let state = MockAuthState::new();
+        let auth = Self {
+            token_value: token.to_owned(),
+            state: state.clone(),
+        };
+        (auth, state)
+    }
+
+    /// Convenience constructor when assertions on state are not needed.
+    fn simple(token: &str) -> Self {
+        let state = MockAuthState::new();
         Self {
             token_value: token.to_owned(),
-            invalidate_count: AtomicU32::new(0),
+            state,
         }
     }
 }
@@ -35,14 +74,19 @@ impl AuthProvider for MockAuth {
 
     fn get_token(
         &self,
-        _scopes: &[Scope],
+        scopes: &[Scope],
     ) -> Pin<Box<dyn Future<Output = Result<Token, Error>> + Send + '_>> {
+        self.state
+            .recorded_scopes
+            .lock()
+            .unwrap()
+            .push(scopes.to_vec());
         let token = Token::new(self.token_value.clone());
         Box::pin(async move { Ok(token) })
     }
 
     fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        self.invalidate_count.fetch_add(1, Ordering::SeqCst);
+        self.state.invalidate_count.fetch_add(1, Ordering::SeqCst);
         Box::pin(async {})
     }
 }
@@ -94,13 +138,13 @@ async fn get_success_no_retry() {
         .mount(&server)
         .await;
 
-    let auth = MockAuth::new("good-token");
+    let auth = MockAuth::simple("good-token");
     let client = RegistryClientBuilder::new(mock_base_url(&server))
         .auth(auth)
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("library/nginx");
+    let repo = RepositoryName::new("library/nginx").unwrap();
     let resp = client
         .get(
             &repo,
@@ -131,13 +175,13 @@ async fn get_401_triggers_invalidate_and_retry() {
         .mount(&server)
         .await;
 
-    let auth = MockAuth::new("test-token");
+    let (auth, state) = MockAuth::new("test-token");
     let client = RegistryClientBuilder::new(mock_base_url(&server))
         .auth(auth)
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("library/nginx");
+    let repo = RepositoryName::new("library/nginx").unwrap();
     let resp = client
         .get(
             &repo,
@@ -148,6 +192,13 @@ async fn get_401_triggers_invalidate_and_retry() {
         .await
         .unwrap();
     assert_eq!(resp.status(), 200);
+
+    // The client should have invalidated exactly once before retrying.
+    assert_eq!(
+        state.invalidate_count(),
+        1,
+        "expected exactly 1 invalidation on 401 retry"
+    );
 }
 
 #[tokio::test]
@@ -160,13 +211,13 @@ async fn get_double_401_returns_unauthorized() {
         .mount(&server)
         .await;
 
-    let auth = MockAuth::new("bad-token");
+    let (auth, state) = MockAuth::new("bad-token");
     let client = RegistryClientBuilder::new(mock_base_url(&server))
         .auth(auth)
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("repo");
+    let repo = RepositoryName::new("repo").unwrap();
     let result = client
         .get(
             &repo,
@@ -177,6 +228,13 @@ async fn get_double_401_returns_unauthorized() {
         .await;
     let err = result.unwrap_err();
     assert_eq!(err.status_code(), Some(StatusCode::UNAUTHORIZED));
+
+    // Double-401 should still have invalidated once (before the retry attempt).
+    assert_eq!(
+        state.invalidate_count(),
+        1,
+        "expected 1 invalidation even on double-401"
+    );
 }
 
 #[tokio::test]
@@ -197,7 +255,7 @@ async fn get_401_retry_only_happens_once() {
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("repo");
+    let repo = RepositoryName::new("repo").unwrap();
     let result = client
         .get(
             &repo,
@@ -219,13 +277,13 @@ async fn get_403_returns_forbidden() {
         .mount(&server)
         .await;
 
-    let auth = MockAuth::new("token");
+    let auth = MockAuth::simple("token");
     let client = RegistryClientBuilder::new(mock_base_url(&server))
         .auth(auth)
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("private/repo");
+    let repo = RepositoryName::new("private/repo").unwrap();
     let result = client
         .get(
             &repo,
@@ -248,13 +306,13 @@ async fn get_404_returns_not_found() {
         .mount(&server)
         .await;
 
-    let auth = MockAuth::new("token");
+    let auth = MockAuth::simple("token");
     let client = RegistryClientBuilder::new(mock_base_url(&server))
         .auth(auth)
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("repo");
+    let repo = RepositoryName::new("repo").unwrap();
     let result = client
         .get(
             &repo,
@@ -276,13 +334,13 @@ async fn get_500_returns_registry_error() {
         .mount(&server)
         .await;
 
-    let auth = MockAuth::new("token");
+    let auth = MockAuth::simple("token");
     let client = RegistryClientBuilder::new(mock_base_url(&server))
         .auth(auth)
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("repo");
+    let repo = RepositoryName::new("repo").unwrap();
     let result = client
         .get(
             &repo,
@@ -309,7 +367,7 @@ async fn no_auth_provider_sends_no_header() {
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("repo");
+    let repo = RepositoryName::new("repo").unwrap();
     let resp = client
         .get(
             &repo,
@@ -391,13 +449,13 @@ async fn head_401_triggers_retry() {
         .mount(&server)
         .await;
 
-    let auth = MockAuth::new("token");
+    let (auth, state) = MockAuth::new("token");
     let client = RegistryClientBuilder::new(mock_base_url(&server))
         .auth(auth)
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("repo");
+    let repo = RepositoryName::new("repo").unwrap();
     let resp = client
         .head(
             &repo,
@@ -408,6 +466,13 @@ async fn head_401_triggers_retry() {
         .await
         .unwrap();
     assert_eq!(resp.status(), 200);
+
+    // The client should have invalidated exactly once before retrying.
+    assert_eq!(
+        state.invalidate_count(),
+        1,
+        "expected exactly 1 invalidation on HEAD 401 retry"
+    );
 }
 
 #[tokio::test]
@@ -420,13 +485,13 @@ async fn head_double_401_returns_unauthorized() {
         .mount(&server)
         .await;
 
-    let auth = MockAuth::new("bad-token");
+    let (auth, state) = MockAuth::new("bad-token");
     let client = RegistryClientBuilder::new(mock_base_url(&server))
         .auth(auth)
         .build()
         .unwrap();
 
-    let repo = RepositoryName::new("repo");
+    let repo = RepositoryName::new("repo").unwrap();
     let result = client
         .head(
             &repo,
@@ -437,6 +502,13 @@ async fn head_double_401_returns_unauthorized() {
         .await;
     let err = result.unwrap_err();
     assert_eq!(err.status_code(), Some(StatusCode::UNAUTHORIZED));
+
+    // Double-401 should still have invalidated once (before the retry attempt).
+    assert_eq!(
+        state.invalidate_count(),
+        1,
+        "expected 1 invalidation even on HEAD double-401"
+    );
 }
 
 #[tokio::test]
@@ -463,7 +535,7 @@ async fn manifest_head_sends_accept_header() {
     let client = RegistryClientBuilder::new(mock_base_url(&server))
         .build()
         .unwrap();
-    let repo = RepositoryName::new("repo");
+    let repo = RepositoryName::new("repo").unwrap();
 
     let result = client.manifest_head(&repo, "latest").await.unwrap();
     assert!(result.is_some());
@@ -487,7 +559,7 @@ async fn manifest_head_missing_digest_header_returns_error() {
     let client = RegistryClientBuilder::new(mock_base_url(&server))
         .build()
         .unwrap();
-    let repo = RepositoryName::new("repo");
+    let repo = RepositoryName::new("repo").unwrap();
 
     let result = client.manifest_head(&repo, "latest").await;
     assert!(result.is_err(), "missing digest header should be an error");
@@ -525,7 +597,7 @@ async fn blob_head_does_not_send_manifest_accept_header() {
     let client = RegistryClientBuilder::new(mock_base_url(&server))
         .build()
         .unwrap();
-    let repo = RepositoryName::new("repo");
+    let repo = RepositoryName::new("repo").unwrap();
     let digest: ocync_distribution::Digest =
         "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
             .parse()
@@ -533,4 +605,385 @@ async fn blob_head_does_not_send_manifest_accept_header() {
 
     let result = client.blob_exists(&repo, &digest).await.unwrap();
     assert_eq!(result, Some(1024));
+}
+
+// ---------------------------------------------------------------------------
+// Tag listing
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn list_tags_returns_all_tags() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v2/repo/tags/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "name": "repo",
+            "tags": ["v1", "v2", "latest"]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .build()
+        .unwrap();
+
+    let repo = RepositoryName::new("repo").unwrap();
+    let tags = client.list_tags(&repo).await.unwrap();
+    assert_eq!(tags, vec!["v1", "v2", "latest"]);
+}
+
+#[tokio::test]
+async fn list_tags_follows_pagination() {
+    let server = MockServer::start().await;
+
+    // Page 2 (higher priority): matches when `last=v2` query param is present.
+    // Mounted first so it doesn't shadow the page-1 mock.
+    Mock::given(method("GET"))
+        .and(path("/v2/repo/tags/list"))
+        .and(query_param("last", "v2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "name": "repo",
+            "tags": ["latest"]
+        })))
+        .expect(1)
+        .with_priority(1)
+        .mount(&server)
+        .await;
+
+    // Page 1 (lower priority): no `last` param, returns Link header.
+    Mock::given(method("GET"))
+        .and(path("/v2/repo/tags/list"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({
+                    "name": "repo",
+                    "tags": ["v1", "v2"]
+                }))
+                .append_header("link", r#"</v2/repo/tags/list?n=2&last=v2>; rel="next""#),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .build()
+        .unwrap();
+
+    let repo = RepositoryName::new("repo").unwrap();
+    let tags = client.list_tags(&repo).await.unwrap();
+    assert_eq!(tags, vec!["v1", "v2", "latest"]);
+}
+
+#[tokio::test]
+async fn list_tags_respects_max_pages() {
+    let server = MockServer::start().await;
+
+    // Every request returns one tag and a self-referencing Link header,
+    // creating an infinite pagination loop.
+    Mock::given(method("GET"))
+        .and(path_regex(r"/v2/repo/tags/list.*"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"name": "repo", "tags": ["t"]}))
+                .append_header("link", r#"</v2/repo/tags/list?n=1&last=t>; rel="next""#),
+        )
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .build()
+        .unwrap();
+
+    let repo = RepositoryName::new("repo").unwrap();
+    let err = client.list_tags(&repo).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("exceeded") && msg.contains("pages"),
+        "expected max-pages error, got: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Rate limiting (429)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn get_429_retries_and_succeeds() {
+    let server = MockServer::start().await;
+
+    // First request: 429 rate limited.
+    Mock::given(method("GET"))
+        .and(path("/v2/repo/blobs/sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+        .respond_with(ResponseTemplate::new(429).set_body_string("rate limited"))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    // Second request: 200 success.
+    Mock::given(method("GET"))
+        .and(path("/v2/repo/blobs/sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("blob-data"))
+        .mount(&server)
+        .await;
+
+    let auth = MockAuth::simple("token");
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .auth(auth)
+        .build()
+        .unwrap();
+
+    let repo = RepositoryName::new("repo").unwrap();
+    // The 429 is classified as an error (not retried by the HTTP layer).
+    // Verify the client surfaces the error so the sync engine can retry.
+    let result = client
+        .get(
+            &repo,
+            "blobs/sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            None,
+            ocync_distribution::aimd::RegistryAction::BlobRead,
+        )
+        .await;
+
+    // The first 429 is returned as an error to the caller.
+    let err = result.unwrap_err();
+    assert_eq!(err.status_code(), Some(StatusCode::TOO_MANY_REQUESTS));
+
+    // A subsequent request (after the AIMD window has shrunk) succeeds.
+    let resp = client
+        .get(
+            &repo,
+            "blobs/sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            None,
+            ocync_distribution::aimd::RegistryAction::BlobRead,
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+// ---------------------------------------------------------------------------
+// Referrers API
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn referrers_returns_index() {
+    let server = MockServer::start().await;
+
+    let digest_str = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let referrers_body = serde_json::json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": [
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "size": 512,
+                "artifactType": "application/vnd.dev.cosign.simplesigning.v1+json"
+            }
+        ]
+    });
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/referrers/{digest_str}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(&referrers_body)
+                .insert_header("content-type", "application/vnd.oci.image.index.v1+json"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .build()
+        .unwrap();
+
+    let repo = RepositoryName::new("repo").unwrap();
+    let digest: ocync_distribution::Digest = digest_str.parse().unwrap();
+
+    let result = client.referrers(&repo, &digest, None).await.unwrap();
+    let index = result.expect("expected Some(ImageIndex) for referrers response");
+    assert_eq!(index.manifests.len(), 1);
+    assert_eq!(
+        index.manifests[0].artifact_type.as_deref(),
+        Some("application/vnd.dev.cosign.simplesigning.v1+json")
+    );
+}
+
+#[tokio::test]
+async fn referrers_404_returns_none() {
+    let server = MockServer::start().await;
+
+    let digest_str = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/referrers/{digest_str}")))
+        .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .build()
+        .unwrap();
+
+    let repo = RepositoryName::new("repo").unwrap();
+    let digest: ocync_distribution::Digest = digest_str.parse().unwrap();
+
+    let result = client.referrers(&repo, &digest, None).await.unwrap();
+    assert!(result.is_none(), "expected None for 404 referrers response");
+}
+
+#[tokio::test]
+async fn referrers_with_artifact_type_filter() {
+    let server = MockServer::start().await;
+
+    let digest_str = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let filter_type = "application/vnd.dev.cosign.simplesigning.v1+json";
+
+    let referrers_body = serde_json::json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": []
+    });
+
+    // Verify the artifactType query parameter is sent.
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/referrers/{digest_str}")))
+        .and(query_param("artifactType", filter_type))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(&referrers_body)
+                .insert_header("content-type", "application/vnd.oci.image.index.v1+json"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .build()
+        .unwrap();
+
+    let repo = RepositoryName::new("repo").unwrap();
+    let digest: ocync_distribution::Digest = digest_str.parse().unwrap();
+
+    let result = client
+        .referrers(&repo, &digest, Some(filter_type))
+        .await
+        .unwrap();
+    let index = result.expect("expected Some(ImageIndex)");
+    assert!(index.manifests.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Auth scopes verification
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn manifest_push_requests_push_scope() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/v2/myuser/myrepo/manifests/v1"))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(&server)
+        .await;
+
+    let (auth, state) = MockAuth::new("push-token");
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .auth(auth)
+        .build()
+        .unwrap();
+
+    let repo = RepositoryName::new("myuser/myrepo").unwrap();
+    let manifest_bytes = serde_json::to_vec(&serde_json::json!({
+        "schemaVersion": 2,
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "size": 100
+        },
+        "layers": []
+    }))
+    .unwrap();
+
+    let _ = client
+        .manifest_push(
+            &repo,
+            "v1",
+            &ocync_distribution::MediaType::OciManifest,
+            &manifest_bytes,
+        )
+        .await;
+
+    // Verify that the scopes passed to get_token included push.
+    let scopes = state.recorded_scopes();
+    assert!(
+        !scopes.is_empty(),
+        "get_token should have been called at least once"
+    );
+
+    // Every scope request for manifest_push should include Push action.
+    let has_push = scopes.iter().any(|scope_set| {
+        scope_set.iter().any(|s| {
+            s.repository == "myuser/myrepo"
+                && s.actions.contains(&ocync_distribution::auth::Action::Push)
+        })
+    });
+    assert!(
+        has_push,
+        "manifest_push must request push scope, got: {scopes:?}"
+    );
+}
+
+#[tokio::test]
+async fn manifest_pull_requests_pull_scope() {
+    let server = MockServer::start().await;
+
+    let manifest_json = serde_json::json!({
+        "schemaVersion": 2,
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "size": 100
+        },
+        "layers": []
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/v2/library/nginx/manifests/latest"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(&manifest_json)
+                .insert_header("content-type", "application/vnd.oci.image.manifest.v1+json"),
+        )
+        .mount(&server)
+        .await;
+
+    let (auth, state) = MockAuth::new("pull-token");
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .auth(auth)
+        .build()
+        .unwrap();
+
+    let repo = RepositoryName::new("library/nginx").unwrap();
+    let _ = client.manifest_pull(&repo, "latest").await;
+
+    // Verify that the scopes passed to get_token are pull-only (no push).
+    let scopes = state.recorded_scopes();
+    assert!(!scopes.is_empty());
+
+    let has_pull_only = scopes.iter().any(|scope_set| {
+        scope_set.iter().any(|s| {
+            s.repository == "library/nginx"
+                && s.actions.contains(&ocync_distribution::auth::Action::Pull)
+                && !s.actions.contains(&ocync_distribution::auth::Action::Push)
+        })
+    });
+    assert!(
+        has_pull_only,
+        "manifest_pull must request pull-only scope, got: {scopes:?}"
+    );
 }

--- a/crates/ocync-distribution/tests/common/mod.rs
+++ b/crates/ocync-distribution/tests/common/mod.rs
@@ -1,0 +1,44 @@
+//! Shared helpers for integration tests against a local registry (registry:2).
+
+use ocync_distribution::client::RegistryClientBuilder;
+use ocync_distribution::{Digest, RegistryClient};
+use url::Url;
+
+/// Compute the SHA-256 digest for test data.
+pub fn test_digest(data: &[u8]) -> Digest {
+    let hash = ocync_distribution::sha256::Sha256::digest(data);
+    Digest::from_sha256(hash)
+}
+
+/// Start a local registry container and return its HTTP base URL.
+pub async fn start_registry() -> (
+    testcontainers::ContainerAsync<testcontainers::GenericImage>,
+    Url,
+) {
+    use testcontainers::GenericImage;
+    use testcontainers::runners::AsyncRunner;
+
+    let container = GenericImage::new("registry", "2")
+        .with_exposed_port(5000.into())
+        .with_wait_for(testcontainers::core::WaitFor::message_on_stderr(
+            "listening on",
+        ))
+        .start()
+        .await
+        .expect("failed to start registry container");
+
+    let port = container
+        .get_host_port_ipv4(5000)
+        .await
+        .expect("failed to get mapped port");
+
+    let url = Url::parse(&format!("http://127.0.0.1:{port}")).unwrap();
+    (container, url)
+}
+
+/// Build a `RegistryClient` for a local registry (no auth, no TLS).
+pub fn local_client(url: Url) -> RegistryClient {
+    RegistryClientBuilder::new(url)
+        .build()
+        .expect("failed to build RegistryClient")
+}

--- a/crates/ocync-distribution/tests/registry2_client.rs
+++ b/crates/ocync-distribution/tests/registry2_client.rs
@@ -11,51 +11,15 @@
 //! - Docker must be running
 //! - Run with: `cargo test --package ocync-distribution --test registry2_client`
 
+#[allow(unreachable_pub)]
+mod common;
+
 use bytes::Bytes;
 use futures_util::stream;
-use ocync_distribution::client::RegistryClientBuilder;
 use ocync_distribution::spec::{Descriptor, ImageManifest, MediaType, RepositoryName};
-use ocync_distribution::{Digest, Error, RegistryClient};
-use url::Url;
+use ocync_distribution::{Digest, Error};
 
-/// Compute the SHA-256 digest for test data.
-fn test_digest(data: &[u8]) -> Digest {
-    let hash = ocync_distribution::sha256::Sha256::digest(data);
-    Digest::from_sha256(hash)
-}
-
-/// Start a local registry container and return its HTTP base URL.
-async fn start_registry() -> (
-    testcontainers::ContainerAsync<testcontainers::GenericImage>,
-    Url,
-) {
-    use testcontainers::GenericImage;
-    use testcontainers::runners::AsyncRunner;
-
-    let container = GenericImage::new("registry", "2")
-        .with_exposed_port(5000.into())
-        .with_wait_for(testcontainers::core::WaitFor::message_on_stderr(
-            "listening on",
-        ))
-        .start()
-        .await
-        .expect("failed to start registry container");
-
-    let port = container
-        .get_host_port_ipv4(5000)
-        .await
-        .expect("failed to get mapped port");
-
-    let url = Url::parse(&format!("http://127.0.0.1:{port}")).unwrap();
-    (container, url)
-}
-
-/// Build a `RegistryClient` for a local registry (no auth, no TLS).
-fn local_client(url: Url) -> RegistryClient {
-    RegistryClientBuilder::new(url)
-        .build()
-        .expect("failed to build RegistryClient")
-}
+use common::{local_client, start_registry, test_digest};
 
 /// Build a minimal valid OCI image manifest.
 fn build_manifest(
@@ -107,7 +71,7 @@ async fn ping() {
 async fn blob_push_monolithic_and_exists() {
     let (_container, url) = start_registry().await;
     let client = local_client(url);
-    let repo = RepositoryName::new("test/monolithic");
+    let repo = RepositoryName::new("test/monolithic").unwrap();
 
     let data = b"hello from ocync integration test";
     let digest = client
@@ -131,7 +95,7 @@ async fn blob_push_monolithic_and_exists() {
 async fn blob_push_stream_chunked() {
     let (_container, url) = start_registry().await;
     let client = local_client(url);
-    let repo = RepositoryName::new("test/streamed");
+    let repo = RepositoryName::new("test/streamed").unwrap();
 
     let data = vec![0xABu8; 2 * 1024 * 1024];
     let expected_digest = test_digest(&data);
@@ -159,7 +123,7 @@ async fn blob_push_stream_chunked() {
 async fn blob_exists_returns_none_for_missing() {
     let (_container, url) = start_registry().await;
     let client = local_client(url);
-    let repo = RepositoryName::new("test/missing");
+    let repo = RepositoryName::new("test/missing").unwrap();
 
     let fake_digest: Digest =
         "sha256:0000000000000000000000000000000000000000000000000000000000000000"
@@ -180,7 +144,7 @@ async fn blob_exists_returns_none_for_missing() {
 async fn full_image_roundtrip() {
     let (_container, url) = start_registry().await;
     let client = local_client(url);
-    let repo = RepositoryName::new("test/roundtrip");
+    let repo = RepositoryName::new("test/roundtrip").unwrap();
     let tag = "v1";
 
     // 1. Push config blob.
@@ -232,7 +196,7 @@ async fn full_image_roundtrip() {
 async fn manifest_head_returns_none_for_missing_tag() {
     let (_container, url) = start_registry().await;
     let client = local_client(url);
-    let repo = RepositoryName::new("test/notfound");
+    let repo = RepositoryName::new("test/notfound").unwrap();
 
     let result = client
         .manifest_head(&repo, "nonexistent-tag")
@@ -247,7 +211,7 @@ async fn manifest_head_returns_none_for_missing_tag() {
 async fn blob_push_idempotent() {
     let (_container, url) = start_registry().await;
     let client = local_client(url);
-    let repo = RepositoryName::new("test/idempotent");
+    let repo = RepositoryName::new("test/idempotent").unwrap();
 
     let data = b"push me twice";
     let d1 = client.blob_push(&repo, data).await.expect("first push");
@@ -260,7 +224,7 @@ async fn blob_push_idempotent() {
 async fn blob_pull_roundtrip() {
     let (_container, url) = start_registry().await;
     let client = local_client(url);
-    let repo = RepositoryName::new("test/blobpull");
+    let repo = RepositoryName::new("test/blobpull").unwrap();
 
     let data = b"blob-pull-roundtrip-data";
     let digest = client.blob_push(&repo, data).await.expect("push failed");

--- a/crates/ocync-distribution/tests/registry2_mount.rs
+++ b/crates/ocync-distribution/tests/registry2_mount.rs
@@ -12,52 +12,16 @@
 //! - Docker must be running
 //! - Run with: `cargo test --package ocync-distribution --test registry2_mount`
 
+#[allow(unreachable_pub)]
+mod common;
+
 use bytes::Bytes;
 use futures_util::StreamExt;
 use ocync_distribution::blob::MountResult;
-use ocync_distribution::client::RegistryClientBuilder;
 use ocync_distribution::spec::RepositoryName;
 use ocync_distribution::{Digest, RegistryClient};
-use url::Url;
 
-/// Compute the SHA-256 digest for test data.
-fn test_digest(data: &[u8]) -> Digest {
-    let hash = ocync_distribution::sha256::Sha256::digest(data);
-    Digest::from_sha256(hash)
-}
-
-/// Start a local registry container and return its HTTP base URL.
-async fn start_registry() -> (
-    testcontainers::ContainerAsync<testcontainers::GenericImage>,
-    Url,
-) {
-    use testcontainers::GenericImage;
-    use testcontainers::runners::AsyncRunner;
-
-    let container = GenericImage::new("registry", "2")
-        .with_exposed_port(5000.into())
-        .with_wait_for(testcontainers::core::WaitFor::message_on_stderr(
-            "listening on",
-        ))
-        .start()
-        .await
-        .expect("failed to start registry container");
-
-    let port = container
-        .get_host_port_ipv4(5000)
-        .await
-        .expect("failed to get mapped port");
-
-    let url = Url::parse(&format!("http://127.0.0.1:{port}")).unwrap();
-    (container, url)
-}
-
-/// Build a `RegistryClient` for a local registry (no auth, no TLS).
-fn local_client(url: Url) -> RegistryClient {
-    RegistryClientBuilder::new(url)
-        .build()
-        .expect("failed to build RegistryClient")
-}
+use common::{local_client, start_registry, test_digest};
 
 /// Push a blob to `repo` via the monolithic path; returns its digest.
 async fn push_blob(client: &RegistryClient, repo: &RepositoryName, data: &[u8]) -> Digest {
@@ -99,8 +63,8 @@ async fn mount_committed_blob_returns_mounted() {
     // also covers the "cross-prefix" mount case -- the OCI spec allows
     // mount between any two repos on the same registry, and the client's
     // `from=` query parameter must accept arbitrary repo paths.
-    let source_repo = RepositoryName::new("org-a/service-x");
-    let target_repo = RepositoryName::new("org-b/mirror/service-x");
+    let source_repo = RepositoryName::new("org-a/service-x").unwrap();
+    let target_repo = RepositoryName::new("org-b/mirror/service-x").unwrap();
     let data = b"registry2 mount test blob";
     let digest = push_blob(&client, &source_repo, data).await;
 
@@ -126,8 +90,8 @@ async fn mount_missing_source_returns_not_fulfilled() {
     let (_container, url) = start_registry().await;
     let client = local_client(url);
 
-    let source_repo = RepositoryName::new("missing/source");
-    let target_repo = RepositoryName::new("missing/target");
+    let source_repo = RepositoryName::new("missing/source").unwrap();
+    let target_repo = RepositoryName::new("missing/target").unwrap();
     // Digest of data that was never pushed anywhere.
     let digest = test_digest(b"blob that does not exist in any repo");
 
@@ -150,8 +114,8 @@ async fn mount_preserves_source_blob() {
     let (_container, url) = start_registry().await;
     let client = local_client(url);
 
-    let source_repo = RepositoryName::new("preserve/source");
-    let target_repo = RepositoryName::new("preserve/target");
+    let source_repo = RepositoryName::new("preserve/source").unwrap();
+    let target_repo = RepositoryName::new("preserve/target").unwrap();
     let data = b"preserve-after-mount test data";
     let digest = push_blob(&client, &source_repo, data).await;
 

--- a/crates/ocync-sync/Cargo.toml
+++ b/crates/ocync-sync/Cargo.toml
@@ -32,4 +32,4 @@ uuid.workspace = true
 tempfile = { version = "3", default-features = false }
 tokio = { workspace = true, features = ["macros", "rt", "test-util"] }
 url.workspace = true
-wiremock = "0.6"
+wiremock = { version = "0.6", default-features = false }

--- a/crates/ocync-sync/src/cache.rs
+++ b/crates/ocync-sync/src/cache.rs
@@ -134,7 +134,8 @@ pub struct TransferStateCache {
     ///
     /// Lives outside `BlobDedupMap` so it's not part of the persisted cache
     /// format. Entries are cleaned up on persist via `reset_transient_state`.
-    blob_notifies: HashMap<(String, Digest), Rc<Notify>>,
+    /// Nested map avoids allocating `(String, Digest)` keys on the read path.
+    blob_notifies: HashMap<String, HashMap<Digest, Rc<Notify>>>,
 }
 
 impl TransferStateCache {
@@ -189,7 +190,9 @@ impl TransferStateCache {
     /// marking the blob completed or failed.
     pub fn blob_notify(&mut self, target: &str, digest: &Digest) -> Rc<Notify> {
         self.blob_notifies
-            .entry((target.to_owned(), digest.clone()))
+            .entry(target.to_owned())
+            .or_default()
+            .entry(digest.clone())
             .or_insert_with(|| Rc::new(Notify::new()))
             .clone()
     }
@@ -200,7 +203,7 @@ impl TransferStateCache {
     /// [`set_blob_failed`] so concurrent transfers of the same blob can
     /// proceed (either to mount from the completed repo or to retry).
     pub fn notify_blob(&self, target: &str, digest: &Digest) {
-        if let Some(n) = self.blob_notifies.get(&(target.to_owned(), digest.clone())) {
+        if let Some(n) = self.blob_notifies.get(target).and_then(|m| m.get(digest)) {
             n.notify_waiters();
         }
     }
@@ -240,6 +243,15 @@ impl TransferStateCache {
             .is_some_and(|repos| repos.contains(repo))
     }
 
+    /// Remove a specific repo from a blob's known repos set at the target.
+    ///
+    /// Used after a failed mount to discard the stale mount source without
+    /// removing the entire blob entry. The blob remains `InProgress` so
+    /// concurrent waiters do not re-claim and start duplicate pushes.
+    pub fn remove_blob_repo(&mut self, target: &str, digest: &Digest, repo: &RepositoryName) {
+        self.dedup.remove_repo(target, digest, repo);
+    }
+
     /// Remove the entry for the given blob at the target.
     ///
     /// Use this for lazy invalidation when a mount or push fails so the next
@@ -264,6 +276,34 @@ impl TransferStateCache {
     /// source tags are deleted.
     pub fn prune_snapshots(&mut self, live_keys: &HashSet<SnapshotKey>) {
         self.snapshots.retain(|k, _| live_keys.contains(k));
+    }
+
+    /// Remove dedup entries for targets no longer in the active configuration.
+    ///
+    /// The dedup map accumulates `ExistsAtTarget`/`Completed` entries for every
+    /// (target, digest) pair observed. When targets are removed from config,
+    /// their entries become stale and grow unboundedly across runs. Call after
+    /// each sync cycle with the set of currently-configured target names.
+    pub fn prune_dedup(&mut self, live_targets: &HashSet<String>) {
+        let removed = self.dedup.retain_targets(live_targets);
+        if removed > 0 {
+            tracing::debug!(removed, "pruned stale dedup entries for removed targets");
+        }
+    }
+
+    /// Drop all in-flight blob notify handles.
+    ///
+    /// [`Notify`] entries are only needed during active blob coordination
+    /// within a single sync run. Once the run completes, all pending
+    /// transfers have resolved and the handles are stale. Call this at the
+    /// end of each sync run to prevent monotonic growth across repeated
+    /// runs in a long-lived process.
+    pub fn clear_notifies(&mut self) {
+        if !self.blob_notifies.is_empty() {
+            let count: usize = self.blob_notifies.values().map(|m| m.len()).sum();
+            tracing::debug!(count, "clearing stale blob notify handles");
+            self.blob_notifies.clear();
+        }
     }
 
     /// Atomically write the cache to `path`.
@@ -469,7 +509,7 @@ mod tests {
     }
 
     fn repo(name: &str) -> RepositoryName {
-        RepositoryName::new(name)
+        RepositoryName::new(name).unwrap()
     }
 
     #[test]
@@ -480,7 +520,7 @@ mod tests {
     #[test]
     fn set_and_read_status() {
         let mut cache = TransferStateCache::new();
-        cache.set_blob_exists("reg.io", digest(), "repo/a".into());
+        cache.set_blob_exists("reg.io", digest(), repo("repo/a"));
         assert_eq!(
             cache.blob_status("reg.io", &digest()),
             Some(&BlobStatus::ExistsAtTarget)
@@ -491,8 +531,8 @@ mod tests {
     #[test]
     fn mount_source_delegates_to_dedup() {
         let mut cache = TransferStateCache::new();
-        cache.set_blob_completed("reg.io", digest(), "repo/a".into());
-        cache.set_blob_completed("reg.io", digest(), "repo/b".into());
+        cache.set_blob_completed("reg.io", digest(), repo("repo/a"));
+        cache.set_blob_completed("reg.io", digest(), repo("repo/b"));
         assert_eq!(
             cache.blob_mount_source("reg.io", &digest(), &repo("repo/b"), &[]),
             Some(&repo("repo/a"))
@@ -502,7 +542,7 @@ mod tests {
     #[test]
     fn blob_known_at_repo_checks_specific_repo() {
         let mut cache = TransferStateCache::new();
-        cache.set_blob_completed("reg.io", digest(), "repo/a".into());
+        cache.set_blob_completed("reg.io", digest(), repo("repo/a"));
         assert!(cache.blob_known_at_repo("reg.io", &digest(), &repo("repo/a")));
         assert!(!cache.blob_known_at_repo("reg.io", &digest(), &repo("repo/b")));
         assert!(!cache.blob_known_at_repo("other.io", &digest(), &repo("repo/a")));
@@ -511,7 +551,7 @@ mod tests {
     #[test]
     fn invalidate_removes_entry() {
         let mut cache = TransferStateCache::new();
-        cache.set_blob_exists("reg.io", digest(), "repo/a".into());
+        cache.set_blob_exists("reg.io", digest(), repo("repo/a"));
         cache.invalidate_blob("reg.io", &digest());
         assert_eq!(cache.blob_status("reg.io", &digest()), None);
     }
@@ -531,8 +571,8 @@ mod tests {
     #[test]
     fn filter_persistable_excludes_transient() {
         let mut cache = TransferStateCache::new();
-        cache.set_blob_exists("reg.io", digest(), "repo/a".into());
-        cache.set_blob_in_progress("reg.io", digest2(), "repo/a".into());
+        cache.set_blob_exists("reg.io", digest(), repo("repo/a"));
+        cache.set_blob_in_progress("reg.io", digest2(), repo("repo/a"));
         cache.set_blob_failed("reg.io", digest2(), "oops".into());
 
         // Only ExistsAtTarget should survive

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -502,6 +502,11 @@ pub const DEFAULT_MAX_CONCURRENT_TRANSFERS: usize = 50;
 
 /// Maximum concurrent blob transfers within a single image.
 ///
+/// Within a single image task, blobs are transferred via `FuturesUnordered`
+/// gated by a local `Semaphore(BLOB_CONCURRENCY)`. This bounds the number of
+/// simultaneous blob uploads/downloads per image while allowing the global
+/// semaphore to independently control total in-flight image tasks.
+///
 /// Matches skopeo's default (6). Higher values risk approaching ECR's
 /// `InitiateLayerUpload` limit (100 TPS shared across all images).
 /// Candidate for `SyncEngine` builder configuration if workloads need tuning.
@@ -821,8 +826,8 @@ impl SyncEngine {
             }
         }
 
-        // Prune snapshot entries for tags no longer in the mapping set.
-        // Prevents unbounded cache growth when source tags are deleted.
+        // Prune stale cache entries for tags/targets no longer in the mapping set.
+        // Prevents unbounded cache growth when source tags or targets are deleted.
         {
             let live_keys: HashSet<SnapshotKey> = mappings
                 .iter()
@@ -832,7 +837,14 @@ impl SyncEngine {
                         .map(|t| SnapshotKey::new(&m.source_authority, &m.source_repo, &t.source))
                 })
                 .collect();
-            cache.borrow_mut().prune_snapshots(&live_keys);
+            let live_targets: HashSet<String> = mappings
+                .iter()
+                .flat_map(|m| m.targets.iter().map(|t| t.name.to_string()))
+                .collect();
+            let mut cache_mut = cache.borrow_mut();
+            cache_mut.prune_snapshots(&live_keys);
+            cache_mut.prune_dedup(&live_targets);
+            cache_mut.clear_notifies();
         }
 
         let mut stats = compute_stats(&results);
@@ -1109,6 +1121,7 @@ async fn full_pull_and_build_tasks(params: FullPullParams<'_>) -> DiscoveryOutco
         Ok(data) => Rc::new(data),
         Err(err) => {
             let error_str = err.to_string();
+            let status_code = err.status_code().map(|s| s.as_u16());
             warn!(
                 source_repo = %source.repo,
                 source_tag = %source.tag,
@@ -1125,6 +1138,7 @@ async fn full_pull_and_build_tasks(params: FullPullParams<'_>) -> DiscoveryOutco
                         kind: ErrorKind::ManifestPull,
                         error: error_str.clone(),
                         retries: retry.max_retries,
+                        status_code,
                     },
                     bytes_transferred: 0,
                     blob_stats: BlobTransferStats::default(),
@@ -1246,6 +1260,7 @@ async fn execute_item(
                 kind: ErrorKind::BlobTransfer,
                 error: err.to_string(),
                 retries: retry.max_retries,
+                status_code: err.status_code().map(|s| s.as_u16()),
             },
             bytes_transferred: outcome.bytes_transferred,
             blob_stats: outcome.stats,
@@ -1311,6 +1326,7 @@ async fn execute_item(
                         kind: ErrorKind::ManifestPush,
                         error: err.to_string(),
                         retries: retry.max_retries,
+                        status_code: err.status_code().map(|s| s.as_u16()),
                     },
                     bytes_transferred: outcome.bytes_transferred,
                     blob_stats: outcome.stats,
@@ -1719,14 +1735,18 @@ async fn transfer_single_blob(
                 return BlobResult::Mounted;
             }
             Ok(MountResult::NotMounted) | Err(_) => {
-                debug!(%digest, target = %ctx.target_name, "mount not fulfilled, falling back to HEAD+push");
-                let mut c = ctx.cache.borrow_mut();
-                c.invalidate_blob(ctx.target_name, digest);
-                c.notify_blob(ctx.target_name, digest);
-                drop(c);
+                debug!(%digest, %from_repo, target = %ctx.target_name, "mount not fulfilled, falling back to HEAD+push");
+                // Remove the stale mount source from repos, but keep the
+                // blob entry as InProgress. This task already owns the claim
+                // and will proceed with HEAD+push. Removing only the stale
+                // repo prevents future mount attempts from retrying it,
+                // while keeping the entry prevents concurrent waiters from
+                // re-claiming and starting duplicate pushes.
+                ctx.cache
+                    .borrow_mut()
+                    .remove_blob_repo(ctx.target_name, digest, &from_repo);
                 mount_attempted = true;
                 tracing::debug!(target: "ocync::metrics", result = "fallback", "mount");
-                tracing::debug!(target: "ocync::metrics", "cache_invalidation");
             }
         }
     }
@@ -1907,6 +1927,14 @@ async fn push_manifests(
 /// Uses synchronous `std::fs::Read` internally. On a single-threaded tokio
 /// runtime, each individual read call blocks for microseconds (local disk),
 /// which is negligible compared to network RTT.
+///
+/// # Assumption: local filesystem
+///
+/// This function performs blocking I/O on the tokio `current_thread` runtime.
+/// The staging directory MUST reside on local disk (tmpfs, ext4, APFS, etc.).
+/// Network filesystems (NFS, EFS, CIFS) can block for milliseconds to seconds
+/// per read, stalling the entire event loop. See [`BlobStage`] documentation
+/// for staging path requirements.
 fn file_read_stream(
     file: std::fs::File,
 ) -> impl futures_util::Stream<Item = Result<Bytes, std::io::Error>> {
@@ -1922,11 +1950,12 @@ fn file_read_stream(
     })
 }
 
-/// Retry an async operation with exponential backoff on transient HTTP errors.
+/// Retry an async operation with exponential backoff on transient errors.
 ///
-/// Calls `f()` in a loop. If the result is `Err` with a retryable HTTP status
-/// (408, 429, 5xx), waits with exponential backoff and tries again up to
-/// `config.max_retries` times. Returns the first `Ok` or the final `Err`.
+/// Calls `f()` in a loop. Retries on HTTP 408/429/5xx status codes and on
+/// transport-level errors (connection refused, DNS failure, request timeout).
+/// Waits with jittered exponential backoff up to `config.max_retries` times.
+/// Returns the first `Ok` or the final `Err`.
 async fn with_retry<T, F, Fut>(
     config: &RetryConfig,
     operation: &str,
@@ -1941,20 +1970,26 @@ where
         match f().await {
             Ok(val) => return Ok(val),
             Err(e) => {
-                if let Some(status) = e.status_code() {
-                    if retry::should_retry(status, attempt, config.max_retries) {
-                        let backoff = config.backoff_for(attempt);
-                        warn!(
-                            operation,
-                            attempt,
-                            status = %status,
-                            backoff_ms = backoff.as_millis(),
-                            "retrying"
-                        );
-                        tokio::time::sleep(backoff).await;
-                        attempt += 1;
-                        continue;
-                    }
+                let retryable = if let Some(status) = e.status_code() {
+                    retry::should_retry(status, attempt, config.max_retries)
+                } else {
+                    // Transport-level errors (connection refused, DNS failure,
+                    // request timeout) are retryable when attempts remain.
+                    attempt < config.max_retries && retry::should_retry_transport(&e)
+                };
+
+                if retryable {
+                    let backoff = config.backoff_for(attempt);
+                    warn!(
+                        operation,
+                        attempt,
+                        error = %e,
+                        backoff_ms = backoff.as_millis(),
+                        "retrying"
+                    );
+                    tokio::time::sleep(backoff).await;
+                    attempt += 1;
+                    continue;
                 }
                 return Err(e);
             }
@@ -2116,6 +2151,7 @@ mod tests {
                     kind: ErrorKind::BlobTransfer,
                     error: "timeout".into(),
                     retries: 3,
+                    status_code: None,
                 },
                 0,
             ),
@@ -2259,11 +2295,11 @@ mod tests {
             target_name: RegistryAlias::new("test-target"),
             target_client: client,
             source: ImageRef {
-                repo: RepositoryName::new(format!("source/{tag}")),
+                repo: RepositoryName::new(format!("source/{tag}")).unwrap(),
                 tag: tag.to_owned(),
             },
             target: ImageRef {
-                repo: RepositoryName::new(format!("target/{tag}")),
+                repo: RepositoryName::new(format!("target/{tag}")).unwrap(),
                 tag: tag.to_owned(),
             },
             batch_checker: None,
@@ -2377,11 +2413,11 @@ mod tests {
             target_name: RegistryAlias::new("target-1"),
             target_client: Arc::clone(&client_a),
             source: ImageRef {
-                repo: RepositoryName::new("src/base"),
+                repo: RepositoryName::new("src/base").unwrap(),
                 tag: "v1".into(),
             },
             target: ImageRef {
-                repo: RepositoryName::new("tgt/base"),
+                repo: RepositoryName::new("tgt/base").unwrap(),
                 tag: "v1".into(),
             },
             batch_checker: None,
@@ -2392,11 +2428,11 @@ mod tests {
             target_name: RegistryAlias::new("target-2"),
             target_client: Arc::clone(&client_b),
             source: ImageRef {
-                repo: RepositoryName::new("src/base"),
+                repo: RepositoryName::new("src/base").unwrap(),
                 tag: "v1".into(),
             },
             target: ImageRef {
-                repo: RepositoryName::new("tgt/base"),
+                repo: RepositoryName::new("tgt/base").unwrap(),
                 tag: "v1".into(),
             },
             batch_checker: None,
@@ -2549,6 +2585,81 @@ mod tests {
                 pending[0].source.tag, "imgB",
                 "tie should break deterministically in favor of later candidate"
             );
+        }
+    }
+
+    #[test]
+    fn elect_leaders_minimal_set_covers_all_follower_shared_blobs() {
+        // Verify the greedy election picks the minimal leader set such that
+        // every shared blob of every follower is present in the leader union.
+        //
+        // Setup: 5 images with overlapping blob sets designed so that 2
+        // leaders suffice to cover all shared blobs.
+        //
+        // img1: {10, a1, a2, a3, f1}  -- shares a1,a2,a3 broadly
+        // img2: {20, a1, a2, f2}       -- shares a1,a2 with img1
+        // img3: {30, a2, a3, f3}       -- shares a2,a3 with img1
+        // img4: {40, b4, b5, f4}       -- disjoint cluster
+        // img5: {50, b4, b5, f5}       -- shares b4,b5 with img4
+        //
+        // Optimal: img1 covers {a1,a2,a3} for cluster 1, img4 or img5 covers
+        // {b4,b5} for cluster 2. Two leaders total.
+        let data1 = Rc::new(test_pulled_manifest(&["10", "a1", "a2", "a3", "f1"]));
+        let data2 = Rc::new(test_pulled_manifest(&["20", "a1", "a2", "f2"]));
+        let data3 = Rc::new(test_pulled_manifest(&["30", "a2", "a3", "f3"]));
+        let data4 = Rc::new(test_pulled_manifest(&["40", "b4", "b5", "f4"]));
+        let data5 = Rc::new(test_pulled_manifest(&["50", "b4", "b5", "f5"]));
+
+        let mut pending = VecDeque::new();
+        pending.push_back(test_task(Rc::clone(&data1), "img1"));
+        pending.push_back(test_task(Rc::clone(&data2), "img2"));
+        pending.push_back(test_task(Rc::clone(&data3), "img3"));
+        pending.push_back(test_task(Rc::clone(&data4), "img4"));
+        pending.push_back(test_task(Rc::clone(&data5), "img5"));
+
+        let n = elect_leaders(&mut pending);
+
+        // Exactly 2 leaders: one per cluster.
+        assert_eq!(
+            n, 2,
+            "should elect exactly 2 leaders for 2 disjoint clusters"
+        );
+
+        // Collect the leader blob union.
+        let leader_blobs = leader_blob_digests(&pending, n);
+
+        // Verify every shared blob of every follower is in the leader union.
+        // Shared blobs are those appearing in more than one image.
+        let all_blob_sets: Vec<HashSet<Digest>> = pending
+            .iter()
+            .map(|t| {
+                blobs_from_manifest(&t.source_data)
+                    .into_iter()
+                    .map(|d| d.digest.clone())
+                    .collect()
+            })
+            .collect();
+
+        for (i, task) in pending.iter().skip(n).enumerate() {
+            let follower_blobs: HashSet<Digest> = blobs_from_manifest(&task.source_data)
+                .into_iter()
+                .map(|d| d.digest.clone())
+                .collect();
+            // A blob is "shared" if it appears in at least one other image.
+            for blob in &follower_blobs {
+                let shared_with_others = all_blob_sets
+                    .iter()
+                    .enumerate()
+                    .any(|(j, set)| j != (i + n) && set.contains(blob));
+                if shared_with_others {
+                    assert!(
+                        leader_blobs.contains(blob),
+                        "follower {} has shared blob {} not covered by leaders",
+                        task.source.tag,
+                        blob
+                    );
+                }
+            }
         }
     }
 }

--- a/crates/ocync-sync/src/lib.rs
+++ b/crates/ocync-sync/src/lib.rs
@@ -110,6 +110,9 @@ pub enum ImageStatus {
         error: String,
         /// Number of retry attempts made.
         retries: u32,
+        /// HTTP status code from the failing request, if available.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        status_code: Option<u16>,
     },
 }
 
@@ -246,6 +249,7 @@ mod tests {
                 kind: ErrorKind::BlobTransfer,
                 error: "timeout".into(),
                 retries: 3,
+                status_code: None,
             },
         ]);
         assert_eq!(report.exit_code(), 1);
@@ -258,11 +262,13 @@ mod tests {
                 kind: ErrorKind::ManifestPull,
                 error: "a".into(),
                 retries: 1,
+                status_code: None,
             },
             ImageStatus::Failed {
                 kind: ErrorKind::ManifestPush,
                 error: "b".into(),
                 retries: 2,
+                status_code: None,
             },
         ]);
         assert_eq!(report.exit_code(), 2);
@@ -335,11 +341,25 @@ mod tests {
             kind: ErrorKind::ManifestPull,
             error: "timeout".into(),
             retries: 3,
+            status_code: None,
         };
         let json = serde_json::to_value(&status).unwrap();
         assert_eq!(json["status"], "failed");
         assert_eq!(json["kind"], "manifest_pull");
         assert_eq!(json["error"], "timeout");
         assert_eq!(json["retries"], 3);
+        assert!(json.get("status_code").is_none(), "None should be skipped");
+    }
+
+    #[test]
+    fn image_status_failed_json_includes_status_code() {
+        let status = ImageStatus::Failed {
+            kind: ErrorKind::ManifestPull,
+            error: "unauthorized".into(),
+            retries: 1,
+            status_code: Some(401),
+        };
+        let json = serde_json::to_value(&status).unwrap();
+        assert_eq!(json["status_code"], 401);
     }
 }

--- a/crates/ocync-sync/src/plan.rs
+++ b/crates/ocync-sync/src/plan.rs
@@ -1,6 +1,6 @@
 //! Blob deduplication map and transfer ordering for cross-repo mount support.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use ocync_distribution::Digest;
 use ocync_distribution::spec::RepositoryName;
@@ -207,6 +207,19 @@ impl BlobDedupMap {
         info.repos.iter().find(|r| *r != target_repo)
     }
 
+    /// Remove a specific repo from a blob's known repos set.
+    ///
+    /// Used after a failed mount to discard the stale mount source without
+    /// removing the entire blob entry (which would let concurrent waiters
+    /// re-claim and start duplicate pushes).
+    pub(crate) fn remove_repo(&mut self, target: &str, digest: &Digest, repo: &RepositoryName) {
+        if let Some(index) = self.inner.get_mut(target) {
+            if let Some(info) = index.get_mut(digest) {
+                info.repos.remove(repo);
+            }
+        }
+    }
+
     /// Remove the entry for the given blob at the target.
     ///
     /// Used for lazy invalidation when a mount or push fails so the next sync
@@ -260,6 +273,23 @@ impl BlobDedupMap {
     pub(crate) fn is_empty(&self) -> bool {
         self.inner.values().all(|index| index.is_empty())
     }
+
+    /// Remove entries for targets not in `live_targets`.
+    ///
+    /// Returns the number of individual blob entries removed. This prevents
+    /// unbounded growth when targets are removed from configuration.
+    pub(crate) fn retain_targets(&mut self, live_targets: &HashSet<String>) -> usize {
+        let mut removed = 0usize;
+        self.inner.retain(|target, index| {
+            if live_targets.contains(target) {
+                true
+            } else {
+                removed += index.len();
+                false
+            }
+        });
+        removed
+    }
 }
 
 impl Default for BlobDedupMap {
@@ -279,7 +309,7 @@ mod tests {
     }
 
     fn repo(name: &str) -> RepositoryName {
-        RepositoryName::new(name)
+        RepositoryName::new(name).unwrap()
     }
 
     #[test]

--- a/crates/ocync-sync/src/retry.rs
+++ b/crates/ocync-sync/src/retry.rs
@@ -1,5 +1,7 @@
 //! Retry configuration and backoff logic for transient failures.
 
+use std::collections::hash_map::RandomState;
+use std::hash::{BuildHasher, Hasher};
 use std::time::Duration;
 
 use http::StatusCode;
@@ -31,12 +33,14 @@ impl Default for RetryConfig {
 impl RetryConfig {
     /// Compute the backoff duration for the given attempt (0-indexed).
     ///
-    /// Uses exponential backoff capped at `max_backoff`. All arithmetic
-    /// saturates instead of overflowing.
+    /// Uses exponential backoff capped at `max_backoff`, then applies
+    /// multiplicative jitter in \[0.75, 1.25) to decorrelate concurrent
+    /// retries. All arithmetic saturates instead of overflowing.
     pub fn backoff_for(&self, attempt: u32) -> Duration {
         let multiplier = self.backoff_multiplier.saturating_pow(attempt);
         let backoff = self.initial_backoff.saturating_mul(multiplier);
-        std::cmp::min(backoff, self.max_backoff)
+        let capped = std::cmp::min(backoff, self.max_backoff);
+        jitter(capped)
     }
 }
 
@@ -53,6 +57,47 @@ pub fn should_retry(status: StatusCode, current_attempt: u32, max_retries: u32) 
         || status.is_server_error()
 }
 
+/// Determine whether a transport-level (non-HTTP) error should be retried.
+///
+/// Returns `true` for connection failures and request timeouts surfaced by
+/// `reqwest` before any HTTP response is received. These are transient by
+/// nature and safe to retry idempotent OCI operations on.
+///
+/// # Known limitation
+///
+/// Only inspects `ocync_distribution::Error::Http(reqwest::Error)`. Transport
+/// errors that arrive wrapped in other variants are NOT retried:
+/// - `Error::Other(...)` -- may contain connection resets from middleware
+/// - `Error::RegistryError { source, .. }` -- may wrap a transport error
+/// - `Error::Manifest { source, .. }` -- may wrap a transport error
+///
+/// If operators observe unretrieved transient errors, the debug log below will
+/// show which variant was encountered so the match can be extended.
+pub fn should_retry_transport(error: &ocync_distribution::Error) -> bool {
+    if let ocync_distribution::Error::Http(reqwest_err) = error {
+        reqwest_err.is_connect() || reqwest_err.is_timeout()
+    } else {
+        tracing::debug!(
+            error = %error,
+            "non-Http error variant not inspectable for transport retry"
+        );
+        false
+    }
+}
+
+/// Apply multiplicative jitter to a backoff duration.
+///
+/// Scales the base duration by a random factor in \[0.75, 1.25) to
+/// decorrelate concurrent retries. Uses [`RandomState`] for per-process
+/// entropy without requiring a `rand` dependency.
+fn jitter(base: Duration) -> Duration {
+    let mut hasher = RandomState::new().build_hasher();
+    hasher.write_u64(base.as_nanos() as u64);
+    let hash = hasher.finish();
+    let factor = 0.75 + (hash % 500) as f64 / 1000.0;
+    base.mul_f64(factor)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -66,13 +111,23 @@ mod tests {
         assert_eq!(cfg.backoff_multiplier, 2);
     }
 
+    /// Helper: assert a duration falls within the jitter range [base*0.75, base*1.25].
+    fn assert_in_jitter_range(actual: Duration, base: Duration) {
+        let lo = base.mul_f64(0.75);
+        let hi = base.mul_f64(1.25);
+        assert!(
+            actual >= lo && actual <= hi,
+            "expected {actual:?} in [{lo:?}, {hi:?}] (base={base:?})"
+        );
+    }
+
     #[test]
     fn backoff_exponential() {
         let cfg = RetryConfig::default();
-        assert_eq!(cfg.backoff_for(0), Duration::from_secs(1));
-        assert_eq!(cfg.backoff_for(1), Duration::from_secs(2));
-        assert_eq!(cfg.backoff_for(2), Duration::from_secs(4));
-        assert_eq!(cfg.backoff_for(3), Duration::from_secs(8));
+        assert_in_jitter_range(cfg.backoff_for(0), Duration::from_secs(1));
+        assert_in_jitter_range(cfg.backoff_for(1), Duration::from_secs(2));
+        assert_in_jitter_range(cfg.backoff_for(2), Duration::from_secs(4));
+        assert_in_jitter_range(cfg.backoff_for(3), Duration::from_secs(8));
     }
 
     #[test]
@@ -81,8 +136,8 @@ mod tests {
             max_backoff: Duration::from_secs(5),
             ..RetryConfig::default()
         };
-        // 2^10 = 1024 seconds, but capped at 5
-        assert_eq!(cfg.backoff_for(10), Duration::from_secs(5));
+        // 2^10 = 1024 seconds, but capped at 5, then jitter applied
+        assert_in_jitter_range(cfg.backoff_for(10), Duration::from_secs(5));
     }
 
     #[test]
@@ -91,9 +146,9 @@ mod tests {
             backoff_multiplier: 1,
             ..RetryConfig::default()
         };
-        assert_eq!(cfg.backoff_for(0), Duration::from_secs(1));
-        assert_eq!(cfg.backoff_for(5), Duration::from_secs(1));
-        assert_eq!(cfg.backoff_for(100), Duration::from_secs(1));
+        assert_in_jitter_range(cfg.backoff_for(0), Duration::from_secs(1));
+        assert_in_jitter_range(cfg.backoff_for(5), Duration::from_secs(1));
+        assert_in_jitter_range(cfg.backoff_for(100), Duration::from_secs(1));
     }
 
     #[test]
@@ -106,7 +161,7 @@ mod tests {
         // 3^30 overflows u32 - saturating_pow caps at u32::MAX,
         // saturating_mul caps Duration, then min caps at max_backoff
         let result = cfg.backoff_for(30);
-        assert_eq!(result, Duration::from_secs(300));
+        assert_in_jitter_range(result, Duration::from_secs(300));
     }
 
     #[test]
@@ -116,10 +171,30 @@ mod tests {
             ..RetryConfig::default()
         };
         // 0^0 = 1, so attempt 0 gives initial_backoff * 1
-        assert_eq!(cfg.backoff_for(0), Duration::from_secs(1));
+        assert_in_jitter_range(cfg.backoff_for(0), Duration::from_secs(1));
         // 0^n = 0 for n > 0, so all subsequent attempts give zero backoff
+        // jitter of zero is still zero
         assert_eq!(cfg.backoff_for(1), Duration::ZERO);
         assert_eq!(cfg.backoff_for(5), Duration::ZERO);
+    }
+
+    #[test]
+    fn jitter_stays_in_range() {
+        // Run jitter many times and verify bounds. RandomState seeds
+        // differ per call, so we get coverage of the range.
+        let base = Duration::from_secs(10);
+        for _ in 0..100 {
+            let j = jitter(base);
+            assert!(
+                j >= base.mul_f64(0.75) && j <= base.mul_f64(1.25),
+                "jitter {j:?} out of range for base {base:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn jitter_of_zero_is_zero() {
+        assert_eq!(jitter(Duration::ZERO), Duration::ZERO);
     }
 
     #[test]
@@ -155,5 +230,21 @@ mod tests {
         assert!(!should_retry(StatusCode::OK, 0, 3));
         assert!(!should_retry(StatusCode::CREATED, 0, 3));
         assert!(!should_retry(StatusCode::NO_CONTENT, 0, 3));
+    }
+
+    #[test]
+    fn should_retry_transport_on_registry_error() {
+        // RegistryError wraps HTTP responses, not transport failures.
+        let err = ocync_distribution::Error::RegistryError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: "broke".into(),
+        };
+        assert!(!should_retry_transport(&err));
+    }
+
+    #[test]
+    fn should_retry_transport_on_other() {
+        let err = ocync_distribution::Error::Other("something".into());
+        assert!(!should_retry_transport(&err));
     }
 }

--- a/crates/ocync-sync/src/staging.rs
+++ b/crates/ocync-sync/src/staging.rs
@@ -29,9 +29,16 @@ use std::collections::HashMap;
 use std::io;
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use ocync_distribution::Digest;
 use tokio::sync::Notify;
+
+/// Shared sequence counter for generating unique temporary file names across
+/// both [`BlobStage::write`] and [`BlobStage::begin_write`]. A single counter
+/// prevents temp filename collisions when both write paths are used for the
+/// same digest.
+static WRITE_SEQ: AtomicU64 = AtomicU64::new(0);
 
 /// Best-effort directory fsync after an atomic rename.
 ///
@@ -75,6 +82,14 @@ pub enum StagePullAction {
 /// When enabled, blobs are pulled once from source and stored locally so all
 /// target pushes can read from the local file rather than re-pulling from
 /// source. When disabled (single-target), all methods are no-ops.
+///
+/// # Staging path requirements
+///
+/// The staging directory MUST reside on local disk (tmpfs, ext4, XFS, APFS,
+/// etc.). The engine performs synchronous I/O on staged files within the
+/// single-threaded tokio runtime (see [`file_read_stream`](crate::engine)). A
+/// network filesystem (NFS, EFS, CIFS, `GlusterFS`) would block the event loop
+/// for the duration of each read call, stalling all concurrent transfers.
 ///
 /// Cross-image source-pull dedup is coordinated via [`claim_or_check`]:
 /// the first task to request a digest claims the pull, concurrent tasks wait
@@ -182,8 +197,6 @@ impl BlobStage {
             std::fs::create_dir_all(parent)?;
         }
 
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static WRITE_SEQ: AtomicU64 = AtomicU64::new(0);
         let seq = WRITE_SEQ.fetch_add(1, Ordering::Relaxed);
         let tmp_path = dest.with_extension(format!("tmp.{}.{seq}", std::process::id()));
 
@@ -271,9 +284,23 @@ impl BlobStage {
                     continue;
                 }
 
-                let size = std::fs::metadata(&file_entry).map(|m| m.len()).unwrap_or(0);
-                total_bytes += size;
-                entries.push((file_entry, size));
+                // Skip symlinks to prevent deletion of symlink targets.
+                // `symlink_metadata` does not follow symlinks, so `is_file()`
+                // returns false for symlinks (unlike `metadata().is_file()`).
+                match std::fs::symlink_metadata(&file_entry) {
+                    Ok(meta) if !meta.is_file() => {
+                        tracing::warn!(
+                            path = %file_entry.display(),
+                            "unexpected non-regular file in staging blobs dir, skipping"
+                        );
+                        continue;
+                    }
+                    Ok(meta) => {
+                        total_bytes += meta.len();
+                        entries.push((file_entry, meta.len()));
+                    }
+                    Err(_) => continue,
+                }
             }
         }
 
@@ -314,8 +341,6 @@ impl BlobStage {
         if let Some(parent) = dest.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static WRITE_SEQ: AtomicU64 = AtomicU64::new(0);
         let seq = WRITE_SEQ.fetch_add(1, Ordering::Relaxed);
         let tmp_path = dest.with_extension(format!("tmp.{}.{seq}", std::process::id()));
         let file = std::fs::File::create(&tmp_path)?;
@@ -323,6 +348,7 @@ impl BlobStage {
             file,
             tmp_path,
             dest,
+            finished: false,
         })
     }
 
@@ -354,12 +380,15 @@ impl BlobStage {
 /// Data is written to a temporary file via [`write_chunk`](Self::write_chunk).
 /// Call [`finish`](Self::finish) to fsync and atomically rename into the
 /// content-addressable location. If dropped without calling `finish`, the
-/// temporary file remains on disk and will be cleaned up by
-/// [`BlobStage::cleanup_tmp_files`] on the next startup.
+/// temporary file is removed immediately by the [`Drop`] impl to prevent
+/// partial files from accumulating during error paths.
 pub struct StagedWriter {
     file: std::fs::File,
     tmp_path: PathBuf,
     dest: PathBuf,
+    /// Set to `true` by [`finish`](Self::finish). When `false` at drop time,
+    /// the temporary file is removed to prevent partial files from accumulating.
+    finished: bool,
 }
 
 impl std::fmt::Debug for StagedWriter {
@@ -379,11 +408,20 @@ impl StagedWriter {
 
     /// Fsync the file and atomically rename it into the content-addressable
     /// location, followed by a directory fsync for durability.
-    pub fn finish(self) -> Result<(), io::Error> {
+    pub fn finish(mut self) -> Result<(), io::Error> {
         self.file.sync_all()?;
         std::fs::rename(&self.tmp_path, &self.dest)?;
         best_effort_dir_fsync(&self.dest);
+        self.finished = true;
         Ok(())
+    }
+}
+
+impl Drop for StagedWriter {
+    fn drop(&mut self) {
+        if !self.finished {
+            let _ = std::fs::remove_file(&self.tmp_path);
+        }
     }
 }
 

--- a/crates/ocync-sync/tests/cache_persistence.rs
+++ b/crates/ocync-sync/tests/cache_persistence.rs
@@ -32,7 +32,7 @@ fn digest2() -> Digest {
 }
 
 fn repo(name: &str) -> RepositoryName {
-    RepositoryName::new(name)
+    RepositoryName::new(name).unwrap()
 }
 
 fn authority(s: &str) -> RegistryAuthority {
@@ -62,7 +62,7 @@ fn round_trip_exists_at_target() {
     let path = dir.path().join("cache.bin");
 
     let mut cache = TransferStateCache::new();
-    cache.set_blob_exists("reg.io", digest_a(), "repo/alpine".into());
+    cache.set_blob_exists("reg.io", digest_a(), repo("repo/alpine"));
 
     cache.persist(&path).unwrap();
 
@@ -79,7 +79,7 @@ fn round_trip_completed() {
     let path = dir.path().join("cache.bin");
 
     let mut cache = TransferStateCache::new();
-    cache.set_blob_completed("reg.io", digest_a(), "repo/alpine".into());
+    cache.set_blob_completed("reg.io", digest_a(), repo("repo/alpine"));
 
     cache.persist(&path).unwrap();
 
@@ -96,15 +96,20 @@ fn round_trip_mount_source_survives() {
     let path = dir.path().join("cache.bin");
 
     let mut cache = TransferStateCache::new();
-    cache.set_blob_completed("reg.io", digest_a(), "repo/a".into());
-    cache.set_blob_completed("reg.io", digest_a(), "repo/b".into());
+    cache.set_blob_completed("reg.io", digest_a(), repo("repo/a"));
+    cache.set_blob_completed("reg.io", digest_a(), repo("repo/b"));
 
     cache.persist(&path).unwrap();
 
     let loaded = TransferStateCache::load(&path, long_ttl());
     assert_eq!(
-        loaded.blob_mount_source("reg.io", &digest_a(), &RepositoryName::from("repo/b"), &[]),
-        Some(&RepositoryName::from("repo/a"))
+        loaded.blob_mount_source(
+            "reg.io",
+            &digest_a(),
+            &RepositoryName::new("repo/b").unwrap(),
+            &[]
+        ),
+        Some(&RepositoryName::new("repo/a").unwrap())
     );
 }
 
@@ -114,8 +119,8 @@ fn round_trip_multiple_targets() {
     let path = dir.path().join("cache.bin");
 
     let mut cache = TransferStateCache::new();
-    cache.set_blob_completed("reg-a.io", digest_a(), "repo/x".into());
-    cache.set_blob_exists("reg-b.io", digest_b(), "repo/y".into());
+    cache.set_blob_completed("reg-a.io", digest_a(), repo("repo/x"));
+    cache.set_blob_exists("reg-b.io", digest_b(), repo("repo/y"));
 
     cache.persist(&path).unwrap();
 
@@ -140,7 +145,7 @@ fn expired_cache_returns_empty() {
     let path = dir.path().join("cache.bin");
 
     let mut cache = TransferStateCache::new();
-    cache.set_blob_completed("reg.io", digest_a(), "repo/a".into());
+    cache.set_blob_completed("reg.io", digest_a(), repo("repo/a"));
     cache.persist(&path).unwrap();
 
     // The cache stores timestamps at second granularity, so we need
@@ -157,7 +162,7 @@ fn zero_ttl_means_never_expire() {
     let path = dir.path().join("cache.bin");
 
     let mut cache = TransferStateCache::new();
-    cache.set_blob_completed("reg.io", digest_a(), "repo/a".into());
+    cache.set_blob_completed("reg.io", digest_a(), repo("repo/a"));
     cache.persist(&path).unwrap();
 
     // Duration::ZERO disables TTL -- the cache never expires by age.
@@ -195,7 +200,7 @@ fn bad_crc_returns_empty() {
     let path = dir.path().join("cache.bin");
 
     let mut cache = TransferStateCache::new();
-    cache.set_blob_completed("reg.io", digest_a(), "repo/a".into());
+    cache.set_blob_completed("reg.io", digest_a(), repo("repo/a"));
     cache.persist(&path).unwrap();
 
     // Flip a byte in the middle of the file to break the CRC.
@@ -242,7 +247,7 @@ fn in_progress_blobs_not_persisted() {
     let path = dir.path().join("cache.bin");
 
     let mut cache = TransferStateCache::new();
-    cache.set_blob_in_progress("reg.io", digest_a(), "repo/a".into());
+    cache.set_blob_in_progress("reg.io", digest_a(), repo("repo/a"));
 
     cache.persist(&path).unwrap();
 
@@ -257,7 +262,7 @@ fn only_stable_entries_survive_persist() {
 
     let mut cache = TransferStateCache::new();
     // Stable
-    cache.set_blob_completed("reg.io", digest_a(), "repo/a".into());
+    cache.set_blob_completed("reg.io", digest_a(), repo("repo/a"));
     // Transient -- should not appear after reload
     cache.set_blob_failed("reg.io", digest_b(), "oops".into());
 
@@ -278,7 +283,7 @@ fn only_stable_entries_survive_persist() {
 #[test]
 fn invalidate_blob_removes_entry() {
     let mut cache = TransferStateCache::new();
-    cache.set_blob_exists("reg.io", digest_a(), "repo/a".into());
+    cache.set_blob_exists("reg.io", digest_a(), repo("repo/a"));
     assert!(cache.blob_status("reg.io", &digest_a()).is_some());
 
     cache.invalidate_blob("reg.io", &digest_a());
@@ -303,7 +308,7 @@ fn persist_creates_nested_parent_dirs() {
     let path = dir.path().join("a").join("b").join("c").join("cache.bin");
 
     let mut cache = TransferStateCache::new();
-    cache.set_blob_completed("reg.io", digest_a(), "repo/a".into());
+    cache.set_blob_completed("reg.io", digest_a(), repo("repo/a"));
 
     // Parent dirs don't exist yet -- persist() must create them.
     cache.persist(&path).unwrap();

--- a/crates/ocync-sync/tests/engine_integration.rs
+++ b/crates/ocync-sync/tests/engine_integration.rs
@@ -127,8 +127,8 @@ fn resolved_mapping(
     ResolvedMapping {
         source_authority: RegistryAuthority::new("source.test.io:443"),
         source_client,
-        source_repo: source_repo.into(),
-        target_repo: target_repo.into(),
+        source_repo: RepositoryName::new(source_repo).unwrap(),
+        target_repo: RepositoryName::new(target_repo).unwrap(),
         targets,
         tags,
         platforms: None,
@@ -2088,8 +2088,16 @@ async fn sync_warm_cache_triggers_cross_repo_mount() {
     {
         let mut c = cache.borrow_mut();
         let target = "target";
-        c.set_blob_completed(target, config_desc.digest.clone(), "repo-a".into());
-        c.set_blob_completed(target, layer_desc.digest.clone(), "repo-a".into());
+        c.set_blob_completed(
+            target,
+            config_desc.digest.clone(),
+            RepositoryName::new("repo-a").unwrap(),
+        );
+        c.set_blob_completed(
+            target,
+            layer_desc.digest.clone(),
+            RepositoryName::new("repo-a").unwrap(),
+        );
     }
 
     let mapping = resolved_mapping(
@@ -2174,8 +2182,16 @@ async fn sync_warm_cache_ecr_target_mount_not_fulfilled() {
     let target_name = "ecr-target";
     {
         let mut c = cache.borrow_mut();
-        c.set_blob_completed(target_name, config_desc.digest.clone(), "repo-a".into());
-        c.set_blob_completed(target_name, layer_desc.digest.clone(), "repo-a".into());
+        c.set_blob_completed(
+            target_name,
+            config_desc.digest.clone(),
+            RepositoryName::new("repo-a").unwrap(),
+        );
+        c.set_blob_completed(
+            target_name,
+            layer_desc.digest.clone(),
+            RepositoryName::new("repo-a").unwrap(),
+        );
     }
 
     let mapping = resolved_mapping(
@@ -2361,8 +2377,16 @@ async fn sync_lazy_invalidation_on_mount_failure() {
     let cache = empty_cache();
     {
         let mut c = cache.borrow_mut();
-        c.set_blob_completed("target", config_desc.digest.clone(), "other-repo".into());
-        c.set_blob_completed("target", layer_desc.digest.clone(), "other-repo".into());
+        c.set_blob_completed(
+            "target",
+            config_desc.digest.clone(),
+            RepositoryName::new("other-repo").unwrap(),
+        );
+        c.set_blob_completed(
+            "target",
+            layer_desc.digest.clone(),
+            RepositoryName::new("other-repo").unwrap(),
+        );
     }
 
     let mapping = resolved_mapping(
@@ -2975,8 +2999,16 @@ async fn sync_lazy_invalidation_clears_cache_and_records_completion() {
     let cache = empty_cache();
     {
         let mut c = cache.borrow_mut();
-        c.set_blob_completed("target", config_desc.digest.clone(), "stale-repo".into());
-        c.set_blob_completed("target", layer_desc.digest.clone(), "stale-repo".into());
+        c.set_blob_completed(
+            "target",
+            config_desc.digest.clone(),
+            RepositoryName::new("stale-repo").unwrap(),
+        );
+        c.set_blob_completed(
+            "target",
+            layer_desc.digest.clone(),
+            RepositoryName::new("stale-repo").unwrap(),
+        );
     }
 
     let mapping = resolved_mapping(
@@ -3836,8 +3868,16 @@ async fn sync_warm_cache_skips_blob_head_check() {
     let cache = empty_cache();
     {
         let mut c = cache.borrow_mut();
-        c.set_blob_completed("target", config_desc.digest.clone(), "repo".into());
-        c.set_blob_completed("target", layer_desc.digest.clone(), "repo".into());
+        c.set_blob_completed(
+            "target",
+            config_desc.digest.clone(),
+            RepositoryName::new("repo").unwrap(),
+        );
+        c.set_blob_completed(
+            "target",
+            layer_desc.digest.clone(),
+            RepositoryName::new("repo").unwrap(),
+        );
     }
 
     let mapping = resolved_mapping(
@@ -5069,7 +5109,11 @@ async fn sync_batch_checker_with_prewarmed_cache() {
     let cache = empty_cache();
     {
         let mut c = cache.borrow_mut();
-        c.set_blob_exists("target", config_desc.digest.clone(), "repo".into());
+        c.set_blob_exists(
+            "target",
+            config_desc.digest.clone(),
+            RepositoryName::new("repo").unwrap(),
+        );
     }
 
     // Batch checker: both blobs exist (config is redundant with cache).

--- a/crates/ocync-sync/tests/engine_integration.rs
+++ b/crates/ocync-sync/tests/engine_integration.rs
@@ -1,4 +1,25 @@
 //! Integration tests for `SyncEngine` using mock HTTP servers.
+//!
+//! # Table of Contents
+//!
+//! - **Helpers** (line ~35) - `make_digest`, `mock_client`, `mount_*` mocks, `ManifestBuilder`
+//! - **Tests** (line ~420) - Happy path, skip on digest match, source errors
+//! - **Transfer state cache** (line ~1860) - Progressive population, cross-repo mount, monolithic
+//! - **Shutdown integration** (line ~2410) - Graceful shutdown, drain deadline
+//! - **Concurrent execution** (line ~2565) - Non-sequential ordering, parallel transfers
+//! - **Nested index rejection** (line ~2745) - Index-in-index error handling
+//! - **Cache invalidation** (line ~2835) - State verification after invalidation
+//! - **Partial failure / concurrent dedup** (line ~2960) - Child failure, blob failure, dedup
+//! - **Staging pull-once** (line ~3295) - Staging pull-once semantics, drain deadline expiry
+//! - **Staging disk verification** (line ~3595) - Staged files exist on disk after sync
+//! - **Warm cache skip** (line ~3720) - Warm cache skips blob entirely (no HEAD)
+//! - **Batch blob checker** (line ~3795) - Batch pre-population, fallback on error
+//! - **Platform filtering** (line ~5045) - Index manifest platform selection
+//! - **Multi-target independence** (line ~5325) - Target isolation, partial target failure
+//! - **Discovery optimization** (line ~5825) - Source HEAD cache, target staleness detection
+//! - **Untriggered shutdown** (line ~8100) - Engine exits cleanly with unused signal
+//! - **Concurrent mount coordination** (line ~8175) - Shared blob mount vs double-upload
+//! - **Blob concurrency bound** (line ~8900) - Semaphore(6) correctness with >6 layers
 
 use std::cell::RefCell;
 use std::collections::HashSet;
@@ -81,7 +102,7 @@ fn empty_cache() -> Rc<RefCell<TransferStateCache>> {
 fn snap_key(repo: &str, tag: &str) -> SnapshotKey {
     SnapshotKey::new(
         &RegistryAuthority::new("source.test.io:443"),
-        &RepositoryName::new(repo),
+        &RepositoryName::new(repo).unwrap(),
         tag,
     )
 }
@@ -145,6 +166,102 @@ fn simple_image_manifest(config_digest: &Digest, layer_digest: &Digest) -> Image
         subject: None,
         artifact_type: None,
         annotations: None,
+    }
+}
+
+/// Builder for constructing `ImageManifest` with sensible test defaults.
+///
+/// Simplifies the common pattern of creating test manifests with real blob
+/// data (matching digests and sizes). Call [`layer`](Self::layer) to add
+/// layers, then [`build`](Self::build) to get the manifest plus all parts
+/// needed for mock setup.
+struct ManifestBuilder {
+    config_data: Vec<u8>,
+    layers_data: Vec<Vec<u8>>,
+}
+
+impl ManifestBuilder {
+    /// Create a new builder with the given config blob data.
+    fn new(config_data: &[u8]) -> Self {
+        Self {
+            config_data: config_data.to_vec(),
+            layers_data: Vec::new(),
+        }
+    }
+
+    /// Add a layer blob to the manifest.
+    fn layer(mut self, data: &[u8]) -> Self {
+        self.layers_data.push(data.to_vec());
+        self
+    }
+
+    /// Build the manifest, returning all parts needed for mock setup.
+    fn build(self) -> ManifestParts {
+        let config_desc = blob_descriptor(&self.config_data, MediaType::OciConfig);
+        let layer_descs: Vec<Descriptor> = self
+            .layers_data
+            .iter()
+            .map(|d| blob_descriptor(d, MediaType::OciLayerGzip))
+            .collect();
+
+        let manifest = ImageManifest {
+            schema_version: 2,
+            media_type: None,
+            config: config_desc.clone(),
+            layers: layer_descs.clone(),
+            subject: None,
+            artifact_type: None,
+            annotations: None,
+        };
+
+        let bytes = serde_json::to_vec(&manifest).unwrap();
+        let hash = ocync_distribution::sha256::Sha256::digest(&bytes);
+        let digest = Digest::from_sha256(hash);
+
+        ManifestParts {
+            manifest,
+            bytes,
+            digest,
+            config_data: self.config_data,
+            config_desc,
+            layers_data: self.layers_data,
+            layer_descs,
+        }
+    }
+}
+
+/// Output of [`ManifestBuilder::build`] with all parts needed for mock setup.
+struct ManifestParts {
+    #[allow(dead_code)]
+    manifest: ImageManifest,
+    bytes: Vec<u8>,
+    #[allow(dead_code)]
+    digest: Digest,
+    config_data: Vec<u8>,
+    config_desc: Descriptor,
+    layers_data: Vec<Vec<u8>>,
+    layer_descs: Vec<Descriptor>,
+}
+
+impl ManifestParts {
+    /// Mount all source mocks (manifest GET + blob GETs) for this image.
+    async fn mount_source(&self, server: &MockServer, repo: &str, tag: &str) {
+        mount_source_manifest(server, repo, tag, &self.bytes).await;
+        mount_blob_pull(server, repo, &self.config_desc.digest, &self.config_data).await;
+        for (data, desc) in self.layers_data.iter().zip(self.layer_descs.iter()) {
+            mount_blob_pull(server, repo, &desc.digest, data).await;
+        }
+    }
+
+    /// Mount target mocks: HEAD 404, blob-not-found for all blobs, push endpoints.
+    async fn mount_target(&self, server: &MockServer, repo: &str, tag: &str) {
+        mount_manifest_head_not_found(server, repo, tag).await;
+        mount_blob_not_found(server, repo, &self.config_desc.digest).await;
+        for desc in &self.layer_descs {
+            mount_blob_not_found(server, repo, &desc.digest).await;
+        }
+        mount_blob_push(server, repo).await;
+        mount_manifest_push(server, repo, tag).await;
     }
 }
 
@@ -2339,7 +2456,7 @@ async fn sync_cache_persist_and_load_round_trip() {
         loaded.blob_known_at_repo(
             "target-reg",
             &config_desc.digest,
-            &RepositoryName::from("repo")
+            &RepositoryName::new("repo").unwrap()
         ),
         "config blob should be recorded as completed at repo"
     );
@@ -2347,7 +2464,7 @@ async fn sync_cache_persist_and_load_round_trip() {
         loaded.blob_known_at_repo(
             "target-reg",
             &layer_desc.digest,
-            &RepositoryName::from("repo")
+            &RepositoryName::new("repo").unwrap()
         ),
         "layer blob should be recorded as completed at repo"
     );
@@ -2355,7 +2472,7 @@ async fn sync_cache_persist_and_load_round_trip() {
         !loaded.blob_known_at_repo(
             "target-reg",
             &config_desc.digest,
-            &RepositoryName::from("other-repo")
+            &RepositoryName::new("other-repo").unwrap()
         ),
         "blob should not appear at an unrelated repo"
     );
@@ -2890,7 +3007,7 @@ async fn sync_lazy_invalidation_clears_cache_and_records_completion() {
         !c.blob_known_at_repo(
             "target",
             &config_desc.digest,
-            &RepositoryName::from("stale-repo")
+            &RepositoryName::new("stale-repo").unwrap()
         ),
         "stale cache entry for config at stale-repo should be invalidated"
     );
@@ -2898,16 +3015,24 @@ async fn sync_lazy_invalidation_clears_cache_and_records_completion() {
         !c.blob_known_at_repo(
             "target",
             &layer_desc.digest,
-            &RepositoryName::from("stale-repo")
+            &RepositoryName::new("stale-repo").unwrap()
         ),
         "stale cache entry for layer at stale-repo should be invalidated"
     );
     assert!(
-        c.blob_known_at_repo("target", &config_desc.digest, &RepositoryName::from("repo")),
+        c.blob_known_at_repo(
+            "target",
+            &config_desc.digest,
+            &RepositoryName::new("repo").unwrap()
+        ),
         "config blob should be recorded as completed at repo after fallback push"
     );
     assert!(
-        c.blob_known_at_repo("target", &layer_desc.digest, &RepositoryName::from("repo")),
+        c.blob_known_at_repo(
+            "target",
+            &layer_desc.digest,
+            &RepositoryName::new("repo").unwrap()
+        ),
         "layer blob should be recorded as completed at repo after fallback push"
     );
 }
@@ -8844,4 +8969,160 @@ async fn sync_source_pull_dedup_with_staging() {
         source_gets_for_shared, 1,
         "shared blob should be pulled from source exactly once (dedup), got {source_gets_for_shared}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Blob concurrency bound: Semaphore(6) correctness with >6 layers
+// ---------------------------------------------------------------------------
+
+/// An image with more layers than the per-image blob concurrency limit (6)
+/// must still sync correctly. All blobs transfer successfully even though the
+/// internal semaphore serializes some of them. This verifies the semaphore
+/// does not deadlock or drop permits when the layer count exceeds the bound.
+#[tokio::test]
+async fn sync_image_with_more_layers_than_blob_concurrency_limit() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    // Build an image with 10 layers (exceeds BLOB_CONCURRENCY = 6).
+    let parts = ManifestBuilder::new(b"config-many-layers")
+        .layer(b"layer-01")
+        .layer(b"layer-02")
+        .layer(b"layer-03")
+        .layer(b"layer-04")
+        .layer(b"layer-05")
+        .layer(b"layer-06")
+        .layer(b"layer-07")
+        .layer(b"layer-08")
+        .layer(b"layer-09")
+        .layer(b"layer-10")
+        .build();
+
+    parts.mount_source(&source_server, "repo/many", "v1").await;
+    parts.mount_target(&target_server, "repo/many", "v1").await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping = resolved_mapping(
+        source_client,
+        "repo/many",
+        "repo/many",
+        vec![target_entry("target", target_client)],
+        vec![TagPair::same("v1")],
+    );
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(
+        matches!(report.images[0].status, ImageStatus::Synced),
+        "image with 10 layers must sync: {:?}",
+        report.images[0].status
+    );
+    // 11 blobs total: 1 config + 10 layers.
+    assert_eq!(report.images[0].blob_stats.transferred, 11);
+    assert_eq!(report.stats.blobs_transferred, 11);
+}
+
+// ---------------------------------------------------------------------------
+// ManifestBuilder demonstration: happy path rewritten
+// ---------------------------------------------------------------------------
+
+/// Same test as `sync_happy_path` but using `ManifestBuilder` to demonstrate
+/// the reduced boilerplate.
+#[tokio::test]
+async fn sync_happy_path_manifest_builder() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let parts = ManifestBuilder::new(b"config-data-mb")
+        .layer(b"layer-data-mb")
+        .build();
+
+    parts
+        .mount_source(&source_server, "library/nginx", "latest")
+        .await;
+    parts
+        .mount_target(&target_server, "mirror/nginx", "latest")
+        .await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping = resolved_mapping(
+        source_client,
+        "library/nginx",
+        "mirror/nginx",
+        vec![target_entry("target-reg", target_client)],
+        vec![TagPair::same("latest")],
+    );
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(matches!(report.images[0].status, ImageStatus::Synced));
+    assert_eq!(report.images[0].blob_stats.transferred, 2);
+    assert_eq!(report.stats.images_synced, 1);
+}
+
+/// Multi-layer manifest builder: verifies 3 layers all transfer correctly.
+#[tokio::test]
+async fn sync_three_layers_manifest_builder() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let parts = ManifestBuilder::new(b"cfg-3layer")
+        .layer(b"base-layer")
+        .layer(b"app-layer")
+        .layer(b"runtime-layer")
+        .build();
+
+    parts.mount_source(&source_server, "app/svc", "v2").await;
+    parts.mount_target(&target_server, "mirror/svc", "v2").await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping = resolved_mapping(
+        source_client,
+        "app/svc",
+        "mirror/svc",
+        vec![target_entry("ecr", target_client)],
+        vec![TagPair::same("v2")],
+    );
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(matches!(report.images[0].status, ImageStatus::Synced));
+    // 1 config + 3 layers = 4 blobs.
+    assert_eq!(report.images[0].blob_stats.transferred, 4);
 }

--- a/crates/ocync-sync/tests/staging_tests.rs
+++ b/crates/ocync-sync/tests/staging_tests.rs
@@ -241,3 +241,210 @@ fn disabled_evict_is_noop() {
     let stage = BlobStage::disabled();
     stage.evict(0).unwrap();
 }
+
+// ---------------------------------------------------------------------------
+// Source-pull dedup: claim_or_check / notify_staged / notify_failed
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn claim_or_check_first_caller_returns_pull() {
+    let dir = tempfile::tempdir().unwrap();
+    let stage = BlobStage::new(dir.path().to_path_buf());
+
+    let action = stage.claim_or_check(&digest_a());
+    assert!(
+        matches!(action, ocync_sync::staging::StagePullAction::Pull),
+        "first caller must get Pull, got: {action:?}"
+    );
+}
+
+#[tokio::test]
+async fn claim_or_check_second_caller_returns_wait() {
+    let dir = tempfile::tempdir().unwrap();
+    let stage = BlobStage::new(dir.path().to_path_buf());
+
+    // First caller claims the pull.
+    let first = stage.claim_or_check(&digest_a());
+    assert!(matches!(first, ocync_sync::staging::StagePullAction::Pull));
+
+    // Second caller for the same digest gets Wait with a Notify.
+    let second = stage.claim_or_check(&digest_a());
+    assert!(
+        matches!(second, ocync_sync::staging::StagePullAction::Wait(_)),
+        "second caller must get Wait, got: {second:?}"
+    );
+}
+
+#[tokio::test]
+async fn notify_staged_makes_subsequent_claim_return_exists() {
+    let dir = tempfile::tempdir().unwrap();
+    let stage = BlobStage::new(dir.path().to_path_buf());
+
+    // Claim the pull.
+    let action = stage.claim_or_check(&digest_a());
+    assert!(matches!(action, ocync_sync::staging::StagePullAction::Pull));
+
+    // Write the blob to disk and signal completion.
+    stage.write(&digest_a(), b"staged data").unwrap();
+    stage.notify_staged(&digest_a());
+
+    // A new caller should see the blob on disk.
+    let action = stage.claim_or_check(&digest_a());
+    assert!(
+        matches!(action, ocync_sync::staging::StagePullAction::Exists),
+        "after notify_staged + disk write, claim_or_check must return Exists, got: {action:?}"
+    );
+}
+
+#[tokio::test]
+async fn notify_failed_makes_subsequent_claim_return_pull() {
+    let dir = tempfile::tempdir().unwrap();
+    let stage = BlobStage::new(dir.path().to_path_buf());
+
+    // First caller claims the pull.
+    let action = stage.claim_or_check(&digest_a());
+    assert!(matches!(action, ocync_sync::staging::StagePullAction::Pull));
+
+    // Simulate a failure (no data written to disk).
+    stage.notify_failed(&digest_a());
+
+    // Next caller should be able to retry (get Pull, not Wait).
+    let action = stage.claim_or_check(&digest_a());
+    assert!(
+        matches!(action, ocync_sync::staging::StagePullAction::Pull),
+        "after notify_failed, claim_or_check must return Pull for retry, got: {action:?}"
+    );
+}
+
+#[tokio::test]
+async fn claim_or_check_disabled_always_returns_pull() {
+    let stage = BlobStage::disabled();
+
+    // Every call on a disabled stage returns Pull (no dedup possible).
+    let first = stage.claim_or_check(&digest_a());
+    assert!(
+        matches!(first, ocync_sync::staging::StagePullAction::Pull),
+        "disabled stage must always return Pull, got: {first:?}"
+    );
+
+    let second = stage.claim_or_check(&digest_a());
+    assert!(
+        matches!(second, ocync_sync::staging::StagePullAction::Pull),
+        "disabled stage must always return Pull on repeated calls, got: {second:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Async wakeup: claim_or_check -> Wait -> notified().await -> Exists
+// ---------------------------------------------------------------------------
+
+/// Verify the full async wakeup flow: a waiter spawned via `spawn_local`
+/// blocks on `notified().await`, is woken by `notify_staged`, and a
+/// subsequent `claim_or_check` returns `Exists`.
+#[tokio::test(flavor = "current_thread")]
+async fn blob_notify_async_wakeup_flow() {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let dir = tempfile::tempdir().unwrap();
+            let stage = Rc::new(BlobStage::new(dir.path().to_path_buf()));
+            let digest = digest_a();
+
+            // Task 1 claims the pull.
+            let action = stage.claim_or_check(&digest);
+            assert!(
+                matches!(action, ocync_sync::staging::StagePullAction::Pull),
+                "first caller must get Pull"
+            );
+
+            // Task 2: call claim_or_check -> Wait, then await the notify.
+            let woke_up = Rc::new(Cell::new(false));
+            let woke_clone = Rc::clone(&woke_up);
+            let stage_clone = Rc::clone(&stage);
+            let digest_clone = digest.clone();
+
+            let handle = tokio::task::spawn_local(async move {
+                let action = stage_clone.claim_or_check(&digest_clone);
+                let notify = match action {
+                    ocync_sync::staging::StagePullAction::Wait(n) => n,
+                    other => panic!("expected Wait, got: {other:?}"),
+                };
+                notify.notified().await;
+                woke_clone.set(true);
+
+                // After waking, claim_or_check should return Exists.
+                let final_action = stage_clone.claim_or_check(&digest_clone);
+                assert!(
+                    matches!(final_action, ocync_sync::staging::StagePullAction::Exists),
+                    "after notify_staged, claim_or_check must return Exists, got: {final_action:?}"
+                );
+            });
+
+            // Yield to let the spawned task reach the await point.
+            tokio::task::yield_now().await;
+            assert!(!woke_up.get(), "waiter must not wake before notify_staged");
+
+            // Write the blob and signal completion.
+            stage.write(&digest, b"staged blob data").unwrap();
+            stage.notify_staged(&digest);
+
+            // Let the spawned task finish.
+            handle.await.unwrap();
+            assert!(woke_up.get(), "waiter must have woken after notify_staged");
+        })
+        .await;
+}
+
+// ---------------------------------------------------------------------------
+// StagedWriter drop cleanup
+// ---------------------------------------------------------------------------
+
+/// Verify that dropping a `StagedWriter` without calling `finish()` removes
+/// the temporary file and does NOT stage the blob.
+#[test]
+fn staged_writer_drop_removes_temp_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let stage = BlobStage::new(dir.path().to_path_buf());
+    let digest = digest_a();
+
+    // Collect the temp file path before dropping.
+    let tmp_path = {
+        let mut writer = stage.begin_write(&digest).unwrap();
+        writer
+            .write_chunk(b"partial data that should be cleaned up")
+            .unwrap();
+        // Extract the tmp_path from the debug repr for verification.
+        // We know the tmp file exists because begin_write creates it.
+        let blobs_dir = dir.path().join("blobs").join("sha256");
+        let entries: Vec<_> = std::fs::read_dir(&blobs_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.contains(".tmp."))
+            })
+            .collect();
+        assert_eq!(entries.len(), 1, "temp file must exist before drop");
+        let tmp = entries[0].clone();
+        // Drop the writer WITHOUT calling finish().
+        drop(writer);
+        tmp
+    };
+
+    // Temp file must be removed by Drop impl.
+    assert!(
+        !tmp_path.exists(),
+        "temp file must be removed after drop without finish()"
+    );
+
+    // The blob must NOT be staged.
+    assert!(
+        !stage.exists(&digest),
+        "blob must not be staged when writer is dropped without finish()"
+    );
+}

--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,8 @@ private = { ignore = true }
 multiple-versions = "warn"
 deny = [
   { crate = "native-tls", wrappers = [] },
+  { crate = "openssl", wrappers = [] },
+  { crate = "openssl-sys", wrappers = [] },
   { crate = "ring", wrappers = [] },
 ]
 

--- a/docs/public/config.schema.json
+++ b/docs/public/config.schema.json
@@ -1,12 +1,14 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Config",
+  "description": "Top-level configuration defining registries, mappings, and sync behavior.",
   "type": "object",
   "required": [
     "mappings"
   ],
   "properties": {
     "defaults": {
+      "description": "Default source, targets, tags, and platforms inherited by all mappings.",
       "default": null,
       "anyOf": [
         {
@@ -30,12 +32,14 @@
       ]
     },
     "mappings": {
+      "description": "Image mapping rules defining what to sync and where.",
       "type": "array",
       "items": {
         "$ref": "#/definitions/MappingConfig"
       }
     },
     "registries": {
+      "description": "Named registry definitions keyed by alias.",
       "default": {},
       "type": "object",
       "additionalProperties": {
@@ -43,6 +47,7 @@
       }
     },
     "target_groups": {
+      "description": "Named groups of registry aliases for multi-target fanout.",
       "default": {},
       "type": "object",
       "additionalProperties": {
@@ -134,6 +139,7 @@
       }
     },
     "DefaultsConfig": {
+      "description": "Default values inherited by all mappings unless individually overridden.",
       "type": "object",
       "properties": {
         "platforms": {
@@ -148,6 +154,7 @@
           }
         },
         "source": {
+          "description": "Default source registry alias for all mappings.",
           "default": null,
           "type": [
             "string",
@@ -155,6 +162,7 @@
           ]
         },
         "tags": {
+          "description": "Default tag filter rules inherited by mappings without their own.",
           "default": null,
           "anyOf": [
             {
@@ -166,6 +174,7 @@
           ]
         },
         "targets": {
+          "description": "Default target registry alias or group for all mappings.",
           "default": null,
           "anyOf": [
             {
@@ -179,11 +188,14 @@
       }
     },
     "GlobOrList": {
+      "description": "A glob pattern: either a single string or a list of patterns.",
       "anyOf": [
         {
+          "description": "A single glob pattern string.",
           "type": "string"
         },
         {
+          "description": "Multiple glob pattern strings.",
           "type": "array",
           "items": {
             "type": "string"
@@ -226,12 +238,14 @@
       }
     },
     "MappingConfig": {
+      "description": "A single image mapping rule: source repo, target registries, and tag filters.",
       "type": "object",
       "required": [
         "from"
       ],
       "properties": {
         "from": {
+          "description": "Source repository path (e.g. `library/nginx`).",
           "type": "string"
         },
         "platforms": {
@@ -246,6 +260,7 @@
           }
         },
         "source": {
+          "description": "Source registry alias, overriding `defaults.source`.",
           "default": null,
           "type": [
             "string",
@@ -253,6 +268,7 @@
           ]
         },
         "tags": {
+          "description": "Tag filter rules for this mapping, overriding `defaults.tags`.",
           "default": null,
           "anyOf": [
             {
@@ -264,6 +280,7 @@
           ]
         },
         "targets": {
+          "description": "Target registry alias or group, overriding `defaults.targets`.",
           "default": null,
           "anyOf": [
             {
@@ -275,6 +292,7 @@
           ]
         },
         "to": {
+          "description": "Destination repository path; defaults to `from` when absent.",
           "default": null,
           "type": [
             "string",
@@ -284,12 +302,14 @@
       }
     },
     "RegistryConfig": {
+      "description": "Per-registry settings: URL, auth method, concurrency, and credentials.",
       "type": "object",
       "required": [
         "url"
       ],
       "properties": {
         "auth_type": {
+          "description": "Authentication method to use for this registry.",
           "default": null,
           "anyOf": [
             {
@@ -330,6 +350,7 @@
           ]
         },
         "url": {
+          "description": "Registry base URL (e.g. `registry-1.docker.io`, `123456789012.dkr.ecr.us-east-1.amazonaws.com`).",
           "type": "string"
         }
       }
@@ -380,9 +401,11 @@
       ]
     },
     "TagsConfig": {
+      "description": "Tag filter and selection rules for a mapping.",
       "type": "object",
       "properties": {
         "exclude": {
+          "description": "Exclude tags matching one or more glob patterns.",
           "default": null,
           "anyOf": [
             {
@@ -394,6 +417,7 @@
           ]
         },
         "glob": {
+          "description": "Include tags matching one or more glob patterns.",
           "default": null,
           "anyOf": [
             {
@@ -405,6 +429,7 @@
           ]
         },
         "latest": {
+          "description": "Keep only the N most recent tags after sorting.",
           "default": null,
           "type": [
             "integer",
@@ -414,6 +439,7 @@
           "minimum": 0.0
         },
         "min_tags": {
+          "description": "Minimum number of tags to retain regardless of filters.",
           "default": null,
           "type": [
             "integer",
@@ -423,6 +449,7 @@
           "minimum": 0.0
         },
         "semver": {
+          "description": "Include tags matching a semver range (e.g. `>=1.0, <2.0`).",
           "default": null,
           "type": [
             "string",
@@ -430,6 +457,7 @@
           ]
         },
         "semver_prerelease": {
+          "description": "Whether to include or exclude semver pre-release tags.",
           "default": null,
           "anyOf": [
             {
@@ -441,6 +469,7 @@
           ]
         },
         "sort": {
+          "description": "Sort order applied before `latest` truncation.",
           "default": null,
           "anyOf": [
             {
@@ -454,11 +483,14 @@
       }
     },
     "TargetsValue": {
+      "description": "Target specification: either a named group or an inline list of registry aliases.",
       "anyOf": [
         {
+          "description": "A single target group name defined in `target_groups`.",
           "type": "string"
         },
         {
+          "description": "An inline list of registry aliases.",
           "type": "array",
           "items": {
             "type": "string"

--- a/docs/src/content/cli-reference.md
+++ b/docs/src/content/cli-reference.md
@@ -24,7 +24,7 @@ ocync version                           Print version and build info
 
 | Flag | Description |
 |---|---|
-| `-v` / `--verbose` | Increase log verbosity (`-v` debug, `-vv` trace) |
+| `-v` / `--verbose` | Increase log verbosity (`-v` debug, `-vv` or higher trace) |
 | `-q`, `--quiet` | Suppress all output except errors |
 | `--log-format` | Set log format: `text` (default) or `json` (auto-detected in Kubernetes) |
 

--- a/docs/src/content/configuration.md
+++ b/docs/src/content/configuration.md
@@ -391,12 +391,14 @@ The schema is generated from the Rust config types and verified in CI to stay in
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Config",
+  "description": "Top-level configuration defining registries, mappings, and sync behavior.",
   "type": "object",
   "required": [
     "mappings"
   ],
   "properties": {
     "defaults": {
+      "description": "Default source, targets, tags, and platforms inherited by all mappings.",
       "default": null,
       "anyOf": [
         {
@@ -420,12 +422,14 @@ The schema is generated from the Rust config types and verified in CI to stay in
       ]
     },
     "mappings": {
+      "description": "Image mapping rules defining what to sync and where.",
       "type": "array",
       "items": {
         "$ref": "#/definitions/MappingConfig"
       }
     },
     "registries": {
+      "description": "Named registry definitions keyed by alias.",
       "default": {},
       "type": "object",
       "additionalProperties": {
@@ -433,6 +437,7 @@ The schema is generated from the Rust config types and verified in CI to stay in
       }
     },
     "target_groups": {
+      "description": "Named groups of registry aliases for multi-target fanout.",
       "default": {},
       "type": "object",
       "additionalProperties": {
@@ -524,6 +529,7 @@ The schema is generated from the Rust config types and verified in CI to stay in
       }
     },
     "DefaultsConfig": {
+      "description": "Default values inherited by all mappings unless individually overridden.",
       "type": "object",
       "properties": {
         "platforms": {
@@ -538,6 +544,7 @@ The schema is generated from the Rust config types and verified in CI to stay in
           }
         },
         "source": {
+          "description": "Default source registry alias for all mappings.",
           "default": null,
           "type": [
             "string",
@@ -545,6 +552,7 @@ The schema is generated from the Rust config types and verified in CI to stay in
           ]
         },
         "tags": {
+          "description": "Default tag filter rules inherited by mappings without their own.",
           "default": null,
           "anyOf": [
             {
@@ -556,6 +564,7 @@ The schema is generated from the Rust config types and verified in CI to stay in
           ]
         },
         "targets": {
+          "description": "Default target registry alias or group for all mappings.",
           "default": null,
           "anyOf": [
             {
@@ -569,11 +578,14 @@ The schema is generated from the Rust config types and verified in CI to stay in
       }
     },
     "GlobOrList": {
+      "description": "A glob pattern: either a single string or a list of patterns.",
       "anyOf": [
         {
+          "description": "A single glob pattern string.",
           "type": "string"
         },
         {
+          "description": "Multiple glob pattern strings.",
           "type": "array",
           "items": {
             "type": "string"
@@ -616,12 +628,14 @@ The schema is generated from the Rust config types and verified in CI to stay in
       }
     },
     "MappingConfig": {
+      "description": "A single image mapping rule: source repo, target registries, and tag filters.",
       "type": "object",
       "required": [
         "from"
       ],
       "properties": {
         "from": {
+          "description": "Source repository path (e.g. `library/nginx`).",
           "type": "string"
         },
         "platforms": {
@@ -636,6 +650,7 @@ The schema is generated from the Rust config types and verified in CI to stay in
           }
         },
         "source": {
+          "description": "Source registry alias, overriding `defaults.source`.",
           "default": null,
           "type": [
             "string",
@@ -643,6 +658,7 @@ The schema is generated from the Rust config types and verified in CI to stay in
           ]
         },
         "tags": {
+          "description": "Tag filter rules for this mapping, overriding `defaults.tags`.",
           "default": null,
           "anyOf": [
             {
@@ -654,6 +670,7 @@ The schema is generated from the Rust config types and verified in CI to stay in
           ]
         },
         "targets": {
+          "description": "Target registry alias or group, overriding `defaults.targets`.",
           "default": null,
           "anyOf": [
             {
@@ -665,6 +682,7 @@ The schema is generated from the Rust config types and verified in CI to stay in
           ]
         },
         "to": {
+          "description": "Destination repository path; defaults to `from` when absent.",
           "default": null,
           "type": [
             "string",
@@ -674,12 +692,14 @@ The schema is generated from the Rust config types and verified in CI to stay in
       }
     },
     "RegistryConfig": {
+      "description": "Per-registry settings: URL, auth method, concurrency, and credentials.",
       "type": "object",
       "required": [
         "url"
       ],
       "properties": {
         "auth_type": {
+          "description": "Authentication method to use for this registry.",
           "default": null,
           "anyOf": [
             {
@@ -720,6 +740,7 @@ The schema is generated from the Rust config types and verified in CI to stay in
           ]
         },
         "url": {
+          "description": "Registry base URL (e.g. `registry-1.docker.io`, `123456789012.dkr.ecr.us-east-1.amazonaws.com`).",
           "type": "string"
         }
       }
@@ -770,9 +791,11 @@ The schema is generated from the Rust config types and verified in CI to stay in
       ]
     },
     "TagsConfig": {
+      "description": "Tag filter and selection rules for a mapping.",
       "type": "object",
       "properties": {
         "exclude": {
+          "description": "Exclude tags matching one or more glob patterns.",
           "default": null,
           "anyOf": [
             {
@@ -784,6 +807,7 @@ The schema is generated from the Rust config types and verified in CI to stay in
           ]
         },
         "glob": {
+          "description": "Include tags matching one or more glob patterns.",
           "default": null,
           "anyOf": [
             {
@@ -795,6 +819,7 @@ The schema is generated from the Rust config types and verified in CI to stay in
           ]
         },
         "latest": {
+          "description": "Keep only the N most recent tags after sorting.",
           "default": null,
           "type": [
             "integer",
@@ -804,6 +829,7 @@ The schema is generated from the Rust config types and verified in CI to stay in
           "minimum": 0.0
         },
         "min_tags": {
+          "description": "Minimum number of tags to retain regardless of filters.",
           "default": null,
           "type": [
             "integer",
@@ -813,6 +839,7 @@ The schema is generated from the Rust config types and verified in CI to stay in
           "minimum": 0.0
         },
         "semver": {
+          "description": "Include tags matching a semver range (e.g. `>=1.0, <2.0`).",
           "default": null,
           "type": [
             "string",
@@ -820,6 +847,7 @@ The schema is generated from the Rust config types and verified in CI to stay in
           ]
         },
         "semver_prerelease": {
+          "description": "Whether to include or exclude semver pre-release tags.",
           "default": null,
           "anyOf": [
             {
@@ -831,6 +859,7 @@ The schema is generated from the Rust config types and verified in CI to stay in
           ]
         },
         "sort": {
+          "description": "Sort order applied before `latest` truncation.",
           "default": null,
           "anyOf": [
             {
@@ -844,11 +873,14 @@ The schema is generated from the Rust config types and verified in CI to stay in
       }
     },
     "TargetsValue": {
+      "description": "Target specification: either a named group or an inline list of registry aliases.",
       "anyOf": [
         {
+          "description": "A single target group name defined in `target_groups`.",
           "type": "string"
         },
         {
+          "description": "An inline list of registry aliases.",
           "type": "array",
           "items": {
             "type": "string"

--- a/docs/src/content/design/engine.md
+++ b/docs/src/content/design/engine.md
@@ -57,7 +57,7 @@ The primary bottleneck for Chainguard -> multi-region ECR is the target side: EC
 
 **PutImage pipeline smoothing.** As early images complete blob transfers and push manifests (consuming PutImage tokens at 10 TPS), later images' blob transfers proceed unblocked. The pipeline naturally spreads PutImage load across the full sync duration rather than concentrating it at the end.
 
-**Immediate execution start.** Execution begins after ~1 second of discovery instead of waiting 10-20 seconds for all discovery to complete. For a minutes-long sync this is a small but free improvement. For Docker Hub as a secondary source (100 manifest GETs / hour authenticated), the pipeline is even more valuable: discovery can take hours, and execution proceeds on already-discovered images while discovery is rate-limited.
+**Immediate execution start.** Execution begins after ~1 second of discovery instead of waiting 10-20 seconds for all discovery to complete. For a minutes-long sync this is a small but free improvement. For Docker Hub as a secondary source (100 manifest GETs / 6 hours authenticated), the pipeline is even more valuable: discovery can take hours, and execution proceeds on already-discovered images while discovery is rate-limited.
 
 ### Select loop discipline
 
@@ -116,7 +116,7 @@ Actions are fine-grained, matching the actual API action granularity of each reg
 | Registry | Windows | Rationale |
 |---|---|---|
 | ECR | 9 (one per action) | Critical: `InitiateLayerUpload` (100 TPS) and `UploadLayerPart` (500 TPS) have a 5x rate disparity, so a 429 on session initiation must not throttle chunk uploads |
-| Docker Hub | 3 (HEAD unmetered; manifest-read separate; others shared) | HEAD and BlobHead are free (no rate limit). ManifestRead gets its own window (counted against 200-pull/6h quota). Other actions share one window |
+| Docker Hub | 3 (HEAD unmetered; manifest-read separate; others shared) | HEAD and BlobHead are free (no rate limit). ManifestRead gets its own window (counted against 100-pull/6h quota). Other actions share one window |
 | GAR | 1 (all shared) | GAR uses a shared per-project quota across all operation types; initial window of 5, grows adaptively to `max_concurrent` |
 | ACR, GHCR, others | 5 (HEAD, READ, UPLOAD, MANIFEST_WRITE, TAG_LIST) | Coarse grouping as safe default for registries without documented per-action limits |
 
@@ -150,7 +150,7 @@ The greedy set-cover provably covers every shared blob. No "uncovered follower" 
 
 AWS launched opt-in `BLOB_MOUNTING` account setting in January 2026. Enable via `aws ecr put-account-setting --name BLOB_MOUNTING --value ENABLED`. Mount POST returns 201 when all conditions are met: BLOB_MOUNTING is ENABLED on the account, the source blob is referenced by a committed manifest (standalone blobs without manifests return 202), the `from` parameter specifies the source repo name, and both repos have identical encryption config (AES256 default works). Requirements: same account + region, identical encryption config, pusher needs `ecr:GetDownloadUrlForLayer` on source repo. Not supported for pull-through cache repos.
 
-Mount attempts are made unconditionally regardless of provider; the 202 fallback is cheap (~100ms) and successful mounts save entire blob uploads. `ProviderKind::fulfills_cross_repo_mount()` exists as a compile-time exhaustiveness guard (exhaustive `match` forces a decision when adding a new provider) but currently returns `true` for all variants and has zero callers.
+Mount attempts are made unconditionally regardless of provider; the 202 fallback is cheap (~100ms) and successful mounts save entire blob uploads.
 
 ### Measured impact
 

--- a/docs/src/content/design/overview.md
+++ b/docs/src/content/design/overview.md
@@ -122,7 +122,7 @@ For single-target mappings, bytes stream directly from source to target with no 
 |---|---|---|---|
 | ECR (private) | Yes (opt-in, same account/region) | Yes (BatchCheck, BatchGet, ListImages) | Per-action TPS (10-3000) |
 | ECR Public | No | Partial (BatchCheck only) | Separate from private |
-| Docker Hub | Yes (implicit global dedup) | No | 200-pull/6h authed manifest GETs; HEADs free |
+| Docker Hub | Yes (implicit global dedup) | No | 100-pull/6h authed manifest GETs; HEADs free |
 | GAR | No | No | Per-project shared quota |
 | GHCR | Yes (implicit global dedup) | No | GitHub API rate limit |
 | ACR | Yes | No | Per-registry |
@@ -130,7 +130,7 @@ For single-target mappings, bytes stream directly from source to target with no 
 
 ### Docker Hub rate limits
 
-Docker Hub tightened limits in April 2025: 10 pulls/hour anonymous, 200 pulls/6 hours authenticated free, unlimited for paid tiers. Only manifest GETs count; blob GETs are free (CDN-served) and manifest HEADs are free (subject to a separate abuse limit). Authentication is mandatory for any serious sync workload.
+Docker Hub tightened limits in April 2025: 10 pulls/hour anonymous, 100 pulls/6 hours authenticated free, unlimited for paid tiers. Only manifest GETs count; blob GETs are free (CDN-served) and manifest HEADs are free (subject to a separate abuse limit). Authentication is mandatory for any serious sync workload.
 
 ### ECR rate limits
 

--- a/docs/src/content/performance.md
+++ b/docs/src/content/performance.md
@@ -73,6 +73,8 @@ Measured 2026-04-20 on c6in.4xlarge (x86_64, 16 vCPUs, 32 GiB, Up to 50 Gigabit)
 | Rate-limit 429s | **0** | **0** | **0** |
 <!-- BENCH-WARM:END -->
 
+> **Note:** `ocync` performs full target HEAD verification on every warm cycle to detect out-of-band changes (e.g., images deleted by lifecycle policies or modified by other tools), ensuring correctness at the cost of additional requests. Alternatives that achieve faster warm sync times typically use tag list caching, which is faster but can miss changes made outside the tool.
+
 ## Why `ocync` is fast
 
 ### Pipelined architecture

--- a/src/cli/commands/analyze.rs
+++ b/src/cli/commands/analyze.rs
@@ -16,8 +16,11 @@ use ocync_distribution::ecr::BatchBlobChecker;
 use ocync_distribution::spec::ManifestKind;
 use ocync_distribution::{Digest, RepositoryName};
 
+use ocync_sync::ShutdownSignal;
+
 use crate::cli::commands::synchronize::{build_clients, resolve_mapping};
 use crate::cli::config::load_config;
+use crate::cli::output::format_bytes;
 use crate::cli::{CliError, ExitCode};
 
 /// Arguments for the `analyze` subcommand.
@@ -45,7 +48,10 @@ struct BlobAggregate {
 }
 
 /// Run the analyze command.
-pub(crate) async fn run(args: &AnalyzeArgs) -> Result<ExitCode, CliError> {
+pub(crate) async fn run(
+    args: &AnalyzeArgs,
+    shutdown: &ShutdownSignal,
+) -> Result<ExitCode, CliError> {
     let config = load_config(&args.config)?;
     let clients = build_clients(&config).await?;
     // Analyze doesn't push anything, so no batch checkers needed.
@@ -55,14 +61,25 @@ pub(crate) async fn run(args: &AnalyzeArgs) -> Result<ExitCode, CliError> {
     let mut image_count = 0usize;
 
     for mapping in &config.mappings {
+        if shutdown.is_triggered() {
+            tracing::info!("shutdown signal received, stopping analysis early");
+            break;
+        }
+
         let resolved = match resolve_mapping(mapping, &config, &clients, &no_checkers).await? {
             Some(r) => r,
             None => continue,
         };
 
         for tag_pair in &resolved.tags {
+            if shutdown.is_triggered() {
+                tracing::info!("shutdown signal received, stopping analysis early");
+                break;
+            }
+
             image_count += 1;
             let image_ref = format!("{}:{}", resolved.source_repo, tag_pair.source);
+            tracing::info!(image = %image_ref, "analyzing");
             collect_blobs(
                 &resolved.source_client,
                 &resolved.source_repo,
@@ -199,6 +216,24 @@ fn record_blob(
 // Output
 // ---------------------------------------------------------------------------
 
+/// Compute per-target-registry mount savings: count of redundant pushes and
+/// total bytes that cross-repo mount would avoid.
+fn compute_mount_savings(blobs: &HashMap<Digest, BlobAggregate>) -> BTreeMap<String, (usize, u64)> {
+    let mut savings: BTreeMap<String, (usize, u64)> = BTreeMap::new();
+    for blob in blobs.values() {
+        for (target, repos) in &blob.target_repos {
+            if repos.len() > 1 {
+                let count = repos.len() - 1;
+                let bytes = blob.size * count as u64;
+                let entry = savings.entry(target.clone()).or_default();
+                entry.0 += count;
+                entry.1 += bytes;
+            }
+        }
+    }
+    savings
+}
+
 fn print_text(blobs: &HashMap<Digest, BlobAggregate>, image_count: usize) {
     let total_blobs = blobs.len();
     let total_bytes: u64 = blobs.values().map(|b| b.size).sum();
@@ -206,22 +241,7 @@ fn print_text(blobs: &HashMap<Digest, BlobAggregate>, image_count: usize) {
     let shared: Vec<&BlobAggregate> = blobs.values().filter(|b| b.images.len() > 1).collect();
     let shared_bytes: u64 = shared.iter().map(|b| b.size).sum();
 
-    // Cross-repo mount opportunity: per target registry, count blobs whose
-    // target_repos set has more than one repo - those are the mount candidates
-    // (a blob pushed once can be mounted into every other repo in the set).
-    let mut mount_savings_by_target: BTreeMap<String, (usize, u64)> = BTreeMap::new();
-    for blob in blobs.values() {
-        for (target, repos) in &blob.target_repos {
-            if repos.len() > 1 {
-                // One blob, pushed once, then mounted into (repos.len() - 1) other repos.
-                let savings_count = repos.len() - 1;
-                let savings_bytes = blob.size * savings_count as u64;
-                let entry = mount_savings_by_target.entry(target.clone()).or_default();
-                entry.0 += savings_count;
-                entry.1 += savings_bytes;
-            }
-        }
-    }
+    let mount_savings_by_target = compute_mount_savings(blobs);
 
     println!("Analyzed {image_count} image mappings");
     println!();
@@ -247,18 +267,7 @@ fn print_text(blobs: &HashMap<Digest, BlobAggregate>, image_count: usize) {
 }
 
 fn print_json(blobs: &HashMap<Digest, BlobAggregate>, image_count: usize) -> Result<(), CliError> {
-    let mut mount_savings_by_target: BTreeMap<String, (usize, u64)> = BTreeMap::new();
-    for blob in blobs.values() {
-        for (target, repos) in &blob.target_repos {
-            if repos.len() > 1 {
-                let savings_count = repos.len() - 1;
-                let savings_bytes = blob.size * savings_count as u64;
-                let entry = mount_savings_by_target.entry(target.clone()).or_default();
-                entry.0 += savings_count;
-                entry.1 += savings_bytes;
-            }
-        }
-    }
+    let mount_savings_by_target = compute_mount_savings(blobs);
 
     let report = serde_json::json!({
         "images_analyzed": image_count,
@@ -278,20 +287,4 @@ fn print_json(blobs: &HashMap<Digest, BlobAggregate>, image_count: usize) -> Res
             .map_err(|e| CliError::Input(format!("serialize report: {e}")))?
     );
     Ok(())
-}
-
-/// Format bytes with SI decimal prefixes (1 KB = 1000 B).
-fn format_bytes(bytes: u64) -> String {
-    const GB: u64 = 1_000_000_000;
-    const MB: u64 = 1_000_000;
-    const KB: u64 = 1_000;
-    if bytes >= GB {
-        format!("{:.1} GB", bytes as f64 / GB as f64)
-    } else if bytes >= MB {
-        format!("{:.1} MB", bytes as f64 / MB as f64)
-    } else if bytes >= KB {
-        format!("{:.1} KB", bytes as f64 / KB as f64)
-    } else {
-        format!("{bytes} B")
-    }
 }

--- a/src/cli/commands/copy.rs
+++ b/src/cli/commands/copy.rs
@@ -4,21 +4,28 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use ocync_distribution::RepositoryName;
 use ocync_sync::cache::TransferStateCache;
 use ocync_sync::engine::{
     DEFAULT_MAX_CONCURRENT_TRANSFERS, RegistryAlias, ResolvedMapping, SyncEngine, TagPair,
     TargetEntry,
 };
 use ocync_sync::retry::RetryConfig;
+use ocync_sync::shutdown::ShutdownSignal;
 use ocync_sync::staging::BlobStage;
 
 use crate::CopyArgs;
-use crate::cli::{CliError, ExitCode, bare_hostname, build_registry_client};
+use crate::cli::config::load_config;
+use crate::cli::{CliError, ExitCode, bare_hostname, build_registry_client, endpoint_host};
 
 /// Run the copy command: transfer a single image from source to destination.
+///
+/// The `shutdown` signal, if provided, will be forwarded to the engine for
+/// graceful drain on SIGINT/SIGTERM.
 pub(crate) async fn run(
     args: &CopyArgs,
     progress: &dyn ocync_sync::progress::ProgressReporter,
+    shutdown: Option<&ShutdownSignal>,
 ) -> Result<ExitCode, CliError> {
     let src_tag = args
         .source
@@ -26,10 +33,30 @@ pub(crate) async fn run(
         .ok_or_else(|| CliError::Input(format!("source '{}' has no tag", args.source)))?;
     let dst_tag = args.destination.tag().unwrap_or(src_tag);
 
-    let source_client =
-        Arc::new(build_registry_client(bare_hostname(args.source.registry()), None).await?);
-    let target_client =
-        Arc::new(build_registry_client(bare_hostname(args.destination.registry()), None).await?);
+    // Resolve auth settings from config if provided, otherwise use auto-detection.
+    let registries = if let Some(ref config_path) = args.config {
+        let config = load_config(config_path)?;
+        config.registries.into_values().collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+
+    let normalized_src = endpoint_host(bare_hostname(args.source.registry()));
+    let src_reg_config = registries
+        .iter()
+        .find(|r| endpoint_host(bare_hostname(&r.url)) == normalized_src);
+
+    let normalized_dst = endpoint_host(bare_hostname(args.destination.registry()));
+    let dst_reg_config = registries
+        .iter()
+        .find(|r| endpoint_host(bare_hostname(&r.url)) == normalized_dst);
+
+    let source_client = Arc::new(
+        build_registry_client(bare_hostname(args.source.registry()), src_reg_config).await?,
+    );
+    let target_client = Arc::new(
+        build_registry_client(bare_hostname(args.destination.registry()), dst_reg_config).await?,
+    );
 
     let source_authority = source_client
         .registry_authority()
@@ -38,8 +65,8 @@ pub(crate) async fn run(
     let mapping = ResolvedMapping {
         source_authority,
         source_client,
-        source_repo: args.source.repository().into(),
-        target_repo: args.destination.repository().into(),
+        source_repo: RepositoryName::new(args.source.repository())?,
+        target_repo: RepositoryName::new(args.destination.repository())?,
         targets: vec![TargetEntry {
             name: RegistryAlias::new(bare_hostname(args.destination.registry())),
             client: target_client,
@@ -54,12 +81,8 @@ pub(crate) async fn run(
     // Single-target copy: staging is not needed.
     let staging = BlobStage::disabled();
     let report = engine
-        .run(vec![mapping], cache, staging, progress, None)
+        .run(vec![mapping], cache, staging, progress, shutdown)
         .await;
 
-    match report.exit_code() {
-        0 => Ok(ExitCode::Success),
-        1 => Ok(ExitCode::PartialFailure),
-        _ => Ok(ExitCode::Failure),
-    }
+    Ok(ExitCode::from_report(report.exit_code()))
 }

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -54,13 +54,18 @@ pub(crate) fn resolve_cache_path(config: &Config, config_file: &Path) -> (PathBu
 }
 
 /// Parse and return the cache TTL from config, defaulting to 12 hours.
-pub(crate) fn resolve_cache_ttl(config: &Config) -> Duration {
-    config
-        .global
-        .as_ref()
-        .and_then(|g| g.cache_ttl.as_deref())
-        .and_then(parse_duration)
-        .unwrap_or(DEFAULT_CACHE_TTL)
+///
+/// Returns an error if the configured value cannot be parsed, rather than
+/// silently falling back to the default.
+pub(crate) fn resolve_cache_ttl(config: &Config) -> Result<Duration, CliError> {
+    match config.global.as_ref().and_then(|g| g.cache_ttl.as_deref()) {
+        Some(raw) => parse_duration(raw.trim()).ok_or_else(|| {
+            CliError::Input(format!(
+                "invalid cache_ttl '{raw}': accepted formats are \"0\", \"<N>s\", \"<N>m\", \"<N>h\", \"<N>d\", or \"<N>\" (seconds)"
+            ))
+        }),
+        None => Ok(DEFAULT_CACHE_TTL),
+    }
 }
 
 /// Run the sync command: load config, resolve mappings, and execute.
@@ -93,7 +98,7 @@ pub(crate) async fn run(
     }
 
     let (cache_dir, cache_path) = resolve_cache_path(&config, &args.config);
-    let cache_ttl = resolve_cache_ttl(&config);
+    let cache_ttl = resolve_cache_ttl(&config)?;
     let (cache, should_persist) = match external_cache {
         Some(ext) => (ext, false),
         None => {
@@ -121,12 +126,19 @@ pub(crate) async fn run(
             tracing::warn!(error = %e, "failed to clean staging tmp files");
         }
         // Evict stale blobs from previous runs before starting new work.
-        if let Some(limit) = config
+        let staging_limit = match config
             .global
             .as_ref()
             .and_then(|g| g.staging_size_limit.as_deref())
-            .and_then(parse_size)
         {
+            Some(raw) => Some(parse_size(raw.trim()).ok_or_else(|| {
+                CliError::Input(format!(
+                    "invalid staging_size_limit '{raw}': accepted formats are \"0\", \"<N>B\", \"<N>KB\", \"<N>MB\", \"<N>GB\", \"<N>TB\""
+                ))
+            })?),
+            None => None,
+        };
+        if let Some(limit) = staging_limit {
             if let Err(e) = stage.evict(limit) {
                 tracing::warn!(error = %e, "failed to evict staged blobs");
             }
@@ -156,11 +168,7 @@ pub(crate) async fn run(
 
     write_output(&report, args.json)?;
 
-    match report.exit_code() {
-        0 => Ok(ExitCode::Success),
-        1 => Ok(ExitCode::PartialFailure),
-        _ => Ok(ExitCode::Failure),
-    }
+    Ok(ExitCode::from_report(report.exit_code()))
 }
 
 /// Parse a human-readable duration string into a [`Duration`].
@@ -176,6 +184,7 @@ pub(crate) async fn run(
 /// Returns `None` for unrecognised strings - callers must decide how to
 /// handle invalid input rather than silently receiving a default.
 fn parse_duration(s: &str) -> Option<Duration> {
+    let s = s.trim();
     if s == "0" {
         return Some(Duration::ZERO);
     }
@@ -202,6 +211,7 @@ fn parse_duration(s: &str) -> Option<Duration> {
 /// Accepts `"0"`, `"<N>B"`, `"<N>KB"`, `"<N>MB"`, `"<N>GB"`, `"<N>TB"`.
 /// Returns `None` for unrecognised strings.
 fn parse_size(s: &str) -> Option<u64> {
+    let s = s.trim();
     if s == "0" {
         return Some(0);
     }
@@ -327,7 +337,7 @@ pub(crate) async fn resolve_mapping(
         .collect::<Result<Vec<_>, CliError>>()?;
 
     // --- Fetch and filter tags ---
-    let source_repo_path = RepositoryName::new(&mapping.from);
+    let source_repo_path = RepositoryName::new(&mapping.from)?;
     let all_tags = source_client.list_tags(&source_repo_path).await?;
 
     let tags_config = mapping
@@ -370,8 +380,8 @@ pub(crate) async fn resolve_mapping(
     Ok(Some(ResolvedMapping {
         source_authority,
         source_client,
-        source_repo: mapping.from.clone().into(),
-        target_repo: target_repo.into(),
+        source_repo: RepositoryName::new(mapping.from.clone())?,
+        target_repo: RepositoryName::new(target_repo)?,
         targets,
         tags: filtered.into_iter().map(TagPair::same).collect(),
         platforms,
@@ -480,6 +490,49 @@ mod tests {
         assert_eq!(parse_duration("invalid"), None);
         assert_eq!(parse_duration(""), None);
         assert_eq!(parse_duration("12hours"), None);
+    }
+
+    #[test]
+    fn parse_duration_trims_whitespace() {
+        assert_eq!(
+            parse_duration("  12h  "),
+            Some(Duration::from_secs(12 * 3600))
+        );
+        assert_eq!(parse_duration(" 30m "), Some(Duration::from_secs(30 * 60)));
+    }
+
+    #[test]
+    fn resolve_cache_ttl_returns_error_for_invalid() {
+        use crate::cli::config::{Config, GlobalConfig};
+
+        let config = Config {
+            global: Some(GlobalConfig {
+                cache_ttl: Some("bogus".into()),
+                ..Default::default()
+            }),
+            registries: Default::default(),
+            target_groups: Default::default(),
+            defaults: None,
+            mappings: Vec::new(),
+        };
+        let result = resolve_cache_ttl(&config);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("invalid cache_ttl"), "got: {err_msg}");
+    }
+
+    #[test]
+    fn resolve_cache_ttl_returns_default_when_absent() {
+        use crate::cli::config::Config;
+
+        let config = Config {
+            global: None,
+            registries: Default::default(),
+            target_groups: Default::default(),
+            defaults: None,
+            mappings: Vec::new(),
+        };
+        assert_eq!(resolve_cache_ttl(&config).unwrap(), DEFAULT_CACHE_TTL);
     }
 
     #[test]
@@ -600,5 +653,11 @@ mod tests {
         assert_eq!(parse_size("2gigabytes"), None);
         assert_eq!(parse_size(""), None);
         assert_eq!(parse_size("abc"), None);
+    }
+
+    #[test]
+    fn parse_size_trims_whitespace() {
+        assert_eq!(parse_size("  500MB  "), Some(500_000_000));
+        assert_eq!(parse_size(" 2GB "), Some(2_000_000_000));
     }
 }

--- a/src/cli/commands/tags.rs
+++ b/src/cli/commands/tags.rs
@@ -5,26 +5,30 @@ use ocync_sync::filter::FilterConfig;
 
 use crate::TagsArgs;
 use crate::cli::config::load_config;
-use crate::cli::{CliError, ExitCode, bare_hostname, build_registry_client};
+use crate::cli::{CliError, ExitCode, bare_hostname, build_registry_client, endpoint_host};
 
 pub(crate) async fn run(args: &TagsArgs) -> Result<ExitCode, CliError> {
     let registry = args.repository.registry();
     let repository = args.repository.repository();
 
     // Resolve auth settings from config if provided, otherwise use anonymous.
+    // Normalize both sides through `endpoint_host` so that `docker.io` matches
+    // `registry-1.docker.io` (and vice versa) -- the same rewrite applied by
+    // the sync command's client builder.
+    let normalized_registry = endpoint_host(bare_hostname(registry));
     let reg_config = if let Some(ref config_path) = args.config {
         let config = load_config(config_path)?;
         config
             .registries
             .into_values()
-            .find(|r| bare_hostname(&r.url) == registry)
+            .find(|r| endpoint_host(bare_hostname(&r.url)) == normalized_registry)
     } else {
         None
     };
 
     let client = build_registry_client(registry, reg_config.as_ref()).await?;
 
-    let repo_path = RepositoryName::from(repository);
+    let repo_path = RepositoryName::new(repository)?;
     let all_tags = client.list_tags(&repo_path).await?;
 
     let filter = FilterConfig {

--- a/src/cli/commands/watch.rs
+++ b/src/cli/commands/watch.rs
@@ -26,26 +26,24 @@ pub(crate) async fn run(
 
     let health_state = Rc::new(RefCell::new(HealthState::new(interval)));
 
-    // Load config once upfront for cache path and TTL resolution.
-    // Uses the same resolution logic as the sync command.
+    // Resolve cache path and TTL from the initial config load. These are
+    // re-resolved each cycle so that config file changes take effect.
     let config = load_config(&args.config)?;
     let (_cache_dir, cache_path) = synchronize::resolve_cache_path(&config, &args.config);
-    let cache_ttl = synchronize::resolve_cache_ttl(&config);
+    let cache_ttl = synchronize::resolve_cache_ttl(&config)?;
 
     // Bind the health listener early so bind errors surface before the
     // sync loop starts. This also avoids TOCTOU races with port allocation.
-    let health_listener = match TcpListener::bind(("0.0.0.0", args.health_port)).await {
+    let health_listener = match TcpListener::bind((args.health_bind, args.health_port)).await {
         Ok(l) => {
             tracing::info!(port = args.health_port, "health server listening");
-            Some(l)
+            l
         }
         Err(err) => {
-            tracing::error!(
-                port = args.health_port,
-                error = %err,
-                "health server failed to bind, watch mode continuing without health endpoint"
-            );
-            None
+            return Err(CliError::Input(format!(
+                "health server failed to bind on port {}: {err} (check if another process is using this port)",
+                args.health_port,
+            )));
         }
     };
 
@@ -59,16 +57,81 @@ pub(crate) async fn run(
                 &cache_path,
                 cache_ttl,
             )));
+            // Track the active cache path so we can detect config changes.
+            let mut active_cache_path = cache_path;
 
             // Spawn the health server as a background local task.
-            let health_handle = health_listener.map(|listener| {
+            let health_handle = {
                 let state = Rc::clone(&health_state);
                 tokio::task::spawn_local(async move {
-                    crate::cli::health::serve(listener, state).await;
+                    crate::cli::health::serve(health_listener, state).await;
                 })
-            });
+            };
+
+            // Track consecutive config reload failures for backoff.
+            let mut config_failures: u32 = 0;
+            const BACKOFF_THRESHOLD: u32 = 3;
+            const MAX_BACKOFF_SECS: u64 = 300; // 5 minutes
 
             let exit_code = loop {
+                // Re-resolve cache_dir and cache_ttl each cycle so that
+                // config file edits (e.g. changing cache_dir or cache_ttl)
+                // take effect without restarting watch mode.
+                if let Ok(cfg) = load_config(&args.config) {
+                    config_failures = 0;
+                    let (_dir, path) = synchronize::resolve_cache_path(&cfg, &args.config);
+                    match synchronize::resolve_cache_ttl(&cfg) {
+                        Ok(ttl) => {
+                            // If the cache path changed, persist the old
+                            // cache and reload from the new location.
+                            if path != active_cache_path {
+                                if let Err(e) = cache.borrow().persist(&active_cache_path) {
+                                    tracing::warn!(
+                                        error = %e,
+                                        "failed to persist cache before path change"
+                                    );
+                                }
+                                *cache.borrow_mut() = TransferStateCache::load(&path, ttl);
+                                active_cache_path = path;
+                            }
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                error = %e,
+                                "invalid cache_ttl in reloaded config, using previous value"
+                            );
+                        }
+                    }
+                } else {
+                    config_failures += 1;
+                    tracing::error!(
+                        consecutive_failures = config_failures,
+                        "failed to reload config for cache resolution, using previous value"
+                    );
+
+                    // After repeated failures, apply exponential backoff
+                    // before the next cycle to avoid log spam.
+                    if config_failures >= BACKOFF_THRESHOLD {
+                        let backoff_secs = interval
+                            .as_secs()
+                            .saturating_mul(1 << (config_failures - BACKOFF_THRESHOLD).min(4))
+                            .min(MAX_BACKOFF_SECS);
+                        let backoff = Duration::from_secs(backoff_secs);
+                        tracing::warn!(
+                            backoff_secs = backoff.as_secs(),
+                            "config reload failing repeatedly, applying backoff"
+                        );
+                        tokio::select! {
+                            () = tokio::time::sleep(backoff) => {}
+                            () = shutdown.notified() => {
+                                tracing::info!("shutdown signal received during backoff");
+                                break ExitCode::Success;
+                            }
+                        }
+                        continue;
+                    }
+                }
+
                 let sync_args = SyncArgs {
                     config: args.config.clone(),
                     dry_run: false,
@@ -105,13 +168,11 @@ pub(crate) async fn run(
             };
 
             // Persist cache on graceful shutdown.
-            if let Err(e) = cache.borrow().persist(&cache_path) {
+            if let Err(e) = cache.borrow().persist(&active_cache_path) {
                 tracing::warn!(error = %e, "failed to persist cache on shutdown");
             }
 
-            if let Some(h) = health_handle {
-                h.abort();
-            }
+            health_handle.abort();
             exit_code
         })
         .await;

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -90,21 +90,26 @@ pub(crate) enum ConfigError {
 // Top-level config
 // ---------------------------------------------------------------------------
 
+/// Top-level configuration defining registries, mappings, and sync behavior.
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub(crate) struct Config {
     /// Global engine settings applied across all syncs.
     #[serde(default)]
     pub global: Option<GlobalConfig>,
 
+    /// Named registry definitions keyed by alias.
     #[serde(default)]
     pub registries: HashMap<String, RegistryConfig>,
 
+    /// Named groups of registry aliases for multi-target fanout.
     #[serde(default)]
     pub target_groups: HashMap<String, Vec<String>>,
 
+    /// Default source, targets, tags, and platforms inherited by all mappings.
     #[serde(default)]
     pub defaults: Option<DefaultsConfig>,
 
+    /// Image mapping rules defining what to sync and where.
     pub mappings: Vec<MappingConfig>,
 }
 
@@ -179,10 +184,13 @@ pub(crate) enum AuthType {
     DockerConfig,
 }
 
+/// Per-registry settings: URL, auth method, concurrency, and credentials.
 #[derive(Deserialize, Serialize, JsonSchema)]
 pub(crate) struct RegistryConfig {
+    /// Registry base URL (e.g. `registry-1.docker.io`, `123456789012.dkr.ecr.us-east-1.amazonaws.com`).
     pub url: String,
 
+    /// Authentication method to use for this registry.
     #[serde(default)]
     pub auth_type: Option<AuthType>,
 
@@ -236,14 +244,18 @@ impl std::fmt::Debug for BasicCredentials {
 // Defaults
 // ---------------------------------------------------------------------------
 
+/// Default values inherited by all mappings unless individually overridden.
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub(crate) struct DefaultsConfig {
+    /// Default source registry alias for all mappings.
     #[serde(default)]
     pub source: Option<String>,
 
+    /// Default target registry alias or group for all mappings.
     #[serde(default)]
     pub targets: Option<TargetsValue>,
 
+    /// Default tag filter rules inherited by mappings without their own.
     #[serde(default)]
     pub tags: Option<TagsConfig>,
 
@@ -259,19 +271,25 @@ pub(crate) struct DefaultsConfig {
 // Mappings
 // ---------------------------------------------------------------------------
 
+/// A single image mapping rule: source repo, target registries, and tag filters.
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub(crate) struct MappingConfig {
+    /// Source repository path (e.g. `library/nginx`).
     pub from: String,
 
+    /// Destination repository path; defaults to `from` when absent.
     #[serde(default)]
     pub to: Option<String>,
 
+    /// Source registry alias, overriding `defaults.source`.
     #[serde(default)]
     pub source: Option<String>,
 
+    /// Target registry alias or group, overriding `defaults.targets`.
     #[serde(default)]
     pub targets: Option<TargetsValue>,
 
+    /// Tag filter rules for this mapping, overriding `defaults.tags`.
     #[serde(default)]
     pub tags: Option<TagsConfig>,
 
@@ -287,10 +305,13 @@ pub(crate) struct MappingConfig {
 // TargetsValue - single group name or inline list
 // ---------------------------------------------------------------------------
 
+/// Target specification: either a named group or an inline list of registry aliases.
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(untagged)]
 pub(crate) enum TargetsValue {
+    /// A single target group name defined in `target_groups`.
     Group(String),
+    /// An inline list of registry aliases.
     List(Vec<String>),
 }
 
@@ -298,34 +319,45 @@ pub(crate) enum TargetsValue {
 // Tags
 // ---------------------------------------------------------------------------
 
+/// Tag filter and selection rules for a mapping.
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema)]
 pub(crate) struct TagsConfig {
+    /// Include tags matching one or more glob patterns.
     #[serde(default)]
     pub glob: Option<GlobOrList>,
 
+    /// Include tags matching a semver range (e.g. `>=1.0, <2.0`).
     #[serde(default)]
     pub semver: Option<String>,
 
+    /// Whether to include or exclude semver pre-release tags.
     #[serde(default)]
     pub semver_prerelease: Option<SemverPrerelease>,
 
+    /// Exclude tags matching one or more glob patterns.
     #[serde(default)]
     pub exclude: Option<GlobOrList>,
 
+    /// Sort order applied before `latest` truncation.
     #[serde(default)]
     pub sort: Option<SortOrder>,
 
+    /// Keep only the N most recent tags after sorting.
     #[serde(default)]
     pub latest: Option<usize>,
 
+    /// Minimum number of tags to retain regardless of filters.
     #[serde(default)]
     pub min_tags: Option<usize>,
 }
 
+/// A glob pattern: either a single string or a list of patterns.
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(untagged)]
 pub(crate) enum GlobOrList {
+    /// A single glob pattern string.
     Single(String),
+    /// Multiple glob pattern strings.
     List(Vec<String>),
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -50,6 +50,17 @@ pub(crate) enum ExitCode {
     AuthError,
 }
 
+impl ExitCode {
+    /// Map a [`SyncReport`](ocync_sync::SyncReport) exit code to a CLI exit code.
+    pub(crate) fn from_report(code: i32) -> Self {
+        match code {
+            0 => Self::Success,
+            1 => Self::PartialFailure,
+            _ => Self::Failure,
+        }
+    }
+}
+
 impl From<ExitCode> for std::process::ExitCode {
     fn from(code: ExitCode) -> Self {
         match code {
@@ -91,6 +102,7 @@ impl CliError {
     pub(crate) fn exit_code(&self) -> ExitCode {
         match self {
             Self::Config(_) => ExitCode::ConfigError,
+            Self::Filter(_) => ExitCode::ConfigError,
             Self::Registry(e) if e.is_auth_error() => ExitCode::AuthError,
             _ => ExitCode::Failure,
         }
@@ -189,32 +201,26 @@ pub(crate) async fn build_registry_client(
             let tok = registry_config
                 .and_then(|r| r.token.as_deref())
                 .expect("token auth requires token field (validated)");
-            let auth = StaticTokenAuth::new(tok);
+            let auth = StaticTokenAuth::new(endpoint, tok);
             RegistryClient::builder(url).auth(auth)
         }
-        Some(AuthType::Ghcr | AuthType::Gcr | AuthType::Acr) => {
-            // These registries will eventually have native providers (OAuth2, GITHUB_TOKEN).
-            // For now, resolve credentials from docker config - covers PATs and helper-stored creds.
-            tracing::debug!(
-                registry = bare_host,
-                auth_type = ?auth_type,
-                "using docker config credential resolution for registry provider"
-            );
+        Some(AuthType::Ghcr | AuthType::Gcr | AuthType::Acr | AuthType::DockerConfig) => {
+            if matches!(
+                auth_type,
+                Some(AuthType::Ghcr | AuthType::Gcr | AuthType::Acr)
+            ) {
+                tracing::debug!(
+                    registry = bare_host,
+                    auth_type = ?auth_type,
+                    "using docker config credential resolution for registry provider"
+                );
+            }
             let docker_config = DockerConfig::load_default().map_err(|e| {
                 CliError::Input(format!(
                     "failed to load docker config for '{bare_host}': {e}"
                 ))
             })?;
-            let auth = DockerConfigAuth::new(endpoint, &docker_config, http)?;
-            RegistryClient::builder(url).auth(auth)
-        }
-        Some(AuthType::DockerConfig) => {
-            let docker_config = DockerConfig::load_default().map_err(|e| {
-                CliError::Input(format!(
-                    "failed to load docker config for '{bare_host}': {e}"
-                ))
-            })?;
-            let auth = DockerConfigAuth::new(endpoint, &docker_config, http)?;
+            let auth = DockerConfigAuth::new(endpoint, &docker_config, http).await?;
             RegistryClient::builder(url).auth(auth)
         }
         Some(AuthType::Anonymous) => {
@@ -235,11 +241,13 @@ pub(crate) async fn build_registry_client(
                 // Try docker config - falls back to anonymous exchange if no creds found.
                 match DockerConfig::load_default() {
                     Ok(config) => {
-                        let auth = DockerConfigAuth::new(endpoint, &config, http).map_err(|e| {
-                            CliError::Input(format!(
-                                "docker config credential resolution for '{bare_host}': {e}"
-                            ))
-                        })?;
+                        let auth = DockerConfigAuth::new(endpoint, &config, http)
+                            .await
+                            .map_err(|e| {
+                                CliError::Input(format!(
+                                    "docker config credential resolution for '{bare_host}': {e}"
+                                ))
+                            })?;
                         RegistryClient::builder(url).auth(auth)
                     }
                     Err(_) => {
@@ -427,7 +435,7 @@ mod tests {
     #[test]
     fn cli_error_exit_code_filter() {
         let err = CliError::Filter(ocync_sync::Error::LatestWithoutSort);
-        assert_eq!(err.exit_code(), ExitCode::Failure);
+        assert_eq!(err.exit_code(), ExitCode::ConfigError);
     }
 
     #[test]

--- a/src/cli/progress.rs
+++ b/src/cli/progress.rs
@@ -300,6 +300,7 @@ mod tests {
                 kind: ErrorKind::ManifestPush,
                 error: "connection refused".into(),
                 retries: 3,
+                status_code: None,
             },
             0,
         );
@@ -316,6 +317,7 @@ mod tests {
                 kind: ErrorKind::BlobTransfer,
                 error: "timeout".into(),
                 retries: 1,
+                status_code: None,
             },
             0,
         );
@@ -335,6 +337,7 @@ mod tests {
                 kind: ErrorKind::ManifestPull,
                 error: String::new(),
                 retries: 0,
+                status_code: None,
             },
             0,
         );
@@ -421,6 +424,7 @@ mod tests {
                 kind: ErrorKind::BlobTransfer,
                 error: "network error".into(),
                 retries: 2,
+                status_code: None,
             },
             0,
         );
@@ -651,6 +655,7 @@ mod tests {
                 kind: ErrorKind::ManifestPush,
                 error: "timeout".into(),
                 retries: 2,
+                status_code: None,
             },
             0,
         );
@@ -671,6 +676,7 @@ mod tests {
                 kind: ErrorKind::ManifestPull,
                 error: "timeout".into(),
                 retries: 2,
+                status_code: None,
             },
             0,
         );
@@ -715,6 +721,7 @@ mod tests {
                 kind: ErrorKind::BlobTransfer,
                 error: "connection lost".into(),
                 retries: 1,
+                status_code: None,
             },
             0,
         ));
@@ -743,6 +750,7 @@ mod tests {
                 kind: ErrorKind::ManifestPush,
                 error: "timeout".into(),
                 retries: 2,
+                status_code: None,
             },
             0,
         );
@@ -802,6 +810,7 @@ mod tests {
                 kind: ErrorKind::ManifestPush,
                 error: "timeout".into(),
                 retries: 2,
+                status_code: None,
             },
             0,
         ));

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,6 +198,12 @@ pub(crate) struct CopyArgs {
     pub(crate) source: Reference,
     /// Destination image reference (e.g., `ghcr.io/myorg/nginx:latest`).
     pub(crate) destination: Reference,
+    /// Config file for registry credentials.
+    ///
+    /// When provided, auth settings are looked up by matching the source
+    /// and destination hostnames against registry URLs in the config.
+    #[arg(short, long)]
+    pub(crate) config: Option<PathBuf>,
 }
 
 /// Arguments for the `tags` subcommand.
@@ -286,6 +292,12 @@ pub(crate) struct WatchArgs {
     /// Output sync reports as JSON instead of text summaries.
     #[arg(long)]
     pub(crate) json: bool,
+    /// IP address for the health endpoint to bind on.
+    ///
+    /// Defaults to `127.0.0.1` (localhost only). Set to `0.0.0.0` for
+    /// container/Kubernetes deployments where probes originate externally.
+    #[arg(long, default_value = "127.0.0.1")]
+    pub(crate) health_bind: std::net::IpAddr,
     /// Port for the health endpoint (default: 8080).
     #[arg(long, default_value = "8080")]
     pub(crate) health_port: u16,
@@ -336,7 +348,7 @@ async fn main() -> std::process::ExitCode {
         Commands::Sync(args) => {
             cli::commands::synchronize::run(&args, &*progress, Some(&shutdown), None).await
         }
-        Commands::Copy(args) => cli::commands::copy::run(&args, &*progress).await,
+        Commands::Copy(args) => cli::commands::copy::run(&args, &*progress, Some(&shutdown)).await,
         Commands::Tags(args) => cli::commands::tags::run(&args).await,
         Commands::Auth { action } => match action {
             AuthAction::Check { config } => cli::commands::auth::run_check(&config).await,
@@ -346,7 +358,7 @@ async fn main() -> std::process::ExitCode {
         Commands::Watch(args) => {
             cli::commands::watch::run(&args, &*progress, shutdown.clone()).await
         }
-        Commands::Analyze(args) => cli::commands::analyze::run(&args).await,
+        Commands::Analyze(args) => cli::commands::analyze::run(&args, &shutdown).await,
         Commands::Version => Ok(cli::commands::version::run()),
     };
 

--- a/xtask/src/bench/config_gen.rs
+++ b/xtask/src/bench/config_gen.rs
@@ -114,8 +114,8 @@ pub(crate) fn ocync_config(corpus: &Corpus) -> String {
         let src_key = registry_key(source_registry(&img.source));
         let path = source_path(&img.source);
         let target_repo = corpus.target_repo(&img.source);
-        out.push_str(&format!("  - from: {path}\n"));
-        out.push_str(&format!("    to: {target_repo}\n"));
+        out.push_str(&format!("  - from: \"{path}\"\n"));
+        out.push_str(&format!("    to: \"{target_repo}\"\n"));
         out.push_str(&format!("    source: {src_key}\n"));
         out.push_str(&format!("    targets: [{ecr_key}]\n"));
         out.push_str("    tags:\n");
@@ -172,8 +172,8 @@ pub(crate) fn dregsy_config(corpus: &Corpus) -> String {
         for img in images {
             let from = source_path(&img.source);
             let to = corpus.target_repo(&img.source);
-            out.push_str(&format!("      - from: {from}\n"));
-            out.push_str(&format!("        to: {to}\n"));
+            out.push_str(&format!("      - from: \"{from}\"\n"));
+            out.push_str(&format!("        to: \"{to}\"\n"));
             // Deep-copy all platforms so dregsy syncs the full manifest
             // list, matching ocync and regsync behavior. Without this,
             // skopeo copies only the native platform (single manifest PUT)
@@ -292,15 +292,15 @@ registries:
     auth_type: ecr
 
 mappings:
-  - from: chainguard/static
-    to: bench/chainguard-static
+  - from: \"chainguard/static\"
+    to: \"bench/chainguard-static\"
     source: cgr-dev
     targets: [ecr]
     tags:
       glob:
         - \"latest\"
-  - from: library/alpine
-    to: bench/library-alpine
+  - from: \"library/alpine\"
+    to: \"bench/library-alpine\"
     source: docker-io
     targets: [ecr]
     tags:
@@ -325,8 +325,8 @@ tasks:
       registry: 111111111111.dkr.ecr.us-east-1.amazonaws.com
       auth-refresh: 12h
     mappings:
-      - from: chainguard/static
-        to: bench/chainguard-static
+      - from: \"chainguard/static\"
+        to: \"bench/chainguard-static\"
         platform: all
         tags:
           - \"latest\"
@@ -337,8 +337,8 @@ tasks:
       registry: 111111111111.dkr.ecr.us-east-1.amazonaws.com
       auth-refresh: 12h
     mappings:
-      - from: library/alpine
-        to: bench/library-alpine
+      - from: \"library/alpine\"
+        to: \"bench/library-alpine\"
         platform: all
         tags:
           - \"3.20\"
@@ -418,15 +418,15 @@ registries:
     auth_type: ecr
 
 mappings:
-  - from: chainguard/static
-    to: bench/chainguard-static
+  - from: \"chainguard/static\"
+    to: \"bench/chainguard-static\"
     source: cgr-dev
     targets: [ecr]
     tags:
       glob:
         - \"latest\"
-  - from: library/alpine
-    to: bench/library-alpine
+  - from: \"library/alpine\"
+    to: \"bench/library-alpine\"
     source: docker-io
     targets: [ecr]
     tags:
@@ -451,8 +451,8 @@ tasks:
       registry: 111111111111.dkr.ecr.us-east-1.amazonaws.com
       auth-refresh: 12h
     mappings:
-      - from: chainguard/static
-        to: bench/chainguard-static
+      - from: \"chainguard/static\"
+        to: \"bench/chainguard-static\"
         platform: all
         tags:
           - \"latest\"
@@ -464,8 +464,8 @@ tasks:
       registry: 111111111111.dkr.ecr.us-east-1.amazonaws.com
       auth-refresh: 12h
     mappings:
-      - from: library/alpine
-        to: bench/library-alpine
+      - from: \"library/alpine\"
+        to: \"bench/library-alpine\"
         platform: all
         tags:
           - \"3.20\"

--- a/xtask/src/bench/mod.rs
+++ b/xtask/src/bench/mod.rs
@@ -259,7 +259,7 @@ pub(crate) async fn run(args: BenchArgs) -> Result<(), Box<dyn std::error::Error
     eprintln!(
         "bench: instance={} cpu={} vcpus={} mem={}MiB net={} region={}",
         instance.instance_type,
-        instance.cpu_model,
+        instance.cpu_manufacturer,
         instance.vcpus,
         instance.memory_mib,
         instance.network_performance,
@@ -571,39 +571,45 @@ async fn run_sync(
         // Cold run.
         progress(&format!("  cold: {tool}"));
         ecr::create_repos(ecr_client, corpus).await?;
-        let cold = run_single_tool(args, tool, corpus, config_dir.path(), output_dir).await?;
-        if cold.exit_code != Some(0) {
-            return Err(format!(
-                "{tool} cold sync failed (exit {:?}); aborting -- \
-                 tainted data cannot be compared",
-                cold.exit_code
-            )
-            .into());
-        }
-        progress(&format!(
-            "  cold: {tool} complete ({:.1}s)",
-            cold.wall_clock_secs
-        ));
-        cold_runs.push(cold);
+        let run_result: Result<(), Box<dyn std::error::Error>> = async {
+            let cold = run_single_tool(args, tool, corpus, config_dir.path(), output_dir).await?;
+            if cold.exit_code != Some(0) {
+                return Err(format!(
+                    "{tool} cold sync failed (exit {:?}); aborting -- \
+                     tainted data cannot be compared",
+                    cold.exit_code
+                )
+                .into());
+            }
+            progress(&format!(
+                "  cold: {tool} complete ({:.1}s)",
+                cold.wall_clock_secs
+            ));
+            cold_runs.push(cold);
 
-        // Warm run: target still populated, same config_dir.
-        progress(&format!("  warm: {tool}"));
-        let warm = run_single_tool(args, tool, corpus, config_dir.path(), output_dir).await?;
-        if warm.exit_code != Some(0) {
-            return Err(format!(
-                "{tool} warm sync failed (exit {:?}); aborting -- \
-                 tainted data cannot be compared",
-                warm.exit_code
-            )
-            .into());
+            // Warm run: target still populated, same config_dir.
+            progress(&format!("  warm: {tool}"));
+            let warm = run_single_tool(args, tool, corpus, config_dir.path(), output_dir).await?;
+            if warm.exit_code != Some(0) {
+                return Err(format!(
+                    "{tool} warm sync failed (exit {:?}); aborting -- \
+                     tainted data cannot be compared",
+                    warm.exit_code
+                )
+                .into());
+            }
+            progress(&format!(
+                "  warm: {tool} complete ({:.1}s)",
+                warm.wall_clock_secs
+            ));
+            warm_runs.push(warm);
+            Ok(())
         }
-        progress(&format!(
-            "  warm: {tool} complete ({:.1}s)",
-            warm.wall_clock_secs
-        ));
-        warm_runs.push(warm);
+        .await;
 
+        // Always clean up ECR repos, even if the tool run failed.
         ecr::delete_repos(ecr_client, corpus).await?;
+        run_result?;
 
         if tool_idx + 1 < tools.len() {
             cooldown().await;
@@ -639,36 +645,43 @@ async fn run_partial(
 
         ecr::create_repos(ecr_client, base_corpus).await?;
 
-        // Prime with base corpus (unmeasured). Reuse the same
-        // config_dir so ocync's TransferStateCache persists.
-        let config_dir = tempfile::tempdir()?;
-        let prime = run_single_tool(args, tool, base_corpus, config_dir.path(), output_dir).await?;
-        if prime.exit_code != Some(0) {
-            return Err(format!(
-                "{tool} partial prime failed (exit {:?}); aborting",
-                prime.exit_code
-            )
-            .into());
-        }
-        progress(&format!("  partial: {} measuring", tool));
+        let run_result: Result<(), Box<dyn std::error::Error>> = async {
+            // Prime with base corpus (unmeasured). Reuse the same
+            // config_dir so ocync's TransferStateCache persists.
+            let config_dir = tempfile::tempdir()?;
+            let prime =
+                run_single_tool(args, tool, base_corpus, config_dir.path(), output_dir).await?;
+            if prime.exit_code != Some(0) {
+                return Err(format!(
+                    "{tool} partial prime failed (exit {:?}); aborting",
+                    prime.exit_code
+                )
+                .into());
+            }
+            progress(&format!("  partial: {} measuring", tool));
 
-        // Measured run with partial corpus (same config_dir).
-        let run =
-            run_single_tool(args, tool, partial_corpus, config_dir.path(), output_dir).await?;
-        if run.exit_code != Some(0) {
-            return Err(format!(
-                "{tool} partial sync failed (exit {:?}); aborting",
-                run.exit_code
-            )
-            .into());
+            // Measured run with partial corpus (same config_dir).
+            let run =
+                run_single_tool(args, tool, partial_corpus, config_dir.path(), output_dir).await?;
+            if run.exit_code != Some(0) {
+                return Err(format!(
+                    "{tool} partial sync failed (exit {:?}); aborting",
+                    run.exit_code
+                )
+                .into());
+            }
+            progress(&format!(
+                "  partial: {} complete ({:.1}s)",
+                tool, run.wall_clock_secs
+            ));
+            runs.push(run);
+            Ok(())
         }
-        progress(&format!(
-            "  partial: {} complete ({:.1}s)",
-            tool, run.wall_clock_secs
-        ));
-        runs.push(run);
+        .await;
 
+        // Always clean up ECR repos, even if the tool run failed.
         ecr::delete_repos(ecr_client, base_corpus).await?;
+        run_result?;
 
         if tool_idx + 1 < tools.len() {
             cooldown().await;
@@ -710,18 +723,25 @@ async fn run_scale(
 
             ecr::create_repos(ecr_client, &subset).await?;
 
-            let config_dir = tempfile::tempdir()?;
-            let run = run_single_tool(args, tool, &subset, config_dir.path(), output_dir).await?;
-            if run.exit_code != Some(0) {
-                return Err(format!(
-                    "{tool} scale sync failed at {size} images (exit {:?}); aborting",
-                    run.exit_code
-                )
-                .into());
+            let run_result: Result<(), Box<dyn std::error::Error>> = async {
+                let config_dir = tempfile::tempdir()?;
+                let run =
+                    run_single_tool(args, tool, &subset, config_dir.path(), output_dir).await?;
+                if run.exit_code != Some(0) {
+                    return Err(format!(
+                        "{tool} scale sync failed at {size} images (exit {:?}); aborting",
+                        run.exit_code
+                    )
+                    .into());
+                }
+                results.insert(tool.to_string(), run.wall_clock_secs);
+                Ok(())
             }
-            results.insert(tool.to_string(), run.wall_clock_secs);
+            .await;
 
+            // Always clean up ECR repos, even if the tool run failed.
             ecr::delete_repos(ecr_client, &subset).await?;
+            run_result?;
 
             if tool_idx + 1 < tools.len() {
                 cooldown().await;
@@ -793,7 +813,12 @@ impl std::fmt::Display for Scenario {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
+
+    /// Serializes tests that mutate process environment variables.
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
     #[test]
     fn days_to_civil_unix_epoch() {
@@ -886,9 +911,8 @@ mod tests {
 
     #[test]
     fn docker_hub_auth_from_env_both_set() {
-        // SAFETY: test-only; env var mutation is safe in single-threaded
-        // test runs (cargo test runs each #[test] in its own thread, but
-        // these env var names are unique to this test suite).
+        let _lock = ENV_MUTEX.lock().unwrap();
+        // SAFETY: env-var mutation is serialized by ENV_MUTEX above.
         unsafe {
             std::env::set_var("DOCKERHUB_USERNAME", "testuser");
             std::env::set_var("DOCKERHUB_ACCESS_TOKEN", "testtoken");
@@ -903,6 +927,8 @@ mod tests {
 
     #[test]
     fn docker_hub_auth_from_env_empty_returns_none() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        // SAFETY: env-var mutation is serialized by ENV_MUTEX above.
         unsafe {
             std::env::set_var("DOCKERHUB_USERNAME", "");
             std::env::set_var("DOCKERHUB_ACCESS_TOKEN", "sometoken");
@@ -917,6 +943,8 @@ mod tests {
 
     #[test]
     fn docker_hub_auth_from_env_missing_returns_none() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        // SAFETY: env-var mutation is serialized by ENV_MUTEX above.
         unsafe {
             std::env::remove_var("DOCKERHUB_USERNAME");
             std::env::remove_var("DOCKERHUB_ACCESS_TOKEN");

--- a/xtask/src/bench/proxy.rs
+++ b/xtask/src/bench/proxy.rs
@@ -107,7 +107,7 @@ pub(crate) async fn start(
 
     let log_path = log_path.to_path_buf();
 
-    let child = tokio::process::Command::new(binary)
+    let mut child = tokio::process::Command::new(binary)
         .args([
             "serve",
             "--ca",
@@ -125,6 +125,12 @@ pub(crate) async fn start(
     // Give the proxy time to bind the port before callers configure the proxy.
     tokio::time::sleep(Duration::from_secs(2)).await;
 
+    // Verify the proxy is still running (catches immediate crashes from
+    // bad args, missing CA files, port conflicts, etc.).
+    if let Some(status) = child.try_wait()? {
+        return Err(format!("bench-proxy exited immediately with status: {status}").into());
+    }
+
     Ok(ProxyHandle {
         child,
         log_path,
@@ -132,13 +138,30 @@ pub(crate) async fn start(
     })
 }
 
-/// Kills the bench-proxy process, waits for it to exit, then parses and
-/// returns all log entries written during its lifetime.
+/// Sends SIGTERM for graceful shutdown, waits briefly, then falls back
+/// to SIGKILL. Parses and returns all log entries written during the
+/// proxy's lifetime.
 pub(crate) async fn stop(
     mut handle: ProxyHandle,
 ) -> Result<Vec<ProxyEntry>, Box<dyn std::error::Error>> {
-    handle.child.kill().await?;
-    handle.child.wait().await?;
+    // Send SIGTERM so the proxy can flush its log and exit cleanly.
+    if let Some(pid) = handle.child.id() {
+        let _ = std::process::Command::new("kill")
+            .args(["-TERM", &pid.to_string()])
+            .status();
+        // Give the proxy time to flush logs and exit.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+
+    // If still running after SIGTERM, fall back to SIGKILL.
+    match handle.child.try_wait()? {
+        Some(_) => {} // Exited gracefully.
+        None => {
+            handle.child.kill().await?;
+            handle.child.wait().await?;
+        }
+    }
+
     parse_log(&handle.log_path)
 }
 
@@ -186,7 +209,9 @@ pub(crate) fn aggregate(entries: &[ProxyEntry], target_registry: &str) -> ProxyM
         total_response_bytes += entry.response_bytes;
 
         if entry.method == "GET" && entry.url.contains("/blobs/sha256:") {
-            *blob_get_counts.entry(entry.url.clone()).or_insert(0) += 1;
+            *blob_get_counts
+                .entry(format!("{}:{}", entry.host, entry.url))
+                .or_insert(0) += 1;
             // Count logical source blob fetches (registry GETs, not CDN).
             if entry.host != target_registry {
                 source_blob_gets += 1;

--- a/xtask/src/bench/remote.rs
+++ b/xtask/src/bench/remote.rs
@@ -135,15 +135,17 @@ pub(crate) fn run(args: BenchRemoteArgs) -> Result<(), Box<dyn std::error::Error
         return Err("git push failed".into());
     }
 
-    // Build the bench command args.
-    let mut bench_args = format!("--tools {}", args.tools);
+    // Build the bench command args. Shell-escape all user-supplied
+    // values to prevent injection via crafted tool names, registry
+    // names, or scenario strings.
+    let mut bench_args = format!("--tools '{}'", shell_escape(&args.tools));
     if let Some(limit) = args.limit {
         bench_args.push_str(&format!(" --limit {limit}"));
     }
     if let Some(ref skip) = args.skip_registries {
-        bench_args.push_str(&format!(" --skip-registries {skip}"));
+        bench_args.push_str(&format!(" --skip-registries '{}'", shell_escape(skip)));
     }
-    bench_args.push_str(&format!(" {}", args.scenario));
+    bench_args.push_str(&format!(" '{}'", shell_escape(&args.scenario)));
 
     // Determine the target registry from the provider.
     let registry_env = match config.provider.as_str() {
@@ -173,6 +175,8 @@ sleep 1
     } else {
         ""
     };
+
+    let escaped_git_ref = shell_escape(&git_ref);
 
     let script = format!(
         r#"#!/bin/bash
@@ -221,8 +225,8 @@ if [ -f "$PID_FILE" ]; then
 fi
 
 # Pull code and build.
-echo '[1/4] Pulling {git_ref}...'
-git fetch origin '{git_ref}' && git checkout '{git_ref}' && git reset --hard 'origin/{git_ref}'
+echo '[1/4] Pulling {escaped_git_ref}...'
+git fetch origin '{escaped_git_ref}' && git checkout '{escaped_git_ref}' && git reset --hard 'origin/{escaped_git_ref}'
 
 echo '[2/4] Building ocync + bench-proxy...'
 source ~/.bench-env 2>/dev/null || true
@@ -368,14 +372,13 @@ fn fetch_results(
         return Err("scp failed".into());
     }
 
-    // Also fetch the per-registry JSON archive.
-    let json_file = ssh_run(
+    // Also fetch all per-registry JSON archives (excluding baseline.json).
+    let json_files = ssh_run(
         config,
-        "ls -t ~/ocync/bench/results/*.json 2>/dev/null | grep -v baseline | head -1",
+        "ls ~/ocync/bench/results/*.json 2>/dev/null | grep -v baseline",
     )?;
-    let json_file = json_file.trim();
 
-    if !json_file.is_empty() {
+    for json_file in json_files.lines().map(str::trim).filter(|l| !l.is_empty()) {
         let json_basename = Path::new(json_file)
             .file_name()
             .unwrap_or_default()
@@ -423,6 +426,14 @@ fn ssh_run(config: &BenchConfig, command: &str) -> Result<String, Box<dyn std::e
     Ok(String::from_utf8(output.stdout)?)
 }
 
+/// Escapes a string for use inside single quotes in a shell command.
+///
+/// Replaces each `'` with `'\''` (end single-quote, backslash-escaped
+/// literal single-quote, restart single-quote).
+fn shell_escape(s: &str) -> String {
+    s.replace('\'', "'\\''")
+}
+
 /// Get the current local git branch name.
 fn current_branch() -> Result<String, Box<dyn std::error::Error>> {
     let output = Command::new("git")
@@ -457,6 +468,21 @@ mod tests {
             msg.contains("unknown provider 'nonexistent'"),
             "expected provider error, got: {msg}"
         );
+    }
+
+    #[test]
+    fn shell_escape_no_quotes() {
+        assert_eq!(shell_escape("main"), "main");
+    }
+
+    #[test]
+    fn shell_escape_with_single_quote() {
+        assert_eq!(shell_escape("it's"), "it'\\''s");
+    }
+
+    #[test]
+    fn shell_escape_multiple_quotes() {
+        assert_eq!(shell_escape("a'b'c"), "a'\\''b'\\''c");
     }
 
     #[test]

--- a/xtask/src/bench/report.rs
+++ b/xtask/src/bench/report.rs
@@ -135,9 +135,9 @@ pub(crate) struct InstanceInfo {
     pub(crate) instance_type: String,
     /// CPU architecture (e.g. `aarch64`, `x86_64`).
     pub(crate) arch: String,
-    /// CPU manufacturer and model from EC2 `DescribeInstanceTypes`
-    /// (e.g. `AWS Graviton3`, `Intel Xeon Platinum 8488C`).
-    pub(crate) cpu_model: String,
+    /// CPU manufacturer from EC2 `DescribeInstanceTypes`
+    /// (e.g. `AWS`, `Intel`).
+    pub(crate) cpu_manufacturer: String,
     /// Number of default vCPUs for this instance type.
     pub(crate) vcpus: usize,
     /// Total memory in MiB (from `DescribeInstanceTypes`).
@@ -159,7 +159,7 @@ impl InstanceInfo {
         let region = read_imds("placement/region").unwrap_or_else(|| "unknown".into());
 
         // Query DescribeInstanceTypes for authoritative hardware specs.
-        let (arch, cpu_model, vcpus, memory_mib, network_performance) =
+        let (arch, cpu_manufacturer, vcpus, memory_mib, network_performance) =
             if instance_type != "unknown" {
                 match describe_instance_type(&instance_type) {
                     Some(info) => info,
@@ -183,10 +183,10 @@ impl InstanceInfo {
             } else {
                 arch
             },
-            cpu_model: if cpu_model.is_empty() {
+            cpu_manufacturer: if cpu_manufacturer.is_empty() {
                 "unknown".into()
             } else {
-                cpu_model
+                cpu_manufacturer
             },
             vcpus,
             memory_mib,
@@ -205,7 +205,7 @@ impl InstanceInfo {
 /// Uses the AWS CLI (guaranteed on the bench instance) rather than
 /// `aws-sdk-ec2` which compiles every EC2 API and adds ~220 crates.
 ///
-/// Returns `(arch, cpu_model, vcpus, memory_mib, network_performance)`.
+/// Returns `(arch, cpu_manufacturer, vcpus, memory_mib, network_performance)`.
 fn describe_instance_type(instance_type: &str) -> Option<(String, String, usize, u64, String)> {
     let output = std::process::Command::new("aws")
         .args([
@@ -227,12 +227,18 @@ fn describe_instance_type(instance_type: &str) -> Option<(String, String, usize,
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
 
     let arch = json["Arch"].as_str().unwrap_or_default().to_string();
-    let cpu_model = json["Cpu"].as_str().unwrap_or_default().to_string();
+    let cpu_manufacturer = json["Cpu"].as_str().unwrap_or_default().to_string();
     let vcpus = json["Vcpus"].as_u64().unwrap_or(0) as usize;
     let memory_mib = json["Mem"].as_u64().unwrap_or(0);
     let network_performance = json["Net"].as_str().unwrap_or_default().to_string();
 
-    Some((arch, cpu_model, vcpus, memory_mib, network_performance))
+    Some((
+        arch,
+        cpu_manufacturer,
+        vcpus,
+        memory_mib,
+        network_performance,
+    ))
 }
 
 /// Read a value from the EC2 Instance Metadata Service (`IMDSv2`).
@@ -343,7 +349,7 @@ fn summary_markdown(report: &BenchReport) -> String {
     out.push_str(&format!("- **Type**: {}\n", inst.instance_type));
     out.push_str(&format!(
         "- **CPU**: {} ({}, {} vCPUs)\n",
-        inst.cpu_model, inst.arch, inst.vcpus
+        inst.cpu_manufacturer, inst.arch, inst.vcpus
     ));
     if inst.memory_mib > 0 {
         let gb = inst.memory_mib as f64 / 1024.0;
@@ -772,7 +778,7 @@ mod tests {
         InstanceInfo {
             instance_type: "c7g.xlarge".into(),
             arch: "arm64".into(),
-            cpu_model: "AWS".into(),
+            cpu_manufacturer: "AWS".into(),
             vcpus: 4,
             memory_mib: 8192,
             network_performance: "Up to 12.5 Gigabit".into(),

--- a/xtask/src/bench/runner.rs
+++ b/xtask/src/bench/runner.rs
@@ -57,13 +57,25 @@ pub(crate) struct RunResult {
     pub(crate) peak_rss_kb: Option<u64>,
 }
 
-/// Runs a tool with `version` and returns a single-line version string.
+/// Returns the version argument(s) for a given tool.
+///
+/// `dregsy` uses `--version` (Go flag convention); `regsync` and `ocync`
+/// use the `version` subcommand.
+fn version_args(tool: Tool) -> &'static [&'static str] {
+    match tool {
+        Tool::Dregsy => &["--version"],
+        Tool::Regsync | Tool::Ocync => &["version"],
+    }
+}
+
+/// Runs a tool with its version flag and returns a single-line version string.
 pub(crate) async fn check_tool(tool: Tool) -> Result<String, String> {
+    let args = version_args(tool);
     let output = tokio::process::Command::new(tool.binary())
-        .arg("version")
+        .args(args)
         .output()
         .await
-        .map_err(|e| format!("failed to run {} version: {}", tool.binary(), e))?;
+        .map_err(|e| format!("failed to run {} {:?}: {}", tool.binary(), args, e))?;
 
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
@@ -114,7 +126,7 @@ pub(crate) async fn build_ocync(workspace_root: &Path) -> Result<(), String> {
 /// Spawns a benchmark tool with timing and output capture.
 ///
 /// Sets `HTTPS_PROXY` to `proxy_url` so all HTTP traffic routes through the
-/// proxy. The mitmproxy CA must be installed in the system trust store
+/// proxy. The bench-proxy CA must be installed in the system trust store
 /// (via `update-ca-trust`) so that both rustls-native-certs (ocync) and
 /// OpenSSL (dregsy/regsync via Go) trust the MITM'd connections.
 ///
@@ -294,6 +306,13 @@ mod tests {
             Tool::parse("unknown").unwrap_err(),
             "unknown tool: \"unknown\"; expected one of: ocync, dregsy, regsync"
         );
+    }
+
+    #[test]
+    fn version_args_per_tool() {
+        assert_eq!(version_args(Tool::Dregsy), &["--version"]);
+        assert_eq!(version_args(Tool::Regsync), &["version"]);
+        assert_eq!(version_args(Tool::Ocync), &["version"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes failure modes that surface under real-world registry traffic: credential injection via Docker config, misleading auth errors that waste debugging time, silent config mistakes, retry storms from synchronized backoff, and duplicate blob pushes after mount fallback. Adds observability to the auth module (previously zero tracing) and fixes documentation drift across rate-limit numbers and config examples.

## Changes

### Auth hardening
- **Credential helper input validation** -- reject path traversal and shell metacharacters in `credsStore`/`credHelpers` names from Docker config.json
- **Clear errors on non-401 registry responses** -- a 403 or 500 from `/v2/` ping now says what happened instead of the misleading "missing WWW-Authenticate header"
- **Escaped quote handling** in `WWW-Authenticate` header parsing
- **Auth tracing** -- debug/warn level logging across all 6 auth providers for cache hits, misses, exchange failures, and invalidation events (previously silent)

### Transfer reliability
- **Mount-fallback preserves InProgress state** -- after a mount fails, the blob stays marked as in-progress so concurrent waiters don't start duplicate pushes (directly addresses design priority #1: efficiency)
- **Retry jitter** -- [0.75, 1.25) multiplicative jitter prevents synchronized retry storms when multiple tasks hit the same transient failure
- **Transport error retry** -- connection refused, DNS failures, and timeouts are now retried (previously failed on first attempt)
- **Tag pagination guard** -- 10k page cap prevents infinite loops from malformed `Link: rel="next"` headers
- **Digest case normalization** -- hex lowercased on parse so uppercase digests from registries match locally-computed ones
- **StagedWriter cleanup on drop** -- partial temp files from failed writes are removed instead of accumulating on disk

### CLI correctness
- **Config validation for cache_ttl and staging_size_limit** -- typos like `"12hrs"` now return an error instead of silently falling back to the 12h default
- **Copy command shutdown** -- SIGINT/SIGTERM now gracefully stops copy operations (was ignored)
- **Tags hostname normalization** -- `docker.io` correctly matches `registry-1.docker.io` when looking up credentials
- **Watch mode config reload** -- cache path and TTL changes in config take effect each cycle without restart

### Bench infrastructure
- **Shell escaping** for git ref and CLI args interpolated into remote bash scripts
- **ECR repo cleanup** runs even when a tool fails mid-benchmark (was silently leaking repos)
- **SIGTERM before SIGKILL** on bench-proxy shutdown so final log entries are flushed
- **Proxy startup validation** -- detect immediate exit instead of returning a dead handle
- **YAML quoting** in generated competitor configs
- **Per-tool version flags** -- dregsy uses `--version`, not `version`

### Dependencies and policy
- Ban `openssl`/`openssl-sys` in deny.toml (closing a gap in the aws-lc-rs-only crypto policy)
- Workspace inheritance for `aws-sdk-ecr`, `reqwest`, `url` (consistent feature resolution)
- `default-features = false` for `ocync-sync` workspace dep
- Remove dead `fulfills_cross_repo_mount()` (returned true for all variants, zero callers)

### Documentation
- Fix Helm values.yaml example config (was using wrong field names: `hostname` instead of `url`, `auth` instead of `auth_type`, etc.)
- Standardize Docker Hub rate limits to 100/6hr across 4 files that disagreed
- Add context to warm-sync benchmark data explaining the correctness-vs-speed tradeoff
- Correct ECR Public blob mount capability (No, not Yes)

### Tests
- Staging state machine unit tests (`claim_or_check`, `notify_staged`, `notify_failed`)
- GAR hostname detection test now calls `detect_provider_kind()` instead of testing a raw string pattern
- Tag listing wiremock tests (basic, pagination, max-pages guard)

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo deny check` -- advisories ok, bans ok, licenses ok, sources ok
- [x] `cargo test` -- 922 passed (8 skipped: Docker-dependent testcontainers)