### PR TITLE
feat: budget circuit breaker for rate-limited source registries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2182,6 +2182,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "url",
  "uuid",
  "wiremock",

--- a/crates/ocync-distribution/src/client.rs
+++ b/crates/ocync-distribution/src/client.rs
@@ -1,5 +1,7 @@
 //! HTTP client for a single OCI registry endpoint.
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use http::StatusCode;
 use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue};
 use url::Url;
@@ -11,6 +13,10 @@ use crate::spec::{RegistryAuthority, RepositoryName};
 
 const DEFAULT_MAX_CONCURRENT_REQUESTS: usize = 50;
 const USER_AGENT_VALUE: &str = concat!("ocync/", env!("CARGO_PKG_VERSION"));
+
+/// Sentinel value stored in [`RegistryClient::rate_limit_remaining`] when no
+/// rate-limit header has been observed yet.
+const RATE_LIMIT_UNKNOWN: u64 = u64::MAX;
 
 use crate::auth::AuthScheme;
 
@@ -92,6 +98,7 @@ impl RegistryClientBuilder {
             http,
             auth: self.auth,
             aimd,
+            rate_limit_remaining: AtomicU64::new(RATE_LIMIT_UNKNOWN),
         })
     }
 }
@@ -105,12 +112,28 @@ pub struct RegistryClient {
     pub(crate) http: reqwest::Client,
     pub(crate) auth: Option<Box<dyn AuthProvider>>,
     pub(crate) aimd: AimdController,
+    /// Last observed rate-limit remaining value from response headers.
+    ///
+    /// Updated atomically on every response that carries a `ratelimit-remaining`
+    /// (Docker Hub) or `x-ratelimit-remaining` (GHCR) header. Stores
+    /// [`RATE_LIMIT_UNKNOWN`] until the first such header is seen. The engine
+    /// reads this to decide whether to pause discovery (budget circuit breaker).
+    rate_limit_remaining: AtomicU64,
 }
 
 impl std::fmt::Debug for RegistryClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let remaining = self.rate_limit_remaining.load(Ordering::Relaxed);
         f.debug_struct("RegistryClient")
             .field("base_url", &self.base_url)
+            .field(
+                "rate_limit_remaining",
+                &if remaining == RATE_LIMIT_UNKNOWN {
+                    None
+                } else {
+                    Some(remaining)
+                },
+            )
             .finish_non_exhaustive()
     }
 }
@@ -148,6 +171,33 @@ impl RegistryClient {
             .ok_or_else(|| Error::Other(format!("registry URL has no host: {}", self.base_url)))?;
         let port = self.base_url.port_or_known_default().unwrap_or(443);
         Ok(RegistryAuthority::new(format!("{host}:{port}")))
+    }
+
+    /// Return the last observed rate-limit remaining value, or `None` if no
+    /// rate-limit header has been seen yet.
+    ///
+    /// Updated automatically by [`send_with_aimd`](Self::send_with_aimd)
+    /// from `ratelimit-remaining` (Docker Hub) or `x-ratelimit-remaining`
+    /// (GHCR) response headers. The engine reads this on source clients to
+    /// pause discovery when the budget is low (budget circuit breaker).
+    pub fn rate_limit_remaining(&self) -> Option<u64> {
+        let v = self.rate_limit_remaining.load(Ordering::Relaxed);
+        if v == RATE_LIMIT_UNKNOWN {
+            None
+        } else {
+            Some(v)
+        }
+    }
+
+    /// Extract and store the rate-limit remaining value from response headers.
+    ///
+    /// Called by [`send_with_aimd`](Self::send_with_aimd) on every successful
+    /// response.
+    fn record_rate_limit(&self, headers: &HeaderMap) {
+        if let Some(remaining) = parse_rate_limit_remaining(headers) {
+            self.rate_limit_remaining
+                .store(remaining, Ordering::Relaxed);
+        }
     }
 
     /// Perform an authenticated GET request.
@@ -211,8 +261,8 @@ impl RegistryClient {
     /// Send a request with AIMD permit tracking and 401 retry.
     ///
     /// Combines permit acquisition, the authenticated retry loop, and AIMD
-    /// feedback reporting into a single call. Callers no longer need to
-    /// manually acquire/report permits.
+    /// feedback reporting into a single call. Also extracts rate-limit
+    /// remaining values from response headers (budget circuit breaker).
     pub(crate) async fn send_with_aimd(
         &self,
         action: RegistryAction,
@@ -222,6 +272,9 @@ impl RegistryClient {
     ) -> Result<reqwest::Response, Error> {
         let permit = self.aimd.acquire(action).await;
         let result = self.send_with_retry(scopes, context, build_request).await;
+        if let Ok(resp) = &result {
+            self.record_rate_limit(resp.headers());
+        }
         report_permit(permit, &result);
         result
     }
@@ -296,6 +349,33 @@ pub(crate) fn report_permit(
         Ok(resp) if resp.status() == StatusCode::TOO_MANY_REQUESTS => permit.throttled(),
         _ => permit.success(),
     }
+}
+
+/// Extract the rate-limit remaining value from response headers.
+///
+/// Docker Hub sends `ratelimit-remaining: N;w=21600` (N remaining in a 6-hour
+/// window). GHCR sends `x-ratelimit-remaining: N`. Returns the parsed integer
+/// from whichever header is present, preferring `ratelimit-remaining`.
+fn parse_rate_limit_remaining(headers: &HeaderMap) -> Option<u64> {
+    // Docker Hub: `ratelimit-remaining: 99;w=21600`
+    if let Some(val) = headers.get("ratelimit-remaining") {
+        if let Ok(s) = val.to_str() {
+            // Take the integer before the first semicolon.
+            let num_part = s.split(';').next().unwrap_or(s).trim();
+            if let Ok(n) = num_part.parse::<u64>() {
+                return Some(n);
+            }
+        }
+    }
+    // GHCR: `x-ratelimit-remaining: 99`
+    if let Some(val) = headers.get("x-ratelimit-remaining") {
+        if let Ok(s) = val.to_str() {
+            if let Ok(n) = s.trim().parse::<u64>() {
+                return Some(n);
+            }
+        }
+    }
+    None
 }
 
 /// Classify an HTTP response into success/error.
@@ -485,6 +565,151 @@ mod tests {
     #[test]
     fn user_agent_value() {
         assert!(USER_AGENT_VALUE.starts_with("ocync/"));
+    }
+
+    #[test]
+    fn parse_rate_limit_docker_hub() {
+        let mut headers = HeaderMap::new();
+        headers.insert("ratelimit-remaining", "99;w=21600".parse().unwrap());
+        assert_eq!(parse_rate_limit_remaining(&headers), Some(99));
+    }
+
+    #[test]
+    fn parse_rate_limit_ghcr() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-ratelimit-remaining", "42".parse().unwrap());
+        assert_eq!(parse_rate_limit_remaining(&headers), Some(42));
+    }
+
+    #[test]
+    fn parse_rate_limit_docker_hub_preferred_over_ghcr() {
+        let mut headers = HeaderMap::new();
+        headers.insert("ratelimit-remaining", "10;w=21600".parse().unwrap());
+        headers.insert("x-ratelimit-remaining", "999".parse().unwrap());
+        // Docker Hub header takes precedence.
+        assert_eq!(parse_rate_limit_remaining(&headers), Some(10));
+    }
+
+    #[test]
+    fn parse_rate_limit_no_header() {
+        let headers = HeaderMap::new();
+        assert_eq!(parse_rate_limit_remaining(&headers), None);
+    }
+
+    #[test]
+    fn parse_rate_limit_zero() {
+        let mut headers = HeaderMap::new();
+        headers.insert("ratelimit-remaining", "0;w=21600".parse().unwrap());
+        assert_eq!(parse_rate_limit_remaining(&headers), Some(0));
+    }
+
+    #[test]
+    fn rate_limit_remaining_none_before_any_response() {
+        let client = RegistryClient::builder(test_base_url()).build().unwrap();
+        assert_eq!(client.rate_limit_remaining(), None);
+    }
+
+    #[tokio::test]
+    async fn rate_limit_remaining_updated_from_response_header() {
+        let server = MockServer::start().await;
+        let base_url = Url::parse(&server.uri()).unwrap();
+
+        let client = RegistryClient::builder(base_url)
+            .auth(StubAuth)
+            .max_concurrent(50)
+            .build()
+            .unwrap();
+
+        Mock::given(method("GET"))
+            .and(path("/v2/repo/manifests/latest"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("ratelimit-remaining", "42;w=21600")
+                    .set_body_string("ok"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let repo = RepositoryName::new("repo").unwrap();
+        let _ = client
+            .get(
+                &repo,
+                "manifests/latest",
+                None,
+                RegistryAction::ManifestRead,
+            )
+            .await;
+
+        assert_eq!(
+            client.rate_limit_remaining(),
+            Some(42),
+            "rate_limit_remaining should be updated from response header"
+        );
+    }
+
+    /// Negative test: `rate_limit_remaining` must NOT be updated when the
+    /// response has no rate-limit header. A missing header means the
+    /// registry does not expose budget info, so the value should stay at
+    /// whatever it was before (not be reset to None or 0).
+    #[tokio::test]
+    async fn rate_limit_remaining_not_reset_without_header() {
+        let server = MockServer::start().await;
+        let base_url = Url::parse(&server.uri()).unwrap();
+
+        let client = RegistryClient::builder(base_url)
+            .auth(StubAuth)
+            .max_concurrent(50)
+            .build()
+            .unwrap();
+
+        // First response: has rate-limit header.
+        Mock::given(method("GET"))
+            .and(path("/v2/repo/manifests/latest"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("ratelimit-remaining", "50;w=21600")
+                    .set_body_string("ok"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let repo = RepositoryName::new("repo").unwrap();
+        let _ = client
+            .get(
+                &repo,
+                "manifests/latest",
+                None,
+                RegistryAction::ManifestRead,
+            )
+            .await;
+        assert_eq!(client.rate_limit_remaining(), Some(50));
+
+        // Second response: no rate-limit header.
+        server.reset().await;
+        Mock::given(method("GET"))
+            .and(path("/v2/repo/manifests/latest"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let _ = client
+            .get(
+                &repo,
+                "manifests/latest",
+                None,
+                RegistryAction::ManifestRead,
+            )
+            .await;
+
+        // Value should still be 50, NOT reset.
+        assert_eq!(
+            client.rate_limit_remaining(),
+            Some(50),
+            "rate_limit_remaining must not be reset when header is absent"
+        );
     }
 
     #[tokio::test]

--- a/crates/ocync-sync/Cargo.toml
+++ b/crates/ocync-sync/Cargo.toml
@@ -31,5 +31,6 @@ uuid.workspace = true
 [dev-dependencies]
 tempfile = { version = "3", default-features = false }
 tokio = { workspace = true, features = ["macros", "rt", "test-util"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry"] }
 url.workspace = true
 wiremock = { version = "0.6", default-features = false }

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -614,6 +614,31 @@ impl SyncEngine {
         // committed manifest for mount to succeed.
         let mut preferred_mount_sources: Vec<RepositoryName> = Vec::new();
 
+        // Budget circuit breaker: pause discovery when a source registry's
+        // rate-limit remaining drops below 10% of the remaining discovery count.
+        // Execution continues for already-discovered images. Discovery resumes
+        // when a subsequent response shows the budget has refilled.
+        //
+        // Pause is all-or-nothing: ANY source below threshold pauses ALL
+        // discovery (not just that source's mappings). This is a structural
+        // constraint -- `FuturesUnordered` doesn't support selective polling,
+        // so per-source pausing would require a different architecture.
+        // In practice, multi-source syncs with mixed rate-limited / unlimited
+        // registries are uncommon, and the anti-stall path prevents deadlock.
+        let mut discovery_paused = false;
+        // Collect unique source clients for rate-limit checking. Deduped by
+        // Arc pointer identity (same source registry = same client).
+        let source_clients: Vec<Arc<RegistryClient>> = {
+            let mut seen = HashSet::new();
+            let mut clients = Vec::new();
+            for m in &mappings {
+                if seen.insert(Arc::as_ptr(&m.source_client)) {
+                    clients.push(Arc::clone(&m.source_client));
+                }
+            }
+            clients
+        };
+
         // Seed discovery with all (mapping, tag) pairs.
         for mapping in &mappings {
             for tag_pair in &mapping.tags {
@@ -674,6 +699,35 @@ impl SyncEngine {
         };
 
         loop {
+            // Budget circuit breaker: check if discovery should resume.
+            // Resume when (a) budget has refilled above the threshold, or
+            // (b) nothing is executing - pending items cannot be promoted until
+            // all discovery completes, so execution draining means no progress
+            // is possible without resuming discovery.
+            if discovery_paused && !discovery_futures.is_empty() {
+                let remaining_discovery = discovery_futures.len() as u64;
+                let threshold = (remaining_discovery / 10).max(1);
+                let budget_ok = source_clients
+                    .iter()
+                    .all(|c| c.rate_limit_remaining().is_none_or(|r| r >= threshold));
+                let must_resume = execution_futures.is_empty();
+                if budget_ok || must_resume {
+                    discovery_paused = false;
+                    if must_resume && !budget_ok {
+                        info!(
+                            remaining_discovery,
+                            pending = pending.len(),
+                            "no active execution, resuming discovery despite low budget"
+                        );
+                    } else {
+                        info!(
+                            remaining_discovery,
+                            "rate-limit budget refilled, resuming discovery"
+                        );
+                    }
+                }
+            }
+
             // Phased promotion: accumulate during discovery, then leader-first.
             if !shutting_down {
                 if matches!(promotion_phase, PromotionPhase::Discovering)
@@ -778,7 +832,7 @@ impl SyncEngine {
                     break;
                 }
                 Some((outcome, route)) = discovery_futures.next(),
-                    if !shutting_down && !discovery_futures.is_empty() =>
+                    if !shutting_down && !discovery_paused && !discovery_futures.is_empty() =>
                 {
                     // Accumulate discovery route counters.
                     match route {
@@ -819,6 +873,31 @@ impl SyncEngine {
                                 progress.image_completed(r);
                             }
                             results.extend(fail_results);
+                        }
+                    }
+
+                    // Budget circuit breaker: check if we should pause discovery.
+                    if !discovery_paused && !discovery_futures.is_empty() {
+                        let remaining_discovery = discovery_futures.len() as u64;
+                        let threshold = (remaining_discovery / 10).max(1);
+                        for client in &source_clients {
+                            if let Some(remaining) = client.rate_limit_remaining() {
+                                if remaining < threshold {
+                                    discovery_paused = true;
+                                    let registry = client
+                                        .registry_authority()
+                                        .map(|a| a.to_string())
+                                        .unwrap_or_else(|_| "unknown".into());
+                                    warn!(
+                                        rate_limit_remaining = remaining,
+                                        remaining_discovery,
+                                        threshold,
+                                        %registry,
+                                        "rate-limit budget low, pausing discovery"
+                                    );
+                                    break;
+                                }
+                            }
                         }
                     }
                 }

--- a/crates/ocync-sync/tests/engine_integration.rs
+++ b/crates/ocync-sync/tests/engine_integration.rs
@@ -20,6 +20,7 @@
 //! - **Untriggered shutdown** (line ~8100) - Engine exits cleanly with unused signal
 //! - **Concurrent mount coordination** (line ~8175) - Shared blob mount vs double-upload
 //! - **Blob concurrency bound** (line ~8900) - Semaphore(6) correctness with >6 layers
+//! - **Budget circuit breaker** (line ~9175) - Rate-limit pause/resume, threshold floor, refill, no-header, threshold verification, multi-source, tracing
 
 use std::cell::RefCell;
 use std::collections::HashSet;
@@ -42,7 +43,7 @@ use ocync_sync::shutdown::ShutdownSignal;
 use ocync_sync::staging::BlobStage;
 use ocync_sync::{ErrorKind, ImageStatus, SkipReason};
 use url::Url;
-use wiremock::matchers::{method, path, query_param};
+use wiremock::matchers::{method, path, path_regex, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 // ---------------------------------------------------------------------------
@@ -9169,4 +9170,765 @@ async fn sync_three_layers_manifest_builder() {
     assert!(matches!(report.images[0].status, ImageStatus::Synced));
     // 1 config + 3 layers = 4 blobs.
     assert_eq!(report.images[0].blob_stats.transferred, 4);
+}
+
+// ---------------------------------------------------------------------------
+// Budget circuit breaker
+// ---------------------------------------------------------------------------
+
+/// Mount a source manifest GET mock that includes a `ratelimit-remaining`
+/// header (Docker Hub format). Used by circuit breaker tests to simulate
+/// rate-limited registries.
+async fn mount_source_manifest_with_rate_limit(
+    server: &MockServer,
+    repo: &str,
+    tag: &str,
+    bytes: &[u8],
+    remaining: u64,
+) {
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/{repo}/manifests/{tag}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(bytes.to_vec())
+                .insert_header("content-type", MediaType::OciManifest.as_str())
+                .insert_header("ratelimit-remaining", format!("{remaining};w=21600")),
+        )
+        .mount(server)
+        .await;
+}
+
+/// Engine completes all images when source returns zero rate-limit budget.
+///
+/// With 15 tags and `ratelimit-remaining: 0`, the circuit breaker fires after
+/// the first discovery completes (threshold = max(14/10, 1) = 1, remaining 0
+/// < 1). The `must_resume` anti-stall path kicks in each time execution drains,
+/// cycling discovery one-at-a-time until all images sync. Proves the breaker
+/// does not deadlock the engine and that the header value was actually parsed
+/// and stored on the source client.
+#[tokio::test]
+async fn budget_circuit_breaker_completes_under_zero_budget() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let parts = ManifestBuilder::new(b"cb-config")
+        .layer(b"cb-layer")
+        .build();
+    let num_tags = 15;
+
+    // Source: every manifest GET returns ratelimit-remaining: 0.
+    for i in 0..num_tags {
+        let tag = format!("v{i}");
+        mount_source_manifest_with_rate_limit(&source_server, "library/app", &tag, &parts.bytes, 0)
+            .await;
+    }
+    mount_blob_pull(
+        &source_server,
+        "library/app",
+        &parts.config_desc.digest,
+        &parts.config_data,
+    )
+    .await;
+    for (data, desc) in parts.layers_data.iter().zip(parts.layer_descs.iter()) {
+        mount_blob_pull(&source_server, "library/app", &desc.digest, data).await;
+    }
+
+    // Target: all tags need syncing.
+    for i in 0..num_tags {
+        let tag = format!("v{i}");
+        mount_manifest_head_not_found(&target_server, "mirror/app", &tag).await;
+        mount_manifest_push(&target_server, "mirror/app", &tag).await;
+    }
+    mount_blob_not_found(&target_server, "mirror/app", &parts.config_desc.digest).await;
+    for desc in &parts.layer_descs {
+        mount_blob_not_found(&target_server, "mirror/app", &desc.digest).await;
+    }
+    mount_blob_push(&target_server, "mirror/app").await;
+
+    let source_client = mock_client(&source_server);
+    let source_client_ref = Arc::clone(&source_client);
+    let target_client = mock_client(&target_server);
+
+    let tags: Vec<TagPair> = (0..num_tags)
+        .map(|i| TagPair::same(format!("v{i}")))
+        .collect();
+
+    let mapping = resolved_mapping(
+        source_client,
+        "library/app",
+        "mirror/app",
+        vec![target_entry("target-reg", target_client)],
+        tags,
+    );
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    assert_eq!(
+        report.images.len(),
+        num_tags,
+        "all tags must produce a result"
+    );
+    assert_eq!(
+        report.stats.images_synced, num_tags as u64,
+        "all images must sync despite zero rate-limit budget"
+    );
+    // Every image transferred blobs (no spurious skips from breaker).
+    for img in &report.images {
+        assert!(
+            matches!(img.status, ImageStatus::Synced),
+            "image {} should be Synced, got {:?}",
+            img.source,
+            img.status,
+        );
+    }
+    // The source client must have observed the zero budget from response
+    // headers. This proves the header was parsed, stored in the AtomicU64,
+    // and was available for the engine's threshold comparison.
+    assert_eq!(
+        source_client_ref.rate_limit_remaining(),
+        Some(0),
+        "source client must reflect the zero budget from response headers"
+    );
+}
+
+/// Circuit breaker fires even with fewer than 10 discovery items.
+///
+/// Regression test for the threshold dead zone: without the `.max(1)` floor,
+/// `remaining_discovery / 10` yields 0 for fewer than 10 items, making the
+/// breaker impossible to trigger. With the floor, threshold = 1 and
+/// `ratelimit-remaining: 0` triggers the pause.
+#[tokio::test]
+async fn budget_circuit_breaker_threshold_floor_small_sync() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let parts = ManifestBuilder::new(b"small-config")
+        .layer(b"small-layer")
+        .build();
+    let num_tags = 5;
+
+    for i in 0..num_tags {
+        let tag = format!("t{i}");
+        mount_source_manifest_with_rate_limit(
+            &source_server,
+            "library/small",
+            &tag,
+            &parts.bytes,
+            0,
+        )
+        .await;
+    }
+    mount_blob_pull(
+        &source_server,
+        "library/small",
+        &parts.config_desc.digest,
+        &parts.config_data,
+    )
+    .await;
+    for (data, desc) in parts.layers_data.iter().zip(parts.layer_descs.iter()) {
+        mount_blob_pull(&source_server, "library/small", &desc.digest, data).await;
+    }
+
+    for i in 0..num_tags {
+        let tag = format!("t{i}");
+        mount_manifest_head_not_found(&target_server, "mirror/small", &tag).await;
+        mount_manifest_push(&target_server, "mirror/small", &tag).await;
+    }
+    mount_blob_not_found(&target_server, "mirror/small", &parts.config_desc.digest).await;
+    for desc in &parts.layer_descs {
+        mount_blob_not_found(&target_server, "mirror/small", &desc.digest).await;
+    }
+    mount_blob_push(&target_server, "mirror/small").await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let tags: Vec<TagPair> = (0..num_tags)
+        .map(|i| TagPair::same(format!("t{i}")))
+        .collect();
+
+    let mapping = resolved_mapping(
+        source_client,
+        "library/small",
+        "mirror/small",
+        vec![target_entry("target-reg", target_client)],
+        tags,
+    );
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    assert_eq!(report.images.len(), num_tags);
+    assert_eq!(report.stats.images_synced, num_tags as u64);
+}
+
+/// Discovery resumes when rate-limit budget refills above threshold.
+///
+/// Uses sequenced mocks (wiremock `up_to_n_times`) so the budget transition
+/// is deterministic regardless of `FuturesUnordered` polling order: the
+/// first 3 manifest GETs (whichever tags they are) return
+/// `ratelimit-remaining: 0`; all subsequent GETs return
+/// `ratelimit-remaining: 100`. The breaker fires after the first low-budget
+/// completion, then the anti-stall path serializes until a high-budget
+/// response arrives, at which point discovery resumes normally.
+#[tokio::test]
+async fn budget_circuit_breaker_resumes_on_budget_refill() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let parts = ManifestBuilder::new(b"refill-config")
+        .layer(b"refill-layer")
+        .build();
+    let num_tags: usize = 12;
+
+    // Sequenced source manifest mocks. Wiremock matches same-priority
+    // mocks by insertion order (first registered wins). The low-budget
+    // mock is registered first with up_to_n_times(3), so the first 3
+    // manifest GETs hit it. Once exhausted, the high-budget fallback
+    // handles the remaining 9.
+    Mock::given(method("GET"))
+        .and(path_regex(r"/v2/library/refill/manifests/v\d+"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(parts.bytes.clone())
+                .insert_header("content-type", MediaType::OciManifest.as_str())
+                .insert_header("ratelimit-remaining", "0;w=21600"),
+        )
+        .up_to_n_times(3)
+        .expect(3)
+        .mount(&source_server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path_regex(r"/v2/library/refill/manifests/v\d+"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(parts.bytes.clone())
+                .insert_header("content-type", MediaType::OciManifest.as_str())
+                .insert_header("ratelimit-remaining", "100;w=21600"),
+        )
+        .expect((num_tags - 3) as u64..)
+        .mount(&source_server)
+        .await;
+
+    mount_blob_pull(
+        &source_server,
+        "library/refill",
+        &parts.config_desc.digest,
+        &parts.config_data,
+    )
+    .await;
+    for (data, desc) in parts.layers_data.iter().zip(parts.layer_descs.iter()) {
+        mount_blob_pull(&source_server, "library/refill", &desc.digest, data).await;
+    }
+
+    for i in 0..num_tags {
+        let tag = format!("v{i}");
+        mount_manifest_head_not_found(&target_server, "mirror/refill", &tag).await;
+        mount_manifest_push(&target_server, "mirror/refill", &tag).await;
+    }
+    mount_blob_not_found(&target_server, "mirror/refill", &parts.config_desc.digest).await;
+    for desc in &parts.layer_descs {
+        mount_blob_not_found(&target_server, "mirror/refill", &desc.digest).await;
+    }
+    mount_blob_push(&target_server, "mirror/refill").await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let tags: Vec<TagPair> = (0..num_tags)
+        .map(|i| TagPair::same(format!("v{i}")))
+        .collect();
+
+    let mapping = resolved_mapping(
+        source_client,
+        "library/refill",
+        "mirror/refill",
+        vec![target_entry("target-reg", target_client)],
+        tags,
+    );
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    assert_eq!(report.images.len(), num_tags);
+    assert_eq!(
+        report.stats.images_synced, num_tags as u64,
+        "all images must sync after budget refill"
+    );
+}
+
+/// Verify the breaker's threshold was met on every discovery cycle.
+///
+/// With 15 tags and zero budget, the breaker condition
+/// (`remaining < max(remaining_discovery / 10, 1)`) holds after every discovery
+/// completion. This test checks that the source client's `rate_limit_remaining`
+/// is `Some(0)` after the run AND that all 15 manifest GETs actually happened
+/// (via wiremock `.expect()`). Together these prove: (a) the breaker condition
+/// was reachable on every cycle, and (b) the engine still completed all work.
+///
+/// The breaker's runtime effect (serializing discovery via the anti-stall path)
+/// is not externally observable without tracing capture, but the condition
+/// being met + all images syncing proves the anti-stall logic is exercised.
+#[tokio::test]
+async fn budget_circuit_breaker_threshold_met_every_cycle() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let parts = ManifestBuilder::new(b"cycle-config")
+        .layer(b"cycle-layer")
+        .build();
+    let num_tags: usize = 15;
+
+    // Use a single regex mock with `.expect(num_tags)` to verify all
+    // manifest GETs happened (wiremock panics on drop if count mismatches).
+    Mock::given(method("GET"))
+        .and(path_regex(r"/v2/library/cycle/manifests/v\d+"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(parts.bytes.clone())
+                .insert_header("content-type", MediaType::OciManifest.as_str())
+                .insert_header("ratelimit-remaining", "0;w=21600"),
+        )
+        .expect(num_tags as u64)
+        .mount(&source_server)
+        .await;
+
+    mount_blob_pull(
+        &source_server,
+        "library/cycle",
+        &parts.config_desc.digest,
+        &parts.config_data,
+    )
+    .await;
+    for (data, desc) in parts.layers_data.iter().zip(parts.layer_descs.iter()) {
+        mount_blob_pull(&source_server, "library/cycle", &desc.digest, data).await;
+    }
+
+    for i in 0..num_tags {
+        let tag = format!("v{i}");
+        mount_manifest_head_not_found(&target_server, "mirror/cycle", &tag).await;
+        mount_manifest_push(&target_server, "mirror/cycle", &tag).await;
+    }
+    mount_blob_not_found(&target_server, "mirror/cycle", &parts.config_desc.digest).await;
+    for desc in &parts.layer_descs {
+        mount_blob_not_found(&target_server, "mirror/cycle", &desc.digest).await;
+    }
+    mount_blob_push(&target_server, "mirror/cycle").await;
+
+    let source_client = mock_client(&source_server);
+    let source_client_ref = Arc::clone(&source_client);
+    let target_client = mock_client(&target_server);
+
+    let tags: Vec<TagPair> = (0..num_tags)
+        .map(|i| TagPair::same(format!("v{i}")))
+        .collect();
+
+    let mapping = resolved_mapping(
+        source_client,
+        "library/cycle",
+        "mirror/cycle",
+        vec![target_entry("target-reg", target_client)],
+        tags,
+    );
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    assert_eq!(report.stats.images_synced, num_tags as u64);
+    // Source client must show zero budget -- proves the AtomicU64 was written
+    // by send_with_aimd and readable from outside the engine.
+    assert_eq!(source_client_ref.rate_limit_remaining(), Some(0));
+    // The `.expect(15)` on the wiremock mock verifies all 15 manifest GETs
+    // happened (wiremock panics on drop if the count doesn't match).
+}
+
+/// Registries without rate-limit headers are unaffected by the circuit breaker.
+///
+/// Verifies that the breaker does not interfere with normal operation when no
+/// `ratelimit-remaining` header is present (e.g., ECR, GAR, Chainguard).
+#[tokio::test]
+async fn budget_circuit_breaker_no_header_unaffected() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let parts = ManifestBuilder::new(b"no-rl-config")
+        .layer(b"no-rl-layer")
+        .build();
+    let num_tags = 10;
+
+    // Source: standard manifests without rate-limit headers.
+    for i in 0..num_tags {
+        let tag = format!("v{i}");
+        mount_source_manifest(&source_server, "library/ecr", &tag, &parts.bytes).await;
+    }
+    mount_blob_pull(
+        &source_server,
+        "library/ecr",
+        &parts.config_desc.digest,
+        &parts.config_data,
+    )
+    .await;
+    for (data, desc) in parts.layers_data.iter().zip(parts.layer_descs.iter()) {
+        mount_blob_pull(&source_server, "library/ecr", &desc.digest, data).await;
+    }
+
+    for i in 0..num_tags {
+        let tag = format!("v{i}");
+        mount_manifest_head_not_found(&target_server, "mirror/ecr", &tag).await;
+        mount_manifest_push(&target_server, "mirror/ecr", &tag).await;
+    }
+    mount_blob_not_found(&target_server, "mirror/ecr", &parts.config_desc.digest).await;
+    for desc in &parts.layer_descs {
+        mount_blob_not_found(&target_server, "mirror/ecr", &desc.digest).await;
+    }
+    mount_blob_push(&target_server, "mirror/ecr").await;
+
+    let source_client = mock_client(&source_server);
+    let source_client_ref = Arc::clone(&source_client);
+    let target_client = mock_client(&target_server);
+
+    let tags: Vec<TagPair> = (0..num_tags)
+        .map(|i| TagPair::same(format!("v{i}")))
+        .collect();
+
+    let mapping = resolved_mapping(
+        source_client,
+        "library/ecr",
+        "mirror/ecr",
+        vec![target_entry("target-reg", target_client)],
+        tags,
+    );
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    assert_eq!(report.images.len(), num_tags);
+    assert_eq!(
+        report.stats.images_synced, num_tags as u64,
+        "registries without rate-limit headers must sync normally"
+    );
+    // Without rate-limit headers, the client should never have stored a value.
+    assert_eq!(
+        source_client_ref.rate_limit_remaining(),
+        None,
+        "source client must remain None when no rate-limit header is present"
+    );
+}
+
+/// Multi-source: one rate-limited source pauses ALL discovery (all-or-nothing).
+///
+/// Two source registries: source A returns `ratelimit-remaining: 0` (rate-limited),
+/// source B returns no rate-limit header (unlimited, e.g. ECR). The all-or-nothing
+/// pause means source B's discovery is paused too, but the anti-stall path ensures
+/// all images eventually sync. Proves the multi-source dedup works and that the
+/// breaker's `any`-trigger / `all`-resume asymmetry does not deadlock.
+#[tokio::test]
+async fn budget_circuit_breaker_multi_source_all_or_nothing() {
+    let source_a_server = MockServer::start().await; // rate-limited (Docker Hub)
+    let source_b_server = MockServer::start().await; // unlimited (ECR-like)
+    let target_server = MockServer::start().await;
+
+    let parts_a = ManifestBuilder::new(b"ms-config-a")
+        .layer(b"ms-layer-a")
+        .build();
+    let parts_b = ManifestBuilder::new(b"ms-config-b")
+        .layer(b"ms-layer-b")
+        .build();
+
+    let tags_per_source = 8;
+
+    // Source A: rate-limited.
+    for i in 0..tags_per_source {
+        let tag = format!("v{i}");
+        mount_source_manifest_with_rate_limit(
+            &source_a_server,
+            "library/alpha",
+            &tag,
+            &parts_a.bytes,
+            0,
+        )
+        .await;
+    }
+    mount_blob_pull(
+        &source_a_server,
+        "library/alpha",
+        &parts_a.config_desc.digest,
+        &parts_a.config_data,
+    )
+    .await;
+    for (data, desc) in parts_a.layers_data.iter().zip(parts_a.layer_descs.iter()) {
+        mount_blob_pull(&source_a_server, "library/alpha", &desc.digest, data).await;
+    }
+
+    // Source B: no rate-limit headers.
+    for i in 0..tags_per_source {
+        let tag = format!("v{i}");
+        mount_source_manifest(&source_b_server, "library/beta", &tag, &parts_b.bytes).await;
+    }
+    mount_blob_pull(
+        &source_b_server,
+        "library/beta",
+        &parts_b.config_desc.digest,
+        &parts_b.config_data,
+    )
+    .await;
+    for (data, desc) in parts_b.layers_data.iter().zip(parts_b.layer_descs.iter()) {
+        mount_blob_pull(&source_b_server, "library/beta", &desc.digest, data).await;
+    }
+
+    // Target: both repos.
+    for i in 0..tags_per_source {
+        let tag = format!("v{i}");
+        mount_manifest_head_not_found(&target_server, "mirror/alpha", &tag).await;
+        mount_manifest_push(&target_server, "mirror/alpha", &tag).await;
+        mount_manifest_head_not_found(&target_server, "mirror/beta", &tag).await;
+        mount_manifest_push(&target_server, "mirror/beta", &tag).await;
+    }
+    mount_blob_not_found(&target_server, "mirror/alpha", &parts_a.config_desc.digest).await;
+    for desc in &parts_a.layer_descs {
+        mount_blob_not_found(&target_server, "mirror/alpha", &desc.digest).await;
+    }
+    mount_blob_push(&target_server, "mirror/alpha").await;
+    mount_blob_not_found(&target_server, "mirror/beta", &parts_b.config_desc.digest).await;
+    for desc in &parts_b.layer_descs {
+        mount_blob_not_found(&target_server, "mirror/beta", &desc.digest).await;
+    }
+    mount_blob_push(&target_server, "mirror/beta").await;
+
+    let source_a_client = mock_client(&source_a_server);
+    let source_a_ref = Arc::clone(&source_a_client);
+    let source_b_client = mock_client(&source_b_server);
+    let source_b_ref = Arc::clone(&source_b_client);
+    let target_client = mock_client(&target_server);
+
+    let tags: Vec<TagPair> = (0..tags_per_source)
+        .map(|i| TagPair::same(format!("v{i}")))
+        .collect();
+
+    let mapping_a = resolved_mapping(
+        source_a_client,
+        "library/alpha",
+        "mirror/alpha",
+        vec![target_entry("target-reg", Arc::clone(&target_client))],
+        tags.clone(),
+    );
+    let mapping_b = resolved_mapping(
+        source_b_client,
+        "library/beta",
+        "mirror/beta",
+        vec![target_entry("target-reg", target_client)],
+        tags,
+    );
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping_a, mapping_b],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    let total = tags_per_source * 2;
+    assert_eq!(
+        report.images.len(),
+        total,
+        "all images from both sources must produce a result"
+    );
+    assert_eq!(
+        report.stats.images_synced, total as u64,
+        "all images must sync despite one source being rate-limited"
+    );
+    for img in &report.images {
+        assert!(
+            matches!(img.status, ImageStatus::Synced),
+            "image {} should be Synced, got {:?}",
+            img.source,
+            img.status,
+        );
+    }
+    // Source A: rate-limited, must reflect zero budget.
+    assert_eq!(
+        source_a_ref.rate_limit_remaining(),
+        Some(0),
+        "rate-limited source must reflect zero budget"
+    );
+    // Source B: no headers, must remain None.
+    assert_eq!(
+        source_b_ref.rate_limit_remaining(),
+        None,
+        "unlimited source must remain None"
+    );
+}
+
+/// Tracing capture: verify the circuit breaker warn! message is emitted.
+///
+/// Uses `tracing-subscriber` with an in-memory layer to capture log output.
+/// Proves the breaker actually fires (not just that the engine completes),
+/// making the "breaker fired" assertion explicit rather than inferred from
+/// side effects.
+#[tokio::test]
+async fn budget_circuit_breaker_emits_tracing_warn() {
+    use std::sync::Mutex;
+    use tracing_subscriber::Layer;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    /// Minimal tracing layer that captures formatted warn-level events.
+    struct CaptureLayer {
+        messages: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl<S: tracing::Subscriber> Layer<S> for CaptureLayer {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            if *event.metadata().level() == tracing::Level::WARN {
+                let mut visitor = MessageVisitor(String::new());
+                event.record(&mut visitor);
+                self.messages.lock().unwrap().push(visitor.0);
+            }
+        }
+    }
+
+    struct MessageVisitor(String);
+
+    impl tracing::field::Visit for MessageVisitor {
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            if field.name() == "message" {
+                self.0 = format!("{value:?}");
+            }
+        }
+    }
+
+    let captured = Arc::new(Mutex::new(Vec::<String>::new()));
+    let layer = CaptureLayer {
+        messages: Arc::clone(&captured),
+    };
+    let subscriber = tracing_subscriber::registry().with(layer);
+
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let parts = ManifestBuilder::new(b"trace-config")
+        .layer(b"trace-layer")
+        .build();
+    let num_tags: usize = 10;
+
+    for i in 0..num_tags {
+        let tag = format!("v{i}");
+        mount_source_manifest_with_rate_limit(
+            &source_server,
+            "library/traced",
+            &tag,
+            &parts.bytes,
+            0,
+        )
+        .await;
+    }
+    mount_blob_pull(
+        &source_server,
+        "library/traced",
+        &parts.config_desc.digest,
+        &parts.config_data,
+    )
+    .await;
+    for (data, desc) in parts.layers_data.iter().zip(parts.layer_descs.iter()) {
+        mount_blob_pull(&source_server, "library/traced", &desc.digest, data).await;
+    }
+
+    for i in 0..num_tags {
+        let tag = format!("v{i}");
+        mount_manifest_head_not_found(&target_server, "mirror/traced", &tag).await;
+        mount_manifest_push(&target_server, "mirror/traced", &tag).await;
+    }
+    mount_blob_not_found(&target_server, "mirror/traced", &parts.config_desc.digest).await;
+    for desc in &parts.layer_descs {
+        mount_blob_not_found(&target_server, "mirror/traced", &desc.digest).await;
+    }
+    mount_blob_push(&target_server, "mirror/traced").await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let tags: Vec<TagPair> = (0..num_tags)
+        .map(|i| TagPair::same(format!("v{i}")))
+        .collect();
+
+    let mapping = resolved_mapping(
+        source_client,
+        "library/traced",
+        "mirror/traced",
+        vec![target_entry("target-reg", target_client)],
+        tags,
+    );
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+
+    // Run the engine under our custom subscriber.
+    let _guard = tracing::subscriber::set_default(subscriber);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+    drop(_guard);
+
+    assert_eq!(report.stats.images_synced, num_tags as u64);
+
+    let messages = captured.lock().unwrap();
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("rate-limit budget low, pausing discovery")),
+        "expected warn message about pausing discovery, got: {messages:?}"
+    );
 }

--- a/docs/src/content/design/engine.md
+++ b/docs/src/content/design/engine.md
@@ -124,9 +124,9 @@ The mapping function is ~20 lines. The window key is derived from HTTP method + 
 
 ### Budget circuit breaker
 
-> **Status: Planned.** The circuit breaker described below is designed but not yet implemented.
+Parse `ratelimit-remaining` from Docker Hub manifest responses (and `x-ratelimit-remaining` from GHCR). Single decision point: if `remaining < max(remaining_discovery_count / 10, 1)`, log warning and pause discovery. The floor of 1 ensures the breaker can fire even for small syncs (fewer than 10 images). Discovery items already in `pending` wait for promotion (which requires all discovery to complete). Resume when a subsequent response shows budget has refilled, or when the execution pool is empty (preventing stall). The resume condition checks execution emptiness alone, not `pending`, because pending items cannot be promoted until all discovery completes -- requiring both to be empty would deadlock when the breaker pauses discovery with items already queued. In practice, the anti-stall path serializes remaining discovery one-at-a-time, preventing burst consumption of the rate-limit budget.
 
-Parse `ratelimit-remaining` from Docker Hub manifest responses (and `X-RateLimit-Remaining` from GHCR). Single decision point: if `remaining < 0.1 * planned_discovery_count`, log warning and pause discovery. Execution continues for already-discovered images. Resume when a subsequent response shows budget has refilled.
+The header is extracted in `RegistryClient::send_with_aimd` on every successful response and stored in an `AtomicU64` on the client. The engine reads this value on source clients after each discovery completion and compares against the threshold. The `discovery_paused` guard disables the discovery `select!` branch, which on `current_thread` prevents paused futures from being polled.
 
 This is not a dynamic priority scheduler. It is a circuit breaker with one threshold. For registries without rate-limit headers (ECR, GAR, Chainguard): AIMD handles capacity discovery automatically through 429 feedback.
 


### PR DESCRIPTION
## Summary

- Parse `ratelimit-remaining` (Docker Hub) and `x-ratelimit-remaining` (GHCR) headers from every source-registry HTTP response, stored as an `AtomicU64` on `RegistryClient`
- When remaining budget drops below 10% of pending discovery count (floor of 1), pause the discovery `select!` branch -- execution continues for already-discovered images
- Resume discovery when budget refills above threshold, or when execution drains (anti-stall)
- Pause is all-or-nothing across sources: any source below threshold pauses all discovery (`FuturesUnordered` does not support selective polling)
- Registries without rate-limit headers (ECR, GAR, Chainguard) are unaffected -- AIMD handles those via 429 feedback

## Design

Header extraction lives in `RegistryClient::send_with_aimd` (called on every response). The engine reads `rate_limit_remaining()` on source clients after each discovery completion and at the top of each loop iteration (for resume). The `discovery_paused` bool disables the discovery `select!` branch, which on `current_thread` prevents paused futures from making HTTP requests.

The threshold floor `.max(1)` prevents a dead zone where fewer than 10 discovery items yields threshold 0, making the breaker impossible to trigger.

## Test plan

**Header parsing (unit)**
- [x] Docker Hub format (`99;w=21600`) and GHCR format (`42`)
- [x] Docker Hub preferred when both present
- [x] Missing header returns `None`; zero value parses correctly
- [x] `rate_limit_remaining()` returns `None` before any response
- [x] Value updated from response header via wiremock integration test
- [x] Value NOT reset when subsequent response lacks the header

**Engine integration**
- [x] Zero budget: 15 tags with `ratelimit-remaining: 0` -- all sync via anti-stall path
- [x] Threshold floor: 5 tags (< 10) with zero budget -- `.max(1)` makes breaker reachable
- [x] Budget refill: sequenced mocks (3 low, then high) -- discovery resumes after refill
- [x] Threshold met every cycle: wiremock `.expect(15)` proves all manifest GETs happened
- [x] No header: 10 tags without rate-limit headers -- unaffected, `rate_limit_remaining()` stays `None`
- [x] Multi-source: two source registries (one rate-limited, one unlimited) -- all-or-nothing pause, no deadlock
- [x] Tracing capture: custom subscriber layer asserts `warn!("rate-limit budget low, pausing discovery")` is emitted

**CI gate**
- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test && cargo deny check`