### PR TITLE
feat: immutable tag skip optimization (Tier 1, zero API calls)

### DIFF
--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -29,7 +29,6 @@ use std::time::Instant;
 use bytes::Bytes;
 use futures_util::StreamExt;
 use futures_util::stream::FuturesUnordered;
-use globset::GlobSet;
 use ocync_distribution::BatchBlobChecker;
 use ocync_distribution::Digest;
 use ocync_distribution::RegistryClient;
@@ -138,17 +137,33 @@ pub struct ResolvedMapping {
     /// The source HEAD from the discovery optimization is reused, so
     /// enabling both features does not issue a redundant HEAD.
     pub head_first: bool,
-    /// Compiled glob pattern for immutable tags.
+    /// Compiled glob pattern identifying immutable tags.
     ///
-    /// When a tag matches this pattern AND exists in all target tag lists,
-    /// the tag is skipped with zero API calls. See the skip optimization
-    /// hierarchy in the design docs.
-    pub immutable_tags: Option<GlobSet>,
-    /// Per-target tag lists, indexed in the same order as [`targets`](Self::targets).
+    /// When a tag matches this pattern AND exists in every target's
+    /// [`existing_tags`](TargetEntry::existing_tags), the tag is skipped with
+    /// zero API calls. See the skip optimization hierarchy in the design docs.
+    pub immutable_glob: Option<globset::GlobSet>,
+}
+
+impl ResolvedMapping {
+    /// Returns `true` when `tag` should be skipped via the immutable-tag
+    /// optimization: the tag matches the configured glob AND already exists
+    /// at every target.
     ///
-    /// Only populated when `immutable_tags` is `Some`. Each entry contains the
-    /// set of tags already present at the corresponding target registry.
-    pub target_tag_lists: Vec<HashSet<String>>,
+    /// Returns `false` (no skip) when:
+    /// - No `immutable_glob` is configured.
+    /// - The tag does not match the pattern.
+    /// - `targets` is empty (degenerate case; `.all()` on empty is `true`).
+    /// - Any target's `existing_tags` does not contain the tag.
+    pub fn should_skip_immutable(&self, tag: &str) -> bool {
+        let Some(ref pattern) = self.immutable_glob else {
+            return false;
+        };
+        if self.targets.is_empty() {
+            return false;
+        }
+        pattern.is_match(tag) && self.targets.iter().all(|t| t.existing_tags.contains(tag))
+    }
 }
 
 /// A single target registry entry.
@@ -169,6 +184,13 @@ pub struct TargetEntry {
     /// When present, [`transfer_image_blobs`] pre-populates the cache via
     /// a single batch call instead of per-blob HEAD checks.
     pub batch_checker: Option<Rc<dyn BatchBlobChecker>>,
+    /// Tags already present at this target registry at resolution time.
+    ///
+    /// Populated when `immutable_glob` is configured on the parent
+    /// [`ResolvedMapping`]. Empty when the pattern is absent OR when
+    /// `list_tags` failed (degraded: the immutable skip is disabled
+    /// for this target, falling through to HEAD-based discovery).
+    pub existing_tags: HashSet<String>,
 }
 
 impl Clone for TargetEntry {
@@ -177,6 +199,7 @@ impl Clone for TargetEntry {
             name: self.name.clone(),
             client: Arc::clone(&self.client),
             batch_checker: self.batch_checker.clone(),
+            existing_tags: self.existing_tags.clone(),
         }
     }
 }
@@ -187,6 +210,7 @@ impl fmt::Debug for TargetEntry {
             .field("name", &self.name)
             .field("client", &self.client)
             .field("batch_checker", &self.batch_checker.as_ref().map(|_| ".."))
+            .field("existing_tags", &self.existing_tags.len())
             .finish()
     }
 }
@@ -671,42 +695,29 @@ impl SyncEngine {
         // Seed discovery with all (mapping, tag) pairs.
         for mapping in &mappings {
             for tag_pair in &mapping.tags {
-                // Tier 1: immutable_tags pattern match (0 API calls).
-                // If the tag matches the pattern AND exists in ALL target tag
-                // lists, skip immediately without entering discovery.
-                if let Some(ref pattern) = mapping.immutable_tags {
-                    if pattern.is_match(&tag_pair.target)
-                        && !mapping.target_tag_lists.is_empty()
-                        && mapping
-                            .target_tag_lists
-                            .iter()
-                            .all(|tags| tags.contains(&tag_pair.target))
-                    {
-                        info!(
-                            source_repo = %mapping.source_repo,
-                            tag = %tag_pair.target,
-                            "skipping -- immutable tag exists at all targets"
-                        );
-                        let source_ref = ImageRef {
-                            repo: mapping.source_repo.clone(),
-                            tag: tag_pair.source.clone(),
-                        };
-                        let target_ref = ImageRef {
-                            repo: mapping.target_repo.clone(),
-                            tag: tag_pair.target.clone(),
-                        };
-                        for _entry in &mapping.targets {
-                            let r = skip_image_result(
-                                &source_ref,
-                                &target_ref,
-                                SkipReason::ImmutableTag,
-                            );
-                            progress.image_completed(&r);
-                            results.push(r);
-                        }
-                        immutable_tag_skips += mapping.targets.len() as u64;
-                        continue;
+                // Tier 1: immutable tag skip (0 API calls).
+                if mapping.should_skip_immutable(&tag_pair.target) {
+                    info!(
+                        source_repo = %mapping.source_repo,
+                        tag = %tag_pair.target,
+                        "skipping -- immutable tag exists at all targets"
+                    );
+                    let source_ref = ImageRef {
+                        repo: mapping.source_repo.clone(),
+                        tag: tag_pair.source.clone(),
+                    };
+                    let target_ref = ImageRef {
+                        repo: mapping.target_repo.clone(),
+                        tag: tag_pair.target.clone(),
+                    };
+                    for _entry in &mapping.targets {
+                        let r =
+                            skip_image_result(&source_ref, &target_ref, SkipReason::ImmutableTag);
+                        progress.image_completed(&r);
+                        results.push(r);
                     }
+                    immutable_tag_skips += mapping.targets.len() as u64;
+                    continue;
                 }
 
                 let params = DiscoveryParams {
@@ -1316,6 +1327,7 @@ async fn check_targets_against_digest(params: TargetCheckParams<'_>) -> TargetCh
                     name: target_name,
                     client: target_client,
                     batch_checker,
+                    existing_tags: HashSet::new(),
                 });
             }
         }

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -29,6 +29,7 @@ use std::time::Instant;
 use bytes::Bytes;
 use futures_util::StreamExt;
 use futures_util::stream::FuturesUnordered;
+use globset::GlobSet;
 use ocync_distribution::BatchBlobChecker;
 use ocync_distribution::Digest;
 use ocync_distribution::RegistryClient;
@@ -137,6 +138,17 @@ pub struct ResolvedMapping {
     /// The source HEAD from the discovery optimization is reused, so
     /// enabling both features does not issue a redundant HEAD.
     pub head_first: bool,
+    /// Compiled glob pattern for immutable tags.
+    ///
+    /// When a tag matches this pattern AND exists in all target tag lists,
+    /// the tag is skipped with zero API calls. See the skip optimization
+    /// hierarchy in the design docs.
+    pub immutable_tags: Option<GlobSet>,
+    /// Per-target tag lists, indexed in the same order as [`targets`](Self::targets).
+    ///
+    /// Only populated when `immutable_tags` is `Some`. Each entry contains the
+    /// set of tags already present at the corresponding target registry.
+    pub target_tag_lists: Vec<HashSet<String>>,
 }
 
 /// A single target registry entry.
@@ -654,9 +666,49 @@ impl SyncEngine {
             clients
         };
 
+        let mut immutable_tag_skips: u64 = 0;
+
         // Seed discovery with all (mapping, tag) pairs.
         for mapping in &mappings {
             for tag_pair in &mapping.tags {
+                // Tier 1: immutable_tags pattern match (0 API calls).
+                // If the tag matches the pattern AND exists in ALL target tag
+                // lists, skip immediately without entering discovery.
+                if let Some(ref pattern) = mapping.immutable_tags {
+                    if pattern.is_match(&tag_pair.target)
+                        && !mapping.target_tag_lists.is_empty()
+                        && mapping
+                            .target_tag_lists
+                            .iter()
+                            .all(|tags| tags.contains(&tag_pair.target))
+                    {
+                        info!(
+                            source_repo = %mapping.source_repo,
+                            tag = %tag_pair.target,
+                            "skipping -- immutable tag exists at all targets"
+                        );
+                        let source_ref = ImageRef {
+                            repo: mapping.source_repo.clone(),
+                            tag: tag_pair.source.clone(),
+                        };
+                        let target_ref = ImageRef {
+                            repo: mapping.target_repo.clone(),
+                            tag: tag_pair.target.clone(),
+                        };
+                        for _entry in &mapping.targets {
+                            let r = skip_image_result(
+                                &source_ref,
+                                &target_ref,
+                                SkipReason::ImmutableTag,
+                            );
+                            progress.image_completed(&r);
+                            results.push(r);
+                        }
+                        immutable_tag_skips += mapping.targets.len() as u64;
+                        continue;
+                    }
+                }
+
                 let params = DiscoveryParams {
                     source_client: Arc::clone(&mapping.source_client),
                     source_authority: mapping.source_authority.clone(),
@@ -951,6 +1003,7 @@ impl SyncEngine {
         stats.discovery_head_failures = discovery_head_failures;
         stats.discovery_target_stale = discovery_target_stale;
         stats.discovery_head_first_skips = discovery_head_first_skips;
+        stats.immutable_tag_skips = immutable_tag_skips;
         let duration = run_start.elapsed();
 
         let report = SyncReport {

--- a/crates/ocync-sync/src/filter.rs
+++ b/crates/ocync-sync/src/filter.rs
@@ -1,7 +1,6 @@
 //! Tag filtering pipeline: glob -> semver -> exclude -> sort + latest.
 
-pub use globset::GlobSet;
-use globset::{Glob, GlobSetBuilder};
+use globset::{Glob, GlobSet, GlobSetBuilder};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
@@ -113,25 +112,8 @@ impl FilterConfig {
 // Individual stages
 // ---------------------------------------------------------------------------
 
-/// Build a single-pattern [`GlobSet`] from a glob string.
-///
-/// Used by the CLI to compile `immutable_tags` patterns before passing them
-/// to the engine via [`ResolvedMapping`](crate::engine::ResolvedMapping).
-pub fn build_immutable_glob(pattern: &str) -> Result<GlobSet, Error> {
-    let g = Glob::new(pattern).map_err(|e| Error::InvalidGlob {
-        pattern: pattern.to_owned(),
-        reason: e.to_string(),
-    })?;
-    let mut builder = GlobSetBuilder::new();
-    builder.add(g);
-    builder.build().map_err(|e| Error::InvalidGlob {
-        pattern: pattern.to_owned(),
-        reason: e.to_string(),
-    })
-}
-
 /// Build a [`GlobSet`] from patterns, returning an error on invalid patterns.
-fn build_glob_set(patterns: &[String]) -> Result<GlobSet, Error> {
+pub fn build_glob_set(patterns: &[String]) -> Result<GlobSet, Error> {
     let mut builder = GlobSetBuilder::new();
     for p in patterns {
         let g = Glob::new(p).map_err(|e| Error::InvalidGlob {
@@ -697,11 +679,11 @@ mod tests {
         ));
     }
 
-    // - build_immutable_glob tests ------------------------------------------
+    // - build_glob_set tests -------------------------------------------------
 
     #[test]
-    fn immutable_glob_matches_semver() {
-        let gs = build_immutable_glob("v[0-9]*.[0-9]*.[0-9]*").unwrap();
+    fn glob_set_semver_with_v_prefix() {
+        let gs = build_glob_set(&["v[0-9]*.[0-9]*.[0-9]*".into()]).unwrap();
         assert!(gs.is_match("v1.2.3"));
         assert!(gs.is_match("v10.20.30"));
         assert!(!gs.is_match("latest"));
@@ -709,8 +691,8 @@ mod tests {
     }
 
     #[test]
-    fn immutable_glob_bare_semver() {
-        let gs = build_immutable_glob("[0-9]*.[0-9]*.[0-9]*").unwrap();
+    fn glob_set_bare_semver() {
+        let gs = build_glob_set(&["[0-9]*.[0-9]*.[0-9]*".into()]).unwrap();
         assert!(gs.is_match("1.2.3"));
         assert!(gs.is_match("10.0.0"));
         assert!(!gs.is_match("v1.2.3"));
@@ -718,19 +700,8 @@ mod tests {
     }
 
     #[test]
-    fn immutable_glob_v_prefix_multidigit() {
-        // `v[0-9]*` matches `v` followed by a digit and any remaining chars
-        // before the first dot. Handles both `v1.2.3` and `v10.20.30`.
-        let gs = build_immutable_glob("v[0-9]*.[0-9]*.[0-9]*").unwrap();
-        assert!(gs.is_match("v1.2.3"));
-        assert!(gs.is_match("v10.20.30"));
-        assert!(!gs.is_match("1.2.3"), "bare version should not match");
-        assert!(!gs.is_match("latest"));
-    }
-
-    #[test]
-    fn immutable_glob_invalid_pattern() {
-        let err = build_immutable_glob("[bad").unwrap_err();
+    fn glob_set_invalid_pattern() {
+        let err = build_glob_set(&["[bad".into()]).unwrap_err();
         assert!(matches!(err, Error::InvalidGlob { .. }));
     }
 }

--- a/crates/ocync-sync/src/filter.rs
+++ b/crates/ocync-sync/src/filter.rs
@@ -1,6 +1,7 @@
 //! Tag filtering pipeline: glob -> semver -> exclude -> sort + latest.
 
-use globset::{Glob, GlobSet, GlobSetBuilder};
+pub use globset::GlobSet;
+use globset::{Glob, GlobSetBuilder};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
@@ -111,6 +112,23 @@ impl FilterConfig {
 // ---------------------------------------------------------------------------
 // Individual stages
 // ---------------------------------------------------------------------------
+
+/// Build a single-pattern [`GlobSet`] from a glob string.
+///
+/// Used by the CLI to compile `immutable_tags` patterns before passing them
+/// to the engine via [`ResolvedMapping`](crate::engine::ResolvedMapping).
+pub fn build_immutable_glob(pattern: &str) -> Result<GlobSet, Error> {
+    let g = Glob::new(pattern).map_err(|e| Error::InvalidGlob {
+        pattern: pattern.to_owned(),
+        reason: e.to_string(),
+    })?;
+    let mut builder = GlobSetBuilder::new();
+    builder.add(g);
+    builder.build().map_err(|e| Error::InvalidGlob {
+        pattern: pattern.to_owned(),
+        reason: e.to_string(),
+    })
+}
 
 /// Build a [`GlobSet`] from patterns, returning an error on invalid patterns.
 fn build_glob_set(patterns: &[String]) -> Result<GlobSet, Error> {
@@ -677,5 +695,42 @@ mod tests {
                 minimum: 2
             }
         ));
+    }
+
+    // - build_immutable_glob tests ------------------------------------------
+
+    #[test]
+    fn immutable_glob_matches_semver() {
+        let gs = build_immutable_glob("v[0-9]*.[0-9]*.[0-9]*").unwrap();
+        assert!(gs.is_match("v1.2.3"));
+        assert!(gs.is_match("v10.20.30"));
+        assert!(!gs.is_match("latest"));
+        assert!(!gs.is_match("nightly"));
+    }
+
+    #[test]
+    fn immutable_glob_bare_semver() {
+        let gs = build_immutable_glob("[0-9]*.[0-9]*.[0-9]*").unwrap();
+        assert!(gs.is_match("1.2.3"));
+        assert!(gs.is_match("10.0.0"));
+        assert!(!gs.is_match("v1.2.3"));
+        assert!(!gs.is_match("latest"));
+    }
+
+    #[test]
+    fn immutable_glob_v_prefix_multidigit() {
+        // `v[0-9]*` matches `v` followed by a digit and any remaining chars
+        // before the first dot. Handles both `v1.2.3` and `v10.20.30`.
+        let gs = build_immutable_glob("v[0-9]*.[0-9]*.[0-9]*").unwrap();
+        assert!(gs.is_match("v1.2.3"));
+        assert!(gs.is_match("v10.20.30"));
+        assert!(!gs.is_match("1.2.3"), "bare version should not match");
+        assert!(!gs.is_match("latest"));
+    }
+
+    #[test]
+    fn immutable_glob_invalid_pattern() {
+        let err = build_immutable_glob("[bad").unwrap_err();
+        assert!(matches!(err, Error::InvalidGlob { .. }));
     }
 }

--- a/crates/ocync-sync/src/lib.rs
+++ b/crates/ocync-sync/src/lib.rs
@@ -195,7 +195,10 @@ pub struct SyncStats {
     /// of `discovery_cache_hits` and `discovery_cache_misses` -- the cache had
     /// no entry, but no full pull was needed either.
     pub discovery_head_first_skips: u64,
-    /// Tags skipped via `immutable_tags` pattern match (zero API calls).
+    /// (Tag, target) pairs skipped via immutable-glob match (zero API calls).
+    ///
+    /// Unit is per-target: 2 tags across 3 targets = 6. Consistent with
+    /// `images_skipped` which also counts per-target.
     pub immutable_tag_skips: u64,
 }
 

--- a/crates/ocync-sync/src/lib.rs
+++ b/crates/ocync-sync/src/lib.rs
@@ -195,6 +195,8 @@ pub struct SyncStats {
     /// of `discovery_cache_hits` and `discovery_cache_misses` -- the cache had
     /// no entry, but no full pull was needed either.
     pub discovery_head_first_skips: u64,
+    /// Tags skipped via `immutable_tags` pattern match (zero API calls).
+    pub immutable_tag_skips: u64,
 }
 
 #[cfg(test)]

--- a/crates/ocync-sync/tests/engine_integration.rs
+++ b/crates/ocync-sync/tests/engine_integration.rs
@@ -37,6 +37,7 @@ use ocync_distribution::spec::{
 use ocync_distribution::{BatchBlobChecker, Digest, RegistryClientBuilder};
 use ocync_sync::cache::{PlatformFilterKey, SnapshotKey, SourceSnapshot, TransferStateCache};
 use ocync_sync::engine::{RegistryAlias, ResolvedMapping, SyncEngine, TagPair, TargetEntry};
+use ocync_sync::filter::build_immutable_glob;
 use ocync_sync::progress::NullProgress;
 use ocync_sync::retry::RetryConfig;
 use ocync_sync::shutdown::ShutdownSignal;
@@ -134,6 +135,8 @@ fn resolved_mapping(
         tags,
         platforms: None,
         head_first: false,
+        immutable_tags: None,
+        target_tag_lists: Vec::new(),
     }
 }
 
@@ -9956,6 +9959,8 @@ fn resolved_mapping_head_first(
         tags,
         platforms,
         head_first: true,
+        immutable_tags: None,
+        target_tag_lists: Vec::new(),
     }
 }
 
@@ -10677,4 +10682,247 @@ async fn head_first_warm_cache_uses_standard_cache_hit() {
     assert_eq!(report.stats.discovery_cache_hits, 1);
     assert_eq!(report.stats.discovery_head_first_skips, 0);
     assert_eq!(report.stats.discovery_cache_misses, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Immutable tags skip optimization
+// ---------------------------------------------------------------------------
+
+/// When a tag matches the `immutable_tags` pattern AND exists in the target's
+/// tag list, the engine must skip with zero API calls - no HEAD, no pull.
+///
+/// Negative assertion: if the optimization were NOT taken, the source server
+/// would receive at least one HEAD request and the test would fail.
+#[tokio::test]
+async fn immutable_tag_skip_when_present_at_target() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    // Do NOT mount any mocks - if the engine issues any request, the mock
+    // server returns 500 which would cause the test to produce a failure
+    // status instead of a skip.
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let immutable_glob = build_immutable_glob("v[0-9]*.[0-9]*.[0-9]*").unwrap();
+    let target_tags: HashSet<String> = ["v1.2.3", "v1.0.0", "v2.0.0"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    let mapping = ResolvedMapping {
+        source_authority: RegistryAuthority::new("source.test.io:443"),
+        source_client,
+        source_repo: RepositoryName::new("library/nginx").unwrap(),
+        target_repo: RepositoryName::new("mirror/nginx").unwrap(),
+        targets: vec![target_entry("target-reg", target_client)],
+        tags: vec![TagPair::same("v1.2.3"), TagPair::same("v1.0.0")],
+        platforms: None,
+        head_first: false,
+        immutable_tags: Some(immutable_glob),
+        target_tag_lists: vec![target_tags],
+    };
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    // Both tags should be skipped as immutable.
+    assert_eq!(report.images.len(), 2);
+    for image in &report.images {
+        assert!(
+            matches!(
+                image.status,
+                ImageStatus::Skipped {
+                    reason: SkipReason::ImmutableTag,
+                }
+            ),
+            "expected ImmutableTag skip, got {:?}",
+            image.status,
+        );
+        assert_eq!(image.bytes_transferred, 0);
+    }
+    assert_eq!(report.stats.images_skipped, 2);
+    assert_eq!(report.stats.immutable_tag_skips, 2);
+
+    // Negative assertion: zero requests issued to either server.
+    let source_requests = source_server.received_requests().await.unwrap();
+    let target_requests = target_server.received_requests().await.unwrap();
+    assert_eq!(
+        source_requests.len(),
+        0,
+        "immutable skip must issue zero source requests, got {}",
+        source_requests.len(),
+    );
+    assert_eq!(
+        target_requests.len(),
+        0,
+        "immutable skip must issue zero target requests, got {}",
+        target_requests.len(),
+    );
+}
+
+/// When a tag matches the `immutable_tags` pattern but does NOT exist in the
+/// target's tag list, the engine must fall through to normal discovery (not
+/// skip). This tests a new tag that needs to be synced for the first time.
+#[tokio::test]
+async fn immutable_tag_not_skipped_when_absent_from_target() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_data = b"immutable-config";
+    let layer_data = b"immutable-layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (manifest_bytes, _) = serialize_manifest(&manifest);
+
+    // Source: serve the manifest and blobs.
+    mount_source_manifest(&source_server, "library/nginx", "v3.0.0", &manifest_bytes).await;
+    mount_blob_pull(
+        &source_server,
+        "library/nginx",
+        &config_desc.digest,
+        config_data,
+    )
+    .await;
+    mount_blob_pull(
+        &source_server,
+        "library/nginx",
+        &layer_desc.digest,
+        layer_data,
+    )
+    .await;
+
+    // Target: manifest HEAD 404, blobs not found, push endpoints.
+    mount_manifest_head_not_found(&target_server, "mirror/nginx", "v3.0.0").await;
+    mount_blob_not_found(&target_server, "mirror/nginx", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "mirror/nginx", &layer_desc.digest).await;
+    mount_blob_push(&target_server, "mirror/nginx").await;
+    mount_manifest_push(&target_server, "mirror/nginx", "v3.0.0").await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let immutable_glob = build_immutable_glob("v[0-9]*.[0-9]*.[0-9]*").unwrap();
+    // v3.0.0 is NOT in the target tag list - it's a new tag.
+    let target_tags: HashSet<String> = ["v1.0.0", "v2.0.0"].iter().map(|s| s.to_string()).collect();
+
+    let mapping = ResolvedMapping {
+        source_authority: RegistryAuthority::new("source.test.io:443"),
+        source_client,
+        source_repo: RepositoryName::new("library/nginx").unwrap(),
+        target_repo: RepositoryName::new("mirror/nginx").unwrap(),
+        targets: vec![target_entry("target-reg", target_client)],
+        tags: vec![TagPair::same("v3.0.0")],
+        platforms: None,
+        head_first: false,
+        immutable_tags: Some(immutable_glob),
+        target_tag_lists: vec![target_tags],
+    };
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    // Tag must be synced, not skipped.
+    assert_eq!(report.images.len(), 1);
+    assert!(
+        matches!(report.images[0].status, ImageStatus::Synced),
+        "new immutable tag should sync, got {:?}",
+        report.images[0].status,
+    );
+    assert_eq!(report.stats.immutable_tag_skips, 0);
+}
+
+/// Tags that do NOT match the `immutable_tags` pattern fall through to the
+/// normal HEAD + digest compare path, even when the tag exists at the target.
+#[tokio::test]
+async fn non_matching_tag_falls_through_to_head_check() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_digest = make_digest("cc");
+    let layer_digest = make_digest("11");
+    let manifest = simple_image_manifest(&config_digest, &layer_digest);
+    let (manifest_bytes, manifest_digest) = serialize_manifest(&manifest);
+
+    // Source: serve manifest for HEAD.
+    mount_source_manifest(&source_server, "repo", "latest", &manifest_bytes).await;
+
+    // Target: manifest HEAD returns matching digest -> should skip via digest match.
+    mount_manifest_head_matching(&target_server, "repo", "latest", &manifest_digest).await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let immutable_glob = build_immutable_glob("v[0-9]*.[0-9]*.[0-9]*").unwrap();
+    // "latest" exists at target but does NOT match the pattern.
+    let target_tags: HashSet<String> = ["latest", "v1.0.0"].iter().map(|s| s.to_string()).collect();
+
+    let mapping = ResolvedMapping {
+        source_authority: RegistryAuthority::new("source.test.io:443"),
+        source_client,
+        source_repo: RepositoryName::new("repo").unwrap(),
+        target_repo: RepositoryName::new("repo").unwrap(),
+        targets: vec![target_entry("target", target_client)],
+        tags: vec![TagPair::same("latest")],
+        platforms: None,
+        head_first: false,
+        immutable_tags: Some(immutable_glob),
+        target_tag_lists: vec![target_tags],
+    };
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    // "latest" does not match the immutable pattern, so it falls through to
+    // HEAD + digest compare. The digest matches, so it should be skipped
+    // with DigestMatch reason, NOT ImmutableTag.
+    assert_eq!(report.images.len(), 1);
+    assert!(
+        matches!(
+            report.images[0].status,
+            ImageStatus::Skipped {
+                reason: SkipReason::DigestMatch,
+            }
+        ),
+        "non-matching tag should use digest compare, got {:?}",
+        report.images[0].status,
+    );
+    assert_eq!(
+        report.stats.immutable_tag_skips, 0,
+        "non-matching tags must not count as immutable skips",
+    );
 }

--- a/crates/ocync-sync/tests/engine_integration.rs
+++ b/crates/ocync-sync/tests/engine_integration.rs
@@ -37,7 +37,7 @@ use ocync_distribution::spec::{
 use ocync_distribution::{BatchBlobChecker, Digest, RegistryClientBuilder};
 use ocync_sync::cache::{PlatformFilterKey, SnapshotKey, SourceSnapshot, TransferStateCache};
 use ocync_sync::engine::{RegistryAlias, ResolvedMapping, SyncEngine, TagPair, TargetEntry};
-use ocync_sync::filter::build_immutable_glob;
+use ocync_sync::filter::build_glob_set;
 use ocync_sync::progress::NullProgress;
 use ocync_sync::retry::RetryConfig;
 use ocync_sync::shutdown::ShutdownSignal;
@@ -115,6 +115,7 @@ fn target_entry(name: &str, client: Arc<ocync_distribution::RegistryClient>) -> 
         name: RegistryAlias::new(name),
         client,
         batch_checker: None,
+        existing_tags: HashSet::new(),
     }
 }
 
@@ -135,8 +136,7 @@ fn resolved_mapping(
         tags,
         platforms: None,
         head_first: false,
-        immutable_tags: None,
-        target_tag_lists: Vec::new(),
+        immutable_glob: None,
     }
 }
 
@@ -3985,6 +3985,7 @@ async fn sync_batch_checker_all_blobs_exist_skips_head() {
             name: RegistryAlias::new("target"),
             client: target_client,
             batch_checker: Some(Rc::new(checker)),
+            existing_tags: HashSet::new(),
         }],
         vec![TagPair::same("v1")],
     );
@@ -4106,6 +4107,7 @@ async fn sync_batch_checker_partial_existence_transfers_missing() {
             name: RegistryAlias::new("target"),
             client: target_client,
             batch_checker: Some(Rc::new(checker)),
+            existing_tags: HashSet::new(),
         }],
         vec![TagPair::same("v1")],
     );
@@ -4299,6 +4301,7 @@ async fn sync_batch_checker_failure_falls_back_to_per_blob_head() {
             name: RegistryAlias::new("target"),
             client: target_client,
             batch_checker: Some(Rc::new(checker)),
+            existing_tags: HashSet::new(),
         }],
         vec![TagPair::same("v1")],
     );
@@ -4431,11 +4434,13 @@ async fn sync_batch_checker_multi_target_independent_checkers() {
                 name: RegistryAlias::new("target-a"),
                 client: mock_client(&target_a_server),
                 batch_checker: Some(Rc::new(checker_a)),
+                existing_tags: HashSet::new(),
             },
             TargetEntry {
                 name: RegistryAlias::new("target-b"),
                 client: mock_client(&target_b_server),
                 batch_checker: Some(Rc::new(checker_b)),
+                existing_tags: HashSet::new(),
             },
         ],
         vec![TagPair::same("v1")],
@@ -4579,6 +4584,7 @@ async fn sync_batch_checker_empty_result_transfers_all() {
             name: RegistryAlias::new("target"),
             client: mock_client(&target_server),
             batch_checker: Some(Rc::new(checker)),
+            existing_tags: HashSet::new(),
         }],
         vec![TagPair::same("v1")],
     );
@@ -4695,6 +4701,7 @@ async fn sync_mixed_batch_and_no_batch_multi_target() {
                 name: RegistryAlias::new("target-a"),
                 client: mock_client(&target_a_server),
                 batch_checker: Some(Rc::new(checker)),
+                existing_tags: HashSet::new(),
             },
             target_entry("target-b", mock_client(&target_b_server)),
         ],
@@ -4818,6 +4825,7 @@ async fn sync_batch_checker_multi_tag_shares_rc() {
             name: RegistryAlias::new("target"),
             client: mock_client(&target_server),
             batch_checker: Some(Rc::new(checker)),
+            existing_tags: HashSet::new(),
         }],
         vec![TagPair::same("v1"), TagPair::same("v2")],
     );
@@ -5011,6 +5019,7 @@ async fn sync_batch_checker_index_manifest_all_exist() {
             name: RegistryAlias::new("target"),
             client: mock_client(&target_server),
             batch_checker: Some(Rc::new(checker)),
+            existing_tags: HashSet::new(),
         }],
         vec![TagPair::same("latest")],
     );
@@ -5133,6 +5142,7 @@ async fn sync_batch_checker_with_prewarmed_cache() {
             name: RegistryAlias::new("target"),
             client: mock_client(&target_server),
             batch_checker: Some(Rc::new(checker)),
+            existing_tags: HashSet::new(),
         }],
         vec![TagPair::same("v1")],
     );
@@ -9951,16 +9961,9 @@ fn resolved_mapping_head_first(
     platforms: Option<Vec<PlatformFilter>>,
 ) -> ResolvedMapping {
     ResolvedMapping {
-        source_authority: RegistryAuthority::new("source.test.io:443"),
-        source_client,
-        source_repo: RepositoryName::new(source_repo).unwrap(),
-        target_repo: RepositoryName::new(target_repo).unwrap(),
-        targets,
-        tags,
         platforms,
         head_first: true,
-        immutable_tags: None,
-        target_tag_lists: Vec::new(),
+        ..resolved_mapping(source_client, source_repo, target_repo, targets, tags)
     }
 }
 
@@ -10688,8 +10691,13 @@ async fn head_first_warm_cache_uses_standard_cache_hit() {
 // Immutable tags skip optimization
 // ---------------------------------------------------------------------------
 
-/// When a tag matches the `immutable_tags` pattern AND exists in the target's
-/// tag list, the engine must skip with zero API calls - no HEAD, no pull.
+/// Helper: build a `GlobSet` for the standard semver immutable pattern.
+fn immutable_semver_glob() -> globset::GlobSet {
+    build_glob_set(&["v[0-9]*.[0-9]*.[0-9]*".into()]).unwrap()
+}
+
+/// When a tag matches the `immutable_glob` pattern AND exists in the target's
+/// `existing_tags`, the engine must skip with zero API calls - no HEAD, no pull.
 ///
 /// Negative assertion: if the optimization were NOT taken, the source server
 /// would receive at least one HEAD request and the test would fail.
@@ -10705,23 +10713,26 @@ async fn immutable_tag_skip_when_present_at_target() {
     let source_client = mock_client(&source_server);
     let target_client = mock_client(&target_server);
 
-    let immutable_glob = build_immutable_glob("v[0-9]*.[0-9]*.[0-9]*").unwrap();
     let target_tags: HashSet<String> = ["v1.2.3", "v1.0.0", "v2.0.0"]
         .iter()
         .map(|s| s.to_string())
         .collect();
 
+    let targets = vec![TargetEntry {
+        existing_tags: target_tags,
+        ..target_entry("target-reg", target_client)
+    }];
+    let tags = vec![TagPair::same("v1.2.3"), TagPair::same("v1.0.0")];
+
     let mapping = ResolvedMapping {
-        source_authority: RegistryAuthority::new("source.test.io:443"),
-        source_client,
-        source_repo: RepositoryName::new("library/nginx").unwrap(),
-        target_repo: RepositoryName::new("mirror/nginx").unwrap(),
-        targets: vec![target_entry("target-reg", target_client)],
-        tags: vec![TagPair::same("v1.2.3"), TagPair::same("v1.0.0")],
-        platforms: None,
-        head_first: false,
-        immutable_tags: Some(immutable_glob),
-        target_tag_lists: vec![target_tags],
+        immutable_glob: Some(immutable_semver_glob()),
+        ..resolved_mapping(
+            source_client,
+            "library/nginx",
+            "mirror/nginx",
+            targets,
+            tags,
+        )
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -10770,8 +10781,8 @@ async fn immutable_tag_skip_when_present_at_target() {
     );
 }
 
-/// When a tag matches the `immutable_tags` pattern but does NOT exist in the
-/// target's tag list, the engine must fall through to normal discovery (not
+/// When a tag matches the `immutable_glob` pattern but does NOT exist in the
+/// target's `existing_tags`, the engine must fall through to normal discovery (not
 /// skip). This tests a new tag that needs to be synced for the first time.
 #[tokio::test]
 async fn immutable_tag_not_skipped_when_absent_from_target() {
@@ -10820,21 +10831,23 @@ async fn immutable_tag_not_skipped_when_absent_from_target() {
     let source_client = mock_client(&source_server);
     let target_client = mock_client(&target_server);
 
-    let immutable_glob = build_immutable_glob("v[0-9]*.[0-9]*.[0-9]*").unwrap();
-    // v3.0.0 is NOT in the target tag list - it's a new tag.
+    // v3.0.0 is NOT in the target's existing_tags - it's a new tag.
     let target_tags: HashSet<String> = ["v1.0.0", "v2.0.0"].iter().map(|s| s.to_string()).collect();
 
+    let targets = vec![TargetEntry {
+        existing_tags: target_tags,
+        ..target_entry("target-reg", target_client)
+    }];
+
     let mapping = ResolvedMapping {
-        source_authority: RegistryAuthority::new("source.test.io:443"),
-        source_client,
-        source_repo: RepositoryName::new("library/nginx").unwrap(),
-        target_repo: RepositoryName::new("mirror/nginx").unwrap(),
-        targets: vec![target_entry("target-reg", target_client)],
-        tags: vec![TagPair::same("v3.0.0")],
-        platforms: None,
-        head_first: false,
-        immutable_tags: Some(immutable_glob),
-        target_tag_lists: vec![target_tags],
+        immutable_glob: Some(immutable_semver_glob()),
+        ..resolved_mapping(
+            source_client,
+            "library/nginx",
+            "mirror/nginx",
+            targets,
+            vec![TagPair::same("v3.0.0")],
+        )
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -10858,7 +10871,7 @@ async fn immutable_tag_not_skipped_when_absent_from_target() {
     assert_eq!(report.stats.immutable_tag_skips, 0);
 }
 
-/// Tags that do NOT match the `immutable_tags` pattern fall through to the
+/// Tags that do NOT match the `immutable_glob` pattern fall through to the
 /// normal HEAD + digest compare path, even when the tag exists at the target.
 #[tokio::test]
 async fn non_matching_tag_falls_through_to_head_check() {
@@ -10879,21 +10892,23 @@ async fn non_matching_tag_falls_through_to_head_check() {
     let source_client = mock_client(&source_server);
     let target_client = mock_client(&target_server);
 
-    let immutable_glob = build_immutable_glob("v[0-9]*.[0-9]*.[0-9]*").unwrap();
     // "latest" exists at target but does NOT match the pattern.
     let target_tags: HashSet<String> = ["latest", "v1.0.0"].iter().map(|s| s.to_string()).collect();
 
+    let targets = vec![TargetEntry {
+        existing_tags: target_tags,
+        ..target_entry("target", target_client)
+    }];
+
     let mapping = ResolvedMapping {
-        source_authority: RegistryAuthority::new("source.test.io:443"),
-        source_client,
-        source_repo: RepositoryName::new("repo").unwrap(),
-        target_repo: RepositoryName::new("repo").unwrap(),
-        targets: vec![target_entry("target", target_client)],
-        tags: vec![TagPair::same("latest")],
-        platforms: None,
-        head_first: false,
-        immutable_tags: Some(immutable_glob),
-        target_tag_lists: vec![target_tags],
+        immutable_glob: Some(immutable_semver_glob()),
+        ..resolved_mapping(
+            source_client,
+            "repo",
+            "repo",
+            targets,
+            vec![TagPair::same("latest")],
+        )
     };
 
     let engine = SyncEngine::new(fast_retry(), 50);
@@ -10924,5 +10939,98 @@ async fn non_matching_tag_falls_through_to_head_check() {
     assert_eq!(
         report.stats.immutable_tag_skips, 0,
         "non-matching tags must not count as immutable skips",
+    );
+}
+
+/// Multi-target: tag must exist in ALL targets' `existing_tags` for the skip to
+/// fire. When target A has the tag but target B does not, the engine must fall
+/// through to normal discovery for both targets (not skip one and sync the other).
+#[tokio::test]
+async fn immutable_tag_not_skipped_when_missing_from_one_target() {
+    let source_server = MockServer::start().await;
+    let target_a_server = MockServer::start().await;
+    let target_b_server = MockServer::start().await;
+
+    let config_data = b"mt-config";
+    let layer_data = b"mt-layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (manifest_bytes, _) = serialize_manifest(&manifest);
+
+    // Source: serve manifest and blobs.
+    mount_source_manifest(&source_server, "repo", "v1.0.0", &manifest_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo", &layer_desc.digest, layer_data).await;
+
+    // Target A: manifest HEAD 404, push endpoints (needs sync).
+    mount_manifest_head_not_found(&target_a_server, "repo", "v1.0.0").await;
+    mount_blob_not_found(&target_a_server, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_a_server, "repo", &layer_desc.digest).await;
+    mount_blob_push(&target_a_server, "repo").await;
+    mount_manifest_push(&target_a_server, "repo", "v1.0.0").await;
+
+    // Target B: manifest HEAD 404, push endpoints (needs sync).
+    mount_manifest_head_not_found(&target_b_server, "repo", "v1.0.0").await;
+    mount_blob_not_found(&target_b_server, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_b_server, "repo", &layer_desc.digest).await;
+    mount_blob_push(&target_b_server, "repo").await;
+    mount_manifest_push(&target_b_server, "repo", "v1.0.0").await;
+
+    let source_client = mock_client(&source_server);
+
+    // Target A has the tag, target B does not.
+    let tags_a: HashSet<String> = ["v1.0.0"].iter().map(|s| s.to_string()).collect();
+
+    let targets = vec![
+        TargetEntry {
+            existing_tags: tags_a,
+            ..target_entry("target-a", mock_client(&target_a_server))
+        },
+        target_entry("target-b", mock_client(&target_b_server)),
+    ];
+
+    let mapping = ResolvedMapping {
+        immutable_glob: Some(immutable_semver_glob()),
+        ..resolved_mapping(
+            source_client,
+            "repo",
+            "repo",
+            targets,
+            vec![TagPair::same("v1.0.0")],
+        )
+    };
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    // Both targets must be synced (not skipped) since target B is missing the tag.
+    assert_eq!(report.images.len(), 2);
+    for image in &report.images {
+        assert!(
+            matches!(image.status, ImageStatus::Synced),
+            "expected Synced when one target is missing the tag, got {:?}",
+            image.status,
+        );
+    }
+    assert_eq!(
+        report.stats.immutable_tag_skips, 0,
+        "must not skip when any target is missing the tag",
     );
 }

--- a/deny.toml
+++ b/deny.toml
@@ -13,27 +13,34 @@ allow = [
   "MIT",
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
-  "BSD-2-Clause",
   "BSD-3-Clause",
   "ISC",
-  "Zlib",
   "CC0-1.0",
   "Unlicense",
-  "MPL-2.0",
   "Unicode-3.0",
   "OpenSSL",
-  "CDLA-Permissive-2.0",
 ]
 confidence-threshold = 0.8
 private = { ignore = true }
 
 [bans]
-multiple-versions = "warn"
+multiple-versions = "deny"
 deny = [
   { crate = "native-tls", wrappers = [] },
   { crate = "openssl", wrappers = [] },
   { crate = "openssl-sys", wrappers = [] },
   { crate = "ring", wrappers = [] },
+]
+# Transitive duplicates from AWS SDK + testcontainers ecosystem version splits.
+# These are unavoidable until upstream unifies major versions.
+skip = [
+  { crate = "core-foundation@0.9" },  # system-configuration (hyper-util) vs security-framework
+  { crate = "getrandom@0.3" },        # cc/jobserver vs uuid/rand 0.10
+  { crate = "http@0.2" },             # AWS SDK smithy internals still on http 0.2
+  { crate = "http-body@0.4" },        # AWS SDK smithy internals still on http-body 0.4
+  { crate = "r-efi@5" },              # getrandom 0.3 vs 0.4
+  { crate = "windows-sys@0.59" },     # indicatif (console) vs clap/tokio
+  { crate = "wit-bindgen@0.51" },     # getrandom 0.4 (wasip3) vs wit-bindgen 0.57
 ]
 
 [sources]

--- a/docs/public/config.schema.json
+++ b/docs/public/config.schema.json
@@ -433,6 +433,14 @@
             }
           ]
         },
+        "immutable_tags": {
+          "description": "Glob pattern for immutable tags (e.g. `\"v?[0-9]*.[0-9]*.[0-9]*\"`).\n\nWhen a tag matches this pattern AND already exists in the target's tag list, the tag is skipped with zero API calls. Semver tags are conventionally immutable; this avoids redundant HEAD checks.",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "latest": {
           "description": "Keep only the N most recent tags after sorting.",
           "default": null,

--- a/docs/src/content/configuration.md
+++ b/docs/src/content/configuration.md
@@ -825,6 +825,14 @@ The schema is generated from the Rust config types and verified in CI to stay in
             }
           ]
         },
+        "immutable_tags": {
+          "description": "Glob pattern for immutable tags (e.g. `\"v?[0-9]*.[0-9]*.[0-9]*\"`).\n\nWhen a tag matches this pattern AND already exists in the target's tag list, the tag is skipped with zero API calls. Semver tags are conventionally immutable; this avoids redundant HEAD checks.",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "latest": {
           "description": "Keep only the N most recent tags after sorting.",
           "default": null,

--- a/docs/src/content/design/overview.md
+++ b/docs/src/content/design/overview.md
@@ -303,7 +303,7 @@ If a requested platform is not available in the source image index, `ocync` logs
 
 If **zero** requested platforms match any manifest in the source index, `ocync` returns an error with actionable context: the configured platform filter, the platforms actually available in the source index, and the source reference. An empty filtered index is never pushed to targets because it would leave targets with an invalid manifest that appears synced but contains no usable platform entries. This surfaces platform configuration mismatches immediately rather than silently degrading into an unusable state.
 
-> **Status: Partially implemented.** Default HEAD + digest compare is implemented. The `immutable_tags` optimization described below is designed but not yet implemented.
+> **Status: Implemented.** Both tiers are implemented: `immutable_tags` pattern match (Tier 1, zero API calls) and default HEAD + digest compare (Tier 2).
 
 ## Skip optimization hierarchy
 

--- a/src/cli/commands/copy.rs
+++ b/src/cli/commands/copy.rs
@@ -1,6 +1,7 @@
 //! The `copy` subcommand - copies a single image between registries.
 
 use std::cell::RefCell;
+use std::collections::HashSet;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -71,12 +72,12 @@ pub(crate) async fn run(
             name: RegistryAlias::new(bare_hostname(args.destination.registry())),
             client: target_client,
             batch_checker: None,
+            existing_tags: HashSet::new(),
         }],
         tags: vec![TagPair::retag(src_tag.to_owned(), dst_tag.to_owned())],
         platforms: None,
         head_first: false,
-        immutable_tags: None,
-        target_tag_lists: Vec::new(),
+        immutable_glob: None,
     };
 
     let engine = SyncEngine::new(RetryConfig::default(), DEFAULT_MAX_CONCURRENT_TRANSFERS);

--- a/src/cli/commands/copy.rs
+++ b/src/cli/commands/copy.rs
@@ -75,6 +75,8 @@ pub(crate) async fn run(
         tags: vec![TagPair::retag(src_tag.to_owned(), dst_tag.to_owned())],
         platforms: None,
         head_first: false,
+        immutable_tags: None,
+        target_tag_lists: Vec::new(),
     };
 
     let engine = SyncEngine::new(RetryConfig::default(), DEFAULT_MAX_CONCURRENT_TRANSFERS);

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -1,7 +1,7 @@
 //! The `sync` subcommand - runs all mappings from config.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
@@ -16,7 +16,7 @@ use ocync_sync::engine::{
     DEFAULT_MAX_CONCURRENT_TRANSFERS, RegistryAlias, ResolvedMapping, SyncEngine, TagPair,
     TargetEntry,
 };
-use ocync_sync::filter::FilterConfig;
+use ocync_sync::filter::{FilterConfig, build_immutable_glob};
 use ocync_sync::retry::RetryConfig;
 use ocync_sync::shutdown::ShutdownSignal;
 use ocync_sync::staging::BlobStage;
@@ -312,8 +312,7 @@ pub(crate) async fn resolve_mapping(
             ))
         })?;
 
-    let known: std::collections::HashSet<&str> =
-        config.registries.keys().map(String::as_str).collect();
+    let known: HashSet<&str> = config.registries.keys().map(String::as_str).collect();
     let context = format!("mapping '{}'", mapping.from);
     let target_names =
         resolve_target_names(targets_value, config, &known, &context).map_err(CliError::Config)?;
@@ -383,6 +382,28 @@ pub(crate) async fn resolve_mapping(
         .map(|r| r.head_first)
         .unwrap_or(false);
 
+    // --- Immutable tags optimization ---
+    let immutable_pattern = tags_config.and_then(|t| t.immutable_tags.as_deref());
+    let (immutable_tags, target_tag_lists) = if let Some(pattern) = immutable_pattern {
+        let glob_set = build_immutable_glob(pattern)?;
+
+        let target_repo_path = RepositoryName::new(&target_repo)?;
+        let mut tag_lists = Vec::with_capacity(targets.len());
+        for entry in &targets {
+            let tags: HashSet<String> = entry
+                .client
+                .list_tags(&target_repo_path)
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .collect();
+            tag_lists.push(tags);
+        }
+        (Some(glob_set), tag_lists)
+    } else {
+        (None, Vec::new())
+    };
+
     Ok(Some(ResolvedMapping {
         source_authority,
         source_client,
@@ -392,6 +413,8 @@ pub(crate) async fn resolve_mapping(
         tags: filtered.into_iter().map(TagPair::same).collect(),
         platforms,
         head_first,
+        immutable_tags,
+        target_tag_lists,
     }))
 }
 
@@ -595,6 +618,7 @@ mod tests {
             sort: Some(SortOrder::Semver),
             latest: Some(5),
             min_tags: Some(1),
+            immutable_tags: None,
         };
         let filter = build_filter(Some(&tags));
         assert_eq!(filter.glob, vec!["*"]);

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -16,7 +16,7 @@ use ocync_sync::engine::{
     DEFAULT_MAX_CONCURRENT_TRANSFERS, RegistryAlias, ResolvedMapping, SyncEngine, TagPair,
     TargetEntry,
 };
-use ocync_sync::filter::{FilterConfig, build_immutable_glob};
+use ocync_sync::filter::{FilterConfig, build_glob_set};
 use ocync_sync::retry::RetryConfig;
 use ocync_sync::shutdown::ShutdownSignal;
 use ocync_sync::staging::BlobStage;
@@ -317,7 +317,7 @@ pub(crate) async fn resolve_mapping(
     let target_names =
         resolve_target_names(targets_value, config, &known, &context).map_err(CliError::Config)?;
 
-    let targets: Vec<TargetEntry> = target_names
+    let mut targets: Vec<TargetEntry> = target_names
         .into_iter()
         .map(|name| {
             let client = clients.get(&name).cloned().ok_or_else(|| {
@@ -331,6 +331,7 @@ pub(crate) async fn resolve_mapping(
                 name: RegistryAlias::new(name),
                 client,
                 batch_checker,
+                existing_tags: HashSet::new(),
             })
         })
         .collect::<Result<Vec<_>, CliError>>()?;
@@ -384,24 +385,25 @@ pub(crate) async fn resolve_mapping(
 
     // --- Immutable tags optimization ---
     let immutable_pattern = tags_config.and_then(|t| t.immutable_tags.as_deref());
-    let (immutable_tags, target_tag_lists) = if let Some(pattern) = immutable_pattern {
-        let glob_set = build_immutable_glob(pattern)?;
+    let immutable_glob = if let Some(pattern) = immutable_pattern {
+        let glob_set = build_glob_set(&[pattern.to_owned()])?;
 
         let target_repo_path = RepositoryName::new(&target_repo)?;
-        let mut tag_lists = Vec::with_capacity(targets.len());
-        for entry in &targets {
-            let tags: HashSet<String> = entry
-                .client
-                .list_tags(&target_repo_path)
-                .await
-                .unwrap_or_default()
-                .into_iter()
-                .collect();
-            tag_lists.push(tags);
+        for entry in &mut targets {
+            match entry.client.list_tags(&target_repo_path).await {
+                Ok(tags) => entry.existing_tags = tags.into_iter().collect(),
+                Err(e) => {
+                    tracing::warn!(
+                        registry = %entry.name,
+                        error = %e,
+                        "failed to list target tags; immutable skip disabled for this target"
+                    );
+                }
+            }
         }
-        (Some(glob_set), tag_lists)
+        Some(glob_set)
     } else {
-        (None, Vec::new())
+        None
     };
 
     Ok(Some(ResolvedMapping {
@@ -413,8 +415,7 @@ pub(crate) async fn resolve_mapping(
         tags: filtered.into_iter().map(TagPair::same).collect(),
         platforms,
         head_first,
-        immutable_tags,
-        target_tag_lists,
+        immutable_glob,
     }))
 }
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -360,6 +360,14 @@ pub(crate) struct TagsConfig {
     /// Minimum number of tags to retain regardless of filters.
     #[serde(default)]
     pub min_tags: Option<usize>,
+
+    /// Glob pattern for immutable tags (e.g. `"v?[0-9]*.[0-9]*.[0-9]*"`).
+    ///
+    /// When a tag matches this pattern AND already exists in the target's tag
+    /// list, the tag is skipped with zero API calls. Semver tags are
+    /// conventionally immutable; this avoids redundant HEAD checks.
+    #[serde(default)]
+    pub immutable_tags: Option<String>,
 }
 
 /// A glob pattern: either a single string or a list of patterns.

--- a/src/cli/progress.rs
+++ b/src/cli/progress.rs
@@ -507,6 +507,7 @@ mod tests {
                 discovery_head_failures: 2,
                 discovery_target_stale: 1,
                 discovery_head_first_skips: 0,
+                immutable_tag_skips: 0,
             },
             duration: Duration::from_secs(47),
         };

--- a/src/cli/progress.rs
+++ b/src/cli/progress.rs
@@ -62,16 +62,22 @@ fn write_run_summary(
     let s = &report.stats;
     let has_discovery = s.discovery_cache_hits > 0
         || s.discovery_cache_misses > 0
-        || s.discovery_head_first_skips > 0;
+        || s.discovery_head_first_skips > 0
+        || s.immutable_tag_skips > 0;
     let discovery = if has_discovery {
         let head_first_suffix = if s.discovery_head_first_skips > 0 {
             format!(", {} head_first", s.discovery_head_first_skips)
         } else {
             String::new()
         };
+        let immutable_suffix = if s.immutable_tag_skips > 0 {
+            format!(", {} immutable", s.immutable_tag_skips)
+        } else {
+            String::new()
+        };
         format!(
-            " | discovery: {} cached, {} pulled{}",
-            s.discovery_cache_hits, s.discovery_cache_misses, head_first_suffix,
+            " | discovery: {} cached, {} pulled{}{}",
+            s.discovery_cache_hits, s.discovery_cache_misses, head_first_suffix, immutable_suffix,
         )
     } else {
         String::new()
@@ -620,6 +626,53 @@ mod tests {
         let output = String::from_utf8(buf.borrow().clone()).unwrap();
         assert!(
             output.contains("discovery: 0 cached, 0 pulled, 5 head_first"),
+            "got: {output}"
+        );
+    }
+
+    #[test]
+    fn summary_with_immutable_skips_includes_suffix() {
+        let buf: Buf = Rc::new(RefCell::new(Vec::new()));
+        let stdout: RefCell<Box<dyn Write>> = RefCell::new(Box::new(RcWriter(Rc::clone(&buf))));
+        let report = SyncReport {
+            run_id: Uuid::now_v7(),
+            images: vec![make_result(ImageStatus::Synced, 1024)],
+            stats: SyncStats {
+                images_synced: 1,
+                images_skipped: 10,
+                discovery_cache_hits: 2,
+                discovery_cache_misses: 1,
+                immutable_tag_skips: 8,
+                ..SyncStats::default()
+            },
+            duration: Duration::from_secs(3),
+        };
+        write_run_summary(&stdout, &report, false);
+        let output = String::from_utf8(buf.borrow().clone()).unwrap();
+        assert!(
+            output.contains("discovery: 2 cached, 1 pulled, 8 immutable"),
+            "got: {output}"
+        );
+    }
+
+    #[test]
+    fn summary_with_only_immutable_skips_includes_discovery() {
+        let buf: Buf = Rc::new(RefCell::new(Vec::new()));
+        let stdout: RefCell<Box<dyn Write>> = RefCell::new(Box::new(RcWriter(Rc::clone(&buf))));
+        let report = SyncReport {
+            run_id: Uuid::now_v7(),
+            images: vec![make_result(ImageStatus::Synced, 1024)],
+            stats: SyncStats {
+                images_synced: 1,
+                immutable_tag_skips: 50,
+                ..SyncStats::default()
+            },
+            duration: Duration::from_secs(1),
+        };
+        write_run_summary(&stdout, &report, false);
+        let output = String::from_utf8(buf.borrow().clone()).unwrap();
+        assert!(
+            output.contains("discovery: 0 cached, 0 pulled, 50 immutable"),
             "got: {output}"
         );
     }


### PR DESCRIPTION
## Summary

- Adds `immutable_tags` config field (glob pattern) to skip known-immutable tags with zero API calls
- When a tag matches the pattern AND exists at all targets, the engine skips it before discovery -- no HEAD, no digest compare, no source manifest pull
- For semver-heavy repos (2000 tags, 5 new per cycle), this eliminates ~1995 HEAD requests per target per run

## Design

Tier 1 of the two-tier skip optimization hierarchy in `docs/src/content/design/overview.md`:

- **Tier 1 (new):** `immutable_glob` pattern match -- zero API calls for known-immutable tags
- **Tier 2 (existing):** HEAD + digest compare -- default path for all other tags

Config example:
```yaml
defaults:
  tags:
    immutable_tags: "v[0-9]*.[0-9]*.[0-9]*"
```

## Key implementation details

- `ResolvedMapping::should_skip_immutable(tag)` encapsulates the skip decision (pattern match + all-targets check + empty-targets guard)
- `TargetEntry::existing_tags` holds the tag list fetched at resolution time; empty on `list_tags` failure (graceful degradation -- falls through to HEAD-based discovery)
- `immutable_tag_skips` stat counts per (tag, target) pair, consistent with `images_skipped`
- Progress summary shows immutable skip count in the discovery suffix

## Changes

- `src/cli/config.rs`: `immutable_tags: Option<String>` on `TagsConfig`
- `crates/ocync-sync/src/engine.rs`: `immutable_glob` field + `should_skip_immutable()` method on `ResolvedMapping`; `existing_tags` on `TargetEntry`
- `crates/ocync-sync/src/lib.rs`: `immutable_tag_skips` counter on `SyncStats`
- `src/cli/commands/synchronize.rs`: compile glob, fetch target tag lists, populate `existing_tags`
- `src/cli/progress.rs`: display immutable skip count in summary line
- `deny.toml`: promote `multiple-versions` to deny + explicit skip list; remove unused license allowances
- `docs/src/content/design/overview.md`: status updated to "Implemented"
- Schema files regenerated

## Test plan

- [x] `immutable_tag_skip_when_present_at_target` -- matching tags + target presence = zero API calls (negative assertion: mock servers receive zero requests)
- [x] `immutable_tag_not_skipped_when_absent_from_target` -- new tag syncs normally despite matching pattern
- [x] `non_matching_tag_falls_through_to_head_check` -- non-matching tags use Tier 2 even when present at target
- [x] `immutable_tag_not_skipped_when_missing_from_one_target` -- multi-target: ALL targets must have the tag
- [x] `build_glob_set` unit tests -- pattern compilation, semver matching, invalid patterns
- [x] Progress summary tests -- immutable suffix rendering
- [x] Full CI gate: `cargo fmt --check && cargo clippy -- -D warnings && cargo test && cargo deny check`