### PR TITLE
feat: OCI artifact sync with referrers API and tag fallback

### DIFF
--- a/crates/ocync-distribution/src/digest.rs
+++ b/crates/ocync-distribution/src/digest.rs
@@ -40,6 +40,14 @@ impl Digest {
     pub fn hex(&self) -> &str {
         &self.raw[self.algo_len + 1..]
     }
+
+    /// Build the OCI tag fallback name for referrers discovery.
+    ///
+    /// Older registries that do not support the referrers API store artifact
+    /// references as tags named `{algorithm}-{hex}` (e.g. `sha256-abcd...`).
+    pub fn tag_fallback(&self) -> String {
+        format!("{}-{}", self.algorithm(), self.hex())
+    }
 }
 
 impl FromStr for Digest {
@@ -289,5 +297,16 @@ mod tests {
         let input = format!("Sha256:{hex}");
         let d: Digest = input.parse().unwrap();
         assert_eq!(d.algorithm(), "sha256");
+    }
+
+    #[test]
+    fn tag_fallback_replaces_colon_with_dash() {
+        let d: Digest = TEST_DIGEST.parse().unwrap();
+        let tag = d.tag_fallback();
+        assert_eq!(
+            tag,
+            "sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert!(!tag.contains(':'), "tag fallback must not contain ':'");
     }
 }

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -36,8 +36,8 @@ use ocync_distribution::blob::MountResult;
 use ocync_distribution::manifest::ManifestPull;
 use ocync_distribution::sha256::Sha256;
 use ocync_distribution::spec::{
-    Descriptor, ImageIndex, ImageManifest, ManifestKind, PlatformFilter, RegistryAuthority,
-    RepositoryName,
+    Descriptor, ImageIndex, ImageManifest, ManifestKind, MediaType, PlatformFilter,
+    RegistryAuthority, RepositoryName,
 };
 use tokio::sync::Semaphore;
 use tracing::{debug, info, warn};
@@ -100,6 +100,65 @@ impl fmt::Display for RegistryAlias {
     }
 }
 
+/// Resolved artifact sync configuration.
+///
+/// Controls whether the engine discovers and transfers OCI referrers
+/// (signatures, SBOMs, attestations) after syncing each image manifest.
+#[derive(Debug, Clone)]
+pub struct ResolvedArtifacts {
+    /// Whether artifact discovery and transfer is enabled.
+    pub enabled: bool,
+    /// Only sync artifacts whose artifact type matches one of these MIME types.
+    /// Empty means all types pass.
+    pub include: Vec<String>,
+    /// Exclude artifacts whose artifact type matches one of these MIME types.
+    pub exclude: Vec<String>,
+    /// When true, images with no referrers cause a sync failure.
+    pub require_artifacts: bool,
+}
+
+impl Default for ResolvedArtifacts {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            include: Vec::new(),
+            exclude: Vec::new(),
+            require_artifacts: false,
+        }
+    }
+}
+
+impl ResolvedArtifacts {
+    /// Check whether a given artifact type passes the include/exclude filters.
+    pub fn type_matches(&self, artifact_type: &str) -> bool {
+        if !self.include.is_empty() && !self.include.iter().any(|t| t == artifact_type) {
+            return false;
+        }
+        if self.exclude.iter().any(|t| t == artifact_type) {
+            return false;
+        }
+        true
+    }
+}
+
+/// Cached result of referrer discovery for a (`source_repo`, `parent_digest`) pair.
+///
+/// Avoids redundant referrers API calls when the same source manifest is synced
+/// to multiple targets.
+#[derive(Clone)]
+#[allow(clippy::large_enum_variant)]
+enum CachedReferrers {
+    /// Successfully discovered referrers (index may have zero entries).
+    Found(ImageIndex),
+    /// No referrers exist (API 404 + tag fallback 404).
+    NotFound,
+    /// Discovery failed due to a transient error.
+    Failed,
+}
+
+/// Per-run cache of referrer discovery results, keyed by (`source_repo`, `parent_digest`).
+type ReferrersCache = Rc<RefCell<HashMap<(RepositoryName, Digest), CachedReferrers>>>;
+
 /// A fully resolved mapping ready for the sync engine.
 ///
 /// All config resolution (registry lookup, tag filtering) is done
@@ -143,6 +202,8 @@ pub struct ResolvedMapping {
     /// [`existing_tags`](TargetEntry::existing_tags), the tag is skipped with
     /// zero API calls. See the skip optimization hierarchy in the design docs.
     pub immutable_glob: Option<globset::GlobSet>,
+    /// Artifact sync configuration (shared across all tasks for this mapping).
+    pub artifacts_config: Rc<ResolvedArtifacts>,
 }
 
 impl ResolvedMapping {
@@ -320,6 +381,8 @@ struct TransferTask {
     target: ImageRef,
     /// Optional batch blob checker for pre-populating the cache.
     batch_checker: Option<Rc<dyn BatchBlobChecker>>,
+    /// Artifact sync configuration (Rc-shared with mapping).
+    artifacts_config: Rc<ResolvedArtifacts>,
 }
 
 /// Discovery outcome for one (mapping, tag) pair.
@@ -545,6 +608,7 @@ struct PromoteContext<'a> {
     staging: &'a Rc<BlobStage>,
     freq_map: &'a BlobFrequencyMap,
     retry: &'a RetryConfig,
+    referrers_cache: &'a ReferrersCache,
 }
 
 /// Default cap for concurrent image transfers (Level 1: global image semaphore).
@@ -643,6 +707,7 @@ impl SyncEngine {
         let mut freq_map = BlobFrequencyMap::new();
         let global_sem = Rc::new(Semaphore::new(self.max_concurrent));
         let staging = Rc::new(staging);
+        let referrers_cache: ReferrersCache = Rc::new(RefCell::new(HashMap::new()));
         let mut results: Vec<ImageResult> = Vec::new();
         let mut shutting_down = false;
         let mut drain_deadline: Option<tokio::time::Instant> = None;
@@ -737,6 +802,7 @@ impl SyncEngine {
                     cache: Rc::clone(&cache),
                     source_head_timeout: self.source_head_timeout,
                     head_first: mapping.head_first,
+                    artifacts_config: mapping.artifacts_config.clone(),
                 };
 
                 discovery_futures.push(async move { discover_tag(params).await });
@@ -759,6 +825,7 @@ impl SyncEngine {
                     .collect()
             };
             let staging_ref = Rc::clone(ctx.staging);
+            let referrers_ref = Rc::clone(ctx.referrers_cache);
             let source_str = item.source.to_string();
             let target_str = item.target.to_string();
             let preferred_mount_sources = preferred_mount_sources.to_vec();
@@ -772,6 +839,7 @@ impl SyncEngine {
                     &freq_counts,
                     &retry,
                     &preferred_mount_sources,
+                    &referrers_ref,
                 )
                 .await
             })
@@ -839,6 +907,7 @@ impl SyncEngine {
                         staging: &staging,
                         freq_map: &freq_map,
                         retry: &self.retry,
+                        referrers_cache: &referrers_cache,
                     };
                     for _ in 0..to_promote {
                         if let Some(item) = pending.pop_front() {
@@ -856,6 +925,7 @@ impl SyncEngine {
                         staging: &staging,
                         freq_map: &freq_map,
                         retry: &self.retry,
+                        referrers_cache: &referrers_cache,
                     };
                     let to_promote = pending.len();
                     promotion_phase = PromotionPhase::Done;
@@ -1047,6 +1117,8 @@ struct DiscoveryParams {
     source_head_timeout: Duration,
     /// When true, HEAD-check targets on cache miss before the full source GET.
     head_first: bool,
+    /// Artifact sync configuration (Rc-shared with mapping).
+    artifacts_config: Rc<ResolvedArtifacts>,
 }
 
 /// Discover a single (mapping, tag) pair: HEAD source, check cache, pull if needed.
@@ -1074,6 +1146,7 @@ async fn discover_tag(params: DiscoveryParams) -> (DiscoveryOutcome, DiscoveryRo
         source,
         target,
         targets,
+        artifacts_config,
         retry,
         platforms,
         cache,
@@ -1158,6 +1231,7 @@ async fn discover_tag(params: DiscoveryParams) -> (DiscoveryOutcome, DiscoveryRo
                     snapshot_key: &snapshot_key,
                     head_digest: Some(head_digest),
                     platform_key: &platform_key,
+                    artifacts_config: &artifacts_config,
                 })
                 .await;
 
@@ -1220,6 +1294,7 @@ async fn discover_tag(params: DiscoveryParams) -> (DiscoveryOutcome, DiscoveryRo
                 snapshot_key: &snapshot_key,
                 head_digest: Some(head_digest),
                 platform_key: &platform_key,
+                artifacts_config: &artifacts_config,
             })
             .await;
 
@@ -1246,6 +1321,7 @@ async fn discover_tag(params: DiscoveryParams) -> (DiscoveryOutcome, DiscoveryRo
         snapshot_key: &snapshot_key,
         head_digest: source_head_digest.as_ref(),
         platform_key: &platform_key,
+        artifacts_config: &artifacts_config,
     })
     .await;
 
@@ -1351,6 +1427,7 @@ struct FullPullParams<'a> {
     snapshot_key: &'a SnapshotKey,
     head_digest: Option<&'a Digest>,
     platform_key: &'a PlatformFilterKey,
+    artifacts_config: &'a Rc<ResolvedArtifacts>,
 }
 
 /// Full discovery: pull source manifest, HEAD-check targets, build transfer tasks.
@@ -1370,6 +1447,7 @@ async fn full_pull_and_build_tasks(params: FullPullParams<'_>) -> DiscoveryOutco
         snapshot_key,
         head_digest,
         platform_key,
+        artifacts_config,
     } = params;
     // Pull source manifest (shared across all targets for this tag).
     let source_data = match pull_source_manifest(
@@ -1472,6 +1550,7 @@ async fn full_pull_and_build_tasks(params: FullPullParams<'_>) -> DiscoveryOutco
                     source: source.clone(),
                     target: target.clone(),
                     batch_checker,
+                    artifacts_config: Rc::clone(artifacts_config),
                 });
             }
         }
@@ -1495,6 +1574,7 @@ async fn execute_item(
     freq_counts: &HashMap<Digest, usize>,
     retry: &RetryConfig,
     preferred_mount_sources: &[RepositoryName],
+    referrers_cache: &ReferrersCache,
 ) -> ImageResult {
     let start = Instant::now();
 
@@ -1541,6 +1621,46 @@ async fn execute_item(
     .await
     {
         Ok(()) => {
+            // Discover and sync artifacts (signatures, SBOMs, attestations).
+            if let Err(err) = discover_and_sync_artifacts(
+                &item.source_client,
+                &item.target_client,
+                &item.source.repo,
+                &item.target.repo,
+                &item.source_data.pull.digest,
+                &item.artifacts_config,
+                retry,
+                referrers_cache,
+            )
+            .await
+            {
+                let (kind, retries) = if err.is_required_artifacts_missing() {
+                    (ErrorKind::RequiredArtifactsMissing, 0)
+                } else {
+                    (ErrorKind::ArtifactSync, retry.max_retries)
+                };
+                warn!(
+                    source_repo = %item.source.repo,
+                    target_repo = %item.target.repo,
+                    error = %err,
+                    "artifact sync failed"
+                );
+                return ImageResult {
+                    image_id: Uuid::now_v7(),
+                    source: item.source.to_string(),
+                    target: item.target.to_string(),
+                    status: ImageStatus::Failed {
+                        kind,
+                        error: err.to_string(),
+                        retries,
+                        status_code: None,
+                    },
+                    bytes_transferred: outcome.bytes_transferred,
+                    blob_stats: outcome.stats,
+                    duration: start.elapsed(),
+                };
+            }
+
             info!(
                 source_repo = %item.source.repo,
                 source_tag = %item.source.tag,
@@ -2181,6 +2301,264 @@ async fn push_manifests(
     Ok(())
 }
 
+/// Discover referrers for a synced manifest and transfer matching artifacts.
+///
+/// Implements the two-step fallback described in the design doc:
+/// 1. Try the referrers API (`GET /v2/{repo}/referrers/{digest}`)
+/// 2. If 404, try tag fallback (`GET /v2/{repo}/manifests/{algo}-{hex}`)
+/// 3. If neither works, log INFO and continue (no artifacts available)
+///
+/// For each matching artifact: push blobs, then push manifest (preserving
+/// the `subject` reference to the parent).
+#[allow(clippy::too_many_arguments)]
+async fn discover_and_sync_artifacts(
+    source_client: &RegistryClient,
+    target_client: &RegistryClient,
+    source_repo: &RepositoryName,
+    target_repo: &RepositoryName,
+    parent_digest: &Digest,
+    artifacts_config: &ResolvedArtifacts,
+    retry: &RetryConfig,
+    referrers_cache: &ReferrersCache,
+) -> Result<(), crate::Error> {
+    if !artifacts_config.enabled {
+        return Ok(());
+    }
+
+    // Check the per-run referrers cache to avoid redundant discovery when
+    // the same source manifest is synced to multiple targets.
+    let cache_key = (source_repo.clone(), parent_digest.clone());
+    let cached = referrers_cache.borrow().get(&cache_key).cloned();
+
+    let (referrers_index, discovery_succeeded) = if let Some(cached_entry) = cached {
+        debug!(
+            repo = %source_repo,
+            digest = %parent_digest,
+            "using cached referrers discovery result"
+        );
+        match cached_entry {
+            CachedReferrers::Found(index) => (Some(index), true),
+            CachedReferrers::NotFound => (None, true),
+            CachedReferrers::Failed => (None, false),
+        }
+    } else {
+        let (index, succeeded) =
+            discover_referrers(source_client, source_repo, parent_digest).await;
+        // Cache the result for subsequent targets.
+        let to_cache = match &index {
+            Some(idx) => CachedReferrers::Found(idx.clone()),
+            None if succeeded => CachedReferrers::NotFound,
+            None => CachedReferrers::Failed,
+        };
+        referrers_cache.borrow_mut().insert(cache_key, to_cache);
+        (index, succeeded)
+    };
+
+    // Filter matching descriptors. When `artifact_type` is None (e.g. for
+    // tag-fallback single-manifest referrers), falls back to media_type per
+    // OCI 1.1 artifact guidance.
+    let matching: Vec<&Descriptor> = match referrers_index {
+        Some(ref index) => index
+            .manifests
+            .iter()
+            .filter(|desc| {
+                let artifact_type = desc
+                    .artifact_type
+                    .as_deref()
+                    .unwrap_or(desc.media_type.as_str());
+                artifacts_config.type_matches(artifact_type)
+            })
+            .collect(),
+        None => Vec::new(),
+    };
+
+    // require_artifacts enforcement: only fire when we successfully confirmed
+    // zero referrers, not when discovery itself failed (transient error).
+    if artifacts_config.require_artifacts && matching.is_empty() && discovery_succeeded {
+        return Err(crate::Error::RequiredArtifactsMissing {
+            reference: parent_digest.to_string(),
+        });
+    }
+
+    if matching.is_empty() {
+        return Ok(());
+    }
+
+    info!(
+        repo = %source_repo,
+        digest = %parent_digest,
+        count = matching.len(),
+        "syncing artifacts"
+    );
+
+    // Transfer each matching artifact: pull manifest, push blobs, push manifest.
+    for desc in &matching {
+        let artifact_digest_str = desc.digest.to_string();
+
+        // Pull the artifact manifest from source.
+        let artifact_pull = with_retry(retry, "artifact manifest pull", || {
+            source_client.manifest_pull(source_repo, &artifact_digest_str)
+        })
+        .await
+        .map_err(|e| crate::Error::ArtifactSync {
+            reference: artifact_digest_str.clone(),
+            reason: format!("manifest pull failed: {e}"),
+        })?;
+
+        // Push artifact blobs.
+        if let ManifestKind::Image(ref manifest) = artifact_pull.manifest {
+            let blobs = collect_image_blobs(manifest);
+            for blob in blobs {
+                // HEAD check target first.
+                let exists = target_client
+                    .blob_exists(target_repo, &blob.digest)
+                    .await
+                    .unwrap_or(None);
+
+                if exists.is_some() {
+                    continue;
+                }
+
+                // Pull from source, push to target.
+                let blob_digest = blob.digest.clone();
+                let blob_size = blob.size;
+                let stream = with_retry(retry, "artifact blob pull", || {
+                    source_client.blob_pull(source_repo, &blob_digest)
+                })
+                .await
+                .map_err(|e| crate::Error::ArtifactSync {
+                    reference: artifact_digest_str.clone(),
+                    reason: format!("blob pull failed for {blob_digest}: {e}"),
+                })?;
+
+                target_client
+                    .blob_push_stream(target_repo, &blob_digest, Some(blob_size), stream)
+                    .await
+                    .map_err(|e| crate::Error::ArtifactSync {
+                        reference: artifact_digest_str.clone(),
+                        reason: format!("blob push failed for {blob_digest}: {e}"),
+                    })?;
+            }
+        }
+
+        // Push artifact manifest by digest (not by tag).
+        with_retry(retry, "artifact manifest push", || {
+            target_client.manifest_push(
+                target_repo,
+                &artifact_digest_str,
+                &artifact_pull.media_type,
+                &artifact_pull.raw_bytes,
+            )
+        })
+        .await
+        .map_err(|e| crate::Error::ArtifactSync {
+            reference: artifact_digest_str.clone(),
+            reason: format!("manifest push failed: {e}"),
+        })?;
+
+        debug!(
+            repo = %source_repo,
+            artifact_digest = %artifact_digest_str,
+            "artifact synced"
+        );
+    }
+
+    Ok(())
+}
+
+/// Discover referrers for a manifest from the source registry.
+///
+/// Tries the referrers API first, falls back to the tag-based lookup.
+/// Returns `(Option<ImageIndex>, discovery_succeeded)`.
+async fn discover_referrers(
+    source_client: &RegistryClient,
+    source_repo: &RepositoryName,
+    parent_digest: &Digest,
+) -> (Option<ImageIndex>, bool) {
+    let mut discovery_succeeded = true;
+
+    // Step 1: Try referrers API.
+    let index = match source_client
+        .referrers(source_repo, parent_digest, None)
+        .await
+    {
+        Ok(Some(index)) => Some(index),
+        Ok(None) => {
+            // 404 - try tag fallback (step 2).
+            let fallback_tag = parent_digest.tag_fallback();
+            debug!(
+                repo = %source_repo,
+                digest = %parent_digest,
+                fallback_tag = %fallback_tag,
+                "referrers API returned 404, trying tag fallback"
+            );
+            match source_client
+                .manifest_pull(source_repo, &fallback_tag)
+                .await
+            {
+                Ok(pull) => match pull.manifest {
+                    ManifestKind::Index(index) => Some(*index),
+                    ManifestKind::Image(_) => {
+                        // A single image manifest at the fallback tag is
+                        // itself an artifact referrer. Wrap in a synthetic
+                        // single-entry index so the filter + transfer loop
+                        // handles it uniformly.
+                        let desc = Descriptor {
+                            media_type: pull.media_type.clone(),
+                            digest: pull.digest.clone(),
+                            size: pull.raw_bytes.len() as u64,
+                            platform: None,
+                            artifact_type: None,
+                            annotations: None,
+                        };
+                        Some(ImageIndex {
+                            schema_version: 2,
+                            media_type: Some(MediaType::OciIndex),
+                            manifests: vec![desc],
+                            subject: None,
+                            artifact_type: None,
+                            annotations: None,
+                        })
+                    }
+                },
+                Err(e) if e.is_not_found() => {
+                    info!(
+                        repo = %source_repo,
+                        digest = %parent_digest,
+                        "no referrers found (API 404, tag fallback 404)"
+                    );
+                    None
+                }
+                Err(e) => {
+                    // Non-404 error on fallback is not fatal; log and continue.
+                    info!(
+                        repo = %source_repo,
+                        digest = %parent_digest,
+                        error = %e,
+                        "tag fallback failed, skipping artifact sync"
+                    );
+                    discovery_succeeded = false;
+                    None
+                }
+            }
+        }
+        Err(e) => {
+            // Non-404 error from referrers API. Log and continue rather
+            // than failing the entire image sync for an artifact query.
+            info!(
+                repo = %source_repo,
+                digest = %parent_digest,
+                error = %e,
+                "referrers API failed, skipping artifact sync"
+            );
+            discovery_succeeded = false;
+            None
+        }
+    };
+
+    (index, discovery_succeeded)
+}
+
 /// Read a file in 256 KB chunks, yielding a stream of `Bytes`.
 ///
 /// Uses synchronous `std::fs::Read` internally. On a single-threaded tokio
@@ -2562,6 +2940,7 @@ mod tests {
                 tag: tag.to_owned(),
             },
             batch_checker: None,
+            artifacts_config: Rc::new(ResolvedArtifacts::default()),
         }
     }
 
@@ -2680,6 +3059,7 @@ mod tests {
                 tag: "v1".into(),
             },
             batch_checker: None,
+            artifacts_config: Rc::new(ResolvedArtifacts::default()),
         });
         pending.push_back(TransferTask {
             source_data: Rc::clone(&base),
@@ -2695,6 +3075,7 @@ mod tests {
                 tag: "v1".into(),
             },
             batch_checker: None,
+            artifacts_config: Rc::new(ResolvedArtifacts::default()),
         });
         pending.push_back(test_task(child_a, "child_a"));
         pending.push_back(test_task(child_b, "child_b"));
@@ -2920,5 +3301,64 @@ mod tests {
                 }
             }
         }
+    }
+
+    // --- ResolvedArtifacts::type_matches tests ---
+
+    #[test]
+    fn type_matches_no_filters_passes_everything() {
+        let config = ResolvedArtifacts::default();
+        assert!(config.type_matches("application/vnd.dev.cosign.artifact.sig.v1+json"));
+        assert!(config.type_matches("application/spdx+json"));
+        assert!(config.type_matches("anything"));
+    }
+
+    #[test]
+    fn type_matches_include_filters() {
+        let config = ResolvedArtifacts {
+            enabled: true,
+            include: vec!["application/spdx+json".to_string()],
+            exclude: Vec::new(),
+            require_artifacts: false,
+        };
+        assert!(config.type_matches("application/spdx+json"));
+        assert!(
+            !config.type_matches("application/vnd.dev.cosign.artifact.sig.v1+json"),
+            "type not in include list should be rejected"
+        );
+    }
+
+    #[test]
+    fn type_matches_exclude_filters() {
+        let config = ResolvedArtifacts {
+            enabled: true,
+            include: Vec::new(),
+            exclude: vec!["application/spdx+json".to_string()],
+            require_artifacts: false,
+        };
+        assert!(
+            !config.type_matches("application/spdx+json"),
+            "excluded type should be rejected"
+        );
+        assert!(config.type_matches("application/vnd.dev.cosign.artifact.sig.v1+json"));
+    }
+
+    #[test]
+    fn type_matches_include_and_exclude() {
+        let config = ResolvedArtifacts {
+            enabled: true,
+            include: vec![
+                "application/spdx+json".to_string(),
+                "application/vnd.dev.cosign.artifact.sig.v1+json".to_string(),
+            ],
+            exclude: vec!["application/spdx+json".to_string()],
+            require_artifacts: false,
+        };
+        // spdx is in both include and exclude - exclude wins.
+        assert!(
+            !config.type_matches("application/spdx+json"),
+            "exclude should take priority over include"
+        );
+        assert!(config.type_matches("application/vnd.dev.cosign.artifact.sig.v1+json"));
     }
 }

--- a/crates/ocync-sync/src/error.rs
+++ b/crates/ocync-sync/src/error.rs
@@ -54,6 +54,22 @@ pub enum Error {
         /// The underlying distribution error.
         source: ocync_distribution::Error,
     },
+
+    /// Artifact sync required but no referrers found.
+    #[error("no artifacts found for {reference} (require_artifacts is enabled)")]
+    RequiredArtifactsMissing {
+        /// The manifest reference that has no referrers.
+        reference: String,
+    },
+
+    /// Artifact discovery or transfer failed.
+    #[error("artifact sync failed for {reference}: {reason}")]
+    ArtifactSync {
+        /// The parent manifest reference.
+        reference: String,
+        /// Why the artifact sync failed.
+        reason: String,
+    },
 }
 
 impl Error {
@@ -65,6 +81,11 @@ impl Error {
             }
             _ => None,
         }
+    }
+
+    /// Whether this error represents a required-artifacts-missing condition.
+    pub fn is_required_artifacts_missing(&self) -> bool {
+        matches!(self, Self::RequiredArtifactsMissing { .. })
     }
 }
 
@@ -162,6 +183,55 @@ mod tests {
     #[test]
     fn status_code_none_for_filter_errors() {
         let err = Error::LatestWithoutSort;
+        assert_eq!(err.status_code(), None);
+    }
+
+    #[test]
+    fn display_required_artifacts_missing() {
+        let err = Error::RequiredArtifactsMissing {
+            reference: "sha256:abc123".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("sha256:abc123"));
+        assert!(msg.contains("require_artifacts"));
+    }
+
+    #[test]
+    fn display_artifact_sync_error() {
+        let err = Error::ArtifactSync {
+            reference: "sha256:def456".into(),
+            reason: "manifest pull failed".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("sha256:def456"));
+        assert!(msg.contains("manifest pull failed"));
+    }
+
+    #[test]
+    fn is_required_artifacts_missing() {
+        let err = Error::RequiredArtifactsMissing {
+            reference: "sha256:abc".into(),
+        };
+        assert!(err.is_required_artifacts_missing());
+
+        let err = Error::LatestWithoutSort;
+        assert!(
+            !err.is_required_artifacts_missing(),
+            "non-artifact error should not match"
+        );
+    }
+
+    #[test]
+    fn status_code_none_for_artifact_errors() {
+        let err = Error::RequiredArtifactsMissing {
+            reference: "sha256:abc".into(),
+        };
+        assert_eq!(err.status_code(), None);
+
+        let err = Error::ArtifactSync {
+            reference: "sha256:def".into(),
+            reason: "failed".into(),
+        };
         assert_eq!(err.status_code(), None);
     }
 }

--- a/crates/ocync-sync/src/lib.rs
+++ b/crates/ocync-sync/src/lib.rs
@@ -150,6 +150,10 @@ pub enum ErrorKind {
     ManifestPush,
     /// Blob transfer (pull, push, or mount) failed.
     BlobTransfer,
+    /// Artifact (referrer) discovery or transfer failed.
+    ArtifactSync,
+    /// Required artifacts are missing (policy enforcement).
+    RequiredArtifactsMissing,
 }
 
 impl std::fmt::Display for ErrorKind {
@@ -158,6 +162,8 @@ impl std::fmt::Display for ErrorKind {
             Self::ManifestPull => f.write_str("manifest pull"),
             Self::ManifestPush => f.write_str("manifest push"),
             Self::BlobTransfer => f.write_str("blob transfer"),
+            Self::ArtifactSync => f.write_str("artifact sync"),
+            Self::RequiredArtifactsMissing => f.write_str("required artifacts missing"),
         }
     }
 }
@@ -322,6 +328,19 @@ mod tests {
     }
 
     #[test]
+    fn error_kind_display_artifact_sync() {
+        assert_eq!(ErrorKind::ArtifactSync.to_string(), "artifact sync");
+    }
+
+    #[test]
+    fn error_kind_display_required_artifacts_missing() {
+        assert_eq!(
+            ErrorKind::RequiredArtifactsMissing.to_string(),
+            "required artifacts missing"
+        );
+    }
+
+    #[test]
     fn blob_transfer_stats_default_is_zeroed() {
         let stats = BlobTransferStats::default();
         assert_eq!(stats.transferred, 0);
@@ -342,6 +361,14 @@ mod tests {
         assert_eq!(
             serde_json::to_value(ErrorKind::BlobTransfer).unwrap(),
             serde_json::Value::String("blob_transfer".into()),
+        );
+        assert_eq!(
+            serde_json::to_value(ErrorKind::ArtifactSync).unwrap(),
+            serde_json::Value::String("artifact_sync".into()),
+        );
+        assert_eq!(
+            serde_json::to_value(ErrorKind::RequiredArtifactsMissing).unwrap(),
+            serde_json::Value::String("required_artifacts_missing".into()),
         );
     }
 

--- a/crates/ocync-sync/tests/engine_integration.rs
+++ b/crates/ocync-sync/tests/engine_integration.rs
@@ -21,6 +21,7 @@
 //! - **Concurrent mount coordination** (line ~8175) - Shared blob mount vs double-upload
 //! - **Blob concurrency bound** (line ~8900) - Semaphore(6) correctness with >6 layers
 //! - **Budget circuit breaker** (line ~9175) - Rate-limit pause/resume, threshold floor, refill, no-header, threshold verification, multi-source, tracing
+//! - **Artifact sync** (line ~11037) - Disabled no-op, referrer transfer, require enforcement, tag fallback, include/exclude filter, blob dedup, transfer failure
 
 use std::cell::RefCell;
 use std::collections::HashSet;
@@ -36,7 +37,9 @@ use ocync_distribution::spec::{
 };
 use ocync_distribution::{BatchBlobChecker, Digest, RegistryClientBuilder};
 use ocync_sync::cache::{PlatformFilterKey, SnapshotKey, SourceSnapshot, TransferStateCache};
-use ocync_sync::engine::{RegistryAlias, ResolvedMapping, SyncEngine, TagPair, TargetEntry};
+use ocync_sync::engine::{
+    RegistryAlias, ResolvedArtifacts, ResolvedMapping, SyncEngine, TagPair, TargetEntry,
+};
 use ocync_sync::filter::build_glob_set;
 use ocync_sync::progress::NullProgress;
 use ocync_sync::retry::RetryConfig;
@@ -137,6 +140,7 @@ fn resolved_mapping(
         platforms: None,
         head_first: false,
         immutable_glob: None,
+        artifacts_config: Rc::new(ResolvedArtifacts::default()),
     }
 }
 
@@ -9873,16 +9877,28 @@ async fn budget_circuit_breaker_emits_tracing_warn() {
         .build();
     let num_tags: usize = 10;
 
+    // The first tag responds instantly (sets rate_limit_remaining=0 on the
+    // client). Remaining tags are delayed 50ms so they are guaranteed to be
+    // in-flight when the budget check fires after the first completion. This
+    // makes the warn emission deterministic regardless of CI load.
     for i in 0..num_tags {
         let tag = format!("v{i}");
-        mount_source_manifest_with_rate_limit(
-            &source_server,
-            "library/traced",
-            &tag,
-            &parts.bytes,
-            0,
-        )
-        .await;
+        let delay = if i == 0 {
+            std::time::Duration::ZERO
+        } else {
+            std::time::Duration::from_millis(50)
+        };
+        Mock::given(method("GET"))
+            .and(path(format!("/v2/library/traced/manifests/{tag}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(parts.bytes.clone())
+                    .insert_header("content-type", MediaType::OciManifest.as_str())
+                    .insert_header("ratelimit-remaining", "0;w=21600")
+                    .set_delay(delay),
+            )
+            .mount(&source_server)
+            .await;
     }
     mount_blob_pull(
         &source_server,
@@ -11033,4 +11049,1184 @@ async fn immutable_tag_not_skipped_when_missing_from_one_target() {
         report.stats.immutable_tag_skips, 0,
         "must not skip when any target is missing the tag",
     );
+}
+
+// ---------------------------------------------------------------------------
+// Artifact sync tests
+// ---------------------------------------------------------------------------
+
+/// When `artifacts.enabled = false`, no referrers API requests are made.
+///
+/// Negative assertion: if the engine issued any referrers request, the mock
+/// server would receive it and the request count would be non-zero.
+#[tokio::test]
+async fn artifact_sync_disabled_issues_no_referrers_requests() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_data = b"art-cfg";
+    let layer_data = b"art-layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (manifest_bytes, _) = serialize_manifest(&manifest);
+
+    mount_source_manifest(&source_server, "repo", "v1.0.0", &manifest_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo", &layer_desc.digest, layer_data).await;
+
+    mount_manifest_head_not_found(&target_server, "repo", "v1.0.0").await;
+    mount_blob_not_found(&target_server, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_desc.digest).await;
+    mount_blob_push(&target_server, "repo").await;
+    mount_manifest_push(&target_server, "repo", "v1.0.0").await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping = ResolvedMapping {
+        artifacts_config: Rc::new(ResolvedArtifacts {
+            enabled: false,
+            ..ResolvedArtifacts::default()
+        }),
+        ..resolved_mapping(
+            source_client,
+            "repo",
+            "repo",
+            vec![target_entry("target", target_client)],
+            vec![TagPair::same("v1.0.0")],
+        )
+    };
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(matches!(report.images[0].status, ImageStatus::Synced));
+
+    // No referrers requests should have been made.
+    let source_requests = source_server.received_requests().await.unwrap();
+    let referrers_requests: Vec<_> = source_requests
+        .iter()
+        .filter(|r| r.url.path().contains("/referrers/"))
+        .collect();
+    assert_eq!(
+        referrers_requests.len(),
+        0,
+        "artifacts disabled must issue zero referrers requests"
+    );
+}
+
+/// When `artifacts.enabled = true` and the referrers API returns an artifact,
+/// the engine pulls and pushes the artifact manifest and its blobs.
+#[tokio::test]
+async fn artifact_sync_transfers_referrer() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    // -- Parent image --
+    let config_data = b"parent-config";
+    let layer_data = b"parent-layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let parent_manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (parent_bytes, parent_digest) = serialize_manifest(&parent_manifest);
+
+    // -- Artifact (signature) --
+    let sig_config_data = b"sig-config";
+    let sig_layer_data = b"sig-payload";
+    let sig_config_desc = blob_descriptor(sig_config_data, MediaType::OciConfig);
+    let sig_layer_desc = blob_descriptor(sig_layer_data, MediaType::OciLayerGzip);
+    let sig_manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: sig_config_desc.clone(),
+        layers: vec![sig_layer_desc.clone()],
+        subject: None,
+        artifact_type: Some("application/vnd.dev.cosign.artifact.sig.v1+json".to_string()),
+        annotations: None,
+    };
+    let (sig_bytes, sig_digest) = serialize_manifest(&sig_manifest);
+
+    // -- Referrers index --
+    let referrers_index = ImageIndex {
+        schema_version: 2,
+        media_type: Some(MediaType::OciIndex),
+        manifests: vec![Descriptor {
+            media_type: MediaType::OciManifest,
+            digest: sig_digest.clone(),
+            size: sig_bytes.len() as u64,
+            platform: None,
+            artifact_type: Some("application/vnd.dev.cosign.artifact.sig.v1+json".to_string()),
+            annotations: None,
+        }],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let referrers_body = serde_json::to_vec(&referrers_index).unwrap();
+
+    // -- Source mocks --
+    mount_source_manifest(&source_server, "repo", "v1.0.0", &parent_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo", &layer_desc.digest, layer_data).await;
+
+    // Referrers API response.
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/referrers/{parent_digest}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(referrers_body)
+                .insert_header("content-type", MediaType::OciIndex.as_str()),
+        )
+        .mount(&source_server)
+        .await;
+
+    // Artifact manifest pull.
+    let sig_digest_str = sig_digest.to_string();
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/manifests/{sig_digest_str}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(sig_bytes.clone())
+                .insert_header("content-type", MediaType::OciManifest.as_str()),
+        )
+        .mount(&source_server)
+        .await;
+
+    // Artifact blob pulls.
+    mount_blob_pull(
+        &source_server,
+        "repo",
+        &sig_config_desc.digest,
+        sig_config_data,
+    )
+    .await;
+    mount_blob_pull(
+        &source_server,
+        "repo",
+        &sig_layer_desc.digest,
+        sig_layer_data,
+    )
+    .await;
+
+    // -- Target mocks --
+    mount_manifest_head_not_found(&target_server, "repo", "v1.0.0").await;
+    mount_blob_not_found(&target_server, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &sig_config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &sig_layer_desc.digest).await;
+    mount_blob_push(&target_server, "repo").await;
+    mount_manifest_push(&target_server, "repo", "v1.0.0").await;
+    mount_manifest_push(&target_server, "repo", &sig_digest_str).await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping = ResolvedMapping {
+        artifacts_config: Rc::new(ResolvedArtifacts::default()),
+        ..resolved_mapping(
+            source_client,
+            "repo",
+            "repo",
+            vec![target_entry("target", target_client)],
+            vec![TagPair::same("v1.0.0")],
+        )
+    };
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(
+        matches!(report.images[0].status, ImageStatus::Synced),
+        "expected Synced, got {:?}",
+        report.images[0].status,
+    );
+
+    // Verify artifact manifest was pushed to target.
+    let target_requests = target_server.received_requests().await.unwrap();
+    let artifact_pushes: Vec<_> = target_requests
+        .iter()
+        .filter(|r| r.method.as_str() == "PUT" && r.url.path().contains(&sig_digest_str))
+        .collect();
+    assert_eq!(
+        artifact_pushes.len(),
+        1,
+        "artifact manifest must be pushed to target"
+    );
+}
+
+/// When `require_artifacts = true` and no referrers exist (confirmed via
+/// successful 200 with empty index), the image sync must fail.
+#[tokio::test]
+async fn artifact_require_artifacts_fails_on_empty() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_data = b"req-cfg";
+    let layer_data = b"req-layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (manifest_bytes, manifest_digest) = serialize_manifest(&manifest);
+
+    mount_source_manifest(&source_server, "repo", "v1.0.0", &manifest_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo", &layer_desc.digest, layer_data).await;
+
+    // Referrers API returns empty index (no artifacts).
+    let empty_index = ImageIndex {
+        schema_version: 2,
+        media_type: Some(MediaType::OciIndex),
+        manifests: Vec::new(),
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/referrers/{manifest_digest}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(serde_json::to_vec(&empty_index).unwrap())
+                .insert_header("content-type", MediaType::OciIndex.as_str()),
+        )
+        .mount(&source_server)
+        .await;
+
+    mount_manifest_head_not_found(&target_server, "repo", "v1.0.0").await;
+    mount_blob_not_found(&target_server, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_desc.digest).await;
+    mount_blob_push(&target_server, "repo").await;
+    mount_manifest_push(&target_server, "repo", "v1.0.0").await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping = ResolvedMapping {
+        artifacts_config: Rc::new(ResolvedArtifacts {
+            enabled: true,
+            require_artifacts: true,
+            ..ResolvedArtifacts::default()
+        }),
+        ..resolved_mapping(
+            source_client,
+            "repo",
+            "repo",
+            vec![target_entry("target", target_client)],
+            vec![TagPair::same("v1.0.0")],
+        )
+    };
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    // Image should fail because require_artifacts is true and no referrers exist.
+    assert_eq!(report.images.len(), 1);
+    assert!(
+        matches!(report.images[0].status, ImageStatus::Failed { .. }),
+        "expected Failed for require_artifacts with no referrers, got {:?}",
+        report.images[0].status,
+    );
+}
+
+/// When `require_artifacts = true` but the referrers API returns a non-404
+/// error (e.g. 500), the image should NOT fail due to `require_artifacts`.
+/// The transient error means we couldn't determine if artifacts exist.
+#[tokio::test]
+async fn artifact_require_artifacts_does_not_fire_on_api_error() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_data = b"err-cfg";
+    let layer_data = b"err-layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (manifest_bytes, manifest_digest) = serialize_manifest(&manifest);
+
+    mount_source_manifest(&source_server, "repo", "v1.0.0", &manifest_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo", &layer_desc.digest, layer_data).await;
+
+    // Referrers API returns 500 (transient error).
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/referrers/{manifest_digest}")))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&source_server)
+        .await;
+
+    mount_manifest_head_not_found(&target_server, "repo", "v1.0.0").await;
+    mount_blob_not_found(&target_server, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_desc.digest).await;
+    mount_blob_push(&target_server, "repo").await;
+    mount_manifest_push(&target_server, "repo", "v1.0.0").await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping = ResolvedMapping {
+        artifacts_config: Rc::new(ResolvedArtifacts {
+            enabled: true,
+            require_artifacts: true,
+            ..ResolvedArtifacts::default()
+        }),
+        ..resolved_mapping(
+            source_client,
+            "repo",
+            "repo",
+            vec![target_entry("target", target_client)],
+            vec![TagPair::same("v1.0.0")],
+        )
+    };
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    // Image should succeed (sync the image) because we couldn't confirm
+    // whether artifacts exist -- require_artifacts only fires on positive
+    // confirmation of zero referrers.
+    assert_eq!(report.images.len(), 1);
+    assert!(
+        matches!(report.images[0].status, ImageStatus::Synced),
+        "transient referrers error should not fail the image, got {:?}",
+        report.images[0].status,
+    );
+}
+
+/// When the referrers API returns 404 but the tag fallback has an artifact,
+/// the engine should discover and transfer it via the fallback path.
+#[tokio::test]
+async fn artifact_sync_tag_fallback_transfers_referrer() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    // -- Parent image --
+    let config_data = b"fb-parent-config";
+    let layer_data = b"fb-parent-layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let parent_manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (parent_bytes, parent_digest) = serialize_manifest(&parent_manifest);
+
+    // -- Signature artifact --
+    let sig_config_data = b"fb-sig-config";
+    let sig_layer_data = b"fb-sig-layer";
+    let sig_config_desc = blob_descriptor(sig_config_data, MediaType::OciConfig);
+    let sig_layer_desc = blob_descriptor(sig_layer_data, MediaType::OciLayerGzip);
+    let sig_manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: sig_config_desc.clone(),
+        layers: vec![sig_layer_desc.clone()],
+        subject: Some(Descriptor {
+            media_type: MediaType::OciManifest,
+            digest: parent_digest.clone(),
+            size: parent_bytes.len() as u64,
+            platform: None,
+            artifact_type: None,
+            annotations: None,
+        }),
+        artifact_type: Some("application/vnd.dev.cosign.artifact.sig.v1+json".into()),
+        annotations: None,
+    };
+    let (sig_bytes, sig_digest) = serialize_manifest(&sig_manifest);
+
+    // -- Source mocks --
+    mount_source_manifest(&source_server, "repo", "v1.0.0", &parent_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo", &layer_desc.digest, layer_data).await;
+
+    // Referrers API returns 404.
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/referrers/{parent_digest}")))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&source_server)
+        .await;
+
+    // Tag fallback: manifest at sha256-<hex> tag is an index with the artifact.
+    let fallback_tag = parent_digest.tag_fallback();
+    let referrers_index = ImageIndex {
+        schema_version: 2,
+        media_type: Some(MediaType::OciIndex),
+        manifests: vec![Descriptor {
+            media_type: MediaType::OciManifest,
+            digest: sig_digest.clone(),
+            size: sig_bytes.len() as u64,
+            platform: None,
+            artifact_type: Some("application/vnd.dev.cosign.artifact.sig.v1+json".into()),
+            annotations: None,
+        }],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let referrers_body = serde_json::to_vec(&referrers_index).unwrap();
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/manifests/{fallback_tag}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(referrers_body)
+                .insert_header("content-type", MediaType::OciIndex.as_str()),
+        )
+        .mount(&source_server)
+        .await;
+
+    // Artifact manifest pull.
+    let sig_digest_str = sig_digest.to_string();
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/manifests/{sig_digest_str}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(sig_bytes.clone())
+                .insert_header("content-type", MediaType::OciManifest.as_str()),
+        )
+        .mount(&source_server)
+        .await;
+
+    // Artifact blob pulls.
+    mount_blob_pull(
+        &source_server,
+        "repo",
+        &sig_config_desc.digest,
+        sig_config_data,
+    )
+    .await;
+    mount_blob_pull(
+        &source_server,
+        "repo",
+        &sig_layer_desc.digest,
+        sig_layer_data,
+    )
+    .await;
+
+    // -- Target mocks --
+    mount_manifest_head_not_found(&target_server, "repo", "v1.0.0").await;
+    mount_blob_not_found(&target_server, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &sig_config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &sig_layer_desc.digest).await;
+    mount_blob_push(&target_server, "repo").await;
+    mount_manifest_push(&target_server, "repo", "v1.0.0").await;
+    mount_manifest_push(&target_server, "repo", &sig_digest_str).await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping = ResolvedMapping {
+        artifacts_config: Rc::new(ResolvedArtifacts::default()),
+        ..resolved_mapping(
+            source_client,
+            "repo",
+            "repo",
+            vec![target_entry("target", target_client)],
+            vec![TagPair::same("v1.0.0")],
+        )
+    };
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(
+        matches!(report.images[0].status, ImageStatus::Synced),
+        "expected Synced via tag fallback, got {:?}",
+        report.images[0].status,
+    );
+
+    // Verify artifact manifest was pushed.
+    let target_requests = target_server.received_requests().await.unwrap();
+    let artifact_pushes: Vec<_> = target_requests
+        .iter()
+        .filter(|r| r.method.as_str() == "PUT" && r.url.path().contains(&sig_digest_str))
+        .collect();
+    assert_eq!(
+        artifact_pushes.len(),
+        1,
+        "artifact manifest must be pushed via tag fallback path"
+    );
+}
+
+/// When include filters are set, only matching artifacts should be transferred.
+///
+/// Setup: source has two artifacts (cosign signature + SBOM). Include filter
+/// only allows cosign signatures. Assert only the cosign artifact is pushed.
+#[tokio::test]
+async fn artifact_sync_include_filter_skips_non_matching() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    // -- Parent image --
+    let config_data = b"filt-parent-config";
+    let layer_data = b"filt-parent-layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let parent_manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (parent_bytes, parent_digest) = serialize_manifest(&parent_manifest);
+
+    // -- Cosign signature artifact --
+    let sig_config_data = b"filt-sig-config";
+    let sig_layer_data = b"filt-sig-layer";
+    let sig_config_desc = blob_descriptor(sig_config_data, MediaType::OciConfig);
+    let sig_layer_desc = blob_descriptor(sig_layer_data, MediaType::OciLayerGzip);
+    let sig_manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: sig_config_desc.clone(),
+        layers: vec![sig_layer_desc.clone()],
+        subject: None,
+        artifact_type: Some("application/vnd.dev.cosign.artifact.sig.v1+json".into()),
+        annotations: None,
+    };
+    let (sig_bytes, sig_digest) = serialize_manifest(&sig_manifest);
+
+    // -- SBOM artifact (should NOT be transferred) --
+    let sbom_config_data = b"filt-sbom-config";
+    let sbom_layer_data = b"filt-sbom-layer";
+    let sbom_config_desc = blob_descriptor(sbom_config_data, MediaType::OciConfig);
+    let sbom_layer_desc = blob_descriptor(sbom_layer_data, MediaType::OciLayerGzip);
+    let sbom_manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: sbom_config_desc.clone(),
+        layers: vec![sbom_layer_desc.clone()],
+        subject: None,
+        artifact_type: Some("application/spdx+json".into()),
+        annotations: None,
+    };
+    let (sbom_bytes, sbom_digest) = serialize_manifest(&sbom_manifest);
+
+    // -- Source mocks --
+    mount_source_manifest(&source_server, "repo", "v1.0.0", &parent_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo", &layer_desc.digest, layer_data).await;
+
+    // Referrers API returns both artifacts.
+    let referrers_index = ImageIndex {
+        schema_version: 2,
+        media_type: Some(MediaType::OciIndex),
+        manifests: vec![
+            Descriptor {
+                media_type: MediaType::OciManifest,
+                digest: sig_digest.clone(),
+                size: sig_bytes.len() as u64,
+                platform: None,
+                artifact_type: Some("application/vnd.dev.cosign.artifact.sig.v1+json".into()),
+                annotations: None,
+            },
+            Descriptor {
+                media_type: MediaType::OciManifest,
+                digest: sbom_digest.clone(),
+                size: sbom_bytes.len() as u64,
+                platform: None,
+                artifact_type: Some("application/spdx+json".into()),
+                annotations: None,
+            },
+        ],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/referrers/{parent_digest}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(serde_json::to_vec(&referrers_index).unwrap())
+                .insert_header("content-type", MediaType::OciIndex.as_str()),
+        )
+        .mount(&source_server)
+        .await;
+
+    // Artifact manifest pulls (both available, but only sig should be requested).
+    let sig_digest_str = sig_digest.to_string();
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/manifests/{sig_digest_str}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(sig_bytes.clone())
+                .insert_header("content-type", MediaType::OciManifest.as_str()),
+        )
+        .mount(&source_server)
+        .await;
+
+    let sbom_digest_str = sbom_digest.to_string();
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/manifests/{sbom_digest_str}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(sbom_bytes.clone())
+                .insert_header("content-type", MediaType::OciManifest.as_str()),
+        )
+        .mount(&source_server)
+        .await;
+
+    // Artifact blob pulls (sig only).
+    mount_blob_pull(
+        &source_server,
+        "repo",
+        &sig_config_desc.digest,
+        sig_config_data,
+    )
+    .await;
+    mount_blob_pull(
+        &source_server,
+        "repo",
+        &sig_layer_desc.digest,
+        sig_layer_data,
+    )
+    .await;
+
+    // -- Target mocks --
+    mount_manifest_head_not_found(&target_server, "repo", "v1.0.0").await;
+    mount_blob_not_found(&target_server, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &sig_config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &sig_layer_desc.digest).await;
+    mount_blob_push(&target_server, "repo").await;
+    mount_manifest_push(&target_server, "repo", "v1.0.0").await;
+    mount_manifest_push(&target_server, "repo", &sig_digest_str).await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping = ResolvedMapping {
+        artifacts_config: Rc::new(ResolvedArtifacts {
+            enabled: true,
+            include: vec!["application/vnd.dev.cosign.artifact.sig.v1+json".into()],
+            exclude: Vec::new(),
+            require_artifacts: false,
+        }),
+        ..resolved_mapping(
+            source_client,
+            "repo",
+            "repo",
+            vec![target_entry("target", target_client)],
+            vec![TagPair::same("v1.0.0")],
+        )
+    };
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(matches!(report.images[0].status, ImageStatus::Synced));
+
+    // Verify: cosign signature was pushed, SBOM was NOT.
+    let target_requests = target_server.received_requests().await.unwrap();
+    let sig_pushes: Vec<_> = target_requests
+        .iter()
+        .filter(|r| r.method.as_str() == "PUT" && r.url.path().contains(&sig_digest_str))
+        .collect();
+    assert_eq!(sig_pushes.len(), 1, "cosign signature must be pushed");
+
+    let sbom_pushes: Vec<_> = target_requests
+        .iter()
+        .filter(|r| r.method.as_str() == "PUT" && r.url.path().contains(&sbom_digest_str))
+        .collect();
+    assert_eq!(
+        sbom_pushes.len(),
+        0,
+        "SBOM must NOT be pushed when include filter excludes it"
+    );
+}
+
+/// When `require_artifacts = true` and referrers exist but are all excluded
+/// by the include/exclude filter, the image should fail. This documents the
+/// intentional semantic: `require_artifacts` means "require matching artifacts",
+/// not "require any referrers at the source."
+#[tokio::test]
+async fn artifact_require_fires_when_all_filtered_out() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let config_data = b"req-filt-cfg";
+    let layer_data = b"req-filt-layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (manifest_bytes, manifest_digest) = serialize_manifest(&manifest);
+
+    // Source has only an SBOM referrer.
+    let sbom_digest = make_digest("5b0e5b0e5b0e");
+    let referrers_index = ImageIndex {
+        schema_version: 2,
+        media_type: Some(MediaType::OciIndex),
+        manifests: vec![Descriptor {
+            media_type: MediaType::OciManifest,
+            digest: sbom_digest,
+            size: 100,
+            platform: None,
+            artifact_type: Some("application/spdx+json".into()),
+            annotations: None,
+        }],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+
+    mount_source_manifest(&source_server, "repo", "v1.0.0", &manifest_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo", &layer_desc.digest, layer_data).await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/referrers/{manifest_digest}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(serde_json::to_vec(&referrers_index).unwrap())
+                .insert_header("content-type", MediaType::OciIndex.as_str()),
+        )
+        .mount(&source_server)
+        .await;
+
+    mount_manifest_head_not_found(&target_server, "repo", "v1.0.0").await;
+    mount_blob_not_found(&target_server, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_desc.digest).await;
+    mount_blob_push(&target_server, "repo").await;
+    mount_manifest_push(&target_server, "repo", "v1.0.0").await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    // require_artifacts + include only cosign (source only has SBOM).
+    let mapping = ResolvedMapping {
+        artifacts_config: Rc::new(ResolvedArtifacts {
+            enabled: true,
+            include: vec!["application/vnd.dev.cosign.artifact.sig.v1+json".into()],
+            exclude: Vec::new(),
+            require_artifacts: true,
+        }),
+        ..resolved_mapping(
+            source_client,
+            "repo",
+            "repo",
+            vec![target_entry("target", target_client)],
+            vec![TagPair::same("v1.0.0")],
+        )
+    };
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    // Should fail because no matching artifacts exist after filtering.
+    assert_eq!(report.images.len(), 1);
+    match &report.images[0].status {
+        ImageStatus::Failed { kind, .. } => {
+            assert!(
+                matches!(kind, ErrorKind::RequiredArtifactsMissing),
+                "expected RequiredArtifactsMissing, got {kind:?}"
+            );
+        }
+        other => panic!("expected Failed, got {other:?}"),
+    }
+}
+
+/// When artifact blobs already exist at the target (HEAD returns 200),
+/// the engine should skip the push and not re-upload them.
+#[tokio::test]
+async fn artifact_blob_dedup_skips_existing() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    // -- Parent image --
+    let config_data = b"dedup-parent-config";
+    let layer_data = b"dedup-parent-layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let parent_manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (parent_bytes, parent_digest) = serialize_manifest(&parent_manifest);
+
+    // -- Artifact --
+    let sig_config_data = b"dedup-sig-config";
+    let sig_layer_data = b"dedup-sig-layer";
+    let sig_config_desc = blob_descriptor(sig_config_data, MediaType::OciConfig);
+    let sig_layer_desc = blob_descriptor(sig_layer_data, MediaType::OciLayerGzip);
+    let sig_manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: sig_config_desc.clone(),
+        layers: vec![sig_layer_desc.clone()],
+        subject: None,
+        artifact_type: Some("application/vnd.dev.cosign.artifact.sig.v1+json".into()),
+        annotations: None,
+    };
+    let (sig_bytes, sig_digest) = serialize_manifest(&sig_manifest);
+
+    // -- Source mocks --
+    mount_source_manifest(&source_server, "repo", "v1.0.0", &parent_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo", &layer_desc.digest, layer_data).await;
+
+    let referrers_index = ImageIndex {
+        schema_version: 2,
+        media_type: Some(MediaType::OciIndex),
+        manifests: vec![Descriptor {
+            media_type: MediaType::OciManifest,
+            digest: sig_digest.clone(),
+            size: sig_bytes.len() as u64,
+            platform: None,
+            artifact_type: Some("application/vnd.dev.cosign.artifact.sig.v1+json".into()),
+            annotations: None,
+        }],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/referrers/{parent_digest}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(serde_json::to_vec(&referrers_index).unwrap())
+                .insert_header("content-type", MediaType::OciIndex.as_str()),
+        )
+        .mount(&source_server)
+        .await;
+
+    let sig_digest_str = sig_digest.to_string();
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/manifests/{sig_digest_str}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(sig_bytes.clone())
+                .insert_header("content-type", MediaType::OciManifest.as_str()),
+        )
+        .mount(&source_server)
+        .await;
+
+    // Artifact blob pulls should NOT be needed since blobs exist at target.
+    // (Not mounting them on source -- if engine tries to pull, it will 404.)
+
+    // -- Target mocks --
+    mount_manifest_head_not_found(&target_server, "repo", "v1.0.0").await;
+    mount_blob_not_found(&target_server, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_desc.digest).await;
+    // Artifact blobs ALREADY EXIST at target (HEAD returns 200).
+    mount_blob_exists(&target_server, "repo", &sig_config_desc.digest).await;
+    mount_blob_exists(&target_server, "repo", &sig_layer_desc.digest).await;
+    mount_blob_push(&target_server, "repo").await;
+    mount_manifest_push(&target_server, "repo", "v1.0.0").await;
+    mount_manifest_push(&target_server, "repo", &sig_digest_str).await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping = ResolvedMapping {
+        artifacts_config: Rc::new(ResolvedArtifacts::default()),
+        ..resolved_mapping(
+            source_client,
+            "repo",
+            "repo",
+            vec![target_entry("target", target_client)],
+            vec![TagPair::same("v1.0.0")],
+        )
+    };
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    assert_eq!(report.images.len(), 1);
+    assert!(
+        matches!(report.images[0].status, ImageStatus::Synced),
+        "expected Synced, got {:?}",
+        report.images[0].status,
+    );
+
+    // Verify no blob upload requests for artifact blobs (no POST for upload initiation).
+    // The parent blobs DO get uploaded, but artifact blobs should be skipped.
+    // We verify by checking no GET was made for the artifact blobs from source.
+    let source_requests = source_server.received_requests().await.unwrap();
+    let sig_blob_pulls: Vec<_> = source_requests
+        .iter()
+        .filter(|r| {
+            r.method.as_str() == "GET"
+                && r.url.path().contains("/blobs/")
+                && (r.url.path().contains(&sig_config_desc.digest.to_string())
+                    || r.url.path().contains(&sig_layer_desc.digest.to_string()))
+        })
+        .collect();
+    assert_eq!(
+        sig_blob_pulls.len(),
+        0,
+        "artifact blobs already at target must not be pulled from source"
+    );
+}
+
+/// When the target returns 500 on artifact manifest push, the image should
+/// fail with `ErrorKind::ArtifactSync` (not `RequiredArtifactsMissing`).
+#[tokio::test]
+async fn artifact_transfer_failure_reports_artifact_sync_error() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    // -- Parent image --
+    let config_data = b"fail-parent-config";
+    let layer_data = b"fail-parent-layer";
+    let config_desc = blob_descriptor(config_data, MediaType::OciConfig);
+    let layer_desc = blob_descriptor(layer_data, MediaType::OciLayerGzip);
+    let parent_manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: config_desc.clone(),
+        layers: vec![layer_desc.clone()],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    let (parent_bytes, parent_digest) = serialize_manifest(&parent_manifest);
+
+    // -- Artifact --
+    let sig_config_data = b"fail-sig-config";
+    let sig_layer_data = b"fail-sig-layer";
+    let sig_config_desc = blob_descriptor(sig_config_data, MediaType::OciConfig);
+    let sig_layer_desc = blob_descriptor(sig_layer_data, MediaType::OciLayerGzip);
+    let sig_manifest = ImageManifest {
+        schema_version: 2,
+        media_type: None,
+        config: sig_config_desc.clone(),
+        layers: vec![sig_layer_desc.clone()],
+        subject: None,
+        artifact_type: Some("application/vnd.dev.cosign.artifact.sig.v1+json".into()),
+        annotations: None,
+    };
+    let (sig_bytes, sig_digest) = serialize_manifest(&sig_manifest);
+
+    // -- Source mocks --
+    mount_source_manifest(&source_server, "repo", "v1.0.0", &parent_bytes).await;
+    mount_blob_pull(&source_server, "repo", &config_desc.digest, config_data).await;
+    mount_blob_pull(&source_server, "repo", &layer_desc.digest, layer_data).await;
+
+    let referrers_index = ImageIndex {
+        schema_version: 2,
+        media_type: Some(MediaType::OciIndex),
+        manifests: vec![Descriptor {
+            media_type: MediaType::OciManifest,
+            digest: sig_digest.clone(),
+            size: sig_bytes.len() as u64,
+            platform: None,
+            artifact_type: Some("application/vnd.dev.cosign.artifact.sig.v1+json".into()),
+            annotations: None,
+        }],
+        subject: None,
+        artifact_type: None,
+        annotations: None,
+    };
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/referrers/{parent_digest}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(serde_json::to_vec(&referrers_index).unwrap())
+                .insert_header("content-type", MediaType::OciIndex.as_str()),
+        )
+        .mount(&source_server)
+        .await;
+
+    let sig_digest_str = sig_digest.to_string();
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/manifests/{sig_digest_str}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(sig_bytes.clone())
+                .insert_header("content-type", MediaType::OciManifest.as_str()),
+        )
+        .mount(&source_server)
+        .await;
+
+    // Artifact blob pulls.
+    mount_blob_pull(
+        &source_server,
+        "repo",
+        &sig_config_desc.digest,
+        sig_config_data,
+    )
+    .await;
+    mount_blob_pull(
+        &source_server,
+        "repo",
+        &sig_layer_desc.digest,
+        sig_layer_data,
+    )
+    .await;
+
+    // -- Target mocks --
+    mount_manifest_head_not_found(&target_server, "repo", "v1.0.0").await;
+    mount_blob_not_found(&target_server, "repo", &config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &layer_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &sig_config_desc.digest).await;
+    mount_blob_not_found(&target_server, "repo", &sig_layer_desc.digest).await;
+    mount_blob_push(&target_server, "repo").await;
+    // Parent manifest push succeeds.
+    mount_manifest_push(&target_server, "repo", "v1.0.0").await;
+    // Artifact manifest push FAILS with 500.
+    Mock::given(method("PUT"))
+        .and(path(format!("/v2/repo/manifests/{sig_digest_str}")))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&target_server)
+        .await;
+
+    let source_client = mock_client(&source_server);
+    let target_client = mock_client(&target_server);
+
+    let mapping = ResolvedMapping {
+        artifacts_config: Rc::new(ResolvedArtifacts::default()),
+        ..resolved_mapping(
+            source_client,
+            "repo",
+            "repo",
+            vec![target_entry("target", target_client)],
+            vec![TagPair::same("v1.0.0")],
+        )
+    };
+
+    let engine = SyncEngine::new(fast_retry(), 50);
+    let report = engine
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &NullProgress,
+            None,
+        )
+        .await;
+
+    assert_eq!(report.images.len(), 1);
+    match &report.images[0].status {
+        ImageStatus::Failed { kind, error, .. } => {
+            assert!(
+                matches!(kind, ErrorKind::ArtifactSync),
+                "expected ArtifactSync, got {kind:?}"
+            );
+            assert!(
+                error.contains("manifest push failed"),
+                "error should mention manifest push, got: {error}"
+            );
+        }
+        other => panic!("expected Failed, got {other:?}"),
+    }
 }

--- a/docs/public/config.schema.json
+++ b/docs/public/config.schema.json
@@ -59,6 +59,38 @@
     }
   },
   "definitions": {
+    "ArtifactsConfig": {
+      "description": "Configuration for OCI artifact (signatures, SBOMs, attestations) sync.\n\nControls whether referrers are discovered and transferred alongside their parent image manifests.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Whether artifact sync is enabled (default: true).",
+          "default": true,
+          "type": "boolean"
+        },
+        "exclude": {
+          "description": "Exclude artifacts whose artifact type matches one of these MIME types.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "include": {
+          "description": "Only sync artifacts whose artifact type matches one of these MIME types.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "require_artifacts": {
+          "description": "When true, every synced image must have at least one referrer. Images without referrers cause a sync failure instead of silently producing unsigned images at the target.",
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
     "AuthType": {
       "description": "Authentication method for a registry.",
       "oneOf": [
@@ -142,6 +174,18 @@
       "description": "Default values inherited by all mappings unless individually overridden.",
       "type": "object",
       "properties": {
+        "artifacts": {
+          "description": "Artifact sync configuration applied to all mappings unless overridden.",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ArtifactsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "platforms": {
           "description": "Platform filter applied to all mappings unless overridden.\n\nEach entry must be `os/arch` or `os/arch/variant` (e.g. `linux/amd64`, `linux/arm/v7`).",
           "default": null,
@@ -244,6 +288,18 @@
         "from"
       ],
       "properties": {
+        "artifacts": {
+          "description": "Artifact sync configuration for this mapping, overriding `defaults.artifacts`.",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ArtifactsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "from": {
           "description": "Source repository path (e.g. `library/nginx`).",
           "type": "string"

--- a/docs/src/content/configuration.md
+++ b/docs/src/content/configuration.md
@@ -451,6 +451,38 @@ The schema is generated from the Rust config types and verified in CI to stay in
     }
   },
   "definitions": {
+    "ArtifactsConfig": {
+      "description": "Configuration for OCI artifact (signatures, SBOMs, attestations) sync.\n\nControls whether referrers are discovered and transferred alongside their parent image manifests.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Whether artifact sync is enabled (default: true).",
+          "default": true,
+          "type": "boolean"
+        },
+        "exclude": {
+          "description": "Exclude artifacts whose artifact type matches one of these MIME types.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "include": {
+          "description": "Only sync artifacts whose artifact type matches one of these MIME types.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "require_artifacts": {
+          "description": "When true, every synced image must have at least one referrer. Images without referrers cause a sync failure instead of silently producing unsigned images at the target.",
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
     "AuthType": {
       "description": "Authentication method for a registry.",
       "oneOf": [
@@ -534,6 +566,18 @@ The schema is generated from the Rust config types and verified in CI to stay in
       "description": "Default values inherited by all mappings unless individually overridden.",
       "type": "object",
       "properties": {
+        "artifacts": {
+          "description": "Artifact sync configuration applied to all mappings unless overridden.",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ArtifactsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "platforms": {
           "description": "Platform filter applied to all mappings unless overridden.\n\nEach entry must be `os/arch` or `os/arch/variant` (e.g. `linux/amd64`, `linux/arm/v7`).",
           "default": null,
@@ -636,6 +680,18 @@ The schema is generated from the Rust config types and verified in CI to stay in
         "from"
       ],
       "properties": {
+        "artifacts": {
+          "description": "Artifact sync configuration for this mapping, overriding `defaults.artifacts`.",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ArtifactsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "from": {
           "description": "Source repository path (e.g. `library/nginx`).",
           "type": "string"

--- a/docs/src/content/design/overview.md
+++ b/docs/src/content/design/overview.md
@@ -184,7 +184,7 @@ macOS and Windows builds use `--no-default-features --features non-fips` (standa
 
 ## OCI artifacts and referrers
 
-> **Status: Partially implemented.** The referrers API client (`RegistryClient::referrers()`) and OCI `subject` field types exist in the distribution crate. The artifact sync orchestration (discovery, transfer ordering, `require_artifacts`, and configuration) described below is planned.
+> **Status: Implemented.** The referrers API client, OCI `subject` field types, artifact config parsing (`ArtifactsConfig`), discovery with tag fallback, transfer ordering, include/exclude filtering, and `require_artifacts` enforcement are all implemented.
 
 OCI 1.1 introduced the referrers API for attaching artifacts (signatures, SBOMs, attestations) to container images. Each artifact manifest includes a `subject` field referencing the parent image digest. This creates a discoverable graph of metadata without polluting the tag namespace.
 

--- a/src/cli/commands/copy.rs
+++ b/src/cli/commands/copy.rs
@@ -8,8 +8,8 @@ use std::sync::Arc;
 use ocync_distribution::RepositoryName;
 use ocync_sync::cache::TransferStateCache;
 use ocync_sync::engine::{
-    DEFAULT_MAX_CONCURRENT_TRANSFERS, RegistryAlias, ResolvedMapping, SyncEngine, TagPair,
-    TargetEntry,
+    DEFAULT_MAX_CONCURRENT_TRANSFERS, RegistryAlias, ResolvedArtifacts, ResolvedMapping,
+    SyncEngine, TagPair, TargetEntry,
 };
 use ocync_sync::retry::RetryConfig;
 use ocync_sync::shutdown::ShutdownSignal;
@@ -78,6 +78,10 @@ pub(crate) async fn run(
         platforms: None,
         head_first: false,
         immutable_glob: None,
+        artifacts_config: Rc::new(ResolvedArtifacts {
+            enabled: false,
+            ..ResolvedArtifacts::default()
+        }),
     };
 
     let engine = SyncEngine::new(RetryConfig::default(), DEFAULT_MAX_CONCURRENT_TRANSFERS);

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -13,8 +13,8 @@ use ocync_distribution::{RegistryClient, RepositoryName};
 use ocync_sync::SyncReport;
 use ocync_sync::cache::TransferStateCache;
 use ocync_sync::engine::{
-    DEFAULT_MAX_CONCURRENT_TRANSFERS, RegistryAlias, ResolvedMapping, SyncEngine, TagPair,
-    TargetEntry,
+    DEFAULT_MAX_CONCURRENT_TRANSFERS, RegistryAlias, ResolvedArtifacts, ResolvedMapping,
+    SyncEngine, TagPair, TargetEntry,
 };
 use ocync_sync::filter::{FilterConfig, build_glob_set};
 use ocync_sync::retry::RetryConfig;
@@ -406,6 +406,21 @@ pub(crate) async fn resolve_mapping(
         None
     };
 
+    // Resolve artifacts config (mapping overrides defaults).
+    let artifacts = match mapping
+        .artifacts
+        .as_ref()
+        .or(config.defaults.as_ref().and_then(|d| d.artifacts.as_ref()))
+    {
+        Some(c) => ResolvedArtifacts {
+            enabled: c.enabled,
+            include: c.include.clone(),
+            exclude: c.exclude.clone(),
+            require_artifacts: c.require_artifacts,
+        },
+        None => ResolvedArtifacts::default(),
+    };
+
     Ok(Some(ResolvedMapping {
         source_authority,
         source_client,
@@ -416,6 +431,7 @@ pub(crate) async fn resolve_mapping(
         platforms,
         head_first,
         immutable_glob,
+        artifacts_config: Rc::new(artifacts),
     }))
 }
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -46,6 +46,18 @@ pub(crate) fn load_config(path: &Path) -> Result<Config, ConfigError> {
         if let Some(ref platforms) = defaults.platforms {
             validate_platforms("defaults", platforms)?;
         }
+        if let Some(ref artifacts) = defaults.artifacts {
+            validate_artifacts("defaults", artifacts)?;
+        }
+    }
+    for mapping in &config.mappings {
+        let effective = mapping
+            .artifacts
+            .as_ref()
+            .or(config.defaults.as_ref().and_then(|d| d.artifacts.as_ref()));
+        if let Some(artifacts) = effective {
+            validate_artifacts(&mapping.from, artifacts)?;
+        }
     }
     validate_references(&config)?;
 
@@ -276,6 +288,10 @@ pub(crate) struct DefaultsConfig {
     /// `linux/arm/v7`).
     #[serde(default)]
     pub platforms: Option<Vec<String>>,
+
+    /// Artifact sync configuration applied to all mappings unless overridden.
+    #[serde(default)]
+    pub artifacts: Option<ArtifactsConfig>,
 }
 
 // ---------------------------------------------------------------------------
@@ -310,6 +326,43 @@ pub(crate) struct MappingConfig {
     /// `linux/arm/v7`).
     #[serde(default)]
     pub platforms: Option<Vec<String>>,
+
+    /// Artifact sync configuration for this mapping, overriding `defaults.artifacts`.
+    #[serde(default)]
+    pub artifacts: Option<ArtifactsConfig>,
+}
+
+// ---------------------------------------------------------------------------
+// Artifacts
+// ---------------------------------------------------------------------------
+
+/// Configuration for OCI artifact (signatures, SBOMs, attestations) sync.
+///
+/// Controls whether referrers are discovered and transferred alongside their
+/// parent image manifests.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+pub(crate) struct ArtifactsConfig {
+    /// Whether artifact sync is enabled (default: true).
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// Only sync artifacts whose artifact type matches one of these MIME types.
+    #[serde(default)]
+    pub include: Vec<String>,
+
+    /// Exclude artifacts whose artifact type matches one of these MIME types.
+    #[serde(default)]
+    pub exclude: Vec<String>,
+
+    /// When true, every synced image must have at least one referrer.
+    /// Images without referrers cause a sync failure instead of silently
+    /// producing unsigned images at the target.
+    #[serde(default)]
+    pub require_artifacts: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 // ---------------------------------------------------------------------------
@@ -581,6 +634,26 @@ fn is_valid_size(s: &str) -> bool {
         }
     }
     false
+}
+
+/// Validate artifact sync configuration.
+///
+/// `require_artifacts: true` with `enabled: false` is contradictory - you
+/// cannot require artifacts while disabling their transfer.
+fn validate_artifacts(context: &str, artifacts: &ArtifactsConfig) -> Result<(), ConfigError> {
+    if artifacts.require_artifacts && !artifacts.enabled {
+        return Err(ConfigError::Validation(format!(
+            "{context}: require_artifacts is true but artifacts.enabled is false \
+             (cannot require artifacts while disabling their transfer)"
+        )));
+    }
+    if !artifacts.enabled {
+        tracing::warn!(
+            context,
+            "artifacts.enabled is false: signatures and SBOMs will be stripped from synced images"
+        );
+    }
+    Ok(())
 }
 
 fn validate_tags(tags: &TagsConfig) -> Result<(), ConfigError> {
@@ -1072,6 +1145,7 @@ mappings:
             targets: None,
             tags: None,
             platforms: None,
+            artifacts: None,
         };
         let err = validate_mapping(&mapping, false).unwrap_err();
         assert!(matches!(err, ConfigError::Validation(_)));
@@ -1086,6 +1160,7 @@ mappings:
             targets: None,
             tags: None,
             platforms: None,
+            artifacts: None,
         };
         validate_mapping(&mapping, true).unwrap();
     }
@@ -1102,6 +1177,7 @@ mappings:
                 ..Default::default()
             }),
             platforms: Some(vec!["linux-amd64".to_string()]),
+            artifacts: None,
         };
         let err = validate_mapping(&mapping, false).unwrap_err();
         match err {
@@ -1128,6 +1204,7 @@ mappings:
                     ..Default::default()
                 }),
                 platforms: Some(vec![platform.to_string()]),
+                artifacts: None,
             };
             validate_mapping(&mapping, false)
                 .unwrap_or_else(|e| panic!("expected valid platform '{platform}': {e}"));
@@ -1665,5 +1742,92 @@ mappings:
         let debug_output = format!("{registry:?}");
         assert!(debug_output.contains("[REDACTED]"));
         assert!(!debug_output.contains("secret-bearer-token"));
+    }
+
+    // - ArtifactsConfig -------------------------------------------------------
+
+    #[test]
+    fn deserialize_artifacts_config() {
+        let yaml = r#"
+defaults:
+  artifacts:
+    enabled: true
+    include:
+      - "application/vnd.dev.cosign.artifact.sig.v1+json"
+    exclude:
+      - "application/spdx+json"
+    require_artifacts: false
+mappings:
+  - from: nginx
+    tags:
+      glob: "*"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let artifacts = config
+            .defaults
+            .as_ref()
+            .unwrap()
+            .artifacts
+            .as_ref()
+            .unwrap();
+        assert!(artifacts.enabled);
+        assert_eq!(artifacts.include.len(), 1);
+        assert_eq!(artifacts.exclude.len(), 1);
+        assert!(!artifacts.require_artifacts);
+    }
+
+    #[test]
+    fn require_artifacts_with_disabled_is_error() {
+        let artifacts = ArtifactsConfig {
+            enabled: false,
+            include: Vec::new(),
+            exclude: Vec::new(),
+            require_artifacts: true,
+        };
+        let err = validate_artifacts("test-mapping", &artifacts).unwrap_err();
+        match err {
+            ConfigError::Validation(msg) => {
+                assert!(msg.contains("require_artifacts"), "msg: {msg}");
+                assert!(msg.contains("enabled"), "msg: {msg}");
+            }
+            other => panic!("expected Validation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn require_artifacts_with_enabled_is_ok() {
+        let artifacts = ArtifactsConfig {
+            enabled: true,
+            include: Vec::new(),
+            exclude: Vec::new(),
+            require_artifacts: true,
+        };
+        validate_artifacts("test-mapping", &artifacts).unwrap();
+    }
+
+    #[test]
+    fn disabled_artifacts_without_require_is_ok() {
+        let artifacts = ArtifactsConfig {
+            enabled: false,
+            include: Vec::new(),
+            exclude: Vec::new(),
+            require_artifacts: false,
+        };
+        validate_artifacts("test-mapping", &artifacts).unwrap();
+    }
+
+    #[test]
+    fn artifacts_defaults_enabled() {
+        let yaml = r#"
+mappings:
+  - from: nginx
+    artifacts:
+      require_artifacts: false
+    tags:
+      glob: "*"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let artifacts = config.mappings[0].artifacts.as_ref().unwrap();
+        assert!(artifacts.enabled, "enabled should default to true");
     }
 }


### PR DESCRIPTION
## Summary

Implements artifact (signatures, SBOMs, attestations) discovery and transfer alongside parent image manifests. Uses the OCI referrers API with automatic tag fallback for registries that lack native support.

- **Referrers discovery**: tries `GET /v2/{repo}/referrers/{digest}` first, falls back to tag-based lookup (`{algo}-{hex}`) on 404
- **Per-run discovery cache**: deduplicates referrers queries across multi-target syncs (keyed by `source_repo` + `parent_digest`)
- **Include/exclude filtering**: artifact type MIME matching with `require_artifacts` enforcement that fires on confirmed-empty (post-filter), not on transient errors
- **ErrorKind split**: `ArtifactSync` (infra failure, retries exhausted) vs `RequiredArtifactsMissing` (policy violation, zero retries)
- **Configuration**: `artifacts` block at `defaults` or per-mapping level with `enabled`, `include`, `exclude`, and `require_artifacts` fields
- **Copy command**: disables artifact sync (single-image semantics)

## Design decisions

| Decision | Rationale |
|----------|-----------|
| Cache stores pre-filter `ImageIndex` | Different mappings may have different filter configs for the same source digest |
| `require_artifacts` fires when all filtered out | Intentional: "require matching artifacts", not "require any referrers exist" |
| Transient discovery errors don't trigger `require_artifacts` | Can't confirm zero referrers on a 500; fail-open preserves sync correctness |
| Artifact blobs HEAD-checked before push | Avoids redundant uploads when artifacts already exist at target |
| Discovery extracted to `discover_referrers()` | Separates cacheable source-side query from per-target transfer logic |

## Test plan

- [x] Disabled config issues zero referrers requests (negative assertion)
- [x] Happy path: referrers API returns artifact, blobs + manifest pushed to target
- [x] `require_artifacts` fails on confirmed-empty referrers index
- [x] `require_artifacts` does NOT fire on transient API errors (500)
- [x] Tag fallback path: referrers 404, fallback tag has artifact index
- [x] Include filter skips non-matching artifacts (2 artifacts, only 1 pushed)
- [x] All referrers filtered out + `require_artifacts` = `RequiredArtifactsMissing`
- [x] Artifact blob HEAD dedup: existing blobs at target skip source pull
- [x] Transfer failure (target 500) reports `ErrorKind::ArtifactSync`
- [x] Unit tests for `type_matches`, error variants, config validation, `tag_fallback()`