### PR TITLE
docs: content integrity principle, remove stale status markers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,14 @@ Ranked by weight. These override local optimization instincts when they conflict
 3. **Wall-clock speed** - a consequence of (1), not a goal separate from it. Reports that prioritize wall-clock without byte/request counts are misleading.
 4. **UX** - clear errors, structured output, sensible defaults. Must be zero-cost when disabled so it never drags on (1).
 
+## Content integrity
+
+ocync syncs content bit-for-bit from source to target(s). We do NOT convert, transform, or rewrite manifest or blob content. Digests are identity -- changing bytes changes the digest, breaks signatures, pin-by-digest workflows, and the OCI content-addressable model.
+
+- Manifest bytes are transferred verbatim. No format conversion (Docker v2 to OCI or vice versa).
+- Blob bytes are streamed directly from source to target without modification.
+- All registries in production accept both Docker v2 and OCI manifests. There is no real-world use case for format conversion, and it would break every digest-based optimization (skip detection, transfer state cache, immutable tag handling, head-first).
+
 ## Scope discipline
 
 Every PR ships the smallest correct change + one test that catches regression. Defer scaffolding to a follow-up PR justified by a second observation.
@@ -29,6 +37,7 @@ Every PR ships the smallest correct change + one test that catches regression. D
 - No Cargo feature flags except crypto backend (`fips` vs `non-fips`) - unavoidable platform linking
 - Test what can break: at least one test that would fail if the intended path is NOT taken (negative assertion)
 - If the change is ~10 LOC of real intent, aim for ~100 LOC total diff. 10x is a smell worth justifying.
+- Challenge the use case before building. If a feature breaks existing optimizations (skip detection, caching, digest comparison), the cost likely exceeds the benefit.
 
 ## Code standards
 
@@ -61,7 +70,8 @@ Every PR ships the smallest correct change + one test that catches regression. D
 - `docs/src/content/design/benchmark.md` - layered benchmark plan (protocol / throughput / cross-tool)
 - `docs/src/content/design/watch-mode.md` - watch mode, discovery optimization, platform filtering
 - `docs/superpowers/plans/` (gitignored) - in-flight implementation plans
-- Unimplemented features are marked with `> **Status: Planned.**` or `> **Status: Partially implemented.**` in design docs. Update these markers when implementing.
+- `docs/superpowers/specs/` (gitignored) - design specs; delete once fully implemented
+- Unimplemented features are marked with `> **Status: Planned.**` in design docs. Remove the marker when implementing -- implemented features are self-evident from code.
 
 When a benchmark or probe run changes our understanding of a registry's behavior, update the relevant per-registry doc in `docs/src/content/registries/` in the same PR as the behavior change.
 

--- a/docs/src/content/design/overview.md
+++ b/docs/src/content/design/overview.md
@@ -184,8 +184,6 @@ macOS and Windows builds use `--no-default-features --features non-fips` (standa
 
 ## OCI artifacts and referrers
 
-> **Status: Implemented.** The referrers API client, OCI `subject` field types, artifact config parsing (`ArtifactsConfig`), discovery with tag fallback, transfer ordering, include/exclude filtering, and `require_artifacts` enforcement are all implemented.
-
 OCI 1.1 introduced the referrers API for attaching artifacts (signatures, SBOMs, attestations) to container images. Each artifact manifest includes a `subject` field referencing the parent image digest. This creates a discoverable graph of metadata without polluting the tag namespace.
 
 ### Discovery
@@ -245,32 +243,11 @@ This two-step fallback ensures artifact sync works across the widest range of re
 
 ## Manifest format preservation
 
-> **Status: Planned.** Manifest format configuration (`manifest_format` per-registry override, format conversion) is designed but not yet implemented. The engine currently preserves manifest bytes verbatim (the `preserve` default behavior).
+ocync preserves manifest bytes bit-for-bit. No conversion between Docker v2 and OCI formats is performed, and none is planned.
 
-### Problem
+Digest preservation is the foundation of the OCI content-addressable model. An image's digest is its identity. If a sync tool changes the digest, consumers cannot verify that the target image is byte-identical to the source. Signature verification breaks (signatures reference the original digest), and deployment pipelines that pin by digest pull a different image than intended.
 
-Pushing a Docker v2 Schema 2 manifest to a registry expecting OCI format (or vice versa) changes the digest. The manifest bytes are different, so the SHA-256 is different, so the content-addressable identity of the image changes. Some registries reject manifests with unexpected media types entirely. Existing tools handle this poorly: digests change silently or copies fail with opaque errors.
-
-Digest preservation matters because it is the foundation of the OCI content-addressable model. An image's digest is its identity. If a sync tool changes the digest, consumers cannot verify that the target image is byte-identical to the source. Signature verification breaks (signatures reference the original digest), and deployment pipelines that pin by digest pull a different image than intended.
-
-### Policy
-
-Default: **preserve the original format exactly.** The manifest bytes are transferred verbatim to maintain digest integrity.
-
-| Setting | Behavior |
-|---|---|
-| `preserve` (default) | Push manifest bytes as-is. Digest unchanged. |
-| `oci` | Convert Docker v2 Schema 2 to OCI Image Manifest before push. Digest WILL change. Log WARNING. |
-| `docker-v2` | Convert OCI to Docker v2 Schema 2 before push. Digest WILL change. Log WARNING. |
-
-Per-registry override is available for broken registries that require a specific format:
-
-```yaml
-registries:
-  legacy-harbor:
-    url: harbor.internal.io
-    manifest_format: oci
-```
+All production registries accept both Docker v2 and OCI manifests natively. Format conversion would break every digest-based optimization (skip detection, transfer state cache, immutable tag handling, head-first) with no real-world benefit.
 
 ### ECR immutable tag handling
 
@@ -302,8 +279,6 @@ The source image index is pulled in full, filtered to the requested platforms, a
 If a requested platform is not available in the source image index, `ocync` logs a WARNING and continues with the platforms that are available. A source image that offers `linux/amd64` but not `linux/arm64` will sync the amd64 platform and warn about the missing arm64 entry.
 
 If **zero** requested platforms match any manifest in the source index, `ocync` returns an error with actionable context: the configured platform filter, the platforms actually available in the source index, and the source reference. An empty filtered index is never pushed to targets because it would leave targets with an invalid manifest that appears synced but contains no usable platform entries. This surfaces platform configuration mismatches immediately rather than silently degrading into an unusable state.
-
-> **Status: Implemented.** Both tiers are implemented: `immutable_tags` pattern match (Tier 1, zero API calls) and default HEAD + digest compare (Tier 2).
 
 ## Skip optimization hierarchy
 

--- a/docs/src/content/design/watch-mode.md
+++ b/docs/src/content/design/watch-mode.md
@@ -138,8 +138,6 @@ Optimization HEADs participate in the AIMD congestion window for the ManifestHea
 
 ### Relationship to head_first
 
-> **Status: Implemented.** The `head_first` per-registry option is available on source registries. When enabled and the discovery cache has no entry, the engine HEAD-checks all targets against the source HEAD digest before performing a full source manifest GET. If all targets match, the GET is skipped. The discovery HEAD result is reused (no redundant second HEAD). Platform-filtered mappings bypass `head_first` because the target holds a filtered digest that differs from the source HEAD digest.
-
 The transfer optimization spec defines a per-registry `head_first` option to conserve rate-limit tokens. The discovery HEAD serves a different purpose: detecting source changes cheaply. These are independent features that happen to use the same HTTP method. When both are active, the discovery HEAD result is reused to avoid a redundant second HEAD.
 
 ## Steady-state savings


### PR DESCRIPTION
## Summary

- Add "Content integrity" section to CLAUDE.md: bit-for-bit sync, no manifest format conversion
- Replace planned manifest_format conversion section in design doc with explicit rejection
- Remove all `Status: Implemented` markers from design docs -- only `Planned` markers carry information
- Add "challenge use case before building" to scope discipline

## Test plan

- [x] Docs-only change, no code modified