### PR TITLE
refactor: eliminate Error::Other with dedicated error variants

### DIFF
--- a/crates/ocync-distribution/src/auth/docker.rs
+++ b/crates/ocync-distribution/src/auth/docker.rs
@@ -63,24 +63,19 @@ impl fmt::Debug for AuthEntry {
 impl DockerConfig {
     /// Load from the default Docker config path (`~/.docker/config.json`).
     pub fn load_default() -> Result<Self, Error> {
-        let path = default_config_path()
-            .ok_or_else(|| Error::Other("unable to determine home directory".into()))?;
+        let path = default_config_path().ok_or_else(|| Error::DockerConfig {
+            reason: "unable to determine home directory".into(),
+        })?;
         Self::load_from(&path)
     }
 
     /// Load from a specific file path.
     fn load_from(path: &Path) -> Result<Self, Error> {
-        let contents = std::fs::read_to_string(path).map_err(|e| {
-            Error::Other(format!(
-                "failed to read docker config at {}: {e}",
-                path.display()
-            ))
+        let contents = std::fs::read_to_string(path).map_err(|e| Error::DockerConfig {
+            reason: format!("failed to read config at {}: {e}", path.display()),
         })?;
-        serde_json::from_str(&contents).map_err(|e| {
-            Error::Other(format!(
-                "failed to parse docker config at {}: {e}",
-                path.display()
-            ))
+        serde_json::from_str(&contents).map_err(|e| Error::DockerConfig {
+            reason: format!("failed to parse config at {}: {e}", path.display()),
         })
     }
 }

--- a/crates/ocync-distribution/src/auth/docker.rs
+++ b/crates/ocync-distribution/src/auth/docker.rs
@@ -63,7 +63,7 @@ impl fmt::Debug for AuthEntry {
 impl DockerConfig {
     /// Load from the default Docker config path (`~/.docker/config.json`).
     pub fn load_default() -> Result<Self, Error> {
-        let path = default_config_path().ok_or_else(|| Error::DockerConfig {
+        let path = default_config_path().ok_or_else(|| Error::CredentialConfig {
             reason: "unable to determine home directory".into(),
         })?;
         Self::load_from(&path)
@@ -71,10 +71,10 @@ impl DockerConfig {
 
     /// Load from a specific file path.
     fn load_from(path: &Path) -> Result<Self, Error> {
-        let contents = std::fs::read_to_string(path).map_err(|e| Error::DockerConfig {
+        let contents = std::fs::read_to_string(path).map_err(|e| Error::CredentialConfig {
             reason: format!("failed to read config at {}: {e}", path.display()),
         })?;
-        serde_json::from_str(&contents).map_err(|e| Error::DockerConfig {
+        serde_json::from_str(&contents).map_err(|e| Error::CredentialConfig {
             reason: format!("failed to parse config at {}: {e}", path.display()),
         })
     }

--- a/crates/ocync-distribution/src/blob.rs
+++ b/crates/ocync-distribution/src/blob.rs
@@ -340,10 +340,9 @@ impl RegistryClient {
         let actual_digest = self.blob_push(repository, &body).await?;
 
         if &actual_digest != expected_digest {
-            return Err(Error::UploadProtocol {
-                reason: format!(
-                    "GAR fallback digest mismatch: expected {expected_digest}, got {actual_digest}"
-                ),
+            return Err(Error::DigestMismatch {
+                expected: expected_digest.clone(),
+                actual: actual_digest,
             });
         }
 
@@ -387,10 +386,9 @@ impl RegistryClient {
         let raw = buffer_stream(stream, known_size).await?;
         let actual_digest = Digest::from_sha256(Sha256::digest(&raw));
         if &actual_digest != expected_digest {
-            return Err(Error::UploadProtocol {
-                reason: format!(
-                    "GHCR fallback: local digest {actual_digest} != expected {expected_digest}"
-                ),
+            return Err(Error::DigestMismatch {
+                expected: expected_digest.clone(),
+                actual: actual_digest,
             });
         }
         let body = Bytes::from(raw);

--- a/crates/ocync-distribution/src/blob.rs
+++ b/crates/ocync-distribution/src/blob.rs
@@ -340,9 +340,11 @@ impl RegistryClient {
         let actual_digest = self.blob_push(repository, &body).await?;
 
         if &actual_digest != expected_digest {
-            return Err(Error::Other(format!(
-                "GAR fallback digest mismatch: expected {expected_digest}, got {actual_digest}"
-            )));
+            return Err(Error::UploadProtocol {
+                reason: format!(
+                    "GAR fallback digest mismatch: expected {expected_digest}, got {actual_digest}"
+                ),
+            });
         }
 
         Ok(actual_digest)
@@ -385,9 +387,11 @@ impl RegistryClient {
         let raw = buffer_stream(stream, known_size).await?;
         let actual_digest = Digest::from_sha256(Sha256::digest(&raw));
         if &actual_digest != expected_digest {
-            return Err(Error::Other(format!(
-                "GHCR fallback: local digest {actual_digest} != expected {expected_digest}"
-            )));
+            return Err(Error::UploadProtocol {
+                reason: format!(
+                    "GHCR fallback: local digest {actual_digest} != expected {expected_digest}"
+                ),
+            });
         }
         let body = Bytes::from(raw);
         let body_len = body.len();
@@ -440,7 +444,9 @@ fn extract_location(resp: &reqwest::Response, base_url: &url::Url) -> Result<Str
         .headers()
         .get(LOCATION)
         .and_then(|v| v.to_str().ok())
-        .ok_or_else(|| Error::Other("missing Location header in upload response".into()))?;
+        .ok_or_else(|| Error::UploadProtocol {
+            reason: "missing Location header in upload response".into(),
+        })?;
 
     if raw.starts_with("http://") || raw.starts_with("https://") {
         Ok(raw.to_owned())
@@ -448,7 +454,9 @@ fn extract_location(resp: &reqwest::Response, base_url: &url::Url) -> Result<Str
         base_url
             .join(raw)
             .map(|u| u.to_string())
-            .map_err(|e| Error::Other(format!("failed to resolve upload URL: {e}")))
+            .map_err(|e| Error::UploadProtocol {
+                reason: format!("failed to resolve upload URL: {e}"),
+            })
     }
 }
 

--- a/crates/ocync-distribution/src/client.rs
+++ b/crates/ocync-distribution/src/client.rs
@@ -168,7 +168,10 @@ impl RegistryClient {
         let host = self
             .base_url
             .host_str()
-            .ok_or_else(|| Error::Other(format!("registry URL has no host: {}", self.base_url)))?;
+            .ok_or_else(|| Error::UrlConstruction {
+                path: self.base_url.to_string(),
+                reason: "URL has no host".into(),
+            })?;
         let port = self.base_url.port_or_known_default().unwrap_or(443);
         Ok(RegistryAuthority::new(format!("{host}:{port}")))
     }
@@ -403,8 +406,10 @@ async fn classify_response(
 
 /// Construct a URL for the `/v2/` endpoint.
 fn build_v2_url(base: &Url) -> Result<Url, Error> {
-    base.join("/v2/")
-        .map_err(|e| Error::Other(format!("failed to build /v2/ URL: {e}")))
+    base.join("/v2/").map_err(|e| Error::UrlConstruction {
+        path: "/v2/".into(),
+        reason: e.to_string(),
+    })
 }
 
 /// Construct a URL for `/v2/{repository}/{path}`.
@@ -418,8 +423,10 @@ fn build_v2_url(base: &Url) -> Result<Url, Error> {
 /// corrupt the URL structure.
 pub(crate) fn build_url(base: &Url, repository: &str, path: &str) -> Result<Url, Error> {
     let full_path = format!("/v2/{repository}/{path}");
-    base.join(&full_path)
-        .map_err(|e| Error::Other(format!("failed to build URL '{full_path}': {e}")))
+    base.join(&full_path).map_err(|e| Error::UrlConstruction {
+        path: full_path,
+        reason: e.to_string(),
+    })
 }
 
 #[cfg(test)]

--- a/crates/ocync-distribution/src/client.rs
+++ b/crates/ocync-distribution/src/client.rs
@@ -329,8 +329,13 @@ impl RegistryClient {
                     AuthScheme::Bearer => "Bearer",
                     AuthScheme::Basic => "Basic",
                 };
-                let header_value = HeaderValue::from_str(&format!("{prefix} {value}"))
-                    .map_err(|e| Error::Other(format!("invalid auth header: {e}")))?;
+                let header_value =
+                    HeaderValue::from_str(&format!("{prefix} {value}")).map_err(|e| {
+                        Error::InvalidHeaderValue {
+                            header: "Authorization".into(),
+                            reason: e.to_string(),
+                        }
+                    })?;
                 headers.insert(AUTHORIZATION, header_value);
             }
         }

--- a/crates/ocync-distribution/src/ecr.rs
+++ b/crates/ocync-distribution/src/ecr.rs
@@ -61,10 +61,8 @@ fn ecr_registry_id(hostname: &str) -> Option<&str> {
 /// FIPS endpoint support is handled at the SDK level: set
 /// `AWS_USE_FIPS_ENDPOINT=true` before calling this function.
 pub(crate) async fn load_sdk_config(hostname: &str) -> Result<aws_config::SdkConfig, Error> {
-    let region = ecr_region(hostname).ok_or_else(|| {
-        Error::Other(format!(
-            "cannot extract AWS region from ECR hostname '{hostname}'"
-        ))
+    let region = ecr_region(hostname).ok_or_else(|| Error::EcrApi {
+        reason: format!("cannot extract AWS region from ECR hostname '{hostname}'"),
     })?;
 
     Ok(aws_config::defaults(BehaviorVersion::latest())
@@ -155,10 +153,8 @@ impl EcrBatchApi for AwsEcrBatchApi {
                 builder = builder.registry_id(id);
             }
 
-            let output = builder.send().await.map_err(|e| {
-                Error::Other(format!(
-                    "ECR BatchCheckLayerAvailability failed for '{repo}': {e}"
-                ))
+            let output = builder.send().await.map_err(|e| Error::EcrApi {
+                reason: format!("BatchCheckLayerAvailability failed for '{repo}': {e}"),
             })?;
 
             let layers: Vec<(String, bool)> = output
@@ -483,7 +479,9 @@ mod tests {
                 self.counts.check.fetch_add(1, Ordering::Relaxed);
                 let mut responses = self.check_responses.lock().await;
                 responses.pop_front().unwrap_or_else(|| {
-                    Err(Error::Other("mock: no check response available".into()))
+                    Err(Error::EcrApi {
+                        reason: "mock: no check response available".into(),
+                    })
                 })
             })
         }
@@ -614,8 +612,11 @@ mod tests {
     #[tokio::test]
     async fn check_propagates_api_error() {
         let counts = CallCounts::default();
-        let mock = MockEcrBatchApi::new("my-repo", counts)
-            .with_check_responses(vec![Err(Error::Other("throttled".into()))]);
+        let mock = MockEcrBatchApi::new("my-repo", counts).with_check_responses(vec![Err(
+            Error::EcrApi {
+                reason: "throttled".into(),
+            },
+        )]);
         let checker = BatchChecker::with_api(mock);
 
         let result = checker
@@ -699,7 +700,9 @@ mod tests {
         let counts = CallCounts::default();
         let mock = MockEcrBatchApi::new("my-repo", counts.clone()).with_check_responses(vec![
             Ok(batch1_response),
-            Err(Error::Other("throttled on batch 2".into())),
+            Err(Error::EcrApi {
+                reason: "throttled on batch 2".into(),
+            }),
         ]);
         let checker = BatchChecker::with_api(mock);
 

--- a/crates/ocync-distribution/src/error.rs
+++ b/crates/ocync-distribution/src/error.rs
@@ -74,6 +74,29 @@ pub enum Error {
         message: String,
     },
 
+    /// A URL could not be constructed or joined.
+    #[error("URL construction failed for '{path}': {reason}")]
+    UrlConstruction {
+        /// The path or URL fragment that failed.
+        path: String,
+        /// Why construction failed.
+        reason: String,
+    },
+
+    /// The upload protocol violated expectations (missing headers, unexpected status).
+    #[error("upload protocol error: {reason}")]
+    UploadProtocol {
+        /// What went wrong during the upload sequence.
+        reason: String,
+    },
+
+    /// Docker config file I/O or parse failure.
+    #[error("docker config error: {reason}")]
+    DockerConfig {
+        /// What went wrong reading or parsing the config.
+        reason: String,
+    },
+
     /// Catch-all for errors without a dedicated variant.
     #[error("{0}")]
     Other(String),
@@ -237,5 +260,50 @@ mod tests {
     fn is_auth_error_other() {
         let err = Error::Other("something".into());
         assert!(!err.is_auth_error());
+    }
+
+    #[test]
+    fn display_url_construction() {
+        let err = Error::UrlConstruction {
+            path: "/v2/".into(),
+            reason: "relative URL without a base".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("/v2/"), "should contain path: {msg}");
+        assert!(
+            msg.contains("relative URL without a base"),
+            "should contain source: {msg}"
+        );
+        // Must not match auth or not-found helpers.
+        assert!(!err.is_auth_error());
+        assert!(!err.is_not_found());
+    }
+
+    #[test]
+    fn display_upload_protocol() {
+        let err = Error::UploadProtocol {
+            reason: "missing Location header".into(),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("missing Location header"),
+            "should contain reason: {msg}"
+        );
+        assert!(!err.is_auth_error());
+        assert!(!err.is_not_found());
+    }
+
+    #[test]
+    fn display_docker_config() {
+        let err = Error::DockerConfig {
+            reason: "unable to determine home directory".into(),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unable to determine home directory"),
+            "should contain reason: {msg}"
+        );
+        assert!(!err.is_auth_error());
+        assert!(!err.is_not_found());
     }
 }

--- a/crates/ocync-distribution/src/error.rs
+++ b/crates/ocync-distribution/src/error.rs
@@ -2,6 +2,8 @@
 
 use thiserror::Error;
 
+use crate::Digest;
+
 /// Errors returned by OCI distribution operations.
 #[derive(Debug, Error)]
 pub enum Error {
@@ -43,6 +45,16 @@ pub enum Error {
     #[error("manifest deserialization failed: {0}")]
     ManifestParse(#[from] serde_json::Error),
 
+    /// A manifest was deserialized successfully but is semantically invalid.
+    ///
+    /// Currently raised when `schemaVersion` is not 2 (the only version
+    /// defined by the OCI Image and Docker v2 specs).
+    #[error("invalid manifest: {reason}")]
+    InvalidManifest {
+        /// Why the manifest is invalid.
+        reason: String,
+    },
+
     /// Authentication with the registry failed.
     #[error("authentication failed for registry '{registry}': {reason}")]
     AuthFailed {
@@ -83,23 +95,74 @@ pub enum Error {
         reason: String,
     },
 
-    /// The upload protocol violated expectations (missing headers, unexpected status).
+    /// The blob upload protocol violated expectations.
+    ///
+    /// Raised during the POST/PUT/PATCH upload sequence when the registry
+    /// returns a missing `Location` header or an unresolvable upload URL.
+    /// For digest mismatches during upload verification, see
+    /// [`DigestMismatch`](Self::DigestMismatch).
     #[error("upload protocol error: {reason}")]
     UploadProtocol {
         /// What went wrong during the upload sequence.
         reason: String,
     },
 
-    /// Docker config file I/O or parse failure.
-    #[error("docker config error: {reason}")]
-    DockerConfig {
+    /// The computed digest does not match the expected digest during blob upload.
+    #[error("digest mismatch: expected {expected}, got {actual}")]
+    DigestMismatch {
+        /// The digest that was expected.
+        expected: Digest,
+        /// The digest that was actually computed.
+        actual: Digest,
+    },
+
+    /// The registry response violated protocol expectations outside of uploads.
+    ///
+    /// Covers missing required headers on non-upload responses (e.g.
+    /// `Docker-Content-Digest` on manifest HEAD), malformed `Link`-header
+    /// pagination, and other spec violations in tag listing or manifest
+    /// retrieval. For upload-specific protocol errors see
+    /// [`UploadProtocol`](Self::UploadProtocol).
+    #[error("registry protocol error: {reason}")]
+    RegistryProtocol {
+        /// What was unexpected in the registry response.
+        reason: String,
+    },
+
+    /// An ECR-specific operation failed (region detection, SDK API call).
+    #[error("ECR error: {reason}")]
+    EcrApi {
+        /// What went wrong with the ECR operation.
+        reason: String,
+    },
+
+    /// An HTTP header value could not be constructed.
+    #[error("invalid {header} header value: {reason}")]
+    InvalidHeaderValue {
+        /// Which header could not be constructed.
+        header: String,
+        /// Why the value is invalid.
+        reason: String,
+    },
+
+    /// Credential configuration file I/O or parse failure.
+    ///
+    /// Covers Docker (`~/.docker/config.json`) and any future credential
+    /// store formats (podman `auth.json`, etc.).
+    #[error("credential config error: {reason}")]
+    CredentialConfig {
         /// What went wrong reading or parsing the config.
         reason: String,
     },
 
-    /// Catch-all for errors without a dedicated variant.
-    #[error("{0}")]
-    Other(String),
+    /// Filesystem I/O failed during a local operation.
+    #[error("I/O error ({context}): {source}")]
+    Io {
+        /// What operation was attempted (e.g. "staging create", "staging read").
+        context: &'static str,
+        /// The underlying I/O error.
+        source: std::io::Error,
+    },
 }
 
 impl Error {
@@ -135,6 +198,20 @@ impl Error {
 mod tests {
     use super::*;
 
+    /// Create a test digest with deterministic hex from a byte value.
+    fn test_digest(n: u8) -> Digest {
+        let hex = format!("{:0>64}", format!("{n:x}"));
+        format!("sha256:{hex}").parse().unwrap()
+    }
+
+    #[test]
+    fn is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Error>();
+    }
+
+    // --- Display (pre-existing variants, guards against accidental message changes) ---
+
     #[test]
     fn display_invalid_reference() {
         let err = Error::InvalidReference {
@@ -163,17 +240,7 @@ mod tests {
         assert!(err.to_string().contains("text/plain"));
     }
 
-    #[test]
-    fn display_other() {
-        let err = Error::Other("something broke".into());
-        assert_eq!(err.to_string(), "something broke");
-    }
-
-    #[test]
-    fn is_send_and_sync() {
-        fn assert_send_sync<T: Send + Sync>() {}
-        assert_send_sync::<Error>();
-    }
+    // --- status_code ---
 
     #[test]
     fn status_code_from_registry_error() {
@@ -186,39 +253,96 @@ mod tests {
 
     #[test]
     fn status_code_none_for_non_registry_errors() {
-        let err = Error::Other("something".into());
-        assert_eq!(err.status_code(), None);
-
-        let err = Error::InvalidReference {
-            input: "bad".into(),
-            reason: "reason".into(),
-        };
-        assert_eq!(err.status_code(), None);
-
-        let err = Error::AuthFailed {
-            registry: "example.com".into(),
-            reason: "bad creds".into(),
-        };
-        assert_eq!(err.status_code(), None);
+        let variants: Vec<Error> = vec![
+            Error::InvalidReference {
+                input: "bad".into(),
+                reason: "reason".into(),
+            },
+            Error::InvalidDigest {
+                digest: "bad".into(),
+                reason: "reason".into(),
+            },
+            Error::InvalidPlatformFilter {
+                input: "bad".into(),
+                reason: "reason".into(),
+            },
+            Error::UnsupportedMediaType {
+                media_type: "text/plain".into(),
+            },
+            Error::InvalidManifest {
+                reason: "bad schema".into(),
+            },
+            Error::AuthFailed {
+                registry: "example.com".into(),
+                reason: "bad creds".into(),
+            },
+            Error::CredentialHelperFailed {
+                helper: "docker-credential-ecr-login".into(),
+                reason: "not found".into(),
+            },
+            Error::UrlConstruction {
+                path: "/v2/".into(),
+                reason: "no base".into(),
+            },
+            Error::UploadProtocol {
+                reason: "missing header".into(),
+            },
+            Error::DigestMismatch {
+                expected: test_digest(1),
+                actual: test_digest(2),
+            },
+            Error::RegistryProtocol {
+                reason: "bad response".into(),
+            },
+            Error::EcrApi {
+                reason: "throttled".into(),
+            },
+            Error::InvalidHeaderValue {
+                header: "Content-Type".into(),
+                reason: "bad chars".into(),
+            },
+            Error::CredentialConfig {
+                reason: "not found".into(),
+            },
+            Error::Io {
+                context: "test",
+                source: std::io::Error::new(std::io::ErrorKind::Other, "disk full"),
+            },
+        ];
+        for err in &variants {
+            assert_eq!(err.status_code(), None, "expected None for {err}, got Some");
+        }
     }
 
+    // --- is_not_found ---
+
     #[test]
-    fn is_not_found() {
+    fn is_not_found_true_for_404() {
         let err = Error::RegistryError {
             status: http::StatusCode::NOT_FOUND,
             message: "missing".into(),
         };
         assert!(err.is_not_found());
+    }
 
+    #[test]
+    fn is_not_found_false_for_other_status() {
         let err = Error::RegistryError {
             status: http::StatusCode::UNAUTHORIZED,
             message: "denied".into(),
         };
         assert!(!err.is_not_found());
+    }
 
-        let err = Error::Other("unrelated".into());
+    #[test]
+    fn is_not_found_false_for_non_registry() {
+        let err = Error::RegistryProtocol {
+            reason: "unrelated".into(),
+        };
         assert!(!err.is_not_found());
     }
+
+    // --- is_auth_error ---
 
     #[test]
     fn is_auth_error_auth_failed() {
@@ -248,7 +372,7 @@ mod tests {
     }
 
     #[test]
-    fn is_auth_error_server_error() {
+    fn is_auth_error_false_for_server_error() {
         let err = Error::RegistryError {
             status: http::StatusCode::INTERNAL_SERVER_ERROR,
             message: "broke".into(),
@@ -257,10 +381,28 @@ mod tests {
     }
 
     #[test]
-    fn is_auth_error_other() {
-        let err = Error::Other("something".into());
-        assert!(!err.is_auth_error());
+    fn is_auth_error_false_for_non_auth_variants() {
+        let variants: Vec<Error> = vec![
+            Error::RegistryProtocol {
+                reason: "bad".into(),
+            },
+            Error::EcrApi {
+                reason: "throttled".into(),
+            },
+            Error::CredentialConfig {
+                reason: "missing".into(),
+            },
+            Error::DigestMismatch {
+                expected: test_digest(1),
+                actual: test_digest(2),
+            },
+        ];
+        for err in &variants {
+            assert!(!err.is_auth_error(), "expected false for {err}");
+        }
     }
+
+    // --- Display (new variants) ---
 
     #[test]
     fn display_url_construction() {
@@ -272,11 +414,8 @@ mod tests {
         assert!(msg.contains("/v2/"), "should contain path: {msg}");
         assert!(
             msg.contains("relative URL without a base"),
-            "should contain source: {msg}"
+            "should contain reason: {msg}"
         );
-        // Must not match auth or not-found helpers.
-        assert!(!err.is_auth_error());
-        assert!(!err.is_not_found());
     }
 
     #[test]
@@ -289,21 +428,130 @@ mod tests {
             msg.contains("missing Location header"),
             "should contain reason: {msg}"
         );
-        assert!(!err.is_auth_error());
-        assert!(!err.is_not_found());
     }
 
     #[test]
-    fn display_docker_config() {
-        let err = Error::DockerConfig {
-            reason: "unable to determine home directory".into(),
+    fn display_registry_protocol() {
+        let err = Error::RegistryProtocol {
+            reason: "missing Docker-Content-Digest header".into(),
         };
         let msg = err.to_string();
         assert!(
-            msg.contains("unable to determine home directory"),
+            msg.contains("missing Docker-Content-Digest header"),
             "should contain reason: {msg}"
         );
-        assert!(!err.is_auth_error());
-        assert!(!err.is_not_found());
+    }
+
+    #[test]
+    fn display_ecr_api() {
+        let err = Error::EcrApi {
+            reason: "BatchCheckLayerAvailability throttled".into(),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("BatchCheckLayerAvailability throttled"),
+            "should contain reason: {msg}"
+        );
+    }
+
+    #[test]
+    fn display_invalid_header_value() {
+        let err = Error::InvalidHeaderValue {
+            header: "Authorization".into(),
+            reason: "invalid byte in header value".into(),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Authorization"),
+            "should contain header name: {msg}"
+        );
+        assert!(
+            msg.contains("invalid byte in header value"),
+            "should contain reason: {msg}"
+        );
+    }
+
+    #[test]
+    fn display_invalid_manifest() {
+        let err = Error::InvalidManifest {
+            reason: "unsupported schemaVersion 1, expected 2".into(),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("schemaVersion"),
+            "should contain reason: {msg}"
+        );
+    }
+
+    #[test]
+    fn display_credential_config() {
+        let err = Error::CredentialConfig {
+            reason: "failed to read config at ~/.docker/config.json: No such file".into(),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("credential config error"),
+            "should contain variant prefix: {msg}"
+        );
+        assert!(
+            msg.contains("config.json"),
+            "should contain path detail: {msg}"
+        );
+    }
+
+    #[test]
+    fn display_io() {
+        let err = Error::Io {
+            context: "staging write",
+            source: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "access denied"),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("staging write"),
+            "should contain context: {msg}"
+        );
+        assert!(msg.contains("access denied"), "should contain cause: {msg}");
+    }
+
+    // --- Structured fields ---
+
+    #[test]
+    fn digest_mismatch_preserves_typed_digests() {
+        let expected = test_digest(1);
+        let actual = test_digest(2);
+        let err = Error::DigestMismatch {
+            expected: expected.clone(),
+            actual: actual.clone(),
+        };
+        match &err {
+            Error::DigestMismatch {
+                expected: e,
+                actual: a,
+            } => {
+                assert_eq!(e, &expected);
+                assert_eq!(a, &actual);
+            }
+            _ => panic!("wrong variant"),
+        }
+        let msg = err.to_string();
+        assert!(
+            msg.contains(&expected.to_string()),
+            "missing expected: {msg}"
+        );
+        assert!(msg.contains(&actual.to_string()), "missing actual: {msg}");
+    }
+
+    #[test]
+    fn io_preserves_source_error_kind() {
+        let err = Error::Io {
+            context: "staging read",
+            source: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "access denied"),
+        };
+        match &err {
+            Error::Io { source, .. } => {
+                assert_eq!(source.kind(), std::io::ErrorKind::PermissionDenied);
+            }
+            _ => panic!("wrong variant"),
+        }
     }
 }

--- a/crates/ocync-distribution/src/error.rs
+++ b/crates/ocync-distribution/src/error.rs
@@ -306,7 +306,7 @@ mod tests {
             },
             Error::Io {
                 context: "test",
-                source: std::io::Error::new(std::io::ErrorKind::Other, "disk full"),
+                source: std::io::Error::other("disk full"),
             },
         ];
         for err in &variants {
@@ -382,19 +382,59 @@ mod tests {
 
     #[test]
     fn is_auth_error_false_for_non_auth_variants() {
+        // Exhaustive: every variant except AuthFailed and RegistryError
+        // (which return true). Compile error if a new variant is added
+        // without being included here.
         let variants: Vec<Error> = vec![
-            Error::RegistryProtocol {
-                reason: "bad".into(),
+            Error::InvalidReference {
+                input: "bad".into(),
+                reason: "reason".into(),
             },
-            Error::EcrApi {
-                reason: "throttled".into(),
+            Error::InvalidDigest {
+                digest: "bad".into(),
+                reason: "reason".into(),
             },
-            Error::CredentialConfig {
-                reason: "missing".into(),
+            Error::InvalidPlatformFilter {
+                input: "bad".into(),
+                reason: "reason".into(),
+            },
+            Error::UnsupportedMediaType {
+                media_type: "text/plain".into(),
+            },
+            Error::InvalidManifest {
+                reason: "bad schema".into(),
+            },
+            Error::CredentialHelperFailed {
+                helper: "docker-credential-ecr-login".into(),
+                reason: "not found".into(),
+            },
+            Error::UrlConstruction {
+                path: "/v2/".into(),
+                reason: "no base".into(),
+            },
+            Error::UploadProtocol {
+                reason: "missing header".into(),
             },
             Error::DigestMismatch {
                 expected: test_digest(1),
                 actual: test_digest(2),
+            },
+            Error::RegistryProtocol {
+                reason: "bad response".into(),
+            },
+            Error::EcrApi {
+                reason: "throttled".into(),
+            },
+            Error::InvalidHeaderValue {
+                header: "Content-Type".into(),
+                reason: "bad chars".into(),
+            },
+            Error::CredentialConfig {
+                reason: "missing".into(),
+            },
+            Error::Io {
+                context: "test",
+                source: std::io::Error::other("disk full"),
             },
         ];
         for err in &variants {

--- a/crates/ocync-distribution/src/manifest.rs
+++ b/crates/ocync-distribution/src/manifest.rs
@@ -90,15 +90,12 @@ impl RegistryClient {
                 let digest_str = headers
                     .get(DOCKER_CONTENT_DIGEST)
                     .and_then(|v| v.to_str().ok())
-                    .ok_or_else(|| {
-                        Error::Other(
-                            "manifest HEAD response missing Docker-Content-Digest header".into(),
-                        )
+                    .ok_or_else(|| Error::RegistryProtocol {
+                        reason: "manifest HEAD response missing Docker-Content-Digest header"
+                            .into(),
                     })?;
-                let digest: Digest = digest_str.parse().map_err(|_| {
-                    Error::Other(format!(
-                        "invalid digest in Docker-Content-Digest header: {digest_str}"
-                    ))
+                let digest: Digest = digest_str.parse().map_err(|_| Error::RegistryProtocol {
+                    reason: format!("invalid digest in Docker-Content-Digest header: {digest_str}"),
                 })?;
 
                 let media_type: MediaType = headers
@@ -183,8 +180,11 @@ impl RegistryClient {
         let url = build_url(&self.base_url, repository, &manifest_path(reference))?;
         let scopes = [Scope::pull_push(repository.as_str())];
 
-        let content_type = HeaderValue::from_str(media_type.as_str())
-            .map_err(|e| Error::Other(format!("invalid media type header value: {e}")))?;
+        let content_type =
+            HeaderValue::from_str(media_type.as_str()).map_err(|e| Error::InvalidHeaderValue {
+                header: "Content-Type".into(),
+                reason: e.to_string(),
+            })?;
 
         let resp = self
             .send_with_aimd(

--- a/crates/ocync-distribution/src/spec.rs
+++ b/crates/ocync-distribution/src/spec.rs
@@ -411,20 +411,24 @@ impl ManifestKind {
             MediaType::OciManifest | MediaType::DockerManifestV2 => {
                 let m: ImageManifest = serde_json::from_slice(bytes)?;
                 if m.schema_version != 2 {
-                    return Err(Error::Other(format!(
-                        "unsupported schemaVersion {}, expected 2",
-                        m.schema_version
-                    )));
+                    return Err(Error::InvalidManifest {
+                        reason: format!(
+                            "unsupported schemaVersion {}, expected 2",
+                            m.schema_version
+                        ),
+                    });
                 }
                 Ok(Self::Image(Box::new(m)))
             }
             MediaType::OciIndex | MediaType::DockerManifestList => {
                 let m: ImageIndex = serde_json::from_slice(bytes)?;
                 if m.schema_version != 2 {
-                    return Err(Error::Other(format!(
-                        "unsupported schemaVersion {}, expected 2",
-                        m.schema_version
-                    )));
+                    return Err(Error::InvalidManifest {
+                        reason: format!(
+                            "unsupported schemaVersion {}, expected 2",
+                            m.schema_version
+                        ),
+                    });
                 }
                 Ok(Self::Index(Box::new(m)))
             }
@@ -886,7 +890,10 @@ mod tests {
         });
         let bytes = serde_json::to_vec(&json).unwrap();
         let err = ManifestKind::from_json(&MediaType::OciManifest, &bytes).unwrap_err();
-        assert!(err.to_string().contains("schemaVersion"), "error: {err}");
+        assert!(
+            matches!(err, Error::InvalidManifest { .. }),
+            "expected ManifestValidation, got: {err}"
+        );
     }
 
     #[test]
@@ -901,7 +908,10 @@ mod tests {
         });
         let bytes = serde_json::to_vec(&json).unwrap();
         let err = ManifestKind::from_json(&MediaType::OciIndex, &bytes).unwrap_err();
-        assert!(err.to_string().contains("schemaVersion"), "error: {err}");
+        assert!(
+            matches!(err, Error::InvalidManifest { .. }),
+            "expected ManifestValidation, got: {err}"
+        );
     }
 
     // --- RepositoryName validation tests ---

--- a/crates/ocync-distribution/src/tags.rs
+++ b/crates/ocync-distribution/src/tags.rs
@@ -76,9 +76,11 @@ impl RegistryClient {
         loop {
             page_count += 1;
             if page_count > MAX_TAG_PAGES {
-                return Err(Error::Other(format!(
-                    "tag listing exceeded {MAX_TAG_PAGES} pages; possible infinite loop from malformed Link headers"
-                )));
+                return Err(Error::RegistryProtocol {
+                    reason: format!(
+                        "tag listing exceeded {MAX_TAG_PAGES} pages; possible infinite loop from malformed Link headers"
+                    ),
+                });
             }
             let resp = self
                 .get(repository, &path, None, RegistryAction::TagList)

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -1772,13 +1772,13 @@ async fn pull_source_manifest(
                         })
                         .collect();
                     let filter_strs: Vec<String> = filters.iter().map(|f| f.to_string()).collect();
-                    return Err(crate::Error::Manifest {
+                    return Err(crate::Error::ManifestLogic {
                         reference: tag.to_owned(),
-                        source: ocync_distribution::Error::Other(format!(
+                        reason: format!(
                             "platform filter [{}] matched no manifests in index (source has: [{}])",
                             filter_strs.join(", "),
                             available.join(", "),
-                        )),
+                        ),
                     });
                 }
 
@@ -1813,11 +1813,9 @@ async fn pull_source_manifest(
                         children.push(child_pull);
                     }
                     ManifestKind::Index(_) => {
-                        return Err(crate::Error::Manifest {
+                        return Err(crate::Error::ManifestLogic {
                             reference: child_digest_str,
-                            source: ocync_distribution::Error::Other(
-                                "nested index manifests are not supported".into(),
-                            ),
+                            reason: "nested index manifests are not supported".into(),
                         });
                     }
                 }
@@ -1835,13 +1833,12 @@ async fn pull_source_manifest(
                     artifact_type: index.artifact_type.clone(),
                     annotations: index.annotations.clone(),
                 };
-                let new_bytes =
-                    serde_json::to_vec(&filtered_index).map_err(|e| crate::Error::Manifest {
+                let new_bytes = serde_json::to_vec(&filtered_index).map_err(|e| {
+                    crate::Error::ManifestLogic {
                         reference: tag.to_owned(),
-                        source: ocync_distribution::Error::Other(format!(
-                            "failed to serialize filtered index: {e}"
-                        )),
-                    })?;
+                        reason: format!("failed to serialize filtered index: {e}"),
+                    }
+                })?;
                 let new_digest = Digest::from_sha256(Sha256::digest(&new_bytes));
                 let filtered_pull = ManifestPull {
                     manifest: ManifestKind::Index(Box::new(filtered_index)),
@@ -2164,19 +2161,25 @@ async fn transfer_single_blob(
                 crate::staging::StagePullAction::Pull => {
                     if let Err(e) = with_retry(ctx.retry, "blob pull (to stage)", || async {
                         let mut writer = ctx.staging.begin_write(digest).map_err(|e| {
-                            ocync_distribution::Error::Other(format!("staging create: {e}"))
+                            ocync_distribution::Error::Io {
+                                context: "staging create",
+                                source: e,
+                            }
                         })?;
                         let stream = ctx.source_client.blob_pull(ctx.source_repo, digest).await?;
                         futures_util::pin_mut!(stream);
                         while let Some(chunk) = stream.next().await {
-                            let chunk = chunk
-                                .map_err(|e| ocync_distribution::Error::Other(e.to_string()))?;
+                            let chunk = chunk?;
                             writer.write_chunk(&chunk).map_err(|e| {
-                                ocync_distribution::Error::Other(format!("staging write: {e}"))
+                                ocync_distribution::Error::Io {
+                                    context: "staging write",
+                                    source: e,
+                                }
                             })?;
                         }
-                        writer.finish().map_err(|e| {
-                            ocync_distribution::Error::Other(format!("staging finalize: {e}"))
+                        writer.finish().map_err(|e| ocync_distribution::Error::Io {
+                            context: "staging finalize",
+                            source: e,
                         })?;
                         Ok::<(), ocync_distribution::Error>(())
                     })
@@ -2204,13 +2207,19 @@ async fn transfer_single_blob(
         }
 
         with_retry(ctx.retry, "blob push (staged)", || async {
-            let file = ctx
-                .staging
-                .open_read(digest)
-                .map_err(|e| ocync_distribution::Error::Other(format!("staging read: {e}")))?;
+            let file =
+                ctx.staging
+                    .open_read(digest)
+                    .map_err(|e| ocync_distribution::Error::Io {
+                        context: "staging open",
+                        source: e,
+                    })?;
             let file_size = file.metadata().map(|m| m.len()).ok();
             let stream = file_read_stream(file).map(|r| {
-                r.map_err(|e| ocync_distribution::Error::Other(format!("staging read: {e}")))
+                r.map_err(|e| ocync_distribution::Error::Io {
+                    context: "staging read",
+                    source: e,
+                })
             });
             ctx.target_client
                 .blob_push_stream(ctx.target_repo, digest, file_size, stream)

--- a/crates/ocync-sync/src/error.rs
+++ b/crates/ocync-sync/src/error.rs
@@ -46,6 +46,19 @@ pub enum Error {
         source: ocync_distribution::Error,
     },
 
+    /// Engine-level manifest processing error (not from the registry).
+    ///
+    /// Covers failures like platform filter matching, unsupported manifest
+    /// structures, and index rewriting -- cases where the engine itself
+    /// rejects or cannot process a manifest, rather than a registry error.
+    #[error("manifest {reference}: {reason}")]
+    ManifestLogic {
+        /// The manifest reference involved.
+        reference: String,
+        /// Why the manifest could not be processed.
+        reason: String,
+    },
+
     /// A blob transfer failed during sync.
     #[error("blob transfer failed for {digest}: {source}")]
     BlobTransfer {
@@ -161,11 +174,51 @@ mod tests {
                 .unwrap();
         let err = Error::BlobTransfer {
             digest: digest.clone(),
-            source: ocync_distribution::Error::Other("timeout".into()),
+            source: ocync_distribution::Error::Io {
+                context: "staging read",
+                source: std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "permission denied",
+                ),
+            },
         };
         let msg = err.to_string();
         assert!(msg.contains("blob transfer"));
         assert!(msg.contains(&digest.to_string()));
+    }
+
+    #[test]
+    fn display_manifest_logic() {
+        let err = Error::ManifestLogic {
+            reference: "latest".into(),
+            reason: "platform filter matched no manifests in index".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("latest"), "should contain reference: {msg}");
+        assert!(
+            msg.contains("platform filter"),
+            "should contain reason: {msg}"
+        );
+    }
+
+    #[test]
+    fn manifest_logic_status_code_is_none() {
+        let err = Error::ManifestLogic {
+            reference: "latest".into(),
+            reason: "no match".into(),
+        };
+        // ManifestLogic is a deterministic engine decision (not a registry
+        // error), so it has no HTTP status and is never retryable.
+        assert_eq!(err.status_code(), None);
+    }
+
+    #[test]
+    fn manifest_logic_is_not_required_artifacts_missing() {
+        let err = Error::ManifestLogic {
+            reference: "v1".into(),
+            reason: "nested index manifests are not supported".into(),
+        };
+        assert!(!err.is_required_artifacts_missing());
     }
 
     #[test]

--- a/crates/ocync-sync/src/retry.rs
+++ b/crates/ocync-sync/src/retry.rs
@@ -246,7 +246,7 @@ mod tests {
     fn should_retry_transport_on_io() {
         let err = ocync_distribution::Error::Io {
             context: "staging read",
-            source: std::io::Error::new(std::io::ErrorKind::Other, "staging read failed"),
+            source: std::io::Error::other("staging read failed"),
         };
         assert!(!should_retry_transport(&err));
     }

--- a/crates/ocync-sync/src/retry.rs
+++ b/crates/ocync-sync/src/retry.rs
@@ -67,9 +67,9 @@ pub fn should_retry(status: StatusCode, current_attempt: u32, max_retries: u32) 
 ///
 /// Only inspects `ocync_distribution::Error::Http(reqwest::Error)`. Transport
 /// errors that arrive wrapped in other variants are NOT retried:
-/// - `Error::Other(...)` -- may contain connection resets from middleware
-/// - `Error::RegistryError { source, .. }` -- may wrap a transport error
-/// - `Error::Manifest { source, .. }` -- may wrap a transport error
+/// - `Error::Io { .. }` -- local filesystem errors, never transient (typed `io::Error`)
+/// - `Error::RegistryError { .. }` -- HTTP-level; retried via `should_retry()` instead
+/// - `Error::RegistryProtocol { .. }` -- deterministic spec violation, never transient
 ///
 /// If operators observe unretrieved transient errors, the debug log below will
 /// show which variant was encountered so the match can be extended.
@@ -243,8 +243,11 @@ mod tests {
     }
 
     #[test]
-    fn should_retry_transport_on_other() {
-        let err = ocync_distribution::Error::Other("something".into());
+    fn should_retry_transport_on_io() {
+        let err = ocync_distribution::Error::Io {
+            context: "staging read",
+            source: std::io::Error::new(std::io::ErrorKind::Other, "staging read failed"),
+        };
         assert!(!should_retry_transport(&err));
     }
 }

--- a/crates/ocync-sync/tests/sync_cache.rs
+++ b/crates/ocync-sync/tests/sync_cache.rs
@@ -114,9 +114,9 @@ impl BatchBlobChecker for FailingBatchChecker {
         );
         Box::pin(async {
             self.call_count.fetch_add(1, Ordering::Relaxed);
-            Err(ocync_distribution::Error::Other(
-                "batch API unavailable".into(),
-            ))
+            Err(ocync_distribution::Error::EcrApi {
+                reason: "batch API unavailable".into(),
+            })
         })
     }
 }


### PR DESCRIPTION
## Summary

- Eliminate `Error::Other` entirely from both `ocync-distribution` and `ocync-sync`
- Add dedicated variants: `UrlConstruction`, `UploadProtocol`, `RegistryProtocol`, `DigestMismatch` (typed `Digest` fields), `EcrApi`, `InvalidHeaderValue`, `InvalidManifest`, `CredentialConfig`, `Io` (typed `std::io::Error` + `&'static str` context)
- Rename `DockerConfig` -> `CredentialConfig` to future-proof for podman/other credential stores
- Split `sync::Error::Manifest` into `Manifest` (registry errors) and `ManifestLogic` (deterministic engine decisions like platform filtering, nested index rejection)
- Restructure `Io` variant from `{ reason: String }` to `{ context: &'static str, source: std::io::Error }` preserving error kind for programmatic inspection
- Improve doc comments on `UploadProtocol` vs `RegistryProtocol` boundary with cross-references
- Update `retry.rs` doc comments to explain why each non-`Http` variant is not retried

Closes #43

## Test plan

- [x] Display tests for all new variants (url_construction, upload_protocol, registry_protocol, ecr_api, invalid_header_value, invalid_manifest, credential_config, io, manifest_logic)
- [x] `io_preserves_source_error_kind` -- proves typed `std::io::Error` is accessible
- [x] `digest_mismatch_preserves_typed_digests` -- proves typed `Digest` fields are accessible
- [x] Exhaustive `status_code_none_for_non_registry_errors` vec covers all 15 non-registry variants (compile error if a new variant is missed)
- [x] Exhaustive `is_auth_error_false_for_non_auth_variants` vec
- [x] `manifest_logic_status_code_is_none` + `manifest_logic_is_not_required_artifacts_missing` -- ManifestLogic is never retryable
- [x] 475 tests pass, zero `Error::Other` references remain
- [x] CI gate: `cargo fmt --check && cargo clippy -- -D warnings && cargo test`