### PR TITLE
feat: surface skipped artifact sync in ImageResult

### DIFF
--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -327,6 +327,7 @@ fn skip_image_result(source: &ImageRef, target: &ImageRef, reason: SkipReason) -
         bytes_transferred: 0,
         blob_stats: BlobTransferStats::default(),
         duration: Duration::ZERO,
+        artifacts_skipped: false,
     }
 }
 
@@ -1484,6 +1485,7 @@ async fn full_pull_and_build_tasks(params: FullPullParams<'_>) -> DiscoveryOutco
                     bytes_transferred: 0,
                     blob_stats: BlobTransferStats::default(),
                     duration: Duration::ZERO,
+                    artifacts_skipped: false,
                 })
                 .collect();
             // Do NOT update cache on pull failure.
@@ -1607,6 +1609,7 @@ async fn execute_item(
             bytes_transferred: outcome.bytes_transferred,
             blob_stats: outcome.stats,
             duration: start.elapsed(),
+            artifacts_skipped: false,
         };
     }
 
@@ -1622,7 +1625,7 @@ async fn execute_item(
     {
         Ok(()) => {
             // Discover and sync artifacts (signatures, SBOMs, attestations).
-            if let Err(err) = discover_and_sync_artifacts(
+            let artifacts_skipped = match discover_and_sync_artifacts(
                 &item.source_client,
                 &item.target_client,
                 &item.source.repo,
@@ -1634,31 +1637,43 @@ async fn execute_item(
             )
             .await
             {
-                let (kind, retries) = if err.is_required_artifacts_missing() {
-                    (ErrorKind::RequiredArtifactsMissing, 0)
-                } else {
-                    (ErrorKind::ArtifactSync, retry.max_retries)
-                };
+                Ok(skipped) => skipped,
+                Err(err) => {
+                    let (kind, retries) = if err.is_required_artifacts_missing() {
+                        (ErrorKind::RequiredArtifactsMissing, 0)
+                    } else {
+                        (ErrorKind::ArtifactSync, retry.max_retries)
+                    };
+                    warn!(
+                        source_repo = %item.source.repo,
+                        target_repo = %item.target.repo,
+                        error = %err,
+                        "artifact sync failed"
+                    );
+                    return ImageResult {
+                        image_id: Uuid::now_v7(),
+                        source: item.source.to_string(),
+                        target: item.target.to_string(),
+                        status: ImageStatus::Failed {
+                            kind,
+                            error: err.to_string(),
+                            retries,
+                            status_code: None,
+                        },
+                        bytes_transferred: outcome.bytes_transferred,
+                        blob_stats: outcome.stats,
+                        duration: start.elapsed(),
+                        artifacts_skipped: false,
+                    };
+                }
+            };
+
+            if artifacts_skipped {
                 warn!(
                     source_repo = %item.source.repo,
                     target_repo = %item.target.repo,
-                    error = %err,
-                    "artifact sync failed"
+                    "artifact discovery skipped due to transient error"
                 );
-                return ImageResult {
-                    image_id: Uuid::now_v7(),
-                    source: item.source.to_string(),
-                    target: item.target.to_string(),
-                    status: ImageStatus::Failed {
-                        kind,
-                        error: err.to_string(),
-                        retries,
-                        status_code: None,
-                    },
-                    bytes_transferred: outcome.bytes_transferred,
-                    blob_stats: outcome.stats,
-                    duration: start.elapsed(),
-                };
             }
 
             info!(
@@ -1677,6 +1692,7 @@ async fn execute_item(
                 bytes_transferred: outcome.bytes_transferred,
                 blob_stats: outcome.stats,
                 duration: start.elapsed(),
+                artifacts_skipped,
             }
         }
         Err(err) => {
@@ -1697,6 +1713,7 @@ async fn execute_item(
                     bytes_transferred: outcome.bytes_transferred,
                     blob_stats: outcome.stats,
                     duration: start.elapsed(),
+                    artifacts_skipped: false,
                 }
             } else {
                 warn!(target_name = %item.target_name, error = %err, "manifest push failed");
@@ -1713,6 +1730,7 @@ async fn execute_item(
                     bytes_transferred: outcome.bytes_transferred,
                     blob_stats: outcome.stats,
                     duration: start.elapsed(),
+                    artifacts_skipped: false,
                 }
             }
         }
@@ -2310,6 +2328,9 @@ async fn push_manifests(
 ///
 /// For each matching artifact: push blobs, then push manifest (preserving
 /// the `subject` reference to the parent).
+///
+/// Returns `Ok(true)` when artifact discovery was skipped due to a transient
+/// error (the image synced but artifacts may be missing at the target).
 #[allow(clippy::too_many_arguments)]
 async fn discover_and_sync_artifacts(
     source_client: &RegistryClient,
@@ -2320,9 +2341,9 @@ async fn discover_and_sync_artifacts(
     artifacts_config: &ResolvedArtifacts,
     retry: &RetryConfig,
     referrers_cache: &ReferrersCache,
-) -> Result<(), crate::Error> {
+) -> Result<bool, crate::Error> {
     if !artifacts_config.enabled {
-        return Ok(());
+        return Ok(false);
     }
 
     // Check the per-run referrers cache to avoid redundant discovery when
@@ -2381,7 +2402,7 @@ async fn discover_and_sync_artifacts(
     }
 
     if matching.is_empty() {
-        return Ok(());
+        return Ok(!discovery_succeeded);
     }
 
     info!(
@@ -2463,7 +2484,7 @@ async fn discover_and_sync_artifacts(
         );
     }
 
-    Ok(())
+    Ok(false)
 }
 
 /// Discover referrers for a manifest from the source registry.
@@ -2653,6 +2674,9 @@ fn compute_stats(images: &[ImageResult]) -> SyncStats {
         stats.blobs_transferred += image.blob_stats.transferred;
         stats.blobs_skipped += image.blob_stats.skipped;
         stats.blobs_mounted += image.blob_stats.mounted;
+        if image.artifacts_skipped {
+            stats.artifacts_skipped += 1;
+        }
     }
     stats
 }
@@ -2770,6 +2794,7 @@ mod tests {
             bytes_transferred: bytes,
             blob_stats: BlobTransferStats::default(),
             duration: Duration::from_millis(100),
+            artifacts_skipped: false,
         }
     }
 

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -2402,6 +2402,8 @@ async fn discover_and_sync_artifacts(
     }
 
     if matching.is_empty() {
+        // Transient discovery failure -> artifacts_skipped = true.
+        // Successful discovery with zero referrers -> false.
         return Ok(!discovery_succeeded);
     }
 

--- a/crates/ocync-sync/src/lib.rs
+++ b/crates/ocync-sync/src/lib.rs
@@ -29,6 +29,11 @@ use uuid::Uuid;
 pub use error::Error;
 pub use shutdown::ShutdownSignal;
 
+/// Serde helper: skip serializing when value is zero.
+fn is_zero(v: &u64) -> bool {
+    *v == 0
+}
+
 /// Result of a complete sync run. The engine never "fails" as a whole.
 #[derive(Debug, Serialize)]
 pub struct SyncReport {
@@ -78,6 +83,14 @@ pub struct ImageResult {
     pub blob_stats: BlobTransferStats,
     /// Wall-clock duration of this image transfer.
     pub duration: Duration,
+    /// Whether artifact discovery or transfer was skipped due to a transient error.
+    ///
+    /// When `true`, the image itself synced successfully but its referrers
+    /// (signatures, SBOMs, attestations) may be missing at the target. Only
+    /// set on the transient-error path -- when discovery confirms zero
+    /// referrers, this remains `false`.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub artifacts_skipped: bool,
 }
 
 /// Per-image blob transfer statistics.
@@ -206,6 +219,10 @@ pub struct SyncStats {
     /// Unit is per-target: 2 tags across 3 targets = 6. Consistent with
     /// `images_skipped` which also counts per-target.
     pub immutable_tag_skips: u64,
+    /// Images where artifact discovery or transfer was skipped due to a
+    /// transient error (e.g. referrers API returned 500).
+    #[serde(skip_serializing_if = "is_zero")]
+    pub artifacts_skipped: u64,
 }
 
 #[cfg(test)]
@@ -225,6 +242,7 @@ mod tests {
                     bytes_transferred: 0,
                     blob_stats: BlobTransferStats::default(),
                     duration: Duration::ZERO,
+                    artifacts_skipped: false,
                 })
                 .collect(),
             stats: SyncStats::default(),
@@ -300,6 +318,7 @@ mod tests {
         assert_eq!(stats.blobs_skipped, 0);
         assert_eq!(stats.blobs_mounted, 0);
         assert_eq!(stats.bytes_transferred, 0);
+        assert_eq!(stats.artifacts_skipped, 0);
     }
 
     #[test]
@@ -398,5 +417,66 @@ mod tests {
         };
         let json = serde_json::to_value(&status).unwrap();
         assert_eq!(json["status_code"], 401);
+    }
+
+    #[test]
+    fn image_result_json_omits_artifacts_skipped_when_false() {
+        let result = ImageResult {
+            image_id: Uuid::now_v7(),
+            source: "src".into(),
+            target: "tgt".into(),
+            status: ImageStatus::Synced,
+            bytes_transferred: 0,
+            blob_stats: BlobTransferStats::default(),
+            duration: Duration::ZERO,
+            artifacts_skipped: false,
+        };
+        let json = serde_json::to_value(&result).unwrap();
+        assert!(
+            json.get("artifacts_skipped").is_none(),
+            "artifacts_skipped=false should be omitted from JSON"
+        );
+    }
+
+    #[test]
+    fn image_result_json_includes_artifacts_skipped_when_true() {
+        let result = ImageResult {
+            image_id: Uuid::now_v7(),
+            source: "src".into(),
+            target: "tgt".into(),
+            status: ImageStatus::Synced,
+            bytes_transferred: 0,
+            blob_stats: BlobTransferStats::default(),
+            duration: Duration::ZERO,
+            artifacts_skipped: true,
+        };
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(
+            json["artifacts_skipped"], true,
+            "artifacts_skipped=true should appear in JSON"
+        );
+    }
+
+    #[test]
+    fn sync_stats_json_omits_artifacts_skipped_when_zero() {
+        let stats = SyncStats::default();
+        let json = serde_json::to_value(&stats).unwrap();
+        assert!(
+            json.get("artifacts_skipped").is_none(),
+            "artifacts_skipped=0 should be omitted from JSON"
+        );
+    }
+
+    #[test]
+    fn sync_stats_json_includes_artifacts_skipped_when_nonzero() {
+        let stats = SyncStats {
+            artifacts_skipped: 3,
+            ..SyncStats::default()
+        };
+        let json = serde_json::to_value(&stats).unwrap();
+        assert_eq!(
+            json["artifacts_skipped"], 3,
+            "artifacts_skipped=3 should appear in JSON"
+        );
     }
 }

--- a/crates/ocync-sync/src/lib.rs
+++ b/crates/ocync-sync/src/lib.rs
@@ -87,7 +87,7 @@ pub struct ImageResult {
     ///
     /// When `true`, the image itself synced successfully but its referrers
     /// (signatures, SBOMs, attestations) may be missing at the target. Only
-    /// set on the transient-error path -- when discovery confirms zero
+    /// `true` on the transient-error path -- when discovery confirms zero
     /// referrers, this remains `false`.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub artifacts_skipped: bool,

--- a/crates/ocync-sync/src/progress.rs
+++ b/crates/ocync-sync/src/progress.rs
@@ -48,6 +48,7 @@ mod tests {
             bytes_transferred: 1024,
             blob_stats: crate::BlobTransferStats::default(),
             duration: Duration::from_secs(1),
+            artifacts_skipped: false,
         };
         p.image_completed(&result);
 

--- a/crates/ocync-sync/tests/sync_artifacts.rs
+++ b/crates/ocync-sync/tests/sync_artifacts.rs
@@ -48,6 +48,10 @@ async fn artifact_sync_disabled_issues_no_referrers_requests() {
 
     assert_eq!(report.images.len(), 1);
     assert_status!(report, 0, ImageStatus::Synced);
+    assert!(
+        !report.images[0].artifacts_skipped,
+        "artifacts_skipped must be false when artifacts are disabled (not a transient skip)"
+    );
 
     // No referrers requests should have been made.
     let source_requests = source_server.received_requests().await.unwrap();
@@ -153,6 +157,10 @@ async fn artifact_require_artifacts_fails_on_empty() {
     // Image should fail because require_artifacts is true and no referrers exist.
     assert_eq!(report.images.len(), 1);
     assert_status!(report, 0, ImageStatus::Failed { .. });
+    assert!(
+        !report.images[0].artifacts_skipped,
+        "artifacts_skipped must be false on hard failure (require_artifacts enforcement, not transient)"
+    );
 }
 
 /// When `require_artifacts = true` but the referrers API returns a non-404
@@ -698,4 +706,63 @@ async fn artifact_transfer_failure_reports_artifact_sync_error() {
         }
         other => panic!("expected Failed, got {other:?}"),
     }
+}
+
+/// When the same image is synced to two targets and the referrers API
+/// returns a transient error, both targets should report `artifacts_skipped`.
+/// The second target hits the referrers cache (`CachedReferrers::Failed`),
+/// so this validates cache-mediated propagation of the skip signal.
+///
+/// Negative assertion: if only the first target set `artifacts_skipped`,
+/// the cache would be swallowing the failure for subsequent targets.
+#[tokio::test]
+async fn artifact_transient_error_propagates_to_all_targets() {
+    let source_server = MockServer::start().await;
+    let target_a = MockServer::start().await;
+    let target_b = MockServer::start().await;
+
+    let parent = ManifestBuilder::new(b"mt-cfg").layer(b"mt-layer").build();
+    parent.mount_source(&source_server, "repo", "v1.0.0").await;
+
+    // Referrers API returns 500 (transient error).
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/referrers/{}", parent.digest)))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&source_server)
+        .await;
+
+    // Both targets accept the image.
+    for target in [&target_a, &target_b] {
+        parent.mount_target(target, "repo", "v1.0.0").await;
+    }
+
+    let mapping = resolved_mapping(
+        mock_client(&source_server),
+        "repo",
+        "repo",
+        vec![
+            target_entry("target-a", mock_client(&target_a)),
+            target_entry("target-b", mock_client(&target_b)),
+        ],
+        vec![TagPair::same("v1.0.0")],
+    );
+
+    let report = run_sync(vec![mapping]).await;
+
+    assert_eq!(report.images.len(), 2);
+    assert!(
+        report
+            .images
+            .iter()
+            .all(|r| matches!(r.status, ImageStatus::Synced)),
+        "both targets should sync successfully"
+    );
+    assert!(
+        report.images.iter().all(|r| r.artifacts_skipped),
+        "both targets must report artifacts_skipped (cache propagation)"
+    );
+    assert_eq!(
+        report.stats.artifacts_skipped, 2,
+        "aggregate count must reflect both targets"
+    );
 }

--- a/crates/ocync-sync/tests/sync_artifacts.rs
+++ b/crates/ocync-sync/tests/sync_artifacts.rs
@@ -196,6 +196,10 @@ async fn artifact_require_artifacts_does_not_fire_on_api_error() {
     // confirmation of zero referrers.
     assert_eq!(report.images.len(), 1);
     assert_status!(report, 0, ImageStatus::Synced);
+    assert!(
+        report.images[0].artifacts_skipped,
+        "artifacts_skipped must be true when referrers API returns transient error"
+    );
 }
 
 /// When the referrers API returns 404 but the tag fallback has an artifact,
@@ -536,6 +540,101 @@ async fn artifact_blob_dedup_skips_existing() {
         sig_blob_pulls.len(),
         0,
         "artifact blobs already at target must not be pulled from source"
+    );
+}
+
+/// When the referrers API returns a transient error (500) and
+/// `require_artifacts = false`, the image should be `Synced` with
+/// `artifacts_skipped = true`.
+///
+/// Negative assertion: if `artifacts_skipped` were false, the user would
+/// see no indication that artifact transfer was skipped.
+#[tokio::test]
+async fn artifact_transient_error_sets_artifacts_skipped() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let parent = ManifestBuilder::new(b"skip-cfg")
+        .layer(b"skip-layer")
+        .build();
+    parent.mount_source(&source_server, "repo", "v1.0.0").await;
+
+    // Referrers API returns 500 (transient error).
+    Mock::given(method("GET"))
+        .and(path(format!("/v2/repo/referrers/{}", parent.digest)))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&source_server)
+        .await;
+
+    parent.mount_target(&target_server, "repo", "v1.0.0").await;
+
+    let mapping = ResolvedMapping {
+        artifacts_config: Rc::new(ResolvedArtifacts {
+            enabled: true,
+            require_artifacts: false,
+            ..ResolvedArtifacts::default()
+        }),
+        ..mapping_from_servers(
+            &source_server,
+            &target_server,
+            "repo",
+            vec![TagPair::same("v1.0.0")],
+        )
+    };
+
+    let report = run_sync(vec![mapping]).await;
+
+    assert_eq!(report.images.len(), 1);
+    assert_status!(report, 0, ImageStatus::Synced);
+    assert!(
+        report.images[0].artifacts_skipped,
+        "artifacts_skipped must be true when referrers API returns transient error"
+    );
+    assert_eq!(
+        report.stats.artifacts_skipped, 1,
+        "aggregate artifacts_skipped count must be incremented"
+    );
+}
+
+/// When artifact discovery succeeds with zero referrers (empty index),
+/// `artifacts_skipped` must remain false -- only transient errors set it.
+#[tokio::test]
+async fn artifact_empty_referrers_does_not_set_artifacts_skipped() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let parent = ManifestBuilder::new(b"noskip-cfg")
+        .layer(b"noskip-layer")
+        .build();
+    parent.mount_source(&source_server, "repo", "v1.0.0").await;
+
+    // Referrers API returns empty index (success, zero referrers).
+    let referrers = ReferrersIndexBuilder::new().build();
+    mount_referrers(&source_server, "repo", &parent.digest, &referrers).await;
+
+    parent.mount_target(&target_server, "repo", "v1.0.0").await;
+
+    let mapping = ResolvedMapping {
+        artifacts_config: Rc::new(ResolvedArtifacts::default()),
+        ..mapping_from_servers(
+            &source_server,
+            &target_server,
+            "repo",
+            vec![TagPair::same("v1.0.0")],
+        )
+    };
+
+    let report = run_sync(vec![mapping]).await;
+
+    assert_eq!(report.images.len(), 1);
+    assert_status!(report, 0, ImageStatus::Synced);
+    assert!(
+        !report.images[0].artifacts_skipped,
+        "artifacts_skipped must be false when discovery confirms zero referrers"
+    );
+    assert_eq!(
+        report.stats.artifacts_skipped, 0,
+        "aggregate artifacts_skipped must remain zero"
     );
 }
 

--- a/src/cli/progress.rs
+++ b/src/cli/progress.rs
@@ -31,13 +31,21 @@ fn format_image_line(result: &ImageResult, verbosity: u8) -> Option<String> {
             "FAILED  {} -> {}  ({kind}: {error})",
             result.source, result.target,
         )),
-        ImageStatus::Synced if verbosity >= 1 => Some(format!(
-            "synced  {} -> {}  ({}, {})",
-            result.source,
-            result.target,
-            format_bytes(result.bytes_transferred),
-            format_duration(result.duration),
-        )),
+        ImageStatus::Synced if verbosity >= 1 => {
+            let suffix = if result.artifacts_skipped {
+                ", artifacts skipped"
+            } else {
+                ""
+            };
+            Some(format!(
+                "synced  {} -> {}  ({}, {}{})",
+                result.source,
+                result.target,
+                format_bytes(result.bytes_transferred),
+                format_duration(result.duration),
+                suffix,
+            ))
+        }
         ImageStatus::Skipped { reason } if verbosity >= 1 => Some(format!(
             "skipped {} -> {}  ({reason})",
             result.source, result.target,
@@ -82,9 +90,14 @@ fn write_run_summary(
     } else {
         String::new()
     };
+    let artifacts_warn = if s.artifacts_skipped > 0 {
+        format!(" | {} artifacts skipped", s.artifacts_skipped)
+    } else {
+        String::new()
+    };
     if let Err(e) = writeln!(
         stdout.borrow_mut(),
-        "sync complete: {} synced, {} skipped, {} failed | blobs: {} transferred, {} skipped, {} mounted | {} in {}{}",
+        "sync complete: {} synced, {} skipped, {} failed | blobs: {} transferred, {} skipped, {} mounted | {} in {}{}{}",
         s.images_synced,
         s.images_skipped,
         s.images_failed,
@@ -94,6 +107,7 @@ fn write_run_summary(
         format_bytes(s.bytes_transferred),
         format_duration(report.duration),
         discovery,
+        artifacts_warn,
     ) {
         tracing::warn!(error = %e, "failed to write progress summary to stdout");
     }
@@ -284,6 +298,7 @@ mod tests {
             bytes_transferred: bytes,
             blob_stats: BlobTransferStats::default(),
             duration: Duration::from_secs(14),
+            artifacts_skipped: false,
         }
     }
 
@@ -432,6 +447,17 @@ mod tests {
     }
 
     #[test]
+    fn image_line_synced_with_artifacts_skipped() {
+        let mut result = make_result(ImageStatus::Synced, 432_000_000);
+        result.artifacts_skipped = true;
+        let line = format_image_line(&result, 1).unwrap();
+        assert_eq!(
+            line,
+            "synced  source/repo:v1 -> target/repo:v1  (432.0 MB, 14s, artifacts skipped)"
+        );
+    }
+
+    #[test]
     fn image_line_exact_format_failed() {
         let result = make_result(
             ImageStatus::Failed {
@@ -514,6 +540,7 @@ mod tests {
                 discovery_target_stale: 1,
                 discovery_head_first_skips: 0,
                 immutable_tag_skips: 0,
+                artifacts_skipped: 0,
             },
             duration: Duration::from_secs(47),
         };
@@ -675,6 +702,35 @@ mod tests {
             output.contains("discovery: 0 cached, 0 pulled, 50 immutable"),
             "got: {output}"
         );
+    }
+
+    #[test]
+    fn summary_with_artifacts_skipped() {
+        let buf: Buf = Rc::new(RefCell::new(Vec::new()));
+        let stdout: RefCell<Box<dyn Write>> = RefCell::new(Box::new(RcWriter(Rc::clone(&buf))));
+        let report = SyncReport {
+            run_id: Uuid::now_v7(),
+            images: vec![make_result(ImageStatus::Synced, 1024)],
+            stats: SyncStats {
+                images_synced: 5,
+                artifacts_skipped: 2,
+                ..SyncStats::default()
+            },
+            duration: Duration::from_secs(10),
+        };
+        write_run_summary(&stdout, &report, false);
+        let output = String::from_utf8(buf.borrow().clone()).unwrap();
+        assert!(output.contains("2 artifacts skipped"), "got: {output}");
+    }
+
+    #[test]
+    fn summary_without_artifacts_skipped_omits_suffix() {
+        let buf: Buf = Rc::new(RefCell::new(Vec::new()));
+        let stdout: RefCell<Box<dyn Write>> = RefCell::new(Box::new(RcWriter(Rc::clone(&buf))));
+        let report = make_report(vec![make_result(ImageStatus::Synced, 1024)]);
+        write_run_summary(&stdout, &report, false);
+        let output = String::from_utf8(buf.borrow().clone()).unwrap();
+        assert!(!output.contains("artifacts skipped"), "got: {output}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `artifacts_skipped: bool` to `ImageResult` (skipped from JSON via `skip_serializing_if` when false) to indicate when artifact discovery/transfer was skipped due to a transient error (e.g. referrers API 500)
- Add `artifacts_skipped: u64` to `SyncStats` (skipped from JSON when zero) for run-level aggregate
- `discover_and_sync_artifacts` now returns `Result<bool, Error>` where `Ok(true)` signals the transient-error skip path
- CLI progress formatters append ", artifacts skipped" to synced image lines and " | N artifacts skipped" to run summary when applicable

Closes #45

## Test plan

- [x] `artifact_transient_error_sets_artifacts_skipped` -- referrers API returns 500, asserts `artifacts_skipped == true` on `ImageResult` and `SyncStats`
- [x] `artifact_empty_referrers_does_not_set_artifacts_skipped` -- successful empty index, asserts `artifacts_skipped == false` (negative assertion: confirms the flag only fires on transient errors)
- [x] `artifact_transient_error_propagates_to_all_targets` -- two targets with referrers API 500, validates `CachedReferrers::Failed` cache propagation sets `artifacts_skipped` on both results and aggregate count is 2
- [x] `artifact_sync_disabled_issues_no_referrers_requests` -- asserts `artifacts_skipped == false` when artifacts are disabled (not a transient skip)
- [x] `artifact_require_artifacts_fails_on_empty` -- asserts `artifacts_skipped == false` on hard failure from `require_artifacts` enforcement (distinct from transient skip)
- [x] Existing `artifact_require_artifacts_does_not_fire_on_api_error` updated to also assert `artifacts_skipped == true`
- [x] JSON serialization tests: `artifacts_skipped` omitted when false/zero, present when true/nonzero
- [x] CLI progress tests: synced line includes suffix, summary includes aggregate count
- [x] Full CI gate passes: `cargo fmt --check && cargo clippy -- -D warnings && cargo test && cargo deny check`