### PR TITLE
refactor: remove indicatif, drop sso feature, trim dep tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,14 +188,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.15"
+version = "1.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
+checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
- "aws-sdk-sso",
- "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -206,14 +204,11 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
- "hex",
  "http 1.4.0",
- "sha1",
  "time",
  "tokio",
  "tracing",
  "url",
- "zeroize",
 ]
 
 [[package]]
@@ -268,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
+checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -293,57 +288,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ecr"
-version = "1.114.0"
+version = "1.115.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd79cc872923874e31b7bba0f5f0dab4880b82ca417c0c669e43ad6891f5d9e"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.0",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-sso"
-version = "1.97.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.0",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ssooidc"
-version = "1.99.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
+checksum = "9b97059a7e76b122096f333cf06cf109bfe8e763ee04ced2315f68ee2a6e0ed0"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -365,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.102.0"
+version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc35b7a14cabdad13795fbbbd26d5ddec0882c01492ceedf2af575aad5f37dd"
+checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -390,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
+checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -582,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.14"
+version = "1.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
+checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -713,11 +660,11 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -860,7 +807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core 0.10.1",
 ]
 
@@ -936,6 +883,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,16 +904,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "console"
-version = "0.15.11"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "windows-sys 0.59.0",
-]
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -990,15 +937,6 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -1017,12 +955,20 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1109,13 +1055,14 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
- "subtle",
+ "ctutils",
 ]
 
 [[package]]
@@ -1169,12 +1116,6 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -1352,16 +1293,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,9 +1407,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest",
 ]
@@ -1558,6 +1489,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1825,18 +1765,6 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "indicatif"
-version = "0.17.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
-dependencies = [
- "console",
- "number_prefix",
- "portable-atomic",
- "web-time",
 ]
 
 [[package]]
@@ -2109,19 +2037,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "ocync"
 version = "0.1.0"
 dependencies = [
  "anstyle",
  "clap",
  "http 1.4.0",
- "indicatif",
  "ocync-distribution",
  "ocync-sync",
  "reqwest",
@@ -2667,9 +2588,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2897,24 +2818,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
-]
-
-[[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -3389,9 +3299,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -3504,12 +3414,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vsimd"
@@ -3769,15 +3673,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,13 @@ license = "Apache-2.0"
 repository = "https://github.com/clowdhaus/ocync"
 
 [workspace.dependencies]
-aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "credentials-process", "rt-tokio", "rustls", "sso"] }
+aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "credentials-process", "rt-tokio", "rustls"] }
 aws-lc-rs = { version = "1", default-features = false }
 aws-sdk-ecr = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client"] }
-clap = { version = "4", default-features = false, features = ["derive", "std", "help", "usage", "error-context", "env"] }
+clap = { version = "4", default-features = false, features = ["derive", "std", "help", "usage", "error-context"] }
 bytes = { version = "1", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 http = { version = "1", default-features = false }
-indicatif = { version = "0.17", default-features = false }
 schemars = { version = "0.8", default-features = false, features = ["derive"] }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
@@ -66,7 +65,6 @@ anstyle = { version = "1", default-features = false }
 clap = { workspace = true, features = ["color"] }
 schemars.workspace = true
 http.workspace = true
-indicatif.workspace = true
 ocync-distribution.workspace = true
 ocync-sync.workspace = true
 serde.workspace = true

--- a/crates/ocync-distribution/Cargo.toml
+++ b/crates/ocync-distribution/Cargo.toml
@@ -30,7 +30,7 @@ rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] 
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["sync", "time"] }
+tokio = { workspace = true, features = ["process", "sync", "time"] }
 tracing.workspace = true
 url = { workspace = true }
 

--- a/crates/ocync-distribution/src/auth/ecr.rs
+++ b/crates/ocync-distribution/src/auth/ecr.rs
@@ -144,7 +144,7 @@ pub(crate) fn validate_ecr_token(encoded: &str, registry: &str) -> Result<(), Er
 /// from the API response, falling back to 12 hours if not provided.
 ///
 /// Supports all AWS credential sources via the default credential chain:
-/// environment variables, shared config/credential files, SSO, IMDS/ECS
+/// environment variables, shared config/credential files, IMDS/ECS
 /// container credentials, IRSA (IAM Roles for Service Accounts), and
 /// EKS Pod Identity.
 pub struct EcrAuth {

--- a/crates/ocync-sync/src/lib.rs
+++ b/crates/ocync-sync/src/lib.rs
@@ -29,9 +29,9 @@ use uuid::Uuid;
 pub use error::Error;
 pub use shutdown::ShutdownSignal;
 
-/// Serde helper: skip serializing when value is zero.
-fn is_zero(v: &u64) -> bool {
-    *v == 0
+/// Serde helper: skip serializing when value equals its type's default.
+fn is_default<T: Default + PartialEq>(v: &T) -> bool {
+    *v == T::default()
 }
 
 /// Result of a complete sync run. The engine never "fails" as a whole.
@@ -89,7 +89,7 @@ pub struct ImageResult {
     /// (signatures, SBOMs, attestations) may be missing at the target. Only
     /// `true` on the transient-error path -- when discovery confirms zero
     /// referrers, this remains `false`.
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "is_default")]
     pub artifacts_skipped: bool,
 }
 
@@ -221,7 +221,7 @@ pub struct SyncStats {
     pub immutable_tag_skips: u64,
     /// Images where artifact discovery or transfer was skipped due to a
     /// transient error (e.g. referrers API returned 500).
-    #[serde(skip_serializing_if = "is_zero")]
+    #[serde(default, skip_serializing_if = "is_default")]
     pub artifacts_skipped: u64,
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,11 +1,6 @@
 [advisories]
 version = 2
-ignore = [
-  # number_prefix is unmaintained but is a transitive dep of indicatif
-  # (used only for byte-count formatting in progress bars, which we don't use --
-  # our bars are spinners). No security impact, just an unmaintained notice.
-  "RUSTSEC-2025-0119",
-]
+ignore = []
 
 [licenses]
 version = 2
@@ -39,7 +34,6 @@ skip = [
   { crate = "http@0.2" },             # AWS SDK smithy internals still on http 0.2
   { crate = "http-body@0.4" },        # AWS SDK smithy internals still on http-body 0.4
   { crate = "r-efi@5" },              # getrandom 0.3 vs 0.4
-  { crate = "windows-sys@0.59" },     # indicatif (console) vs clap/tokio
   { crate = "wit-bindgen@0.51" },     # getrandom 0.4 (wasip3) vs wit-bindgen 0.57
 ]
 

--- a/src/cli/progress.rs
+++ b/src/cli/progress.rs
@@ -1,16 +1,11 @@
 //! Verbosity-aware progress reporters for sync output.
 //!
-//! [`TextProgress`] writes plain status lines to stderr (non-TTY).
-//! [`TtyProgress`] shows `indicatif` spinners on stderr (TTY).
-//! Both write the run summary to stdout.
+//! [`TextProgress`] writes plain status lines to stderr (non-TTY and TTY
+//! alike). The run summary always goes to stdout.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::io::{self, Write};
 
-#[cfg(test)]
-use indicatif::ProgressDrawTarget;
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use ocync_sync::progress::ProgressReporter;
 use ocync_sync::{ImageResult, ImageStatus, SyncReport};
 
@@ -163,93 +158,9 @@ impl TextProgress {
     }
 }
 
-/// TTY progress reporter using `indicatif` spinners.
-///
-/// Shows a spinner per in-flight image on stderr. When an image completes,
-/// the spinner is replaced with a final status line (failures always shown,
-/// synced/skipped shown at verbosity >= 1, silently cleared at verbosity 0).
-///
-/// Falls back to [`TextProgress`] when stderr is not a terminal - the
-/// selection is made in `main.rs`, not here.
-pub(crate) struct TtyProgress {
-    multi: MultiProgress,
-    spinners: RefCell<HashMap<(String, String), ProgressBar>>,
-    style: ProgressStyle,
-    verbosity: u8,
-    suppress_summary: bool,
-    stdout: RefCell<Box<dyn Write>>,
-}
-
-impl TtyProgress {
-    /// Create a new TTY progress reporter writing spinners to stderr
-    /// and the run summary to stdout.
-    pub(crate) fn new(verbosity: u8, suppress_summary: bool) -> Self {
-        Self {
-            multi: MultiProgress::new(),
-            spinners: RefCell::new(HashMap::new()),
-            style: Self::spinner_style(),
-            verbosity,
-            suppress_summary,
-            stdout: RefCell::new(Box::new(io::stdout())),
-        }
-    }
-
-    /// Create a TTY progress reporter with a hidden draw target and
-    /// custom stdout writer (for testing).
-    #[cfg(test)]
-    fn with_writers(verbosity: u8, suppress_summary: bool, stdout: Box<dyn Write>) -> Self {
-        Self {
-            multi: MultiProgress::with_draw_target(ProgressDrawTarget::hidden()),
-            spinners: RefCell::new(HashMap::new()),
-            style: Self::spinner_style(),
-            verbosity,
-            suppress_summary,
-            stdout: RefCell::new(stdout),
-        }
-    }
-
-    /// Spinner style shared by all spinners.
-    fn spinner_style() -> ProgressStyle {
-        ProgressStyle::with_template("{spinner:.cyan} {msg}").expect("hardcoded template is valid")
-    }
-}
-
-impl ProgressReporter for TtyProgress {
-    fn image_started(&self, source: &str, target: &str) {
-        let pb = self.multi.add(ProgressBar::new_spinner());
-        pb.set_style(self.style.clone());
-        pb.set_message(format!("syncing {source} -> {target}"));
-        self.spinners
-            .borrow_mut()
-            .insert((source.to_owned(), target.to_owned()), pb);
-    }
-
-    fn image_completed(&self, result: &ImageResult) {
-        let key = (result.source.clone(), result.target.clone());
-        let mut spinners = self.spinners.borrow_mut();
-        let Some(pb) = spinners.remove(&key) else {
-            tracing::warn!(
-                source = %result.source,
-                target = %result.target,
-                "image_completed called without matching image_started"
-            );
-            return;
-        };
-
-        match format_image_line(result, self.verbosity) {
-            Some(line) => pb.finish_with_message(line),
-            None => pb.finish_and_clear(),
-        }
-    }
-
-    fn run_completed(&self, report: &SyncReport) {
-        write_run_summary(&self.stdout, report, self.suppress_summary);
-    }
-}
-
 impl ProgressReporter for TextProgress {
     fn image_started(&self, _source: &str, _target: &str) {
-        // No-op for text output - only progress bar implementations need this.
+        // No-op for text output.
     }
 
     fn image_completed(&self, result: &ImageResult) {
@@ -934,152 +845,4 @@ mod tests {
             "suppress_summary should suppress stdout"
         );
     }
-
-    // - TtyProgress tests (wiring: spinner lifecycle and summary output) --
-
-    fn test_tty_progress(verbosity: u8) -> (TtyProgress, Buf) {
-        let stdout_buf = Rc::new(RefCell::new(Vec::new()));
-        let progress =
-            TtyProgress::with_writers(verbosity, false, Box::new(RcWriter(Rc::clone(&stdout_buf))));
-        (progress, stdout_buf)
-    }
-
-    #[test]
-    fn tty_started_creates_entry() {
-        let (progress, _stdout) = test_tty_progress(0);
-        progress.image_started("source/repo:v1", "target/repo:v1");
-        assert_eq!(progress.spinners.borrow().len(), 1);
-    }
-
-    #[test]
-    fn tty_started_multiple_creates_multiple() {
-        let (progress, _stdout) = test_tty_progress(0);
-        progress.image_started("source/a:v1", "target/a:v1");
-        progress.image_started("source/b:v1", "target/b:v1");
-        assert_eq!(progress.spinners.borrow().len(), 2);
-    }
-
-    #[test]
-    fn tty_completed_removes_entry() {
-        let (progress, _stdout) = test_tty_progress(0);
-        progress.image_started("source/repo:v1", "target/repo:v1");
-        progress.image_completed(&make_result(ImageStatus::Synced, 1024));
-        assert!(progress.spinners.borrow().is_empty());
-    }
-
-    #[test]
-    fn tty_completed_failed_removes_entry() {
-        let (progress, _stdout) = test_tty_progress(0);
-        progress.image_started("source/repo:v1", "target/repo:v1");
-        progress.image_completed(&make_result(
-            ImageStatus::Failed {
-                kind: ErrorKind::ManifestPush,
-                error: "timeout".into(),
-                retries: 2,
-                status_code: None,
-            },
-            0,
-        ));
-        assert!(progress.spinners.borrow().is_empty());
-    }
-
-    #[test]
-    fn tty_completed_without_started_does_not_panic() {
-        let (progress, _stdout) = test_tty_progress(0);
-        // No image_started - should warn and return, not panic.
-        progress.image_completed(&make_result(ImageStatus::Synced, 1024));
-        assert!(progress.spinners.borrow().is_empty());
-    }
-
-    #[test]
-    fn tty_multiple_images_all_cleaned_up() {
-        let (progress, _stdout) = test_tty_progress(1);
-        progress.image_started("source/a:v1", "target/a:v1");
-        progress.image_started("source/b:v1", "target/b:v1");
-
-        let mut r1 = make_result(ImageStatus::Synced, 1024);
-        r1.source = "source/a:v1".into();
-        r1.target = "target/a:v1".into();
-        progress.image_completed(&r1);
-
-        let mut r2 = make_result(
-            ImageStatus::Skipped {
-                reason: SkipReason::DigestMatch,
-            },
-            0,
-        );
-        r2.source = "source/b:v1".into();
-        r2.target = "target/b:v1".into();
-        progress.image_completed(&r2);
-
-        assert!(progress.spinners.borrow().is_empty());
-    }
-
-    #[test]
-    fn tty_run_completed_writes_summary_to_stdout() {
-        let (progress, stdout) = test_tty_progress(0);
-        let report = make_report(vec![make_result(ImageStatus::Synced, 1024)]);
-        progress.run_completed(&report);
-        let output = String::from_utf8(stdout.borrow().clone()).unwrap();
-        assert!(
-            output.starts_with("sync complete:"),
-            "summary should go to stdout, got: {output}"
-        );
-    }
-
-    #[test]
-    fn tty_suppress_summary_produces_no_stdout() {
-        let stdout_buf = Rc::new(RefCell::new(Vec::new()));
-        let progress =
-            TtyProgress::with_writers(0, true, Box::new(RcWriter(Rc::clone(&stdout_buf))));
-        let report = make_report(vec![make_result(ImageStatus::Synced, 1024)]);
-        progress.run_completed(&report);
-        assert!(
-            stdout_buf.borrow().is_empty(),
-            "suppress_summary should suppress stdout"
-        );
-    }
-
-    #[test]
-    fn tty_suppress_summary_still_runs_spinners() {
-        // Spinner lifecycle must work even when summary is suppressed
-        // (e.g., --json mode). Spinners go to stderr, summary to stdout --
-        // suppressing stdout must not interfere with spinner create/remove.
-        let stdout_buf = Rc::new(RefCell::new(Vec::new()));
-        let progress =
-            TtyProgress::with_writers(0, true, Box::new(RcWriter(Rc::clone(&stdout_buf))));
-
-        progress.image_started("source/repo:v1", "target/repo:v1");
-        assert_eq!(progress.spinners.borrow().len(), 1);
-
-        progress.image_completed(&make_result(ImageStatus::Synced, 1024));
-        assert!(progress.spinners.borrow().is_empty());
-
-        let report = make_report(vec![make_result(ImageStatus::Synced, 1024)]);
-        progress.run_completed(&report);
-        assert!(
-            stdout_buf.borrow().is_empty(),
-            "suppress_summary should suppress stdout"
-        );
-    }
-
-    #[test]
-    fn tty_started_same_image_twice_overwrites() {
-        // If image_started is called twice for the same (source, target),
-        // the second spinner replaces the first. The map should still have
-        // exactly one entry, and image_completed should clean it up.
-        let (progress, _stdout) = test_tty_progress(0);
-        progress.image_started("source/repo:v1", "target/repo:v1");
-        progress.image_started("source/repo:v1", "target/repo:v1");
-        assert_eq!(progress.spinners.borrow().len(), 1);
-
-        progress.image_completed(&make_result(ImageStatus::Synced, 1024));
-        assert!(progress.spinners.borrow().is_empty());
-    }
-
-    // Note: spinner message content (the transient "syncing ..." text shown
-    // during in-flight transfers) cannot be asserted because indicatif's
-    // ProgressDrawTarget::hidden() swallows all rendering. The final message
-    // on completion uses format_image_line(), which IS thoroughly tested above.
-    // Only the cosmetic in-flight prefix is untested.
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@
 
 mod cli;
 
-use std::io::IsTerminal as _;
 use std::path::PathBuf;
 
 use anstyle::{Ansi256Color, Color, Style};
@@ -332,11 +331,6 @@ async fn main() -> std::process::ExitCode {
 
     let progress: Box<dyn ocync_sync::progress::ProgressReporter> = if cli.quiet {
         Box::new(NullProgress)
-    } else if std::io::stderr().is_terminal() {
-        Box::new(cli::progress::TtyProgress::new(
-            effective_verbosity,
-            suppress_summary,
-        ))
     } else {
         Box::new(cli::progress::TextProgress::new(
             effective_verbosity,


### PR DESCRIPTION
## Summary

- Remove `indicatif` dep and `TtyProgress` spinner -- per-image completion lines and the summary already cover output needs; spinners were visual noise that pulled in `console`, `number_prefix`, and a `windows-sys` version split
- Drop `aws-config` `sso` feature -- ocync targets K8s/CI (IMDS, IRSA, Pod Identity, env vars), not developer laptop SSO sessions. This eliminates `sha1 0.10` which was the sole cause of a 4-crate duplicate chain (`digest`, `block-buffer`, `crypto-common`, `cpufeatures`) against `aws-sigv4`'s `sha2 0.11`
- Drop `clap` `env` feature -- no `#[arg(env = ...)]` exists in the codebase
- Add explicit `tokio/process` to `ocync-distribution` -- Docker credential helper support was silently depending on `aws-config`'s `credentials-process` transitively enabling it (latent bug)
- Remove `deny.toml` advisory ignore (number_prefix) and skip (windows-sys 0.59) that only existed for indicatif
- Regenerate `Cargo.lock` with all crates at latest compatible versions

Net result: 376 packages (down from ~390), zero new `deny.toml` workarounds, clean `cargo deny check`.

## Test plan

- [x] Full CI gate: `cargo fmt --check && cargo clippy -- -D warnings && cargo test --workspace && cargo deny check`
- [x] 1047 tests pass, 0 failures
- [x] `cargo deny check` passes with no new skip entries
- [x] `sha1` no longer in Cargo.lock
- [x] `indicatif`/`console`/`number_prefix` no longer in Cargo.lock