### PR TITLE
feat(bench): CDN fairness, warm-run optimization, us-east-2 migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Every PR ships the smallest correct change + one test that catches regression. D
 - One PR at a time, merge to main, then next. No stacked PRs ever.
 - When dispatching parallel worktree agents, each MUST create its own branch from `main` (`git checkout -b feat/xxx main`). Never push to an existing branch from a worktree agent.
 - Never include `Co-Authored-By: Claude` or Anthropic attribution
-- Run the CI gate locally before push: `cargo fmt --check && cargo clippy -- -D warnings && cargo test && cargo deny check`
+- Run the CI gate locally before push: `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test && cargo deny check`
 - During rebase conflicts on `Cargo.lock`, regenerate with `git checkout --theirs Cargo.lock && cargo generate-lockfile`
 
 ## Plans and specs
@@ -79,7 +79,7 @@ When a benchmark or probe run changes our understanding of a registry's behavior
 
 ```bash
 # CI gate (run before every push)
-cargo fmt --check && cargo clippy -- -D warnings && cargo test && cargo deny check
+cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test && cargo deny check
 
 # Run all tests
 cargo test
@@ -91,7 +91,7 @@ cargo test --package ocync-distribution --test registry2_mount
 
 ## Benchmarks
 
-Prerequisites: Terraform, AWS credentials with ECR access, SSM parameters populated:
+Prerequisites: Terraform, AWS credentials with ECR access, SSM parameters populated in us-east-2:
 - `/ocync/bench/dockerhub-username` - Docker Hub account name
 - `/ocync/bench/dockerhub-access-token` - Docker Hub PAT for authenticated pulls
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,6 +801,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,8 +1305,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1310,9 +1318,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1894,6 +1904,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2315,6 +2331,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2479,6 +2550,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -2559,6 +2631,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2583,6 +2656,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3080,6 +3154,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -3914,6 +4003,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-ecr",
  "clap",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml_ng",

--- a/bench/CLAUDE.md
+++ b/bench/CLAUDE.md
@@ -7,7 +7,7 @@ Benchmark infrastructure for comparing ocync against dregsy and regsync.
 - `~/.ssh/id_ed25519` exists, public key added to GitHub
 - AWS credentials with ECR access + SSM parameter read (Docker Hub creds)
 - Terraform installed
-- SSM parameters populated:
+- SSM parameters populated in us-east-2:
   - `/ocync/bench/dockerhub-access-token` - Docker Hub PAT for authenticated pulls
   - `/ocync/bench/dockerhub-username` - Docker Hub account name
 
@@ -65,22 +65,28 @@ cargo xtask bench-remote --provider aws --fetch
 | Source blob bytes | Bench-proxy (non-target host) | lowest |
 | Mounts (success/attempt) | Bench-proxy (POST with mount=) | highest |
 | Duplicate blob GETs | Bench-proxy (same URL fetched twice) | lowest |
+| CDN hits | Bench-proxy (X-Cache header, source requests only) | highest (after pre-warm) |
+| CDN misses | Bench-proxy (X-Cache header, source requests only) | lowest |
 | Rate-limit 429s | Bench-proxy (HTTP 429 responses) | lowest |
 
 Instance metadata (type, CPU, memory, network, region) is captured from `ec2:DescribeInstanceTypes`.
 
 ## Benchmark fairness invariants
 
-Every tool run (including the first) must start from a verified clean slate. The harness enforces this automatically -- do not bypass it.
+The harness enforces these automatically -- do not bypass them.
 
-**Before every tool run:**
-1. **Drop OS page cache** -- `sudo sh -c 'sync && echo 3 > /proc/sys/vm/drop_caches'`. Without this, tool 2 benefits from tool 1's source blobs cached in RAM (55GB corpus = massive unfair advantage).
-2. **Clean staging tmpdir** -- remove all files in `$TMPDIR`. Prevents staged blobs from a previous tool consuming disk.
-3. **Delete + recreate ECR repos** -- not just create-if-not-exists. Repos from aborted runs or previous tools may contain partial data that makes a "cold" sync warm.
-4. **30s cooldown** -- allows TCP TIME_WAIT connections to drain and EBS burst credits to stabilize.
+**Before any tool runs (once per scenario):**
+0. **CDN pre-warm** -- HEAD every source manifest with OCI token exchange to populate CDN edge caches. Wait 6 minutes for CloudFront propagation. Without this, the first tool hits cold CDN (7% hit rate) while the last tool gets 99% hits -- a massive unfair advantage from execution order.
+1. **Randomize tool order** -- Fisher-Yates shuffle so no tool systematically runs first or last. The randomized order is logged for traceability.
+
+**Before every tool run (including the first):**
+2. **Drop OS page cache** -- `sudo sh -c 'sync && echo 3 > /proc/sys/vm/drop_caches'`. Without this, tool 2 benefits from tool 1's source blobs cached in RAM (55GB corpus = massive unfair advantage).
+3. **Clean staging tmpdir** -- remove all files in `$TMPDIR`. Prevents staged blobs from a previous tool consuming disk.
+4. **Delete + recreate ECR repos** -- not just create-if-not-exists. Repos from aborted runs or previous tools may contain partial data that makes a "cold" sync warm.
+5. **10s cooldown** -- allows process cleanup between tool runs. CDN state is handled by pre-warm (invariant 0), not by inter-tool cooldown.
 
 **After every tool run (cold and warm):**
-5. **Verify sync correctness** -- list tags in every target ECR repo, confirm all expected tags are present. An unverified benchmark may report fast times for incomplete syncs.
+6. **Verify sync correctness** -- list tags in every target ECR repo (per-repo output), confirm all expected tags are present. An unverified benchmark may report fast times for incomplete syncs.
 
 **Never run benchmarks manually via SSH.** The `bench-remote` xtask handles all of the above. Manual `cargo xtask bench` on the instance skips TMPDIR setup and other safeguards. SSH is for debugging only.
 
@@ -96,7 +102,7 @@ cd ~/ocync
 export TMPDIR=$HOME/ocync/bench/.tmp
 rm -rf "$TMPDIR" && mkdir -p "$TMPDIR"
 ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
-export BENCH_TARGET_REGISTRY=${ACCOUNT}.dkr.ecr.us-east-1.amazonaws.com
+export BENCH_TARGET_REGISTRY=${ACCOUNT}.dkr.ecr.us-east-2.amazonaws.com
 cargo xtask bench --tools ocync,dregsy,regsync sync
 ```
 

--- a/bench/proxy/src/proxy.rs
+++ b/bench/proxy/src/proxy.rs
@@ -62,6 +62,13 @@ struct ProxyEntry<'a> {
     response_bytes: u64,
     status: u16,
     duration_ms: u64,
+    /// CDN cache status from the upstream `X-Cache` response header
+    /// (e.g. `"Hit from cloudfront"`, `"Miss from cloudfront"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    x_cache: Option<&'a str>,
+    /// Seconds since the CDN cached this response, from the `Age` header.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    age: Option<u64>,
 }
 
 /// Append-only JSONL log writer, shared across all proxy tasks.
@@ -358,6 +365,8 @@ async fn handle_request(
                 response_bytes: 0,
                 status: 0,
                 duration_ms: start.elapsed().as_millis() as u64,
+                x_cache: None,
+                age: None,
             };
             log.write_entry(&entry).await;
             return Ok(error_response(
@@ -369,6 +378,18 @@ async fn handle_request(
 
     let status = upstream_resp.status();
     let resp_headers = forward_headers(upstream_resp.headers());
+
+    // Extract CDN cache headers before consuming the response.
+    let x_cache = upstream_resp
+        .headers()
+        .get("x-cache")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_owned());
+    let age = upstream_resp
+        .headers()
+        .get("age")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok());
 
     // Stream the body back to the client, counting bytes, then log once
     // the stream fully drains.
@@ -409,6 +430,8 @@ async fn handle_request(
                         response_bytes: entry_bytes,
                         status: status_code,
                         duration_ms: elapsed.as_millis() as u64,
+                        x_cache: x_cache.as_deref(),
+                        age,
                     };
                     log.write_entry(&entry).await;
                 });
@@ -852,6 +875,8 @@ mod tests {
                             response_bytes: 42,
                             status: 200,
                             duration_ms: 1,
+                            x_cache: None,
+                            age: None,
                         };
                         log_for_cb.write_entry(&entry).await;
                     });
@@ -884,6 +909,8 @@ mod tests {
             method,
             host: "registry.test",
             url: "/v2/",
+            x_cache: None,
+            age: None,
             request_bytes: 0,
             response_bytes: 0,
             status,

--- a/bench/results/ecr.json
+++ b/bench/results/ecr.json
@@ -31,7 +31,9 @@
             "mount_successes": 243,
             "mount_attempts": 243,
             "duplicate_blob_gets": 0,
-            "rate_limit_429s": 0
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
           },
           {
             "tool": "dregsy",
@@ -45,7 +47,9 @@
             "mount_successes": 326,
             "mount_attempts": 326,
             "duplicate_blob_gets": 0,
-            "rate_limit_429s": 0
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
           },
           {
             "tool": "regsync",
@@ -59,7 +63,9 @@
             "mount_successes": 0,
             "mount_attempts": 865,
             "duplicate_blob_gets": 0,
-            "rate_limit_429s": 0
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
           }
         ]
       }
@@ -97,7 +103,9 @@
             "mount_successes": 88,
             "mount_attempts": 88,
             "duplicate_blob_gets": 0,
-            "rate_limit_429s": 0
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
           }
         ]
       }
@@ -135,7 +143,9 @@
             "mount_successes": 0,
             "mount_attempts": 0,
             "duplicate_blob_gets": 0,
-            "rate_limit_429s": 0
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
           }
         ]
       }
@@ -173,7 +183,9 @@
             "mount_successes": 0,
             "mount_attempts": 0,
             "duplicate_blob_gets": 0,
-            "rate_limit_429s": 0
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
           }
         ]
       }
@@ -211,7 +223,9 @@
             "mount_successes": 0,
             "mount_attempts": 0,
             "duplicate_blob_gets": 0,
-            "rate_limit_429s": 0
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
           }
         ]
       }
@@ -249,7 +263,9 @@
             "mount_successes": 0,
             "mount_attempts": 0,
             "duplicate_blob_gets": 0,
-            "rate_limit_429s": 0
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
           }
         ]
       }
@@ -287,7 +303,9 @@
             "mount_successes": 0,
             "mount_attempts": 0,
             "duplicate_blob_gets": 0,
-            "rate_limit_429s": 0
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
           }
         ]
       }
@@ -325,7 +343,9 @@
             "mount_successes": 0,
             "mount_attempts": 0,
             "duplicate_blob_gets": 0,
-            "rate_limit_429s": 0
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
           }
         ]
       }
@@ -363,7 +383,9 @@
             "mount_successes": 88,
             "mount_attempts": 88,
             "duplicate_blob_gets": 0,
-            "rate_limit_429s": 0
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
           },
           {
             "tool": "dregsy",
@@ -377,7 +399,9 @@
             "mount_successes": 78,
             "mount_attempts": 78,
             "duplicate_blob_gets": 1,
-            "rate_limit_429s": 0
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
           },
           {
             "tool": "regsync",
@@ -391,7 +415,9 @@
             "mount_successes": 0,
             "mount_attempts": 0,
             "duplicate_blob_gets": 0,
-            "rate_limit_429s": 0
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
           }
         ]
       }
@@ -429,7 +455,9 @@
             "mount_successes": 349,
             "mount_attempts": 365,
             "duplicate_blob_gets": 0,
-            "rate_limit_429s": 0
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
           },
           {
             "tool": "dregsy",
@@ -443,7 +471,9 @@
             "mount_successes": 324,
             "mount_attempts": 324,
             "duplicate_blob_gets": 0,
-            "rate_limit_429s": 0
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
           },
           {
             "tool": "regsync",
@@ -457,7 +487,9 @@
             "mount_successes": 0,
             "mount_attempts": 0,
             "duplicate_blob_gets": 0,
-            "rate_limit_429s": 0
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
           }
         ]
       }
@@ -495,7 +527,9 @@
             "mount_successes": 0,
             "mount_attempts": 0,
             "duplicate_blob_gets": 0,
-            "rate_limit_429s": 0
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
           },
           {
             "tool": "dregsy",
@@ -509,7 +543,9 @@
             "mount_successes": 0,
             "mount_attempts": 0,
             "duplicate_blob_gets": 0,
-            "rate_limit_429s": 0
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
           },
           {
             "tool": "regsync",
@@ -523,7 +559,259 @@
             "mount_successes": 0,
             "mount_attempts": 0,
             "duplicate_blob_gets": 0,
-            "rate_limit_429s": 0
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "timestamp": "2026-04-22-000654",
+    "git_ref": "ae45a23",
+    "machine": {
+      "provider": "aws",
+      "instance_type": "c6in.4xlarge",
+      "arch": "x86_64",
+      "vcpus": 16,
+      "memory_gib": 32.0,
+      "network": "Up to 50 Gigabit",
+      "region": "us-east-2"
+    },
+    "corpus": {
+      "images": 39,
+      "tags": 51
+    },
+    "scenarios": [
+      {
+        "name": "Cold sync",
+        "tools": [
+          {
+            "tool": "ocync",
+            "version": "ocync 0.1.0",
+            "wall_clock_secs": 465.772145254,
+            "peak_rss_kb": 52312,
+            "requests": 7709,
+            "response_bytes": 55442732444,
+            "source_blob_gets": 1453,
+            "source_blob_bytes": 55442473737,
+            "mount_successes": 301,
+            "mount_attempts": 365,
+            "duplicate_blob_gets": 3,
+            "rate_limit_429s": 23,
+            "cdn_hits": 76,
+            "cdn_misses": 979
+          },
+          {
+            "tool": "regsync",
+            "version": "VCSTag:     v0.11.3",
+            "wall_clock_secs": 1509.182771728,
+            "peak_rss_kb": 28156,
+            "requests": 9532,
+            "response_bytes": 65282760587,
+            "source_blob_gets": 1694,
+            "source_blob_bytes": 65282756422,
+            "mount_successes": 0,
+            "mount_attempts": 0,
+            "duplicate_blob_gets": 0,
+            "rate_limit_429s": 0,
+            "cdn_hits": 240,
+            "cdn_misses": 747
+          },
+          {
+            "tool": "dregsy",
+            "version": "time=\"2026-04-22T00:06:54Z\" level=error msg=\"flag provided but not defined: -version\"",
+            "wall_clock_secs": 1156.102257413,
+            "peak_rss_kb": 305312,
+            "requests": 11291,
+            "response_bytes": 55302680476,
+            "source_blob_gets": 1370,
+            "source_blob_bytes": 55302645916,
+            "mount_successes": 324,
+            "mount_attempts": 324,
+            "duplicate_blob_gets": 0,
+            "rate_limit_429s": 0,
+            "cdn_hits": 968,
+            "cdn_misses": 7
+          }
+        ]
+      },
+      {
+        "name": "Warm sync (no-op)",
+        "tools": [
+          {
+            "tool": "ocync",
+            "version": "ocync 0.1.0",
+            "wall_clock_secs": 151.14448624,
+            "peak_rss_kb": 21056,
+            "requests": 655,
+            "response_bytes": 22779854,
+            "source_blob_gets": 0,
+            "source_blob_bytes": 22775773,
+            "mount_successes": 0,
+            "mount_attempts": 0,
+            "duplicate_blob_gets": 0,
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
+          },
+          {
+            "tool": "regsync",
+            "version": "VCSTag:     v0.11.3",
+            "wall_clock_secs": 14.624605877,
+            "peak_rss_kb": 20256,
+            "requests": 171,
+            "response_bytes": 129856,
+            "source_blob_gets": 0,
+            "source_blob_bytes": 120355,
+            "mount_successes": 0,
+            "mount_attempts": 0,
+            "duplicate_blob_gets": 0,
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
+          },
+          {
+            "tool": "dregsy",
+            "version": "time=\"2026-04-22T00:06:54Z\" level=error msg=\"flag provided but not defined: -version\"",
+            "wall_clock_secs": 100.627212002,
+            "peak_rss_kb": 33388,
+            "requests": 3145,
+            "response_bytes": 1925761,
+            "source_blob_gets": 227,
+            "source_blob_bytes": 1891201,
+            "mount_successes": 0,
+            "mount_attempts": 0,
+            "duplicate_blob_gets": 0,
+            "rate_limit_429s": 0,
+            "cdn_hits": 165,
+            "cdn_misses": 0
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "timestamp": "2026-04-22-021352",
+    "git_ref": "809f685",
+    "machine": {
+      "provider": "aws",
+      "instance_type": "c6in.4xlarge",
+      "arch": "x86_64",
+      "vcpus": 16,
+      "memory_gib": 32.0,
+      "network": "Up to 50 Gigabit",
+      "region": "us-east-2"
+    },
+    "corpus": {
+      "images": 39,
+      "tags": 51
+    },
+    "scenarios": [
+      {
+        "name": "Cold sync",
+        "tools": [
+          {
+            "tool": "dregsy",
+            "version": "time=\"2026-04-22T02:13:52Z\" level=error msg=\"flag provided but not defined: -version\"",
+            "wall_clock_secs": 1094.799679749,
+            "peak_rss_kb": 312344,
+            "requests": 11631,
+            "response_bytes": 55302685882,
+            "source_blob_gets": 1370,
+            "source_blob_bytes": 55302645988,
+            "mount_successes": 324,
+            "mount_attempts": 324,
+            "duplicate_blob_gets": 0,
+            "rate_limit_429s": 0,
+            "cdn_hits": 975,
+            "cdn_misses": 0
+          },
+          {
+            "tool": "ocync",
+            "version": "ocync 0.1.0",
+            "wall_clock_secs": 257.029771722,
+            "peak_rss_kb": 46620,
+            "requests": 7189,
+            "response_bytes": 55420072947,
+            "source_blob_gets": 1450,
+            "source_blob_bytes": 55419814372,
+            "mount_successes": 319,
+            "mount_attempts": 365,
+            "duplicate_blob_gets": 0,
+            "rate_limit_429s": 21,
+            "cdn_hits": 1047,
+            "cdn_misses": 8
+          },
+          {
+            "tool": "regsync",
+            "version": "VCSTag:     v0.11.3",
+            "wall_clock_secs": 986.337893828,
+            "peak_rss_kb": 27624,
+            "requests": 9527,
+            "response_bytes": 65282734222,
+            "source_blob_gets": 1694,
+            "source_blob_bytes": 65282730057,
+            "mount_successes": 0,
+            "mount_attempts": 0,
+            "duplicate_blob_gets": 0,
+            "rate_limit_429s": 0,
+            "cdn_hits": 987,
+            "cdn_misses": 0
+          }
+        ]
+      },
+      {
+        "name": "Warm sync (no-op)",
+        "tools": [
+          {
+            "tool": "dregsy",
+            "version": "time=\"2026-04-22T02:13:52Z\" level=error msg=\"flag provided but not defined: -version\"",
+            "wall_clock_secs": 109.68968546,
+            "peak_rss_kb": 33368,
+            "requests": 3145,
+            "response_bytes": 1925614,
+            "source_blob_gets": 227,
+            "source_blob_bytes": 1891055,
+            "mount_successes": 0,
+            "mount_attempts": 0,
+            "duplicate_blob_gets": 0,
+            "rate_limit_429s": 0,
+            "cdn_hits": 165,
+            "cdn_misses": 0
+          },
+          {
+            "tool": "ocync",
+            "version": "ocync 0.1.0",
+            "wall_clock_secs": 2.329967248,
+            "peak_rss_kb": 16080,
+            "requests": 181,
+            "response_bytes": 131803,
+            "source_blob_gets": 0,
+            "source_blob_bytes": 127722,
+            "mount_successes": 0,
+            "mount_attempts": 0,
+            "duplicate_blob_gets": 0,
+            "rate_limit_429s": 0,
+            "cdn_hits": 0,
+            "cdn_misses": 0
+          },
+          {
+            "tool": "regsync",
+            "version": "VCSTag:     v0.11.3",
+            "wall_clock_secs": 18.587196803,
+            "peak_rss_kb": 21032,
+            "requests": 325,
+            "response_bytes": 61952024,
+            "source_blob_gets": 21,
+            "source_blob_bytes": 61952024,
+            "mount_successes": 0,
+            "mount_attempts": 0,
+            "duplicate_blob_gets": 0,
+            "rate_limit_429s": 0,
+            "cdn_hits": 15,
+            "cdn_misses": 6
           }
         ]
       }

--- a/bench/terraform/aws/main.tf
+++ b/bench/terraform/aws/main.tf
@@ -22,7 +22,7 @@ terraform {
 }
 
 provider "aws" {
-  region = "us-east-1"
+  region = "us-east-2"
 }
 
 locals {
@@ -221,9 +221,9 @@ module "ec2" {
   # IAM instance profile with ECR full access and instance metadata
   create_iam_instance_profile = true
   iam_role_policies = {
-    AmazonEC2ContainerRegistryFullAccess           = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess"
-    AmazonElasticContainerRegistryPublicReadOnly    = "arn:aws:iam::aws:policy/AmazonElasticContainerRegistryPublicReadOnly"
-    Bench                                          = aws_iam_policy.bench.arn
+    AmazonEC2ContainerRegistryFullAccess         = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess"
+    AmazonElasticContainerRegistryPublicReadOnly = "arn:aws:iam::aws:policy/AmazonElasticContainerRegistryPublicReadOnly"
+    Bench                                        = aws_iam_policy.bench.arn
   }
 
   # Security group -- SSH from operator IP, all egress
@@ -265,6 +265,7 @@ module "ec2" {
     dockerhub_username = data.aws_ssm_parameter.dockerhub_username.value
     dockerhub_token    = data.aws_ssm_parameter.dockerhub_token.value
     account_id         = data.aws_caller_identity.current.account_id
+    region             = "us-east-2"
   })
   user_data_replace_on_change = true
 

--- a/bench/terraform/aws/user-data.sh
+++ b/bench/terraform/aws/user-data.sh
@@ -120,7 +120,7 @@ cp /root/go/bin/docker-credential-ecr-login /usr/local/bin/
 
 mkdir -p /home/ec2-user/.docker
 cat > /home/ec2-user/.docker/config.json <<'DCEOF'
-{"credHelpers":{"${account_id}.dkr.ecr.us-east-1.amazonaws.com":"ecr-login","public.ecr.aws":"ecr-login"}}
+{"credHelpers":{"${account_id}.dkr.ecr.${region}.amazonaws.com":"ecr-login","public.ecr.aws":"ecr-login"}}
 DCEOF
 chown -R ec2-user:ec2-user /home/ec2-user/.docker
 

--- a/docs/src/content/design/benchmark.md
+++ b/docs/src/content/design/benchmark.md
@@ -124,7 +124,7 @@ scenario, one question, one headline number per run.
 
 **Headline number per scenario:** one sentence. "`ocync` syncs 15 GB of
 images in X seconds (p50, N=5) on c6in.4xlarge, Docker Hub to
-us-east-1 ECR, from commit `<sha>`." If a scenario cannot be
+us-east-2 ECR, from commit `<sha>`." If a scenario cannot be
 summarized in one sentence, it's measuring too many things and needs
 to be split.
 

--- a/docs/src/content/design/overview.md
+++ b/docs/src/content/design/overview.md
@@ -138,15 +138,17 @@ The 50:1 ratio between `UploadLayerPart` (500 TPS) and `PutImage` (10 TPS) means
 
 ## Competitive position
 
-See [Performance](../performance) for the full benchmark table. Summary (39 images, 51 tags, cold sync to ECR on c6in.4xlarge):
+See [Performance](../performance) for the full benchmark table. Summary (39 images, 51 tags, cold sync to ECR on c6in.4xlarge, CDN pre-warmed):
 
-- **4x faster** wall clock than comparable tools
-- **25-38% fewer API requests** through global blob dedup and mount-first strategy
-- **Cross-repo blob mounting** avoids re-pulling shared layers from source (95.6% mount success rate)
+- **4x faster** cold sync wall clock than comparable tools (3.8-4.3x depending on tool)
+- **2-second warm sync** (no-op re-sync with 181 requests vs 325-3,145 for comparable tools)
+- **24-38% fewer API requests** through global blob dedup and mount-first strategy
+- **Cross-repo blob mounting** avoids re-pulling shared layers from source (87% mount success rate)
 - **Zero duplicate blob GETs** (source-pull dedup via staging)
-- **Zero rate-limit 429s** (AIMD congestion control adapts before hitting limits)
+- **AIMD congestion control** adapts to registry capacity before hitting rate limits
+- **Typed error handling** for registry responses -- non-JSON bodies (HTML rate-limit pages, proxy errors) produce structured `RegistryError` variants with status code and body context, not parse failures. Comparable tools that deserialize every response as JSON crash or log parse errors (`invalid character 'b' looking for beginning of value`) when a registry returns HTML.
 
-The lower peak RSS of sequential tools reflects their one-image-at-a-time architecture. `ocync`'s ~51 MB comes from concurrent blob transfers, staging maps, and the transfer state cache -- the memory trade-off buys the wall-clock advantage.
+The lower peak RSS of sequential tools reflects their one-image-at-a-time architecture. `ocync`'s ~48 MB comes from concurrent blob transfers, staging maps, and the transfer state cache -- the memory trade-off buys the wall-clock advantage.
 
 Methodology: all traffic routed through bench-proxy (pure-Rust MITM) for byte-accurate request/response counting. Instance metadata captured from `ec2:DescribeInstanceTypes`. Run records archived to `bench/results/ecr.json`.
 

--- a/docs/src/content/performance.md
+++ b/docs/src/content/performance.md
@@ -1,6 +1,6 @@
 ---
 title: Performance
-description: How ocync achieves 4x faster sync than comparable tools with fewer requests and cross-repo blob mounting.
+description: How ocync achieves 4x faster cold sync and 2-second warm sync than comparable tools with fewer requests and cross-repo blob mounting.
 order: 6
 ---
 
@@ -8,19 +8,20 @@ order: 6
 
 <!-- Auto-updated by `cargo xtask bench`; shows first scenario (cold sync) only. -->
 <!-- BENCH:START -->
-Measured 2026-04-19 on c6in.4xlarge (x86_64, 16 vCPUs, 32 GiB, up to 50 Gbps). Full corpus: 39 images, 51 tags across quay.io, Docker Hub, cgr.dev, public ECR. Cold sync to ECR us-east-1. All traffic routed through bench-proxy for byte-accurate measurement.
+Measured 2026-04-22 on c6in.4xlarge (x86_64, 16 vCPUs, 32 GiB, up to 50 Gbps) in us-east-2. Full corpus: 39 images, 51 tags across quay.io, Docker Hub, cgr.dev, public ECR. Cold sync to ECR. CDN pre-warmed for fair comparison. All traffic routed through bench-proxy for byte-accurate measurement.
 
 | Metric | `ocync` | `dregsy` | `regsync` |
 |---|---:|---:|---:|
-| Wall clock | **7m 9s** | 32m 15s | 25m 35s |
-| Peak RSS | 50.6 MB | 293.5 MB | **28.0 MB** |
-| Requests | **7,140** | 11,604 | 9,532 |
-| Response bytes | **55.3 GB** | **55.3 GB** | 65.3 GB |
-| Source blob GETs | **1,370** | **1,370** | 1,694 |
-| Source blob bytes | **55.3 GB** | **55.3 GB** | 65.3 GB |
-| Mounts (success/attempt) | **349/365** | 324/324 | 0/0 |
+| Wall clock | **4m 17s** | 18m 14s | 16m 26s |
+| Peak RSS | 47.7 MB | 319.8 MB | **28.3 MB** |
+| Requests | **7,189** | 11,631 | 9,527 |
+| Response bytes | 55.4 GB | **55.3 GB** | 65.3 GB |
+| Source blob GETs | 1,450 | **1,370** | 1,694 |
+| Source blob bytes | 55.4 GB | **55.3 GB** | 65.3 GB |
+| Mounts (success/attempt) | 319/365 | **324/324** | 0/0 |
 | Duplicate blob GETs | **0** | **0** | **0** |
-| Rate-limit 429s | **0** | **0** | **0** |
+| CDN hits/misses | **1,047/8** | 975/0 | 987/0 |
+| Rate-limit 429s | 21 | **0** | **0** |
 <!-- BENCH:END -->
 
 ## How tools compare
@@ -58,22 +59,23 @@ Measured 2026-04-19 on c6in.4xlarge (x86_64, 16 vCPUs, 32 GiB, up to 50 Gbps). F
 ### Warm sync efficiency
 
 <!-- BENCH-WARM:START -->
-Measured 2026-04-20 on c6in.4xlarge (x86_64, 16 vCPUs, 32 GiB, Up to 50 Gigabit). Full corpus: 39 images, 51 tags. Warm sync (no changes) to ECR us-east-1. All traffic routed through bench-proxy for byte-accurate measurement.
+Measured 2026-04-22 on c6in.4xlarge (x86_64, 16 vCPUs, 32 GiB, up to 50 Gbps) in us-east-2. Full corpus: 39 images, 51 tags. Warm sync (no changes) to ECR. All traffic routed through bench-proxy for byte-accurate measurement.
 
 | Metric | `ocync` | `dregsy` | `regsync` |
 |---|---:|---:|---:|
-| Wall clock | 2m 32s | 1m 43s | **12s** |
-| Peak RSS | 22.2 MB | 33.9 MB | **21.0 MB** |
-| Requests | 925 | 3,145 | **169** |
-| Response bytes | 23.3 MB | 1.9 MB | **119.9 KB** |
-| Source blob GETs | **0** | 227 | **0** |
-| Source blob bytes | 23.3 MB | 1.9 MB | **119.9 KB** |
+| Wall clock | **2s** | 1m 49s | 18s |
+| Peak RSS | **16.5 MB** | 34.2 MB | 21.5 MB |
+| Requests | **181** | 3,145 | 325 |
+| Response bytes | **131.8 KB** | 1.9 MB | 62.0 MB |
+| Source blob GETs | **0** | 227 | 21 |
+| Source blob bytes | **127.7 KB** | 1.9 MB | 62.0 MB |
 | Mounts (success/attempt) | **0/0** | **0/0** | **0/0** |
 | Duplicate blob GETs | **0** | **0** | **0** |
+| CDN hits/misses | 0/0 | **165/0** | 15/6 |
 | Rate-limit 429s | **0** | **0** | **0** |
 <!-- BENCH-WARM:END -->
 
-> **Note:** `ocync` performs full target HEAD verification on every warm cycle to detect out-of-band changes (e.g., images deleted by lifecycle policies or modified by other tools), ensuring correctness at the cost of additional requests. Alternatives that achieve faster warm sync times typically use tag list caching, which is faster but can miss changes made outside the tool.
+`ocync` skips tag enumeration when exact tags are configured (no wildcard, semver, or latest filters), using the configured tag names directly instead of paginating through the registry's full tag list. Combined with the transfer state cache and source manifest HEAD checks, this reduces a no-op warm sync to ~180 requests regardless of how many tags exist at the source.
 
 ## Why `ocync` is fast
 

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -338,16 +338,25 @@ pub(crate) async fn resolve_mapping(
 
     // --- Fetch and filter tags ---
     let source_repo_path = RepositoryName::new(&mapping.from)?;
-    let all_tags = source_client.list_tags(&source_repo_path).await?;
 
     let tags_config = mapping
         .tags
         .as_ref()
         .or(config.defaults.as_ref().and_then(|d| d.tags.as_ref()));
 
-    let filter = build_filter(tags_config);
-    let tag_refs: Vec<&str> = all_tags.iter().map(String::as_str).collect();
-    let filtered = filter.apply(&tag_refs)?;
+    // Fast path: when the config specifies only exact tag names (no
+    // wildcards, semver, latest, exclude), use them directly without
+    // enumerating all tags from the source registry. This avoids
+    // hundreds of paginated tags/list requests for repos with thousands
+    // of tags.
+    let filtered = if let Some(exact) = tags_config.and_then(|t| t.exact_tags()) {
+        exact
+    } else {
+        let all_tags = source_client.list_tags(&source_repo_path).await?;
+        let filter = build_filter(tags_config);
+        let tag_refs: Vec<&str> = all_tags.iter().map(String::as_str).collect();
+        filter.apply(&tag_refs)?
+    };
 
     if filtered.is_empty() {
         tracing::warn!(

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -423,6 +423,38 @@ pub(crate) struct TagsConfig {
     pub immutable_tags: Option<String>,
 }
 
+impl TagsConfig {
+    /// Returns the exact tag names if this config requires no enumeration.
+    ///
+    /// Returns `Some` when `glob` contains only literal strings (no wildcard
+    /// characters) and no other filter fields (`semver`, `latest`, `sort`,
+    /// `min_tags`) are set. In this case the tags can be used directly
+    /// without listing all tags from the registry.
+    pub(crate) fn exact_tags(&self) -> Option<Vec<String>> {
+        // Any field that requires the full tag list forces enumeration.
+        if self.semver.is_some()
+            || self.latest.is_some()
+            || self.sort.is_some()
+            || self.min_tags.is_some()
+            || self.exclude.is_some()
+        {
+            return None;
+        }
+        let patterns = match &self.glob {
+            Some(GlobOrList::Single(s)) => vec![s.clone()],
+            Some(GlobOrList::List(v)) => v.clone(),
+            None => return None, // No glob = sync all tags = must enumerate.
+        };
+        // A pattern is "exact" if it contains no glob metacharacters.
+        let is_exact = |s: &str| !s.contains('*') && !s.contains('?') && !s.contains('[');
+        if patterns.iter().all(|p| is_exact(p)) {
+            Some(patterns)
+        } else {
+            None
+        }
+    }
+}
+
 /// A glob pattern: either a single string or a list of patterns.
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(untagged)]
@@ -1815,6 +1847,95 @@ mappings:
         };
         validate_artifacts("test-mapping", &artifacts).unwrap();
     }
+
+    // - TagsConfig::exact_tags() -------------------------------------------
+
+    #[test]
+    fn exact_tags_plain_list() {
+        let tags = TagsConfig {
+            glob: Some(GlobOrList::List(vec!["latest".into(), "3.20".into()])),
+            ..Default::default()
+        };
+        assert_eq!(
+            tags.exact_tags(),
+            Some(vec!["latest".into(), "3.20".into()])
+        );
+    }
+
+    #[test]
+    fn exact_tags_single() {
+        let tags = TagsConfig {
+            glob: Some(GlobOrList::Single("v1.0.0".into())),
+            ..Default::default()
+        };
+        assert_eq!(tags.exact_tags(), Some(vec!["v1.0.0".into()]));
+    }
+
+    #[test]
+    fn exact_tags_with_wildcard_returns_none() {
+        let tags = TagsConfig {
+            glob: Some(GlobOrList::Single("v1.*".into())),
+            ..Default::default()
+        };
+        assert!(tags.exact_tags().is_none());
+    }
+
+    #[test]
+    fn exact_tags_with_semver_returns_none() {
+        let tags = TagsConfig {
+            glob: Some(GlobOrList::Single("latest".into())),
+            semver: Some(">=1.0".into()),
+            ..Default::default()
+        };
+        assert!(tags.exact_tags().is_none());
+    }
+
+    #[test]
+    fn exact_tags_with_latest_returns_none() {
+        let tags = TagsConfig {
+            glob: Some(GlobOrList::Single("latest".into())),
+            latest: Some(5),
+            sort: Some(SortOrder::Semver),
+            ..Default::default()
+        };
+        assert!(tags.exact_tags().is_none());
+    }
+
+    #[test]
+    fn exact_tags_no_glob_returns_none() {
+        let tags = TagsConfig::default();
+        assert!(tags.exact_tags().is_none());
+    }
+
+    #[test]
+    fn exact_tags_question_mark_returns_none() {
+        let tags = TagsConfig {
+            glob: Some(GlobOrList::Single("v1.?".into())),
+            ..Default::default()
+        };
+        assert!(tags.exact_tags().is_none());
+    }
+
+    #[test]
+    fn exact_tags_bracket_returns_none() {
+        let tags = TagsConfig {
+            glob: Some(GlobOrList::Single("[0-9]*".into())),
+            ..Default::default()
+        };
+        assert!(tags.exact_tags().is_none());
+    }
+
+    #[test]
+    fn exact_tags_with_exclude_returns_none() {
+        let tags = TagsConfig {
+            glob: Some(GlobOrList::List(vec!["v1.0".into(), "v2.0".into()])),
+            exclude: Some(GlobOrList::Single("v2.0".into())),
+            ..Default::default()
+        };
+        assert!(tags.exact_tags().is_none());
+    }
+
+    // - ArtifactsConfig -------------------------------------------------------
 
     #[test]
     fn artifacts_defaults_enabled() {

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -16,4 +16,5 @@ serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 tempfile.workspace = true
+reqwest = { workspace = true, features = ["rustls-tls-native-roots"] }
 tokio = { workspace = true, features = ["rt", "process", "time"] }

--- a/xtask/src/bench/ecr.rs
+++ b/xtask/src/bench/ecr.rs
@@ -72,19 +72,15 @@ pub(crate) async fn verify_sync(
         total_tags += expected_tags.len() as u64;
 
         // List all tags at target.
-        let mut actual_tags: std::collections::HashSet<String> =
-            std::collections::HashSet::new();
+        let mut actual_tags: std::collections::HashSet<String> = std::collections::HashSet::new();
         let mut next_token: Option<String> = None;
 
         loop {
-            let mut req = client
-                .list_images()
-                .repository_name(&repo_name)
-                .filter(
-                    aws_sdk_ecr::types::ListImagesFilter::builder()
-                        .tag_status(aws_sdk_ecr::types::TagStatus::Tagged)
-                        .build(),
-                );
+            let mut req = client.list_images().repository_name(&repo_name).filter(
+                aws_sdk_ecr::types::ListImagesFilter::builder()
+                    .tag_status(aws_sdk_ecr::types::TagStatus::Tagged)
+                    .build(),
+            );
             if let Some(token) = &next_token {
                 req = req.next_token(token);
             }
@@ -107,10 +103,19 @@ pub(crate) async fn verify_sync(
             }
         }
 
+        let mut repo_missing = 0u64;
         for tag in &expected_tags {
             if !actual_tags.contains(*tag) {
                 missing.push(format!("{repo_name}:{tag}"));
+                repo_missing += 1;
             }
+        }
+        if repo_missing == 0 {
+            eprintln!(
+                "  verify: {repo_name} OK ({}/{} tags)",
+                actual_tags.len(),
+                expected_tags.len()
+            );
         }
     }
 

--- a/xtask/src/bench/mod.rs
+++ b/xtask/src/bench/mod.rs
@@ -10,6 +10,8 @@ pub(crate) mod report;
 pub(crate) mod runner;
 
 use std::collections::BTreeMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
 use clap::{Args, Subcommand};
@@ -103,8 +105,6 @@ fn read_ssm_parameter(name: &str) -> Option<String> {
             "Parameter.Value",
             "--output",
             "text",
-            "--region",
-            "us-east-1",
         ])
         .output()
         .ok()
@@ -337,11 +337,24 @@ pub(crate) async fn run(args: BenchArgs) -> Result<(), Box<dyn std::error::Error
         other => vec![other],
     };
 
+    // Pre-warm CDN so all tools see identically cached source manifests.
+    cdn_prewarm(&corpus).await;
+
     for scenario in scenarios {
+        // Randomize tool execution order to prevent systematic bias from
+        // CDN warming, network burst credit depletion, etc.
+        let mut shuffled = tools.clone();
+        shuffle_tools(&mut shuffled);
+        let tool_order: Vec<_> = shuffled.iter().map(|t| t.to_string()).collect();
+        eprintln!(
+            "bench: tool order for {scenario:?}: {}",
+            tool_order.join(", ")
+        );
+
         match scenario {
             Scenario::Sync => {
                 let (cold, warm) =
-                    run_sync(&args, &corpus, &tools, &ecr_client, &output_dir).await?;
+                    run_sync(&args, &corpus, &shuffled, &ecr_client, &output_dir).await?;
                 report.scenarios.push(cold);
                 report.scenarios.push(warm);
             }
@@ -356,7 +369,7 @@ pub(crate) async fn run(args: BenchArgs) -> Result<(), Box<dyn std::error::Error
                     &args,
                     &corpus,
                     &partial_corpus,
-                    &tools,
+                    &shuffled,
                     &ecr_client,
                     &output_dir,
                 )
@@ -429,6 +442,8 @@ pub(crate) async fn run(args: BenchArgs) -> Result<(), Box<dyn std::error::Error
                             mount_attempts: metrics.map_or(0, |m| m.mount_attempts),
                             duplicate_blob_gets: metrics.map_or(0, |m| m.duplicate_blob_gets),
                             rate_limit_429s: metrics.map_or(0, |m| m.status_429_count),
+                            cdn_hits: metrics.map_or(0, |m| m.cdn_hits),
+                            cdn_misses: metrics.map_or(0, |m| m.cdn_misses),
                         }
                     })
                     .collect(),
@@ -507,6 +522,7 @@ async fn run_single_tool(
     corpus: &Corpus,
     config_dir: &Path,
     output_dir: &Path,
+    phase: &str,
 ) -> Result<ToolRun, Box<dyn std::error::Error>> {
     // 1. Generate config.
     let config_content = match tool {
@@ -531,7 +547,7 @@ async fn run_single_tool(
     // which API calls the tool issued.
     std::fs::create_dir_all(output_dir)
         .map_err(|e| format!("create output dir {}: {e}", output_dir.display()))?;
-    let log_path = output_dir.join(format!("{tool}-proxy.jsonl"));
+    let log_path = output_dir.join(format!("{tool}-{phase}-proxy.jsonl"));
     let handle = proxy::start(
         &args.proxy_binary,
         &args.proxy_ca,
@@ -637,7 +653,8 @@ async fn run_sync(
         // Cold run.
         progress(&format!("  cold: {tool}"));
         let run_result: Result<(), Box<dyn std::error::Error>> = async {
-            let cold = run_single_tool(args, tool, corpus, config_dir.path(), output_dir).await?;
+            let cold =
+                run_single_tool(args, tool, corpus, config_dir.path(), output_dir, "cold").await?;
             if cold.exit_code != Some(0) {
                 return Err(format!(
                     "{tool} cold sync failed (exit {:?}); aborting -- \
@@ -658,7 +675,8 @@ async fn run_sync(
 
             // Warm run: target still populated, same config_dir.
             progress(&format!("  warm: {tool}"));
-            let warm = run_single_tool(args, tool, corpus, config_dir.path(), output_dir).await?;
+            let warm =
+                run_single_tool(args, tool, corpus, config_dir.path(), output_dir, "warm").await?;
             if warm.exit_code != Some(0) {
                 return Err(format!(
                     "{tool} warm sync failed (exit {:?}); aborting -- \
@@ -721,8 +739,15 @@ async fn run_partial(
             // Prime with base corpus (unmeasured). Reuse the same
             // config_dir so ocync's TransferStateCache persists.
             let config_dir = tempfile::tempdir()?;
-            let prime =
-                run_single_tool(args, tool, base_corpus, config_dir.path(), output_dir).await?;
+            let prime = run_single_tool(
+                args,
+                tool,
+                base_corpus,
+                config_dir.path(),
+                output_dir,
+                "prime",
+            )
+            .await?;
             if prime.exit_code != Some(0) {
                 return Err(format!(
                     "{tool} partial prime failed (exit {:?}); aborting",
@@ -733,8 +758,15 @@ async fn run_partial(
             progress(&format!("  partial: {} measuring", tool));
 
             // Measured run with partial corpus (same config_dir).
-            let run =
-                run_single_tool(args, tool, partial_corpus, config_dir.path(), output_dir).await?;
+            let run = run_single_tool(
+                args,
+                tool,
+                partial_corpus,
+                config_dir.path(),
+                output_dir,
+                "partial",
+            )
+            .await?;
             if run.exit_code != Some(0) {
                 return Err(format!(
                     "{tool} partial sync failed (exit {:?}); aborting",
@@ -797,7 +829,8 @@ async fn run_scale(
             let run_result: Result<(), Box<dyn std::error::Error>> = async {
                 let config_dir = tempfile::tempdir()?;
                 let run =
-                    run_single_tool(args, tool, &subset, config_dir.path(), output_dir).await?;
+                    run_single_tool(args, tool, &subset, config_dir.path(), output_dir, "scale")
+                        .await?;
                 if run.exit_code != Some(0) {
                     return Err(format!(
                         "{tool} scale sync failed at {size} images (exit {:?}); aborting",
@@ -836,9 +869,177 @@ fn prepare_clean_slate() {
     clean_staging_tmpdir();
 }
 
+/// Pull every source manifest once to warm CDN edge caches.
+///
+/// Runs before any tool so all tools see identically warm CDN. Uses
+/// OCI token exchange for authentication so requests succeed (2xx) and
+/// `CloudFront` actually caches the responses. Unauthenticated 401s are
+/// NOT cached by CDN and would warm nothing.
+async fn cdn_prewarm(corpus: &Corpus) {
+    let total = corpus.total_tags();
+    eprintln!("bench: pre-warming CDN ({total} manifests)...");
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap();
+
+    // Group images by registry so we can reuse tokens per scope.
+    let mut hits = 0u64;
+    let mut misses = 0u64;
+    let mut errors = 0u64;
+
+    for image in &corpus.images {
+        let (raw_registry, repo) = match image.source.find('/') {
+            Some(i) => (&image.source[..i], &image.source[i + 1..]),
+            None => continue,
+        };
+        // Docker Hub's API endpoint is registry-1.docker.io, not docker.io.
+        let registry = if raw_registry == "docker.io" {
+            "registry-1.docker.io"
+        } else {
+            raw_registry
+        };
+
+        // OCI token exchange: GET /v2/ -> 401 with WWW-Authenticate ->
+        // GET {realm}?service={service}&scope=repository:{repo}:pull -> bearer token.
+        let token = match oci_token(&client, registry, repo, corpus).await {
+            Some(t) => t,
+            None => {
+                errors += image.tags.len() as u64;
+                eprintln!("  CDN pre-warm: {registry}/{repo}: auth failed, skipping");
+                continue;
+            }
+        };
+
+        for tag in &image.tags {
+            let url = format!("https://{registry}/v2/{repo}/manifests/{tag}");
+            let resp = client
+                .head(&url)
+                .header("Authorization", format!("Bearer {token}"))
+                .send()
+                .await;
+            match resp {
+                Ok(r) if r.status().is_success() || r.status().is_redirection() => {
+                    let x_cache = r
+                        .headers()
+                        .get("x-cache")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or("");
+                    if x_cache.to_ascii_lowercase().contains("hit") {
+                        hits += 1;
+                    } else {
+                        misses += 1;
+                    }
+                }
+                Ok(r) => {
+                    errors += 1;
+                    eprintln!("  CDN pre-warm: {registry}/{repo}:{tag} -> {}", r.status());
+                }
+                Err(e) => {
+                    errors += 1;
+                    eprintln!("  CDN pre-warm: {registry}/{repo}:{tag} -> {e}");
+                }
+            }
+        }
+    }
+
+    eprintln!("bench: CDN pre-warm done ({hits} hits, {misses} misses, {errors} errors)");
+
+    // Wait for CDN propagation. CloudFront edges need time to fully
+    // populate after the first request hits the origin.
+    let wait_secs = 360; // 6 minutes
+    eprintln!("bench: waiting {wait_secs}s for CDN propagation...");
+    tokio::time::sleep(std::time::Duration::from_secs(wait_secs)).await;
+}
+
+/// OCI token exchange for a single repository scope.
+///
+/// Follows the standard flow: challenge /v2/, parse `WWW-Authenticate`,
+/// request a bearer token from the auth realm. For Docker Hub, includes
+/// basic auth credentials if available in the corpus.
+async fn oci_token(
+    client: &reqwest::Client,
+    registry: &str,
+    repo: &str,
+    corpus: &Corpus,
+) -> Option<String> {
+    // Step 1: challenge the registry to get the auth parameters.
+    let challenge = client
+        .get(format!("https://{registry}/v2/"))
+        .send()
+        .await
+        .ok()?;
+
+    let www_auth = challenge
+        .headers()
+        .get("www-authenticate")
+        .and_then(|v| v.to_str().ok())?;
+
+    // Parse: Bearer realm="https://...",service="...",scope="..."
+    let realm = parse_auth_param(www_auth, "realm")?;
+    let service = parse_auth_param(www_auth, "service").unwrap_or_default();
+
+    // Step 2: exchange for a bearer token.
+    let scope = format!("repository:{repo}:pull");
+    let mut token_req = client
+        .get(&realm)
+        .query(&[("service", &service), ("scope", &scope)]);
+
+    // Docker Hub: include basic auth for authenticated pull rates.
+    if registry.contains("docker.io") {
+        if let Some(ref auth) = corpus.dockerhub_auth {
+            token_req = token_req.basic_auth(&auth.username, Some(&auth.token));
+        }
+    }
+
+    let token_resp = token_req.send().await.ok()?;
+    if !token_resp.status().is_success() {
+        return None;
+    }
+
+    let text = token_resp.text().await.ok()?;
+    let body: serde_json::Value = serde_json::from_str(&text).ok()?;
+    body.get("token")
+        .or_else(|| body.get("access_token"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_owned())
+}
+
+/// Extract a parameter value from a `WWW-Authenticate: Bearer ...` header.
+fn parse_auth_param(header: &str, key: &str) -> Option<String> {
+    let pattern = format!("{key}=\"");
+    let start = header.find(&pattern)? + pattern.len();
+    let end = header[start..].find('"')? + start;
+    Some(header[start..end].to_owned())
+}
+
 async fn cooldown() {
-    eprintln!("bench: cooling down for 30s...");
-    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+    eprintln!("bench: cooling down for 10s...");
+    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+}
+
+/// Shuffle a tool list in-place using Fisher-Yates with a timestamp seed.
+/// Not cryptographic -- just enough to randomize execution order across runs.
+fn shuffle_tools(tools: &mut [Tool]) {
+    if tools.len() <= 1 {
+        return;
+    }
+    let mut hasher = DefaultHasher::new();
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+        .hash(&mut hasher);
+    let mut state = hasher.finish();
+    for i in (1..tools.len()).rev() {
+        // xorshift64 step for cheap pseudo-randomness.
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        let j = (state as usize) % (i + 1);
+        tools.swap(i, j);
+    }
 }
 
 /// Attempt to drop the OS page cache via `/proc/sys/vm/drop_caches`.
@@ -855,8 +1056,12 @@ fn drop_page_cache() {
         .status();
     match result {
         Ok(s) if s.success() => eprintln!("bench: dropped page cache"),
-        Ok(s) => eprintln!("bench: warning: drop_caches exited {s}; later tools may benefit from cached data"),
-        Err(e) => eprintln!("bench: warning: could not drop page cache ({e}); later tools may benefit from cached data"),
+        Ok(s) => eprintln!(
+            "bench: warning: drop_caches exited {s}; later tools may benefit from cached data"
+        ),
+        Err(e) => eprintln!(
+            "bench: warning: could not drop page cache ({e}); later tools may benefit from cached data"
+        ),
     }
 }
 

--- a/xtask/src/bench/proxy.rs
+++ b/xtask/src/bench/proxy.rs
@@ -45,6 +45,12 @@ pub(crate) struct ProxyEntry {
     pub(crate) status: u16,
     /// Request duration in milliseconds (preserved from log for latency analysis).
     pub(crate) duration_ms: u64,
+    /// CDN cache status from `X-Cache` header (e.g. `"Hit from cloudfront"`).
+    #[serde(default)]
+    pub(crate) x_cache: Option<String>,
+    /// Seconds since CDN cached the response, from `Age` header.
+    #[serde(default)]
+    pub(crate) age: Option<u64>,
 }
 
 /// Aggregated metrics computed from a set of proxy log entries.
@@ -79,6 +85,12 @@ pub(crate) struct ProxyMetrics {
     /// Includes both registry redirect responses and CDN follow-up responses
     /// where the actual blob data flows (`CloudFront`, S3, R2, etc.).
     pub(crate) source_blob_bytes: u64,
+    /// Source requests where `X-Cache` contained `"Hit"` (CDN cache hit).
+    #[serde(default)]
+    pub(crate) cdn_hits: u64,
+    /// Source requests where `X-Cache` contained `"Miss"` (CDN cache miss).
+    #[serde(default)]
+    pub(crate) cdn_misses: u64,
 }
 
 /// Spawns a `bench-proxy` process and waits for it to bind its port.
@@ -194,6 +206,8 @@ pub(crate) fn aggregate(entries: &[ProxyEntry], target_registry: &str) -> ProxyM
     let mut existence_check_posts = 0u64;
     let mut source_blob_gets = 0u64;
     let mut source_blob_bytes = 0u64;
+    let mut cdn_hits = 0u64;
+    let mut cdn_misses = 0u64;
 
     // Track GET requests to blob URLs for duplicate detection.
     let mut blob_get_counts: HashMap<String, u64> = HashMap::new();
@@ -225,6 +239,18 @@ pub(crate) fn aggregate(entries: &[ProxyEntry], target_registry: &str) -> ProxyM
         // GET responses captures both the redirect and CDN responses.
         if entry.method == "GET" && entry.host != target_registry {
             source_blob_bytes += entry.response_bytes;
+        }
+
+        // CDN cache status from X-Cache header (source requests only).
+        if entry.host != target_registry {
+            if let Some(ref xc) = entry.x_cache {
+                let lower = xc.to_ascii_lowercase();
+                if lower.contains("hit") {
+                    cdn_hits += 1;
+                } else if lower.contains("miss") {
+                    cdn_misses += 1;
+                }
+            }
         }
 
         // OCI cross-repo blob mount: `POST /v2/.../blobs/uploads/?mount=<digest>&from=<repo>`.
@@ -268,6 +294,8 @@ pub(crate) fn aggregate(entries: &[ProxyEntry], target_registry: &str) -> ProxyM
         existence_check_posts,
         source_blob_gets,
         source_blob_bytes,
+        cdn_hits,
+        cdn_misses,
     }
 }
 
@@ -276,44 +304,66 @@ mod tests {
     use super::*;
     use std::io::Write;
 
+    fn entry(
+        method: &str,
+        host: &str,
+        url: &str,
+        request_bytes: u64,
+        response_bytes: u64,
+        status: u16,
+        duration_ms: u64,
+    ) -> ProxyEntry {
+        ProxyEntry {
+            method: method.into(),
+            host: host.into(),
+            url: url.into(),
+            request_bytes,
+            response_bytes,
+            status,
+            duration_ms,
+            x_cache: None,
+            age: None,
+        }
+    }
+
     fn sample_entries() -> Vec<ProxyEntry> {
         vec![
-            ProxyEntry {
-                method: "HEAD".into(),
-                host: "ecr.aws".into(),
-                url: "/v2/bench/nginx/manifests/latest".into(),
-                request_bytes: 100,
-                response_bytes: 0,
-                status: 200,
-                duration_ms: 30,
-            },
-            ProxyEntry {
-                method: "GET".into(),
-                host: "ecr.aws".into(),
-                url: "/v2/bench/nginx/blobs/sha256:abc123".into(),
-                request_bytes: 50,
-                response_bytes: 5000,
-                status: 200,
-                duration_ms: 120,
-            },
-            ProxyEntry {
-                method: "GET".into(),
-                host: "ecr.aws".into(),
-                url: "/v2/bench/nginx/blobs/sha256:abc123".into(),
-                request_bytes: 50,
-                response_bytes: 5000,
-                status: 200,
-                duration_ms: 115,
-            },
-            ProxyEntry {
-                method: "PUT".into(),
-                host: "ecr.aws".into(),
-                url: "/v2/bench/nginx/manifests/latest".into(),
-                request_bytes: 2000,
-                response_bytes: 100,
-                status: 429,
-                duration_ms: 10,
-            },
+            entry(
+                "HEAD",
+                "ecr.aws",
+                "/v2/bench/nginx/manifests/latest",
+                100,
+                0,
+                200,
+                30,
+            ),
+            entry(
+                "GET",
+                "ecr.aws",
+                "/v2/bench/nginx/blobs/sha256:abc123",
+                50,
+                5000,
+                200,
+                120,
+            ),
+            entry(
+                "GET",
+                "ecr.aws",
+                "/v2/bench/nginx/blobs/sha256:abc123",
+                50,
+                5000,
+                200,
+                115,
+            ),
+            entry(
+                "PUT",
+                "ecr.aws",
+                "/v2/bench/nginx/manifests/latest",
+                2000,
+                100,
+                429,
+                10,
+            ),
         ]
     }
 
@@ -402,24 +452,24 @@ mod tests {
     #[test]
     fn aggregate_head_on_blob_url_not_counted_as_duplicate() {
         let entries = vec![
-            ProxyEntry {
-                method: "GET".into(),
-                host: "ecr.aws".into(),
-                url: "/v2/bench/nginx/blobs/sha256:abc123".into(),
-                request_bytes: 50,
-                response_bytes: 5000,
-                status: 200,
-                duration_ms: 100,
-            },
-            ProxyEntry {
-                method: "HEAD".into(),
-                host: "ecr.aws".into(),
-                url: "/v2/bench/nginx/blobs/sha256:abc123".into(),
-                request_bytes: 50,
-                response_bytes: 0,
-                status: 200,
-                duration_ms: 10,
-            },
+            entry(
+                "GET",
+                "ecr.aws",
+                "/v2/bench/nginx/blobs/sha256:abc123",
+                50,
+                5000,
+                200,
+                100,
+            ),
+            entry(
+                "HEAD",
+                "ecr.aws",
+                "/v2/bench/nginx/blobs/sha256:abc123",
+                50,
+                0,
+                200,
+                10,
+            ),
         ];
         let metrics = aggregate(&entries, "ecr.aws");
         assert_eq!(metrics.duplicate_blob_gets, 0);
@@ -428,24 +478,24 @@ mod tests {
     #[test]
     fn aggregate_no_duplicates_with_unique_blobs() {
         let entries = vec![
-            ProxyEntry {
-                method: "GET".into(),
-                host: "ecr.aws".into(),
-                url: "/v2/bench/nginx/blobs/sha256:aaa".into(),
-                request_bytes: 50,
-                response_bytes: 5000,
-                status: 200,
-                duration_ms: 100,
-            },
-            ProxyEntry {
-                method: "GET".into(),
-                host: "ecr.aws".into(),
-                url: "/v2/bench/nginx/blobs/sha256:bbb".into(),
-                request_bytes: 50,
-                response_bytes: 3000,
-                status: 200,
-                duration_ms: 80,
-            },
+            entry(
+                "GET",
+                "ecr.aws",
+                "/v2/bench/nginx/blobs/sha256:aaa",
+                50,
+                5000,
+                200,
+                100,
+            ),
+            entry(
+                "GET",
+                "ecr.aws",
+                "/v2/bench/nginx/blobs/sha256:bbb",
+                50,
+                3000,
+                200,
+                80,
+            ),
         ];
         let metrics = aggregate(&entries, "ecr.aws");
         assert_eq!(metrics.duplicate_blob_gets, 0);
@@ -455,37 +505,37 @@ mod tests {
     fn aggregate_source_blob_gets() {
         let entries = vec![
             // Source blob GET (host != target).
-            ProxyEntry {
-                method: "GET".into(),
-                host: "docker.io".into(),
-                url: "/v2/library/nginx/blobs/sha256:abc".into(),
-                request_bytes: 50,
-                response_bytes: 9000,
-                status: 200,
-                duration_ms: 100,
-            },
+            entry(
+                "GET",
+                "docker.io",
+                "/v2/library/nginx/blobs/sha256:abc",
+                50,
+                9000,
+                200,
+                100,
+            ),
             // Target blob GET (host == target).
-            ProxyEntry {
-                method: "GET".into(),
-                host: "ecr.aws".into(),
-                url: "/v2/bench/nginx/blobs/sha256:abc".into(),
-                request_bytes: 50,
-                response_bytes: 9000,
-                status: 200,
-                duration_ms: 80,
-            },
+            entry(
+                "GET",
+                "ecr.aws",
+                "/v2/bench/nginx/blobs/sha256:abc",
+                50,
+                9000,
+                200,
+                80,
+            ),
             // Source non-blob GET (manifest, not /blobs/sha256:).
             // Does NOT count as a source_blob_get, but its response bytes
             // ARE included in source_blob_bytes (all non-target GET bytes).
-            ProxyEntry {
-                method: "GET".into(),
-                host: "docker.io".into(),
-                url: "/v2/library/nginx/manifests/latest".into(),
-                request_bytes: 50,
-                response_bytes: 1000,
-                status: 200,
-                duration_ms: 50,
-            },
+            entry(
+                "GET",
+                "docker.io",
+                "/v2/library/nginx/manifests/latest",
+                50,
+                1000,
+                200,
+                50,
+            ),
         ];
         let metrics = aggregate(&entries, "ecr.aws");
         assert_eq!(metrics.source_blob_gets, 1);

--- a/xtask/src/bench/remote.rs
+++ b/xtask/src/bench/remote.rs
@@ -150,7 +150,7 @@ pub(crate) fn run(args: BenchRemoteArgs) -> Result<(), Box<dyn std::error::Error
     // Determine the target registry from the provider.
     let registry_env = match config.provider.as_str() {
         "aws" => {
-            "ACCOUNT=$(aws sts get-caller-identity --query Account --output text)\nexport BENCH_TARGET_REGISTRY=${ACCOUNT}.dkr.ecr.us-east-1.amazonaws.com".to_string()
+            "TOKEN=$(curl -s -X PUT 'http://169.254.169.254/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600')\nREGION=$(curl -s -H \"X-aws-ec2-metadata-token: $TOKEN\" http://169.254.169.254/latest/meta-data/placement/region)\nACCOUNT=$(aws sts get-caller-identity --query Account --output text)\nexport BENCH_TARGET_REGISTRY=${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com".to_string()
         }
         _ => {
             return Err(format!(

--- a/xtask/src/bench/report.rs
+++ b/xtask/src/bench/report.rs
@@ -93,6 +93,12 @@ pub(crate) struct ToolRecord {
     pub(crate) duplicate_blob_gets: u64,
     /// HTTP 429 rate-limit responses.
     pub(crate) rate_limit_429s: u64,
+    /// Source CDN cache hits (X-Cache contained "Hit").
+    #[serde(default)]
+    pub(crate) cdn_hits: u64,
+    /// Source CDN cache misses (X-Cache contained "Miss").
+    #[serde(default)]
+    pub(crate) cdn_misses: u64,
 }
 
 /// Results for one tool in one scenario.
@@ -217,8 +223,6 @@ fn describe_instance_type(instance_type: &str) -> Option<(String, String, usize,
             "InstanceTypes[0].{Arch:ProcessorInfo.SupportedArchitectures[0],Cpu:ProcessorInfo.Manufacturer,Vcpus:VCpuInfo.DefaultVCpus,Mem:MemoryInfo.SizeInMiB,Net:NetworkInfo.NetworkPerformance}",
             "--output",
             "json",
-            "--region",
-            "us-east-1",
         ])
         .output()
         .ok()
@@ -511,6 +515,16 @@ fn metric_rows() -> Vec<MetricRow> {
                     .map(|m| m.duplicate_blob_gets.to_string())
             }),
             lower_is_better: true,
+        },
+        MetricRow {
+            label: "CDN hits/misses",
+            rank: Box::new(|r| r.proxy_metrics.as_ref().map(|m| m.cdn_hits)),
+            display: Box::new(|r| {
+                r.proxy_metrics
+                    .as_ref()
+                    .map(|m| format!("{}/{}", m.cdn_hits, m.cdn_misses))
+            }),
+            lower_is_better: false,
         },
         MetricRow {
             label: "Rate-limit 429s",
@@ -995,6 +1009,8 @@ mod tests {
                     mount_attempts: 379,
                     duplicate_blob_gets: 0,
                     rate_limit_429s: 0,
+                    cdn_hits: 0,
+                    cdn_misses: 0,
                 }],
             }],
         };
@@ -1234,6 +1250,8 @@ mod tests {
                             existence_check_posts: 0,
                             source_blob_gets: 726,
                             source_blob_bytes: 77_200,
+                            cdn_hits: 0,
+                            cdn_misses: 0,
                         }),
                     },
                     ToolRun {
@@ -1253,6 +1271,8 @@ mod tests {
                             existence_check_posts: 0,
                             source_blob_gets: 1324,
                             source_blob_bytes: 120_100,
+                            cdn_hits: 0,
+                            cdn_misses: 0,
                         }),
                     },
                 ],
@@ -1331,6 +1351,8 @@ mod tests {
                             existence_check_posts: 0,
                             source_blob_gets: 726,
                             source_blob_bytes: 77_200,
+                            cdn_hits: 0,
+                            cdn_misses: 0,
                         }),
                     },
                     ToolRun {
@@ -1390,6 +1412,8 @@ mod tests {
                             existence_check_posts: 0,
                             source_blob_gets: 0,
                             source_blob_bytes: 0,
+                            cdn_hits: 0,
+                            cdn_misses: 0,
                         }),
                     },
                     ToolRun {
@@ -1409,6 +1433,8 @@ mod tests {
                             existence_check_posts: 0,
                             source_blob_gets: 0,
                             source_blob_bytes: 0,
+                            cdn_hits: 0,
+                            cdn_misses: 0,
                         }),
                     },
                 ],

--- a/xtask/src/bench/runner.rs
+++ b/xtask/src/bench/runner.rs
@@ -142,7 +142,7 @@ pub(crate) async fn run_tool(
 ) -> Result<RunResult, String> {
     let config_str = config_path.to_string_lossy();
     let args: Vec<&str> = match tool {
-        Tool::Ocync => vec!["sync", "--config", &config_str, "--json"],
+        Tool::Ocync => vec!["sync", "--config", &config_str, "--json", "-v"],
         Tool::Dregsy => vec!["-config", &config_str],
         Tool::Regsync => vec!["once", "-c", &config_str],
     };


### PR DESCRIPTION
## Summary

Benchmark fairness and warm-run performance overhaul:

- **CDN pre-warm**: HEAD all source manifests with OCI token exchange before any tool runs, wait 6 min for CloudFront propagation. Equalizes CDN hit rates across all tools (~97-100% vs previous 7%/24%/99% ordering bias).
- **Tool order randomization**: Fisher-Yates shuffle per scenario prevents systematic ordering bias.
- **CDN measurement**: Capture X-Cache/Age headers in bench-proxy JSONL, aggregate cdn_hits/cdn_misses in ProxyMetrics and summary table.
- **Skip tag enumeration**: `TagsConfig::exact_tags()` bypasses `list_tags()` when config specifies only literal tag names. Eliminates 440 wasted tags/list pagination requests on warm runs.
- **us-east-2 migration**: Terraform provider, IMDS-derived ECR hostname, removed hardcoded `--region` flags.
- **Per-image progress**: ocync benchmark runs now emit synced/skipped lines via `-v` flag.
- **Per-repo verification**: Each repo logs tag count during sync validation.
- **Extended cooldown**: 30s -> 180s between tools for CDN TTL expiry and network burst credit recovery.
- **Doc updates**: Fixed stale claims (mount rate, 429s, request counts), documented all new fairness invariants.

## Results

**Cold sync** (CDN pre-warmed, c6in.4xlarge us-east-2):
| Tool | Wall clock | Requests | CDN hits/misses |
|---|---|---|---|
| ocync | **4m 17s** | **7,189** | 1,047/8 |
| dregsy | 18m 14s | 11,631 | 975/0 |
| regsync | 16m 26s | 9,527 | 987/0 |

**Warm sync** (no-op re-sync):
| Tool | Wall clock | Requests | Response bytes |
|---|---|---|---|
| ocync | **2s** | **181** | **132 KB** |
| dregsy | 1m 49s | 3,145 | 1.9 MB |
| regsync | 18s | 325 | 62 MB |

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test` -- 215 passed
- [x] `cargo deny check` passes
- [x] Benchmark run on us-east-2 c6in.4xlarge validates CDN pre-warm equalization
- [x] Benchmark run validates exact-tags warm-run improvement (2m 31s -> 2s)
- [x] Documentation accuracy verified by review agents