### PR TITLE
docs(ecr): add multi-account access patterns

### DIFF
--- a/docs/src/content/registries/ecr.md
+++ b/docs/src/content/registries/ecr.md
@@ -124,3 +124,69 @@ env:
 ```
 
 For other secret-injection patterns (External Secrets Operator, CSI Secrets Store), see [Kubernetes secrets](./secrets).
+
+## Multi-account access
+
+ocync uses one ambient AWS credential chain per process. Syncing across accounts (e.g., one source ECR plus several target ECRs in different accounts) means giving that one principal the right permissions for every account it touches. There are three patterns, in order of preference.
+
+### Cross-account ECR repository policies
+
+Simplest. Attach a repository policy on each destination ECR repository that grants pull/push permissions to the principal ocync runs as. No assume-role hop, one set of credentials, the AWS SDK does no extra work.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "AllowOcyncFromOriginAccount",
+    "Effect": "Allow",
+    "Principal": { "AWS": "arn:aws:iam::ORIGIN_ACCOUNT:role/ocync" },
+    "Action": [
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+      "ecr:PutImage"
+    ]
+  }]
+}
+```
+
+Pair with `ecr:GetAuthorizationToken` on the ocync principal in the origin account. This works on every host (EKS, ECS, EC2, Lambda, local).
+
+### EKS Pod Identity with `targetRoleArn`
+
+When repository policies aren't an option (e.g., the destination accounts are owned by a different team and they prefer trust-policy-based access), EKS Pod Identity natively supports cross-account role chaining. Configure a `PodIdentityAssociation` with both `roleArn` (the local cluster role) and `targetRoleArn` (the role in the destination account):
+
+```bash
+aws eks create-pod-identity-association \
+  --cluster-name my-cluster \
+  --namespace ocync \
+  --service-account my-release-ocync \
+  --role-arn arn:aws:iam::ORIGIN_ACCOUNT:role/ocync-source \
+  --target-role-arn arn:aws:iam::DESTINATION_ACCOUNT:role/ocync-target
+```
+
+The Pod Identity Agent assumes `targetRoleArn` for you; the credentials ocync sees are already the destination-account credentials. No ocync configuration needed.
+
+### Shared-config role chains (non-EKS)
+
+On hosts that don't use Pod Identity (ECS, EC2, on-prem, local dev), use the AWS shared-config role-chaining mechanism. Define a profile that names a `source_profile` and a `role_arn`, and run ocync with `AWS_PROFILE=<chain-profile>`:
+
+```ini
+# ~/.aws/config
+[profile ocync-base]
+region = us-east-1
+# Resolves base credentials from env, IMDS, or another source
+
+[profile ocync-target]
+source_profile = ocync-base
+role_arn = arn:aws:iam::DESTINATION_ACCOUNT:role/ocync-target
+```
+
+```bash
+AWS_PROFILE=ocync-target ocync sync --config ocync.yaml
+```
+
+The AWS SDK handles the `AssumeRole` call and credential refresh transparently. This works for one destination role per ocync invocation; if you need different roles per registry in a single process, file an issue describing the deployment shape — there is no built-in support today, and the workarounds (one process per role, or unified cross-account repository policies) cover most cases.


### PR DESCRIPTION
## Summary

Adds a "Multi-account access" section to the ECR docs page covering the three established patterns for mirroring images across multiple AWS accounts.

## Why

During review of #68 we considered building per-registry AWS credential overrides (a `aws:` block on each registry definition with `profile` / `role_arn` / `external_id` / `session_name`). After working through the design and validation rules, we concluded the feature is too niche to earn its complexity:

- Modern EKS deployments cover cross-account natively via Pod Identity `targetRoleArn`.
- Cross-account ECR repository policies cover most non-EKS cases with one principal.
- AWS shared-config role chains (`source_profile` + `role_arn`) cover non-EKS hosts that need a single assume-role hop.

The remaining slice (single ocync process, multiple destination accounts, each with a different role, on a non-EKS host) is small enough that we'd rather wait for a real user to file an issue with their specific deployment shape than build for a hypothetical scenario.

What was missing was documentation pointing users at the right existing pattern. This PR fixes that.

## Contents

Three patterns in `docs/src/content/registries/ecr.md`, in order of preference:

1. **Cross-account ECR repository policies** — simplest, works everywhere.
2. **EKS Pod Identity with `targetRoleArn`** — native cluster-side cross-account.
3. **Shared-config role chains** — for non-EKS hosts via `AWS_PROFILE` + `source_profile`.

Plus a closing note that anyone who can't fit their deployment into these patterns should file an issue describing it. That gives the second observation we'd want before revisiting the feature.

## Verification

- ` npm run --prefix docs build` clean
- 66-line addition to `ecr.md`, no other files touched