### PR TITLE
feat(ecr): per-registry aws_profile for third-party access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
 dependencies = [
  "filetime",
  "futures-core",
@@ -802,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1050,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deadpool"
@@ -1615,9 +1615,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -1859,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1997,9 +1997,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2789,9 +2789,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2816,9 +2816,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3771,9 +3771,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3784,9 +3784,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3794,9 +3794,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3804,9 +3804,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3817,9 +3817,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -3873,9 +3873,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crates/ocync-distribution/CLAUDE.md
+++ b/crates/ocync-distribution/CLAUDE.md
@@ -5,6 +5,7 @@ OCI Distribution Specification client library - registry auth, blob/manifest tra
 ## Auth protocol
 
 - ECR private uses HTTP Basic auth (not Bearer token exchange). AWS SDK `GetAuthorizationToken` returns a pre-encoded base64 token used directly.
+- `EcrAuth::new(hostname, profile)` accepts an optional named AWS profile. When `Some(p)`, the SDK builder calls `.profile_name(p)`, scoping credential resolution to that profile in the shared credentials/config file. When `None`, the ambient default credential chain is used. Per-registry isolation is structural — each `EcrAuth` instance holds its own `SdkConfig` — so a profile override on one registry does not affect any other registry's credential resolution. `EcrPublicAuth` is unchanged (out of scope).
 - ECR Public uses SDK `GetAuthorizationToken` -> decode base64 -> OCI Bearer token exchange with those credentials. SDK tokens are NOT valid as direct Bearer tokens; they must drive standard `/v2/token` exchange.
 - Both ECR providers cache SDK credentials via `SdkCredentialCache<T>` in `auth/ecr.rs` (generic read-lock fast path / write-lock + double-check). New ECR-style providers must use this cache, not hand-roll the RwLock pattern.
 - GAR/GCR uses `google-cloud-auth` ADC (`devstorage.read_write` scope) -> `oauth2accesstoken:<token>` Basic creds -> `token_exchange::exchange()` -> Bearer token. Same flow as ECR Public. Auto-detected via `ProviderKind::Gar`/`Gcr`. SDK credential TTL is 600s (conservative: `google-cloud-auth` does not expose `expires_in`). Implementation in `auth/gcp.rs`.

--- a/crates/ocync-distribution/src/auth/ecr.rs
+++ b/crates/ocync-distribution/src/auth/ecr.rs
@@ -236,6 +236,11 @@ pub(super) fn validate_ecr_token(encoded: &str, registry: &str) -> Result<(), Er
 /// environment variables, shared config/credential files, IMDS/ECS
 /// container credentials, IRSA (IAM Roles for Service Accounts), and
 /// EKS Pod Identity.
+///
+/// A named profile can be supplied at construction time (see
+/// [`EcrAuth::new`]) to scope credential resolution to a specific profile
+/// in the shared credentials/config file, overriding the ambient chain
+/// for this provider instance only.
 pub struct EcrAuth {
     /// The ECR registry hostname.
     hostname: String,
@@ -258,9 +263,15 @@ impl EcrAuth {
     ///
     /// Loads AWS credentials and constructs the ECR SDK client once. Returns
     /// an error if the region cannot be extracted from the hostname.
-    pub async fn new(hostname: impl Into<String>) -> Result<Self, Error> {
+    ///
+    /// When `profile` is `Some`, credential resolution is scoped to that
+    /// named profile in the shared credentials/config file. When `None`,
+    /// the ambient default credential chain is used unchanged. Each
+    /// `EcrAuth` instance holds its own [`aws_config::SdkConfig`], so
+    /// per-instance profile overrides do not leak across registries.
+    pub async fn new(hostname: impl Into<String>, profile: Option<&str>) -> Result<Self, Error> {
         let hostname = hostname.into();
-        let config = crate::ecr::load_sdk_config(&hostname, None)
+        let config = crate::ecr::load_sdk_config(&hostname, profile)
             .await
             .map_err(|e| Error::AuthFailed {
                 registry: hostname.clone(),
@@ -630,8 +641,35 @@ mod tests {
 
     #[tokio::test]
     async fn new_rejects_non_ecr_hostname() {
-        let result = EcrAuth::new("ghcr.io").await;
+        let result = EcrAuth::new("ghcr.io", None).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("region"));
+    }
+
+    #[tokio::test]
+    async fn new_accepts_optional_profile() {
+        // Profile name does not validate here; SDK config load is permissive
+        // about unknown profile names. This test asserts the signature and that
+        // construction itself does not fail.
+        let auth = EcrAuth::new(
+            "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+            Some("nonexistent-test-profile"),
+        )
+        .await;
+        assert!(
+            auth.is_ok(),
+            "EcrAuth::new with profile should succeed: {:?}",
+            auth.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn new_accepts_none_profile() {
+        let auth = EcrAuth::new("123456789012.dkr.ecr.us-east-1.amazonaws.com", None).await;
+        assert!(
+            auth.is_ok(),
+            "EcrAuth::new without profile should succeed: {:?}",
+            auth.err()
+        );
     }
 }

--- a/crates/ocync-distribution/src/auth/ecr.rs
+++ b/crates/ocync-distribution/src/auth/ecr.rs
@@ -260,13 +260,12 @@ impl EcrAuth {
     /// an error if the region cannot be extracted from the hostname.
     pub async fn new(hostname: impl Into<String>) -> Result<Self, Error> {
         let hostname = hostname.into();
-        let config =
-            crate::ecr::load_sdk_config(&hostname)
-                .await
-                .map_err(|e| Error::AuthFailed {
-                    registry: hostname.clone(),
-                    reason: format!("failed to load AWS SDK config: {e}"),
-                })?;
+        let config = crate::ecr::load_sdk_config(&hostname, None)
+            .await
+            .map_err(|e| Error::AuthFailed {
+                registry: hostname.clone(),
+                reason: format!("failed to load AWS SDK config: {e}"),
+            })?;
 
         let ecr_client = aws_sdk_ecr::Client::new(&config);
         let registry = hostname.clone();

--- a/crates/ocync-distribution/src/auth/ecr.rs
+++ b/crates/ocync-distribution/src/auth/ecr.rs
@@ -236,11 +236,6 @@ pub(super) fn validate_ecr_token(encoded: &str, registry: &str) -> Result<(), Er
 /// environment variables, shared config/credential files, IMDS/ECS
 /// container credentials, IRSA (IAM Roles for Service Accounts), and
 /// EKS Pod Identity.
-///
-/// A named profile can be supplied at construction time (see
-/// [`EcrAuth::new`]) to scope credential resolution to a specific profile
-/// in the shared credentials/config file, overriding the ambient chain
-/// for this provider instance only.
 pub struct EcrAuth {
     /// The ECR registry hostname.
     hostname: String,
@@ -659,16 +654,6 @@ mod tests {
         assert!(
             auth.is_ok(),
             "EcrAuth::new with profile should succeed: {:?}",
-            auth.err()
-        );
-    }
-
-    #[tokio::test]
-    async fn new_accepts_none_profile() {
-        let auth = EcrAuth::new("123456789012.dkr.ecr.us-east-1.amazonaws.com", None).await;
-        assert!(
-            auth.is_ok(),
-            "EcrAuth::new without profile should succeed: {:?}",
             auth.err()
         );
     }

--- a/crates/ocync-distribution/src/ecr.rs
+++ b/crates/ocync-distribution/src/ecr.rs
@@ -55,20 +55,34 @@ fn ecr_registry_id(hostname: &str) -> Option<&str> {
     }
 }
 
-/// Load an AWS SDK config for the given ECR hostname.
+/// Load an SDK config for the given ECR hostname.
 ///
 /// Extracts the region from the hostname and configures the SDK with it.
 /// FIPS endpoint support is handled at the SDK level: set
 /// `AWS_USE_FIPS_ENDPOINT=true` before calling this function.
-pub(crate) async fn load_sdk_config(hostname: &str) -> Result<aws_config::SdkConfig, Error> {
+///
+/// When `profile` is `Some`, the SDK builder calls
+/// [`aws_config::ConfigLoader::profile_name`] to scope credential resolution
+/// to that named profile in the shared credentials/config file. When `None`,
+/// the ambient default credential chain is used unchanged (env vars,
+/// shared-config `[default]`, IRSA, EKS Pod Identity, IMDS).
+///
+/// Profile-not-found errors do not surface here; they surface at the first
+/// ECR API call as `Error::AuthFailed`.
+pub(crate) async fn load_sdk_config(
+    hostname: &str,
+    profile: Option<&str>,
+) -> Result<aws_config::SdkConfig, Error> {
     let region = ecr_region(hostname).ok_or_else(|| Error::EcrApi {
         reason: format!("cannot extract AWS region from ECR hostname '{hostname}'"),
     })?;
 
-    Ok(aws_config::defaults(BehaviorVersion::latest())
-        .region(aws_config::Region::new(region.to_owned()))
-        .load()
-        .await)
+    let mut builder = aws_config::defaults(BehaviorVersion::latest())
+        .region(aws_config::Region::new(region.to_owned()));
+    if let Some(p) = profile {
+        builder = builder.profile_name(p);
+    }
+    Ok(builder.load().await)
 }
 
 /// Maximum number of layer digests per `BatchCheckLayerAvailability` API call.
@@ -205,7 +219,7 @@ impl BatchChecker {
     /// then builds an SDK config and ECR client internally. Returns an error
     /// if the region cannot be determined from the hostname.
     pub async fn from_hostname(hostname: &str) -> Result<Self, Error> {
-        let sdk_config = load_sdk_config(hostname).await?;
+        let sdk_config = load_sdk_config(hostname, None).await?;
         let registry_id = ecr_registry_id(hostname).map(|s| s.to_owned());
         let client = aws_sdk_ecr::Client::new(&sdk_config);
         Ok(Self {
@@ -737,5 +751,32 @@ mod tests {
     fn batch_blob_checker_is_object_safe() {
         // Verify the trait can be used as Rc<dyn BatchBlobChecker>.
         fn _assert_object_safe(_: std::rc::Rc<dyn BatchBlobChecker>) {}
+    }
+}
+
+#[cfg(test)]
+mod profile_tests {
+    use super::load_sdk_config;
+
+    #[tokio::test]
+    async fn load_sdk_config_accepts_none_profile() {
+        let cfg = load_sdk_config("123456789012.dkr.ecr.us-east-1.amazonaws.com", None)
+            .await
+            .unwrap();
+        assert_eq!(cfg.region().map(|r| r.as_ref()), Some("us-east-1"));
+    }
+
+    #[tokio::test]
+    async fn load_sdk_config_accepts_named_profile() {
+        // Profile-not-found does NOT error at config-load time -- it surfaces
+        // at the first SDK API call. This test asserts the load itself succeeds
+        // with an unknown profile name.
+        let cfg = load_sdk_config(
+            "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+            Some("nonexistent-profile-for-test"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(cfg.region().map(|r| r.as_ref()), Some("us-east-1"));
     }
 }

--- a/crates/ocync-distribution/src/ecr.rs
+++ b/crates/ocync-distribution/src/ecr.rs
@@ -61,14 +61,9 @@ fn ecr_registry_id(hostname: &str) -> Option<&str> {
 /// FIPS endpoint support is handled at the SDK level: set
 /// `AWS_USE_FIPS_ENDPOINT=true` before calling this function.
 ///
-/// When `profile` is `Some`, the SDK builder calls
-/// [`aws_config::ConfigLoader::profile_name`] to scope credential resolution
-/// to that named profile in the shared credentials/config file. When `None`,
-/// the ambient default credential chain is used unchanged (env vars,
-/// shared-config `[default]`, IRSA, EKS Pod Identity, IMDS).
-///
-/// Profile-not-found errors do not surface here; they surface at the first
-/// ECR API call as `Error::AuthFailed`.
+/// When `profile` is `Some`, credential resolution is scoped to that named
+/// profile; when `None`, the ambient credential chain is used. Profile-not-found
+/// errors surface at the first ECR API call, not here.
 pub(crate) async fn load_sdk_config(
     hostname: &str,
     profile: Option<&str>,
@@ -218,8 +213,14 @@ impl BatchChecker {
     /// Extracts the AWS region and 12-digit registry ID from the hostname,
     /// then builds an SDK config and ECR client internally. Returns an error
     /// if the region cannot be determined from the hostname.
-    pub async fn from_hostname(hostname: &str) -> Result<Self, Error> {
-        let sdk_config = load_sdk_config(hostname, None).await?;
+    ///
+    /// `profile` must match the value passed to the corresponding
+    /// [`crate::auth::EcrAuth::new`]; otherwise the batch checker authenticates
+    /// as a different identity than the auth provider, which silently breaks
+    /// `BatchCheckLayerAvailability` for registries reachable only via the
+    /// named profile.
+    pub async fn from_hostname(hostname: &str, profile: Option<&str>) -> Result<Self, Error> {
+        let sdk_config = load_sdk_config(hostname, profile).await?;
         let registry_id = ecr_registry_id(hostname).map(|s| s.to_owned());
         let client = aws_sdk_ecr::Client::new(&sdk_config);
         Ok(Self {
@@ -752,25 +753,25 @@ mod tests {
         // Verify the trait can be used as Rc<dyn BatchBlobChecker>.
         fn _assert_object_safe(_: std::rc::Rc<dyn BatchBlobChecker>) {}
     }
-}
-
-#[cfg(test)]
-mod profile_tests {
-    use super::load_sdk_config;
 
     #[tokio::test]
-    async fn load_sdk_config_accepts_none_profile() {
-        let cfg = load_sdk_config("123456789012.dkr.ecr.us-east-1.amazonaws.com", None)
-            .await
-            .unwrap();
-        assert_eq!(cfg.region().map(|r| r.as_ref()), Some("us-east-1"));
+    async fn batch_checker_from_hostname_accepts_named_profile() {
+        // Pins the BatchChecker / EcrAuth symmetry: both must thread the same
+        // profile, otherwise sync runs against profile-scoped registries get
+        // split-brain auth.
+        let checker = BatchChecker::from_hostname(
+            "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+            Some("nonexistent-profile-for-test"),
+        )
+        .await;
+        assert!(checker.is_ok(), "{:?}", checker.err());
     }
 
     #[tokio::test]
     async fn load_sdk_config_accepts_named_profile() {
-        // Profile-not-found does NOT error at config-load time -- it surfaces
-        // at the first SDK API call. This test asserts the load itself succeeds
-        // with an unknown profile name.
+        // SdkConfig has no public profile accessor, so this only verifies the
+        // load path itself does not reject an unknown profile name (resolution
+        // is deferred to the first SDK API call).
         let cfg = load_sdk_config(
             "123456789012.dkr.ecr.us-east-1.amazonaws.com",
             Some("nonexistent-profile-for-test"),

--- a/docs/public/config.schema.json
+++ b/docs/public/config.schema.json
@@ -383,6 +383,14 @@
             }
           ]
         },
+        "aws_profile": {
+          "description": "Named AWS profile for ECR credential resolution.\n\nWhen set, ECR auth for this registry uses `aws_config::ConfigLoader::profile_name(p)` instead of the ambient credential chain. Only valid with explicit `auth_type: ecr`.\n\nUse this when the registry requires credentials distinct from the ambient identity (for example, a third-party ECR accessed with static IAM-user keys while the ambient chain serves the rest of the workload).",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "credentials": {
           "description": "Credentials for Basic auth (`auth_type: basic`).",
           "default": null,

--- a/docs/src/content/registries/ecr.md
+++ b/docs/src/content/registries/ecr.md
@@ -127,7 +127,7 @@ For other secret-injection patterns (External Secrets Operator, CSI Secrets Stor
 
 ## Multi-account access
 
-ocync uses one ambient AWS credential chain per process. Syncing across accounts (e.g., one source ECR plus several target ECRs in different accounts) means giving that one principal the right permissions for every account it touches. There are three patterns, in order of preference.
+ocync uses one ambient AWS credential chain per process. Syncing across accounts (e.g., one source ECR plus several target ECRs in different accounts) means giving that one principal the right permissions for every account it touches. There are four patterns, in order of preference.
 
 ### Cross-account ECR repository policies
 
@@ -189,4 +189,36 @@ role_arn = arn:aws:iam::DESTINATION_ACCOUNT:role/ocync-target
 AWS_PROFILE=ocync-target ocync sync --config ocync.yaml
 ```
 
-The AWS SDK handles the `AssumeRole` call and credential refresh transparently. This works for one destination role per ocync invocation; if you need different roles per registry in a single process, file an issue describing the deployment shape — there is no built-in support today, and the workarounds (one process per role, or unified cross-account repository policies) cover most cases.
+The AWS SDK handles the `AssumeRole` call and credential refresh transparently. The whole-process `AWS_PROFILE` mechanism applies one profile to every ECR registry; for per-registry overrides, see the next section.
+
+### Per-registry static credentials (third-party access)
+
+Use this when one ECR registry needs credentials distinct from the ambient chain. The canonical case is a third-party ECR accessed with static IAM-user keys: Pod Identity / IRSA serves your own ECRs, and one specific registry uses keys the third party issued.
+
+The `aws_profile` per-registry field scopes ECR credential resolution for that registry to a named AWS profile, leaving every other ECR registry on the ambient chain.
+
+```yaml
+registries:
+  my-source:
+    url: 111111111111.dkr.ecr.us-east-1.amazonaws.com
+    auth_type: ecr
+    # no aws_profile -> ambient chain (Pod Identity, IRSA, env, IMDS)
+
+  vendor-source:
+    url: 222222222222.dkr.ecr.us-east-1.amazonaws.com
+    auth_type: ecr        # required when aws_profile is set
+    aws_profile: vendor   # reads [vendor] from the shared credentials file
+```
+
+Author the credentials file with the section the third party gave you:
+
+```ini
+[vendor]
+aws_access_key_id = AKIA...
+aws_secret_access_key = ...
+# session_token = ...   # only if they issued STS temporary credentials
+```
+
+The AWS SDK reads the file from `~/.aws/credentials` by default, or from the path in `AWS_SHARED_CREDENTIALS_FILE`. The file does not need a `[default]` section — the ambient chain skips the file entirely when no profile is named, so Pod Identity / IRSA still serves `my-source`.
+
+For Kubernetes deployments, see the AWS shared-config files section of [Kubernetes secrets](./secrets) for two production-grade injection patterns (External Secrets Operator and CSI Secrets Store).

--- a/docs/src/content/registries/secrets.md
+++ b/docs/src/content/registries/secrets.md
@@ -150,6 +150,79 @@ The Azure provider sets both the SA annotation (`azure.workload.identity/client-
 
 EKS Pod Identity is *not* represented in `workloadIdentity` because it is configured cluster-side via `PodIdentityAssociation` (not via the pod spec). Set up the association out-of-band and link it to the chart's ServiceAccount; no chart values are needed.
 
+## AWS shared-config files
+
+Use this pattern when one ECR registry needs credentials distinct from the ambient chain (see [ECR per-registry profile](./ecr#per-registry-static-credentials-third-party-access)). The `aws_profile` config field reads from a credentials file mounted at the path in `AWS_SHARED_CREDENTIALS_FILE`; this section covers two production-grade ways to populate that file.
+
+The recommended secret-store layout is to store the entire INI blob -- including the `[profile-name]` header -- as a single string value at one key. This keeps the chart values minimal and avoids per-field templating.
+
+### External Secrets Operator (AWS shared-config)
+
+The third party's credentials are mirrored into AWS Secrets Manager, Vault, Azure Key Vault, GCP Secret Manager, or another store. ESO syncs to a native `Secret` that the chart mounts as a file:
+
+```yaml
+# values.yaml
+externalSecrets:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: cluster-secret-store
+    kind: ClusterSecretStore
+  data:
+    - secretKey: credentials
+      remoteRef:
+        key: vendor/aws-creds   # value: full INI blob, one string
+
+extraVolumes:
+  - name: aws-creds
+    secret:
+      secretName: my-release-ocync   # default ExternalSecret target
+extraVolumeMounts:
+  - name: aws-creds
+    mountPath: /etc/aws
+    readOnly: true
+env:
+  - name: AWS_SHARED_CREDENTIALS_FILE
+    value: /etc/aws/credentials
+```
+
+Rotation handled upstream; audit trail in the source store; nothing plaintext in your repos.
+
+If your secret store holds the access key and secret key as separate fields, flatten them upstream into a single INI blob value. The chart does not currently expose ESO's `target.template:` for in-cluster assembly; if you have a hard requirement to keep them separate at rest, open an issue describing the constraint.
+
+### CSI Secrets Store driver (AWS shared-config)
+
+For clusters where policy mandates the CSI driver and forbids long-lived `Secret` resources. Same source-of-truth as the ESO path, but the driver mounts directly from the cloud secret store:
+
+```yaml
+# values.yaml
+secretProviderClass:
+  enabled: true
+  provider: aws  # | azure | gcp | vault
+  parameters:
+    objects: |
+      - objectName: vendor/aws-creds
+        objectType: secretsmanager
+        objectAlias: credentials
+
+extraVolumes:
+  - name: aws-creds
+    csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: ocync   # release name (matches the existing CSI section above)
+extraVolumeMounts:
+  - name: aws-creds
+    mountPath: /etc/aws
+    readOnly: true
+env:
+  - name: AWS_SHARED_CREDENTIALS_FILE
+    value: /etc/aws/credentials
+```
+
+The CSI race-on-startup behavior described in the [CSI Secrets Store](#csi-secrets-store) section above applies here too: the file may not exist for the first few seconds after a brand-new pod starts.
+
 ## Combining patterns
 
 A typical mixed deployment (mirror from Docker Hub to ECR using IRSA + envFrom):

--- a/src/cli/auth_dispatch_tests.rs
+++ b/src/cli/auth_dispatch_tests.rs
@@ -488,3 +488,20 @@ fn auth_type_ecr_public_is_a_parse_error() {
         "auth_type 'ecr_public' must be rejected at parse time (no AuthType::EcrPublic variant)"
     );
 }
+
+#[tokio::test]
+async fn ecr_dispatch_with_aws_profile_succeeds() {
+    let cfg = RegistryConfig {
+        url: "123456789012.dkr.ecr.us-east-1.amazonaws.com".to_owned(),
+        auth_type: Some(AuthType::Ecr),
+        credentials: None,
+        token: None,
+        max_concurrent: None,
+        head_first: false,
+        aws_profile: Some("vendor".to_owned()),
+    };
+    let client = build_registry_client("123456789012.dkr.ecr.us-east-1.amazonaws.com", Some(&cfg))
+        .await
+        .expect("ECR dispatch with aws_profile should succeed");
+    assert_eq!(client.auth_name(), Some("ecr"));
+}

--- a/src/cli/auth_dispatch_tests.rs
+++ b/src/cli/auth_dispatch_tests.rs
@@ -84,6 +84,7 @@ fn config(url: &str, auth_type: Option<AuthType>) -> RegistryConfig {
         token: None,
         max_concurrent: None,
         head_first: false,
+        aws_profile: None,
     }
 }
 
@@ -98,6 +99,7 @@ fn config_with_basic(url: &str) -> RegistryConfig {
         token: None,
         max_concurrent: None,
         head_first: false,
+        aws_profile: None,
     }
 }
 
@@ -109,6 +111,7 @@ fn config_with_token(url: &str) -> RegistryConfig {
         token: Some("ci-token".to_owned()),
         max_concurrent: None,
         head_first: false,
+        aws_profile: None,
     }
 }
 
@@ -162,6 +165,7 @@ async fn auth_type_token_alias_dispatches_to_static_token() {
         token: Some("ci-token".to_owned()),
         max_concurrent: None,
         head_first: false,
+        aws_profile: None,
     };
     let client = build_registry_client(&cfg.url, Some(&cfg))
         .await

--- a/src/cli/auth_dispatch_tests.rs
+++ b/src/cli/auth_dispatch_tests.rs
@@ -488,20 +488,3 @@ fn auth_type_ecr_public_is_a_parse_error() {
         "auth_type 'ecr_public' must be rejected at parse time (no AuthType::EcrPublic variant)"
     );
 }
-
-#[tokio::test]
-async fn ecr_dispatch_with_aws_profile_succeeds() {
-    let cfg = RegistryConfig {
-        url: "123456789012.dkr.ecr.us-east-1.amazonaws.com".to_owned(),
-        auth_type: Some(AuthType::Ecr),
-        credentials: None,
-        token: None,
-        max_concurrent: None,
-        head_first: false,
-        aws_profile: Some("vendor".to_owned()),
-    };
-    let client = build_registry_client("123456789012.dkr.ecr.us-east-1.amazonaws.com", Some(&cfg))
-        .await
-        .expect("ECR dispatch with aws_profile should succeed");
-    assert_eq!(client.auth_name(), Some("ecr"));
-}

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -261,7 +261,7 @@ async fn build_batch_checkers(
             continue;
         }
 
-        let checker = BatchChecker::from_hostname(hostname)
+        let checker = BatchChecker::from_hostname(hostname, reg.aws_profile.as_deref())
             .await
             .map_err(|e| CliError::Input(format!("ECR batch checker for '{name}': {e}")))?;
         checkers.insert(name.clone(), Rc::new(checker));

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -232,6 +232,18 @@ pub(crate) struct RegistryConfig {
     /// quotas (e.g., Docker Hub).
     #[serde(default)]
     pub head_first: bool,
+
+    /// Named AWS profile for ECR credential resolution.
+    ///
+    /// When set, ECR auth for this registry uses
+    /// `aws_config::ConfigLoader::profile_name(p)` instead of the ambient
+    /// credential chain. Only valid with explicit `auth_type: ecr`.
+    ///
+    /// Use this when the registry requires credentials distinct from the
+    /// ambient identity (for example, a third-party ECR accessed with static
+    /// IAM-user keys while the ambient chain serves the rest of the workload).
+    #[serde(default)]
+    pub aws_profile: Option<String>,
 }
 
 impl std::fmt::Debug for RegistryConfig {
@@ -243,6 +255,7 @@ impl std::fmt::Debug for RegistryConfig {
             .field("head_first", &self.head_first)
             .field("credentials", &self.credentials)
             .field("token", &"[REDACTED]")
+            .field("aws_profile", &self.aws_profile)
             .finish()
     }
 }
@@ -1582,6 +1595,7 @@ mappings:
             credentials: None,
             token: None,
             head_first: false,
+            aws_profile: None,
         };
         let err = validate_registry("example", &registry).unwrap_err();
         match err {
@@ -1602,6 +1616,7 @@ mappings:
             credentials: None,
             token: None,
             head_first: false,
+            aws_profile: None,
         };
         validate_registry("example", &registry).unwrap();
     }
@@ -1741,10 +1756,46 @@ mappings:
             credentials: None,
             token: Some("secret-bearer-token".to_string()),
             head_first: false,
+            aws_profile: None,
         };
         let debug_output = format!("{registry:?}");
         assert!(debug_output.contains("[REDACTED]"));
         assert!(!debug_output.contains("secret-bearer-token"));
+    }
+
+    #[test]
+    fn parses_registry_with_aws_profile() {
+        let yaml = r#"
+registries:
+  vendor:
+    url: 222222222222.dkr.ecr.us-east-1.amazonaws.com
+    auth_type: ecr
+    aws_profile: vendor
+mappings:
+  - from: nginx
+    tags:
+      glob: "*"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let reg = &config.registries["vendor"];
+        assert_eq!(reg.auth_type, Some(AuthType::Ecr));
+        assert_eq!(reg.aws_profile.as_deref(), Some("vendor"));
+    }
+
+    #[test]
+    fn registry_aws_profile_defaults_to_none() {
+        let yaml = r#"
+registries:
+  ecr:
+    url: 123456789012.dkr.ecr.us-east-1.amazonaws.com
+    auth_type: ecr
+mappings:
+  - from: nginx
+    tags:
+      glob: "*"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.registries["ecr"].aws_profile, None);
     }
 
     // - ArtifactsConfig -------------------------------------------------------

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -2017,9 +2017,17 @@ mappings:
             head_first: false,
             aws_profile: Some("vendor".to_string()),
         };
-        let err = validate_registry("vendor", &registry).unwrap_err().to_string();
-        assert!(err.contains("aws_profile"), "error must mention aws_profile: {err}");
-        assert!(err.contains("auth_type"), "error must mention auth_type: {err}");
+        let err = validate_registry("vendor", &registry)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("aws_profile"),
+            "error must mention aws_profile: {err}"
+        );
+        assert!(
+            err.contains("auth_type"),
+            "error must mention auth_type: {err}"
+        );
         assert!(err.contains("ecr"), "error must mention ecr: {err}");
     }
 
@@ -2037,8 +2045,13 @@ mappings:
             head_first: false,
             aws_profile: Some("vendor".to_string()),
         };
-        let err = validate_registry("vendor", &registry).unwrap_err().to_string();
-        assert!(err.contains("aws_profile"), "error must mention aws_profile: {err}");
+        let err = validate_registry("vendor", &registry)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("aws_profile"),
+            "error must mention aws_profile: {err}"
+        );
         assert!(err.contains("ecr"), "error must mention ecr: {err}");
     }
 
@@ -2053,8 +2066,13 @@ mappings:
             head_first: false,
             aws_profile: Some(String::new()),
         };
-        let err = validate_registry("vendor", &registry).unwrap_err().to_string();
-        assert!(err.contains("aws_profile"), "error must mention aws_profile: {err}");
+        let err = validate_registry("vendor", &registry)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("aws_profile"),
+            "error must mention aws_profile: {err}"
+        );
         assert!(err.contains("empty"), "error must mention empty: {err}");
     }
 }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -644,6 +644,22 @@ fn validate_registry(name: &str, registry: &RegistryConfig) -> Result<(), Config
         }
     }
 
+    if let Some(ref profile) = registry.aws_profile {
+        if profile.is_empty() {
+            return Err(ConfigError::Validation(format!(
+                "registries.{name}: aws_profile must not be empty"
+            )));
+        }
+        match registry.auth_type {
+            Some(AuthType::Ecr) => {}
+            _ => {
+                return Err(ConfigError::Validation(format!(
+                    "registries.{name}: aws_profile requires explicit 'auth_type: ecr'"
+                )));
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -1972,5 +1988,73 @@ mappings:
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         let artifacts = config.mappings[0].artifacts.as_ref().unwrap();
         assert!(artifacts.enabled, "enabled should default to true");
+    }
+
+    // - aws_profile validation -----------------------------------------------
+
+    #[test]
+    fn aws_profile_with_ecr_auth_type_passes() {
+        let registry = RegistryConfig {
+            url: "123456789012.dkr.ecr.us-east-1.amazonaws.com".to_string(),
+            auth_type: Some(AuthType::Ecr),
+            max_concurrent: None,
+            credentials: None,
+            token: None,
+            head_first: false,
+            aws_profile: Some("vendor".to_string()),
+        };
+        validate_registry("vendor", &registry).unwrap();
+    }
+
+    #[test]
+    fn aws_profile_without_auth_type_fails() {
+        let registry = RegistryConfig {
+            url: "123456789012.dkr.ecr.us-east-1.amazonaws.com".to_string(),
+            auth_type: None,
+            max_concurrent: None,
+            credentials: None,
+            token: None,
+            head_first: false,
+            aws_profile: Some("vendor".to_string()),
+        };
+        let err = validate_registry("vendor", &registry).unwrap_err().to_string();
+        assert!(err.contains("aws_profile"), "error must mention aws_profile: {err}");
+        assert!(err.contains("auth_type"), "error must mention auth_type: {err}");
+        assert!(err.contains("ecr"), "error must mention ecr: {err}");
+    }
+
+    #[test]
+    fn aws_profile_with_non_ecr_auth_type_fails() {
+        let registry = RegistryConfig {
+            url: "ghcr.io".to_string(),
+            auth_type: Some(AuthType::Basic),
+            max_concurrent: None,
+            credentials: Some(BasicCredentials {
+                username: "u".into(),
+                password: "p".into(),
+            }),
+            token: None,
+            head_first: false,
+            aws_profile: Some("vendor".to_string()),
+        };
+        let err = validate_registry("vendor", &registry).unwrap_err().to_string();
+        assert!(err.contains("aws_profile"), "error must mention aws_profile: {err}");
+        assert!(err.contains("ecr"), "error must mention ecr: {err}");
+    }
+
+    #[test]
+    fn aws_profile_empty_string_fails() {
+        let registry = RegistryConfig {
+            url: "123456789012.dkr.ecr.us-east-1.amazonaws.com".to_string(),
+            auth_type: Some(AuthType::Ecr),
+            max_concurrent: None,
+            credentials: None,
+            token: None,
+            head_first: false,
+            aws_profile: Some(String::new()),
+        };
+        let err = validate_registry("vendor", &registry).unwrap_err().to_string();
+        assert!(err.contains("aws_profile"), "error must mention aws_profile: {err}");
+        assert!(err.contains("empty"), "error must mention empty: {err}");
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -217,8 +217,6 @@ pub(crate) async fn build_registry_client(
 
     let mut builder = match auth_type {
         Some(AuthType::Ecr) => {
-            // aws_profile is only honored on the explicit-auth_type path.
-            // Validation guarantees aws_profile is None on every other branch.
             let profile = registry_config.and_then(|r| r.aws_profile.as_deref());
             let auth = EcrAuth::new(bare_host, profile)
                 .await

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -217,7 +217,10 @@ pub(crate) async fn build_registry_client(
 
     let mut builder = match auth_type {
         Some(AuthType::Ecr) => {
-            let auth = EcrAuth::new(bare_host)
+            // aws_profile is only honored on the explicit-auth_type path.
+            // Validation guarantees aws_profile is None on every other branch.
+            let profile = registry_config.and_then(|r| r.aws_profile.as_deref());
+            let auth = EcrAuth::new(bare_host, profile)
                 .await
                 .map_err(|e| CliError::Input(format!("ECR auth setup for '{bare_host}': {e}")))?;
             RegistryClient::builder(url).auth(auth)
@@ -278,7 +281,7 @@ pub(crate) async fn build_registry_client(
             // the result to avoid redundant regex evaluation.
             match detect_provider_kind(bare_host) {
                 Some(ProviderKind::Ecr) => {
-                    let auth = EcrAuth::new(bare_host).await.map_err(|e| {
+                    let auth = EcrAuth::new(bare_host, None).await.map_err(|e| {
                         CliError::Input(format!("ECR auth setup for '{bare_host}': {e}"))
                     })?;
                     RegistryClient::builder(url).auth(auth)


### PR DESCRIPTION
## Summary

Adds a per-registry `aws_profile` config field for ECR auth, scoping credential resolution for one registry to a named AWS profile while every other ECR registry continues using the ambient credential chain.

The motivating use case: ocync runs in EKS with Pod Identity for the operator's own AWS account, but needs to pull from a third-party ECR using static IAM-user keys the third party issued. Pod Identity / `targetRoleArn` / cross-account repo policies all assume there's a role to assume; static keys from a third party have no role to chain to. Process-level `AWS_PROFILE` would force every ECR registry through one profile, destroying the ambient path. Per-registry `aws_profile` solves this: explicit `auth_type: ecr` registries can opt into a named profile; everything else stays on the ambient chain.

```yaml
registries:
  my-source:
    url: 111111111111.dkr.ecr.us-east-1.amazonaws.com
    auth_type: ecr
    # ambient chain (Pod Identity, IRSA, env, IMDS)

  vendor-source:
    url: 222222222222.dkr.ecr.us-east-1.amazonaws.com
    auth_type: ecr
    aws_profile: vendor   # reads [vendor] from the shared credentials file
```

The shared credentials file (mounted at `~/.aws/credentials` or via `AWS_SHARED_CREDENTIALS_FILE`) doesn't need a `[default]` section — the ambient chain skips the file entirely when no profile is named, so Pod Identity / IRSA still serves `my-source`. Per-registry isolation is structural: each `EcrAuth` and `BatchChecker` instance holds its own `SdkConfig`, no cross-talk.

## What changed

- `RegistryConfig.aws_profile: Option<String>` (purely additive; defaults to `None`)
- Validation: `aws_profile` requires explicit `auth_type: ecr` and rejects empty strings
- `load_sdk_config(host, profile)` calls `aws_config::ConfigLoader::profile_name(p)` when `Some`
- `EcrAuth::new(host, profile)` and `BatchChecker::from_hostname(host, profile)` thread the profile through (the BatchChecker fix is critical — without it, sync runs against profile-scoped registries get split-brain auth)
- Auto-detect ECR branch passes `None` (validation prevents profile-bearing configs from reaching it)
- 8 new tests across 3 files: validation pass/fail, SDK config load, EcrAuth/BatchChecker construction
- Schema regenerated
- `docs/src/content/registries/ecr.md` — replaces "file an issue" caveat with new "Per-registry static credentials" subsection
- `docs/src/content/registries/secrets.md` — new "AWS shared-config files" section with ESO and CSI Secrets Store patterns
- `crates/ocync-distribution/CLAUDE.md` — one bullet noting the new `EcrAuth::new` parameter

No new dependencies. No chart changes — existing `extraVolumes` / `extraVolumeMounts` / `env` / `externalSecrets` / `secretProviderClass` knobs cover both Kubernetes deployment patterns documented.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (1241 passed, 1 ignored)
- [x] `npm run --prefix docs build`
- [x] `helm template charts/ocync -f charts/ocync/ci/*.yaml | kubeconform -` across all 5 fixtures
- [ ] Manual smoke test against a real third-party ECR with static IAM-user credentials before adopting the feature in production