### PR TITLE
chore(release): skip cargo publish for root crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ license.workspace = true
 repository.workspace = true
 description = "OCI registry sync tool"
 
+[package.metadata.release]
+publish = false
+
 [features]
 default = ["fips"]
 fips = ["ocync-distribution/fips"]


### PR DESCRIPTION
## Summary

- `cargo release minor` failed when cargo-release attempted `cargo publish` on the root crate: workspace path deps (`ocync-distribution`, `ocync-sync`) have no `version = "..."` requirement, so the published manifest would have unresolvable dependencies.
- Per `.github/RELEASING.md`, the release flow is tag-driven (binaries / Docker / Helm); crates.io is not a target. The library crates are already opted out via `[package.metadata.release] release = false`. The root crate just needed the same opt-out for the publish step specifically.
- Adds `[package.metadata.release] publish = false` to the root `Cargo.toml`. Cargo-release still bumps the version, regenerates `Cargo.lock`, commits, tags, and pushes — only the `cargo publish` step is skipped.

Verified by re-running `cargo release minor` (dry-run): output now matches an explicit `--no-publish` invocation exactly. `[package.metadata.*]` is opaque to cargo, so build/test behavior is unchanged.

## Test plan

- [x] `cargo release minor` (dry-run) no longer attempts `cargo publish`
- [x] `cargo metadata` parses cleanly
- [ ] On merge, retry `cargo release minor --execute` from a clean main checkout