### PR TITLE
fix(docs): rewrite internal links to root-absolute slugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Each crate has its own CLAUDE.md with targeted context:
 - `crates/ocync-distribution/CLAUDE.md` - auth protocols, AIMD, registry detection, upload quirks, testing (wiremock/testcontainers)
 - `crates/ocync-sync/CLAUDE.md` - concurrency model, RefCell rules, notify contracts, leader-follower, engine architecture, testing
 - `bench/CLAUDE.md` - benchmark infrastructure, bench-proxy, competitor config gotchas, instance ops
+- `docs/CLAUDE.md` - cross-page link convention, build-time link plugin, GH Pages trailing-slash bug class, link-verification approach
 
 ## Design priorities
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,40 @@
+# docs
+
+Astro static site, deployed to GitHub Pages at <https://clowdhaus.github.io/ocync/>.
+
+## Cross-page link convention
+
+All internal markdown links use root-absolute slug paths. The remark plugin `plugins/rewrite-internal-links.mjs` prepends the Astro `base` and rejects relative paths at build time.
+
+```markdown
+[Helm chart](/helm)                  -> /ocync/helm
+[ECR auth](/registries/ecr#auth)     -> /ocync/registries/ecr#auth
+[Schema](/config.schema.json)        -> /ocync/config.schema.json
+[Helm](./helm)                       build error
+[Helm](../helm)                      build error
+```
+
+The reason is GitHub Pages serves both `/ocync/foo` and `/ocync/foo/` from the same `dist/foo/index.html`. Relative `href`s like `./bar` resolve to `/ocync/foo/bar` (404) under the trailing-slash variant. Root-absolute hrefs are immune to the document URL.
+
+## Verifying links
+
+Status checks on canonical URLs are not enough. To catch the trailing-slash class, resolve every `<a href>` against both the canonical and the trailing-slash form of the document URL and assert the resolved paths match. Pure `#fragment` hrefs are exempt.
+
+```python
+canon = urlparse(urljoin(doc_url,        href)).path
+slash = urlparse(urljoin(doc_url + "/",  href)).path
+assert canon == slash
+```
+
+`urllib.parse.urljoin` canonicalizes before joining when called from a slash-free document URL, which hides the bug. The two-form check is the actual reproduction.
+
+When the user reports a specific dead URL, fetch that exact URL first and reproduce its failing href. Do not re-run a crawler that already passed -- it has a blind spot, or it would not have passed.
+
+## Build commands
+
+```bash
+npm install                           # once
+npm run dev                           # base = /, http://localhost:4321
+NODE_ENV=production npm run build     # base = /ocync/, output in dist/
+npm run preview                       # serve dist/ at http://localhost:4321/ocync/
+```

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -3,17 +3,22 @@ import sitemap from "@astrojs/sitemap";
 import rehypeSlug from "rehype-slug";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeExternalLinks from "rehype-external-links";
+import { rewriteInternalLinks } from "./plugins/rewrite-internal-links.mjs";
 import ocyncLight from "./src/themes/ocync-light.json";
 import ocyncDark from "./src/themes/ocync-dark.json";
 
 const isProd = process.env.NODE_ENV === "production";
+const base = isProd ? "/ocync/" : "/";
 
 export default defineConfig({
   site: "https://clowdhaus.github.io",
-  base: isProd ? "/ocync/" : "/",
+  base,
   trailingSlash: "never",
   integrations: [sitemap()],
   markdown: {
+    remarkPlugins: [
+      [rewriteInternalLinks, { base }],
+    ],
     rehypePlugins: [
       rehypeSlug,
       [rehypeAutolinkHeadings, {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -7,7 +7,7 @@
       "name": "ocync-docs",
       "dependencies": {
         "@astrojs/sitemap": "3.7.2",
-        "astro": "6.1.9",
+        "astro": "6.1.10",
         "rehype-autolink-headings": "^7.1.0",
         "rehype-external-links": "^3.0.0",
         "rehype-slug": "^6.0.0"
@@ -156,25 +156,31 @@
       }
     },
     "node_modules/@clack/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.3.0.tgz",
+      "integrity": "sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA==",
       "license": "MIT",
       "dependencies": {
-        "fast-wrap-ansi": "^0.1.3",
+        "fast-wrap-ansi": "^0.2.0",
         "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
       }
     },
     "node_modules/@clack/prompts": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.2.0.tgz",
-      "integrity": "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.3.0.tgz",
+      "integrity": "sha512-GgcWwRCs/xPtaqlMy8qRhPnZf9vlWcWZNHAitnVQ3yk7JmSralSiq5q07yaffYE8SogtDm7zFeKccx1QNVARpw==",
       "license": "MIT",
       "dependencies": {
-        "@clack/core": "1.2.0",
-        "fast-string-width": "^1.1.0",
-        "fast-wrap-ansi": "^0.1.3",
+        "@clack/core": "1.3.0",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
         "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -696,9 +702,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -714,9 +717,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -734,9 +734,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -752,9 +749,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -772,9 +766,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -790,9 +781,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -810,9 +798,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -829,9 +814,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -847,9 +829,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -873,9 +852,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -897,9 +873,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -923,9 +896,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -947,9 +917,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -973,9 +940,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -998,9 +962,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1022,9 +983,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1236,9 +1194,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1251,9 +1206,6 @@
       "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1268,9 +1220,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1283,9 +1232,6 @@
       "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1300,9 +1246,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1315,9 +1258,6 @@
       "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1332,9 +1272,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1347,9 +1284,6 @@
       "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1364,9 +1298,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1379,9 +1310,6 @@
       "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1396,9 +1324,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1412,9 +1337,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1427,9 +1349,6 @@
       "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1750,9 +1669,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.1.9",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.9.tgz",
-      "integrity": "sha512-NsAHzMzpznB281g2aM5qnBt2QjfH6ttKiZ3hSZw52If8JJ+62kbnBKbyKhR2glQcJLl7Jfe4GSl0DihFZ36rRQ==",
+      "version": "6.1.10",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.10.tgz",
+      "integrity": "sha512-jQAIki6c862oxRr7OXXC+h3n4wg1EpmKgCH3vv1FtXM9VFmD2iTjlaxrfb0I6eQCwtUjSBxfJBFBDSXHu7Wing==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^3.0.1",
@@ -2244,9 +2163,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -2321,27 +2240,27 @@
       "license": "MIT"
     },
     "node_modules/fast-string-truncated-width": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
-      "integrity": "sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
       "license": "MIT"
     },
     "node_modules/fast-string-width": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-1.1.0.tgz",
-      "integrity": "sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
       "license": "MIT",
       "dependencies": {
-        "fast-string-truncated-width": "^1.2.0"
+        "fast-string-truncated-width": "^3.0.2"
       }
     },
     "node_modules/fast-wrap-ansi": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.1.6.tgz",
-      "integrity": "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
       "license": "MIT",
       "dependencies": {
-        "fast-string-width": "^1.1.0"
+        "fast-string-width": "^3.0.2"
       }
     },
     "node_modules/fdir": {
@@ -3752,12 +3671,12 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.2.tgz",
-      "integrity": "sha512-ktsDOALzTYTWWF1PbkNVg2rOt+HaOaMWJMUnt7T3qf5tvZ1L8dBW3tObzprBcXNMKkwj+yFSLqHso0x+UFcJXw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.2.0.tgz",
+      "integrity": "sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==",
       "license": "MIT",
       "dependencies": {
-        "eventemitter3": "^5.0.1",
+        "eventemitter3": "^5.0.4",
         "p-timeout": "^7.0.0"
       },
       "engines": {
@@ -3840,9 +3759,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",
@@ -4431,9 +4350,9 @@
       }
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4503,9 +4422,9 @@
       "optional": true
     },
     "node_modules/ufo": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "license": "MIT"
     },
     "node_modules/ultrahtml": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "3.7.2",
-    "astro": "6.1.9",
+    "astro": "6.1.10",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-external-links": "^3.0.0",
     "rehype-slug": "^6.0.0"

--- a/docs/plugins/rewrite-internal-links.mjs
+++ b/docs/plugins/rewrite-internal-links.mjs
@@ -1,0 +1,61 @@
+// Rewrite cross-page markdown links into root-absolute URLs prefixed with the
+// Astro `base`. This guarantees that links resolve identically regardless of
+// whether the host serves the page at the canonical URL (no trailing slash)
+// or at the directory variant (with trailing slash) -- a distinction GitHub
+// Pages erases by serving both variants of every directory page.
+//
+// Convention for cross-page links in markdown source:
+//
+//   `/some/page`         -- root-absolute slug; rewritten to `${base}some/page`
+//   `/some/page#anchor`  -- same, with fragment preserved
+//   `#anchor`            -- in-page anchor, left alone
+//   `https://...`,
+//   `mailto:`, `tel:`    -- left alone
+//
+// Relative forms (`./foo`, `../foo`) are intentionally rejected at build time
+// so that authors don't introduce links whose resolution depends on whether
+// the URL has a trailing slash.
+
+import { visit } from "unist-util-visit";
+
+const SCHEME_RE = /^[a-z][a-z0-9+.\-]*:/i;
+
+export function rewriteInternalLinks({ base } = {}) {
+  if (!base) throw new Error("rewriteInternalLinks: `base` is required");
+  const norm = base.endsWith("/") ? base : `${base}/`;
+
+  return function transformer(tree, file) {
+    visit(tree, "link", (node) => {
+      const url = node.url;
+      if (!url) return;
+      if (SCHEME_RE.test(url)) return;     // mailto:, https:, etc.
+      if (url.startsWith("//")) return;    // protocol-relative
+      if (url.startsWith("#")) return;     // in-page anchor
+
+      if (url.startsWith("./") || url.startsWith("../")) {
+        const where = file?.path ? `${file.path}: ` : "";
+        throw new Error(
+          `${where}relative markdown link "${url}" is not allowed; ` +
+          `use a root-absolute slug like "/some/page" instead. ` +
+          `Relative links break under trailing-slash URLs that GitHub Pages serves.`
+        );
+      }
+
+      if (url.startsWith("/")) {
+        // Root-absolute content slug: /foo/bar -> ${base}foo/bar
+        let tail = url.slice(1);
+        if (tail.endsWith(".md")) tail = tail.slice(0, -3);
+        const hashIdx = tail.indexOf("#");
+        if (hashIdx !== -1) {
+          const slug = tail.slice(0, hashIdx).replace(/\/$/, "");
+          const frag = tail.slice(hashIdx);
+          node.url = `${norm}${slug}${frag}`;
+        } else {
+          node.url = `${norm}${tail.replace(/\/$/, "")}`;
+        }
+      }
+      // Anything else (bare strings without a scheme or leading slash) is left
+      // alone -- e.g. authors writing inline `<file>` references.
+    });
+  };
+}

--- a/docs/src/content/cli-reference.md
+++ b/docs/src/content/cli-reference.md
@@ -93,7 +93,7 @@ ocync watch -c config.yaml --interval 600 --health-port 8080
 | `--health-port` | `8080` | Port for `/healthz` and `/readyz` endpoints |
 | `--json` | | Output sync reports as JSON |
 
-See [observability](../observability) for health endpoint details.
+See [observability](/observability) for health endpoint details.
 
 ## analyze
 

--- a/docs/src/content/configuration.md
+++ b/docs/src/content/configuration.md
@@ -129,7 +129,7 @@ registries:
 
 Auto-detected from hostname. ECR (private and Public), GAR, GCR, and ACR each route to a dedicated native-auth provider. GHCR, Docker Hub, Chainguard, and any unrecognized hostname share the same fallback path: `docker_config` first (using `~/.docker/config.json` or `$DOCKER_CONFIG/config.json`), then anonymous if no entry is found. Set `auth_type` explicitly to override detection.
 
-See the [registry guides](../registries/ecr) for provider-specific auth details.
+See the [registry guides](/registries/ecr) for provider-specific auth details.
 
 ## Target groups
 
@@ -359,7 +359,7 @@ mappings:
 
 ## JSON schema
 
-A [JSON schema](/ocync/config.schema.json) is available for editor autocompletion and validation. Add the schema comment to the top of your config file:
+A [JSON schema](/config.schema.json) is available for editor autocompletion and validation. Add the schema comment to the top of your config file:
 
 ```yaml
 # yaml-language-server: $schema=https://clowdhaus.github.io/ocync/config.schema.json
@@ -383,7 +383,7 @@ mappings:
 
 This works with any editor that supports the [YAML Language Server](https://github.com/redhat-developer/yaml-language-server) (VS Code with the YAML extension, Neovim with `yaml-language-server`, JetBrains IDEs).
 
-The schema is generated from the Rust config types and verified in CI to stay in sync. View the full schema at [`/ocync/config.schema.json`](/ocync/config.schema.json).
+The schema is generated from the Rust config types and verified in CI to stay in sync. View the full schema at [`/ocync/config.schema.json`](/config.schema.json).
 
 ## Validation
 

--- a/docs/src/content/design/overview.md
+++ b/docs/src/content/design/overview.md
@@ -47,15 +47,15 @@ The naive approach -- discover all images, plan all transfers, execute all trans
                      +-------------------------------------------------+
 ```
 
-The `select!` loop uses `biased;` to prefer execution completions over new discovery results, maximizing throughput. Execution begins after ~1 second of discovery instead of waiting for all images to be enumerated. See [pipeline architecture in the engine doc](./engine#pipeline-architecture) for select loop discipline and backpressure details.
+The `select!` loop uses `biased;` to prefer execution completions over new discovery results, maximizing throughput. Execution begins after ~1 second of discovery instead of waiting for all images to be enumerated. See [pipeline architecture in the engine doc](/design/engine#pipeline-architecture) for select loop discipline and backpressure details.
 
 ### Progressive cache population
 
-Early transfers teach the cache about blob locations. Later images benefit from accumulated knowledge -- the pipeline saves hundreds of API calls compared to plan-then-execute by populating the cache as work proceeds. See [progressive cache population in the engine doc](./engine#progressive-cache-population-amplified-by-pipelining) for scale examples.
+Early transfers teach the cache about blob locations. Later images benefit from accumulated knowledge -- the pipeline saves hundreds of API calls compared to plan-then-execute by populating the cache as work proceeds. See [progressive cache population in the engine doc](/design/engine#progressive-cache-population-amplified-by-pipelining) for scale examples.
 
 ### Frequency ordering
 
-Within each image, blobs are transferred in descending order of reference count across all discovered images. On crash or interruption, the most-shared blobs have been pushed first, providing maximum mount opportunities for the next run. See [frequency ordering in the engine doc](./engine#frequency-ordering) for details.
+Within each image, blobs are transferred in descending order of reference count across all discovered images. On crash or interruption, the most-shared blobs have been pushed first, providing maximum mount opportunities for the next run. See [frequency ordering in the engine doc](/design/engine#frequency-ordering) for details.
 
 ## Adaptive concurrency (AIMD)
 
@@ -65,7 +65,7 @@ Static concurrency limits force operators to guess at registry capacity. Too low
 - **On 429:** `window /= 2` (multiplicative decrease, once per congestion epoch)
 - **Cap:** `max_concurrent` per registry (default 50)
 
-If the registry throttles at 30 concurrent, the controller oscillates between ~15 and ~30 (the classic AIMD sawtooth), settling to an effective average of ~22.5. See [AIMD formula in the engine doc](./engine#aimd-formula) for the full derivation.
+If the registry throttles at 30 concurrent, the controller oscillates between ~15 and ~30 (the classic AIMD sawtooth), settling to an effective average of ~22.5. See [AIMD formula in the engine doc](/design/engine#aimd-formula) for the full derivation.
 
 ### Why per-action, not per-host
 
@@ -80,7 +80,7 @@ ECR rate limits vary dramatically by API action:
 
 A 429 on `PutImage` must not throttle `UploadLayerPart`. Per-action windows ensure each adapts independently.
 
-Window grouping is registry-specific and matches each provider's actual rate-limit granularity: ECR private (9 windows, one per API action); ECR Public (5 windows, read paths share, write paths split); Docker Hub (3 windows, HEAD unmetered, manifest-read quota'd, rest shared); GAR / GCR (1 shared per-project window); GHCR (1 shared window, since GitHub enforces a single aggregate cap across reads and writes); ACR (2 windows, ReadOps and WriteOps); unknown (5-window coarse grouping). Congestion epochs prevent catastrophic window collapse when multiple 429s arrive simultaneously (TCP Reno's approach -- halve once per epoch, not once per response). Concurrency is controlled at four levels -- global image semaphore, per-registry aggregate semaphore, per-action AIMD windows, and an opt-in per-window token bucket for documented caps. See [per-registry window groupings](./engine#per-registry-window-groupings), [congestion epochs](./engine#congestion-epochs), and [four-level hierarchy](./engine#four-level-hierarchy) in the engine doc.
+Window grouping is registry-specific and matches each provider's actual rate-limit granularity: ECR private (9 windows, one per API action); ECR Public (5 windows, read paths share, write paths split); Docker Hub (3 windows, HEAD unmetered, manifest-read quota'd, rest shared); GAR / GCR (1 shared per-project window); GHCR (1 shared window, since GitHub enforces a single aggregate cap across reads and writes); ACR (2 windows, ReadOps and WriteOps); unknown (5-window coarse grouping). Congestion epochs prevent catastrophic window collapse when multiple 429s arrive simultaneously (TCP Reno's approach -- halve once per epoch, not once per response). Concurrency is controlled at four levels -- global image semaphore, per-registry aggregate semaphore, per-action AIMD windows, and an opt-in per-window token bucket for documented caps. See [per-registry window groupings](/design/engine#per-registry-window-groupings), [congestion epochs](/design/engine#congestion-epochs), and [four-level hierarchy](/design/engine#four-level-hierarchy) in the engine doc.
 
 ### Token-bucket layer for documented caps
 
@@ -88,21 +88,21 @@ AIMD discovers a healthy concurrency level via 429 feedback but cannot bound TPS
 
 ## Cross-repo blob mounting
 
-When a blob already exists in another repository on the same target registry, OCI registries can "mount" it -- zero bytes over the wire. `ocync` maximizes mount success through leader-follower election and per-blob synchronization. See [cross-repo blob mounting in the engine doc](./engine#cross-repo-blob-mounting) for the full implementation.
+When a blob already exists in another repository on the same target registry, OCI registries can "mount" it -- zero bytes over the wire. `ocync` maximizes mount success through leader-follower election and per-blob synchronization. See [cross-repo blob mounting in the engine doc](/design/engine#cross-repo-blob-mounting) for the full implementation.
 
 ### Leader-follower election
 
-Multiple images in a sync run often share base layers. If all images push independently, shared blobs are uploaded N times. `ocync` uses leader-follower election via a greedy set-cover algorithm (`elect_leaders()`) to ensure shared blobs are uploaded once by leaders and mounted everywhere else by followers. The algorithm provably covers every shared blob -- there is no "uncovered follower" path. See [leader-follower election in the engine doc](./engine#leader-follower-election) for the algorithm details.
+Multiple images in a sync run often share base layers. If all images push independently, shared blobs are uploaded N times. `ocync` uses leader-follower election via a greedy set-cover algorithm (`elect_leaders()`) to ensure shared blobs are uploaded once by leaders and mounted everywhere else by followers. The algorithm provably covers every shared blob -- there is no "uncovered follower" path. See [leader-follower election in the engine doc](/design/engine#leader-follower-election) for the algorithm details.
 
 ### Progressive promotion
 
-Followers cannot mount from a leader until the leader's manifest is committed. All tasks are promoted simultaneously after discovery, with leaders ordered first so they acquire semaphore permits and claim blob uploads before followers. Followers that need a blob still in-flight wait on per-blob `Notify` handles via `ClaimAction::Wait`. Mount sources are restricted to repos with committed manifests, ensuring mount attempts only target repos that can fulfill them. See [progressive promotion in the engine doc](./engine#progressive-promotion) for details.
+Followers cannot mount from a leader until the leader's manifest is committed. All tasks are promoted simultaneously after discovery, with leaders ordered first so they acquire semaphore permits and claim blob uploads before followers. Followers that need a blob still in-flight wait on per-blob `Notify` handles via `ClaimAction::Wait`. Mount sources are restricted to repos with committed manifests, ensuring mount attempts only target repos that can fulfill them. See [progressive promotion in the engine doc](/design/engine#progressive-promotion) for details.
 
 ### ECR BLOB_MOUNTING
 
-ECR requires an opt-in account setting (`BLOB_MOUNTING=ENABLED`, launched January 2026) for cross-repo mount to succeed. Mount POST returns 201 when the `from` repo has a committed manifest, both repos use identical encryption, and both are in the same account and region. Without `BLOB_MOUNTING` enabled, ECR returns 202 and starts a regular upload; `ocync` detects this and falls through to the standard upload path. See [ECR blob mounting in the engine doc](./engine#ecr-blob-mounting) for full requirements.
+ECR requires an opt-in account setting (`BLOB_MOUNTING=ENABLED`, launched January 2026) for cross-repo mount to succeed. Mount POST returns 201 when the `from` repo has a committed manifest, both repos use identical encryption, and both are in the same account and region. Without `BLOB_MOUNTING` enabled, ECR returns 202 and starts a regular upload; `ocync` detects this and falls through to the standard upload path. See [ECR blob mounting in the engine doc](/design/engine#ecr-blob-mounting) for full requirements.
 
-In testing (5-image Jupyter corpus, cold sync to ECR), leader-follower election reduced requests by 44%, response bytes by 57%, and improved wall clock by 3.8x with 100% mount success. See [measured impact in the engine doc](./engine#measured-impact) for the full breakdown.
+In testing (5-image Jupyter corpus, cold sync to ECR), leader-follower election reduced requests by 44%, response bytes by 57%, and improved wall clock by 3.8x with 100% mount success. See [measured impact in the engine doc](/design/engine#measured-impact) for the full breakdown.
 
 ## Transfer state cache
 
@@ -112,11 +112,11 @@ The cache eliminates redundant API calls by recording what is known about blob l
 
 **Tier 2 - warm cache (persistent disk).** Serialized on sync completion using binary format (~1 MB at typical scale). Only confirmed states are persisted. The warm cache enables CronJob deployments to skip HEAD checks for known blobs on every run.
 
-Stale entries self-heal via lazy invalidation: failed mounts or pushes invalidate the entry and fall back to fresh HEAD checks. See [transfer state cache in the engine doc](./engine#transfer-state-cache) for persistence rules, corruption detection, cold start behavior, and [lazy invalidation](./engine#lazy-invalidation).
+Stale entries self-heal via lazy invalidation: failed mounts or pushes invalidate the entry and fall back to fresh HEAD checks. See [transfer state cache in the engine doc](/design/engine#transfer-state-cache) for persistence rules, corruption detection, cold start behavior, and [lazy invalidation](/design/engine#lazy-invalidation).
 
 ## Streaming transfers
 
-For single-target mappings, bytes stream directly from source to target with no disk I/O -- two HTTP requests per blob (POST + streaming PUT), memory bounded by chunk size. For multi-target mappings (e.g., us-ecr + eu-ecr + ap-ecr), `ocync` pulls each source blob once and writes it to a content-addressable disk file; all target pushes read from disk independently, with recently-written data served from OS page cache at memory speed. Single-target deployments pay zero staging overhead. See [streaming transfers and staging](./engine#streaming-transfers-and-staging) and [upload strategy per registry](./engine#upload-strategy-per-registry) in the engine doc.
+For single-target mappings, bytes stream directly from source to target with no disk I/O -- two HTTP requests per blob (POST + streaming PUT), memory bounded by chunk size. For multi-target mappings (e.g., us-ecr + eu-ecr + ap-ecr), `ocync` pulls each source blob once and writes it to a content-addressable disk file; all target pushes read from disk independently, with recently-written data served from OS page cache at memory speed. Single-target deployments pay zero staging overhead. See [streaming transfers and staging](/design/engine#streaming-transfers-and-staging) and [upload strategy per registry](/design/engine#upload-strategy-per-registry) in the engine doc.
 
 ## Deployment model
 
@@ -128,7 +128,7 @@ For large sync runs (hundreds of images, multi-GB layers), increase memory to `5
 
 ### Graceful shutdown
 
-On SIGTERM or SIGINT, the engine stops accepting new work, drains in-flight transfers with a 25-second deadline (fitting Kubernetes' default 30s `terminationGracePeriodSeconds`), and persists the transfer state cache to disk. See [graceful shutdown in the engine doc](./engine#graceful-shutdown) for the full 5-step sequence.
+On SIGTERM or SIGINT, the engine stops accepting new work, drains in-flight transfers with a 25-second deadline (fitting Kubernetes' default 30s `terminationGracePeriodSeconds`), and persists the transfer state cache to disk. See [graceful shutdown in the engine doc](/design/engine#graceful-shutdown) for the full 5-step sequence.
 
 ### Deployment modes
 

--- a/docs/src/content/design/watch-mode.md
+++ b/docs/src/content/design/watch-mode.md
@@ -176,7 +176,7 @@ For CronJob + PVC deployments, the pod mounts a ReadWriteOnce PVC and the cache 
 
 ### Cache format versioning
 
-The tag digest cache extends the existing [transfer state cache](./engine#transfer-state-cache) format. The cache version will increment from v1 to v2 when the source snapshot map is added, with the new source snapshot map appended after the existing blob dedup map. Reads accept both v1 and v2: a v1 cache loads with an empty snapshot map, preserving blob dedup data across the version transition. An older binary encountering a v2 cache falls back to empty cache, which is the existing behavior for version mismatches. The same TTL and atomic write (tmp + rename + fsync) apply to both sections.
+The tag digest cache extends the existing [transfer state cache](/design/engine#transfer-state-cache) format. The cache version will increment from v1 to v2 when the source snapshot map is added, with the new source snapshot map appended after the existing blob dedup map. Reads accept both v1 and v2: a v1 cache loads with an empty snapshot map, preserving blob dedup data across the version transition. An older binary encountering a v2 cache falls back to empty cache, which is the existing behavior for version mismatches. The same TTL and atomic write (tmp + rename + fsync) apply to both sections.
 
 ### Observability
 

--- a/docs/src/content/getting-started.md
+++ b/docs/src/content/getting-started.md
@@ -33,7 +33,7 @@ Multi-arch image (`linux/amd64`, `linux/arm64`) based on `chainguard/static` wit
 helm install ocync oci://public.ecr.aws/clowdhaus/ocync --version 0.1.0
 ```
 
-See the [Helm chart guide](../helm) for deployment modes and configuration.
+See the [Helm chart guide](/helm) for deployment modes and configuration.
 
 ### Build from source
 
@@ -116,8 +116,8 @@ ocync sync -c config.yaml --dry-run
 
 ## Next steps
 
-- [Configuration reference](../configuration) for full config file syntax and options
-- [CLI reference](../cli-reference) for all commands, flags, and exit codes
-- [Helm chart](../helm) for Kubernetes deployment (CronJob, Deployment, or Job)
-- [Observability](../observability) for logging, JSON output, and health endpoints
-- Registry guides: [Amazon ECR](../registries/ecr), [Amazon ECR Public](../registries/ecr-public), [Docker Hub](../registries/docker-hub), [GHCR](../registries/ghcr), [GAR](../registries/gar), [ACR](../registries/acr), [Chainguard](../registries/chainguard), [Kubernetes secrets](../registries/secrets)
+- [Configuration reference](/configuration) for full config file syntax and options
+- [CLI reference](/cli-reference) for all commands, flags, and exit codes
+- [Helm chart](/helm) for Kubernetes deployment (CronJob, Deployment, or Job)
+- [Observability](/observability) for logging, JSON output, and health endpoints
+- Registry guides: [Amazon ECR](/registries/ecr), [Amazon ECR Public](/registries/ecr-public), [Docker Hub](/registries/docker-hub), [GHCR](/registries/ghcr), [GAR](/registries/gar), [ACR](/registries/acr), [Chainguard](/registries/chainguard), [Kubernetes secrets](/registries/secrets)

--- a/docs/src/content/helm.md
+++ b/docs/src/content/helm.md
@@ -78,7 +78,7 @@ watch:
   healthPort: 8080
 ```
 
-Exposes `/healthz` (liveness) and `/readyz` (readiness) endpoints. See [observability](../observability) for logging configuration.
+Exposes `/healthz` (liveness) and `/readyz` (readiness) endpoints. See [observability](/observability) for logging configuration.
 
 ## Job mode
 

--- a/docs/src/content/observability.md
+++ b/docs/src/content/observability.md
@@ -90,7 +90,7 @@ In watch mode, `ocync` exposes HTTP health endpoints:
 | `/healthz` | Liveness probe | Process is running |
 | `/readyz` | Readiness probe | At least one successful sync completed |
 
-Configure the port via `--health-port` (default 8080) or in [Helm values](../helm):
+Configure the port via `--health-port` (default 8080) or in [Helm values](/helm):
 
 ```yaml
 mode: watch
@@ -98,4 +98,4 @@ watch:
   healthPort: 8080
 ```
 
-See [CLI reference](../cli-reference#watch) for all `watch` flags including `--interval` and `--json`.
+See [CLI reference](/cli-reference#watch) for all `watch` flags including `--interval` and `--json`.

--- a/docs/src/content/performance.md
+++ b/docs/src/content/performance.md
@@ -44,7 +44,7 @@ Measured 2026-04-26 on c6in.4xlarge (x86_64, 16 vCPUs, 32 GiB, Up to 50 Gigabit)
 
 | Tool | Default concurrency | Adaptive backoff | Rate limit strategy |
 |------|:---:|:---:|-----|
-| `ocync` | 5 initial, 50 cap ([AIMD](../design/overview#adaptive-concurrency-aimd) adaptive) | Yes (per-registry, per-action) | [AIMD](../design/overview#adaptive-concurrency-aimd) congestion control on 429 |
+| `ocync` | 5 initial, 50 cap ([AIMD](/design/overview#adaptive-concurrency-aimd) adaptive) | Yes (per-registry, per-action) | [AIMD](/design/overview#adaptive-concurrency-aimd) congestion control on 429 |
 | containerd | 3 layers | No | Lock-based dedup, retries on 429 (no backoff) |
 | regsync | 3 per registry | No | Reads `RateLimit-Remaining` header, pauses proactively |
 | crane | 4 jobs | Retry with backoff (0.1s-0.9s transport, 1s-9s operation) | Retry on 408/5xx, 3 attempts |
@@ -97,7 +97,7 @@ When a blob already exists in another repository on the same registry, `ocync` m
 
 ### Adaptive rate limiting
 
-Per-(registry, action) [AIMD](../design/overview#adaptive-concurrency-aimd) (additive increase, multiplicative decrease) concurrency windows discover actual registry capacity through feedback, using the same algorithm TCP uses for congestion control. ECR has 9 independent rate limits (one per API action), and `ocync` tracks each independently. This avoids under-utilization and minimizes 429 errors through capacity discovery.
+Per-(registry, action) [AIMD](/design/overview#adaptive-concurrency-aimd) (additive increase, multiplicative decrease) concurrency windows discover actual registry capacity through feedback, using the same algorithm TCP uses for congestion control. ECR has 9 independent rate limits (one per API action), and `ocync` tracks each independently. This avoids under-utilization and minimizes 429 errors through capacity discovery.
 
 ### Transfer state cache
 
@@ -109,7 +109,7 @@ In single-target mode, bytes flow directly from source to target with no interme
 
 ## Tuning
 
-`ocync` auto-discovers registry capacity through [AIMD](../design/overview#adaptive-concurrency-aimd) feedback. Manual tuning is rarely needed. The key settings (see [configuration](../configuration) for full reference):
+`ocync` auto-discovers registry capacity through [AIMD](/design/overview#adaptive-concurrency-aimd) feedback. Manual tuning is rarely needed. The key settings (see [configuration](/configuration) for full reference):
 
 - **Concurrency**: starts conservatively and ramps up. Each registry action has its own window. Override with `global.max_concurrent_transfers` or per-registry `max_concurrent`.
 - **Platform filter**: sync only the architectures you deploy. `linux/amd64` alone halves transfer volume for multi-arch images.

--- a/docs/src/content/registries/acr.md
+++ b/docs/src/content/registries/acr.md
@@ -13,7 +13,7 @@ ocync auto-detects ACR (`*.azurecr.io`, `*.azurecr.cn`, `*.azurecr.us`) and auth
 3. Managed Identity (`IDENTITY_ENDPOINT` / `IDENTITY_HEADER`; AKS pod-managed identity, App Service, Functions)
 4. Azure CLI (`az login`; developer machines)
 
-See the [Azure DefaultAzureCredential docs](https://learn.microsoft.com/azure/developer/intro/authentication-overview#defaultazurecredential) for credential precedence.
+See the [Azure DefaultAzureCredential docs](https://learn.microsoft.com/en-us/dotnet/azure/sdk/authentication/credential-chains) for credential precedence.
 
 Notable behaviors:
 
@@ -79,4 +79,4 @@ workloadIdentity:
 
 For sovereign clouds, the AAD authority is selected automatically from the registry hostname suffix; the chart values are unchanged. Configuring the AAD app, federated identity credential, and ACR `AcrPull` role assignment is the user's IAM/AAD work; see [Azure Workload Identity docs](https://azure.github.io/azure-workload-identity/docs/).
 
-For other secret-injection patterns, see [Kubernetes secret patterns](./secrets).
+For other secret-injection patterns, see [Kubernetes secret patterns](/registries/secrets).

--- a/docs/src/content/registries/chainguard.md
+++ b/docs/src/content/registries/chainguard.md
@@ -132,7 +132,7 @@ kubectl create secret generic ocync-credentials \
   --from-literal=GITHUB_TOKEN="$(gh auth token)"
 ```
 
-For credential rotation -- pulling the pull-token out of AWS Secrets Manager / GCP Secret Manager / Azure Key Vault / Vault and refreshing it on a schedule -- use the External Secrets Operator or CSI Secrets Store patterns documented in [Kubernetes secret patterns](./secrets); the `auth_type: basic` configuration above stays unchanged, only the source of `CHAINGUARD_USERNAME` / `CHAINGUARD_PASSWORD` changes.
+For credential rotation -- pulling the pull-token out of AWS Secrets Manager / GCP Secret Manager / Azure Key Vault / Vault and refreshing it on a schedule -- use the External Secrets Operator or CSI Secrets Store patterns documented in [Kubernetes secret patterns](/registries/secrets); the `auth_type: basic` configuration above stays unchanged, only the source of `CHAINGUARD_USERNAME` / `CHAINGUARD_PASSWORD` changes.
 
 ### Docker config volume
 

--- a/docs/src/content/registries/docker-hub.md
+++ b/docs/src/content/registries/docker-hub.md
@@ -102,4 +102,4 @@ kubectl create secret generic ocync-credentials \
   --from-literal=DOCKER_PASSWORD="$(cat ~/dockerhub-pat)"
 ```
 
-For ExternalSecrets-managed credentials or CSI-mounted secret stores, see [Kubernetes secret patterns](./secrets).
+For ExternalSecrets-managed credentials or CSI-mounted secret stores, see [Kubernetes secret patterns](/registries/secrets).

--- a/docs/src/content/registries/ecr-public.md
+++ b/docs/src/content/registries/ecr-public.md
@@ -35,4 +35,4 @@ For authenticated pulls, ensure ambient AWS credentials are present (env vars, s
 
 ## Kubernetes deployment
 
-Anonymous pulls require no AWS identity, so the simplest pod has no `workloadIdentity` block at all -- accept the lower per-IP rate limit. For authenticated reads (higher rate limit), the SDK uses whatever AWS identity the workload has, exactly as for ECR private. See [ECR Kubernetes deployment](./ecr#kubernetes-deployment) for the EKS Pod Identity and IRSA setups; both apply unchanged.
+Anonymous pulls require no AWS identity, so the simplest pod has no `workloadIdentity` block at all -- accept the lower per-IP rate limit. For authenticated reads (higher rate limit), the SDK uses whatever AWS identity the workload has, exactly as for ECR private. See [ECR Kubernetes deployment](/registries/ecr#kubernetes-deployment) for the EKS Pod Identity and IRSA setups; both apply unchanged.

--- a/docs/src/content/registries/ecr.md
+++ b/docs/src/content/registries/ecr.md
@@ -18,7 +18,7 @@ No Docker config or static credentials are needed. See the [AWS credential prece
 Notable behaviors:
 
 - HTTP Basic, not Bearer exchange. SDK `GetAuthorizationToken` returns a base64-encoded `AWS:<password>` blob that the registry accepts directly; ocync sends `Authorization: Basic <token>` and skips the `/v2/token` round-trip.
-- FIPS endpoints: set `AWS_USE_FIPS_ENDPOINT=true` to route SDK calls through `*.dkr.ecr-fips.<region>.amazonaws.com`. See the [FIPS guide](../../fips) for crypto provider details.
+- FIPS endpoints: set `AWS_USE_FIPS_ENDPOINT=true` to route SDK calls through `*.dkr.ecr-fips.<region>.amazonaws.com`. See the [FIPS guide](/fips) for crypto provider details.
 - Cross-repo blob mounting requires `BLOB_MOUNTING=ENABLED` on the account *and* a committed manifest in the source repo that references the specific blob. Enable per-account: `aws ecr put-account-setting --name BLOB_MOUNTING --value ENABLED`. Mount POSTs returning 202 (not yet fulfilled) fall back to a normal upload.
 - Batch existence checks use `BatchCheckLayerAvailability` (up to 100 digests per call) instead of per-blob HEADs, reducing API volume on cold syncs.
 - Per-action rate limits: ECR enforces independent quotas per API action (`UploadLayerPart` 500 TPS, `InitiateLayerUpload` / `CompleteLayerUpload` 100 TPS, `PutImage` 10 TPS). ocync tracks 9 separate AIMD windows so a 429 on uploads does not throttle manifest reads.
@@ -123,7 +123,7 @@ env:
     value: "true"
 ```
 
-For other secret-injection patterns (External Secrets Operator, CSI Secrets Store), see [Kubernetes secrets](./secrets).
+For other secret-injection patterns (External Secrets Operator, CSI Secrets Store), see [Kubernetes secrets](/registries/secrets).
 
 ## Multi-account access
 
@@ -221,4 +221,4 @@ aws_secret_access_key = ...
 
 The AWS SDK reads the file from `~/.aws/credentials` by default, or from the path in `AWS_SHARED_CREDENTIALS_FILE`. The file does not need a `[default]` section — the ambient chain skips the file entirely when no profile is named, so Pod Identity / IRSA still serves `my-source`.
 
-For Kubernetes deployments, see the AWS shared-config files section of [Kubernetes secrets](./secrets) for two production-grade injection patterns (External Secrets Operator and CSI Secrets Store).
+For Kubernetes deployments, see the AWS shared-config files section of [Kubernetes secrets](/registries/secrets) for two production-grade injection patterns (External Secrets Operator and CSI Secrets Store).

--- a/docs/src/content/registries/gar.md
+++ b/docs/src/content/registries/gar.md
@@ -95,4 +95,4 @@ extraVolumeMounts:
     readOnly: true
 ```
 
-For ExternalSecrets-managed key files or CSI Secrets Store, see [Kubernetes secret patterns](./secrets).
+For ExternalSecrets-managed key files or CSI Secrets Store, see [Kubernetes secret patterns](/registries/secrets).

--- a/docs/src/content/registries/ghcr.md
+++ b/docs/src/content/registries/ghcr.md
@@ -92,4 +92,4 @@ kubectl create secret generic ocync-credentials \
   --from-literal=GITHUB_TOKEN="$(gh auth token)"
 ```
 
-For PAT rotation via External Secrets Operator or CSI Secrets Store, see [Kubernetes secret patterns](./secrets).
+For PAT rotation via External Secrets Operator or CSI Secrets Store, see [Kubernetes secret patterns](/registries/secrets).

--- a/docs/src/content/registries/secrets.md
+++ b/docs/src/content/registries/secrets.md
@@ -152,7 +152,7 @@ EKS Pod Identity is *not* represented in `workloadIdentity` because it is config
 
 ## AWS shared-config files
 
-Use this pattern when one ECR registry needs credentials distinct from the ambient chain (see [ECR per-registry profile](./ecr#per-registry-static-credentials-third-party-access)). The `aws_profile` config field reads from a credentials file mounted at the path in `AWS_SHARED_CREDENTIALS_FILE`; this section covers two production-grade ways to populate that file.
+Use this pattern when one ECR registry needs credentials distinct from the ambient chain (see [ECR per-registry profile](/registries/ecr#per-registry-static-credentials-third-party-access)). The `aws_profile` config field reads from a credentials file mounted at the path in `AWS_SHARED_CREDENTIALS_FILE`; this section covers two production-grade ways to populate that file.
 
 The recommended secret-store layout is to store the entire INI blob -- including the `[profile-name]` header -- as a single string value at one key. This keeps the chart values minimal and avoids per-field templating.
 


### PR DESCRIPTION
## Summary

- GitHub Pages serves both `/foo` and `/foo/` from the same `dist/foo/index.html`. Relative markdown links resolved correctly at the canonical URL but to `/registries/ecr/secrets` (404) under the trailing-slash variant -- the next-page link from `/registries/ecr/` was dead in production. Every `../`-style cross-page link in docs had the same class of bug, all authored assuming trailing slash.
- Add `docs/plugins/rewrite-internal-links.mjs`: a remark plugin that prepends the Astro `base` to root-absolute slug paths and fails the build on `./` or `../` links. Convert every cross-page markdown link to root-absolute form. Refresh one stale Microsoft Learn URL (`authentication-overview` retired -> `credential-chains`).
- Add `docs/CLAUDE.md` documenting the link convention, the GH Pages trailing-slash bug class, and the browser-spec verification approach. Library helpers like Python's `urljoin` canonicalize before joining and hide the bug; the actual reproduction resolves every `<a href>` against both the canonical and the trailing-slash form of the document URL.

## Test plan

- [ ] `cd docs && NODE_ENV=production npm run build` succeeds; the plugin throws on any new `./` or `../` markdown link
- [ ] `npm run preview`, then verify in a browser that `https://localhost:4321/ocync/registries/ecr/` (trailing slash) renders correctly and the "Next" link goes to `/ocync/registries/ecr-public`, not `/ocync/registries/ecr/ecr-public`
- [ ] Crawler check: for every doc page, every cross-page `<a href>` resolves to an identical path against both `urljoin(canonical, href)` and `urljoin(canonical + "/", href)` (348 hrefs across 19 pages, 0 mismatches locally)
- [ ] After merge: confirm `https://clowdhaus.github.io/ocync/registries/ecr/secrets` returns 404 (the page does not exist) AND the "Next" link from `https://clowdhaus.github.io/ocync/registries/ecr/` now points to `/ocync/registries/ecr-public`