### PR TITLE
feat(chart): expose deployment/job/cronJob annotations for workload metadata

### DIFF
--- a/charts/ocync/README.md
+++ b/charts/ocync/README.md
@@ -26,10 +26,12 @@ See the [Helm chart documentation](https://clowdhaus.github.io/ocync/helm) and [
 |-----|------|---------|-------------|
 | affinity | object | See [values.yaml](./values.yaml) for the full instance-type list. | Pod affinity / anti-affinity. Defaults to preferring EC2 network-optimized instance types (`c5n` / `c6in` / `m5n` / `m6in` / `r5n` / `r6in` families, 25-200 Gbps). Soft preference -- pods schedule on any node if these are unavailable. Override with `affinity: {}` to disable. |
 | config | object | `{}` (you must supply registries, defaults, and mappings) | ocync configuration YAML, rendered into a ConfigMap mounted at `/etc/ocync/config.yaml`. `global.cache_dir` is auto-injected as `/tmp/ocync-cache` if not set, so the transfer state cache and blob staging area land in the writable `/tmp` emptyDir. |
+| cronJobAnnotations | object | `{}` | Annotations applied to the CronJob's `metadata.annotations` when `mode: cronjob`. Common uses: Helm lifecycle hooks (`helm.sh/hook`), Argo CD sync-wave / hook annotations, policy-controller selectors (Kyverno, Gatekeeper), cost-allocation tags. Pod-template annotations belong under `podAnnotations`. |
 | cronjob.concurrencyPolicy | string | `"Forbid"` | CronJob concurrency policy: `Allow` | `Forbid` | `Replace`. |
 | cronjob.failedJobsHistoryLimit | int | `3` | Number of failed CronJob runs to retain. |
 | cronjob.schedule | string | `"0 */6 * * *"` | Cron schedule expression (cronjob mode only). |
 | cronjob.successfulJobsHistoryLimit | int | `3` | Number of successful CronJob runs to retain. |
+| deploymentAnnotations | object | `{}` | Annotations applied to the Deployment's `metadata.annotations` when `mode: watch`. Use for controllers that key off workload-level metadata: Stakater Reloader (`reloader.stakater.com/auto`), Argo Rollouts notification subscriptions, etc. Pod-template annotations belong under `podAnnotations`. |
 | env | list | `[]` | Additional environment variables for the container. Set `AWS_USE_FIPS_ENDPOINT=true` to route ECR API calls through FIPS endpoints. |
 | envFrom | list | `[]` | envFrom sources (Secret/ConfigMap references). Use for token-based auth: DOCKER_PASSWORD, GITHUB_TOKEN, chainctl tokens. The referenced resource must already exist or be created alongside (e.g. via `externalSecrets`). |
 | externalSecrets.data | list | `[]` | Mapping of secret keys to remote references. Shape: `[{ secretKey, remoteRef: { key, property? } }]`. |
@@ -45,6 +47,7 @@ See the [Helm chart documentation](https://clowdhaus.github.io/ocync/helm) and [
 | image.repository | string | `"public.ecr.aws/clowdhaus/ocync"` | Container image repository. |
 | image.tag | string | `<chart-app-version>-fips` | Container image tag. |
 | imagePullSecrets | list | `[]` | Image pull secrets for the workload pods. |
+| jobAnnotations | object | `{}` | Annotations applied to the Job's `metadata.annotations` when `mode: job`. Common uses: Helm lifecycle hooks (`helm.sh/hook: post-install` etc.), Argo CD sync-wave / hook annotations on one-shot Jobs, policy-controller selectors. Pod-template annotations belong under `podAnnotations`. |
 | mode | string | `"watch"` | Deployment mode: `watch` (Deployment with sync interval), `cronjob` (CronJob), or `job` (one-shot Job). |
 | nameOverride | string | `""` | Override the chart name used in resource names and labels. |
 | nodeSelector | object | `{}` | Node selector for the pod. |

--- a/charts/ocync/templates/cronjob.yaml
+++ b/charts/ocync/templates/cronjob.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "ocync.fullname" . }}
   labels:
     {{- include "ocync.labels" . | nindent 4 }}
+  {{- with .Values.cronJobAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   schedule: {{ .Values.cronjob.schedule | quote }}
   successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit }}

--- a/charts/ocync/templates/deployment.yaml
+++ b/charts/ocync/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "ocync.fullname" . }}
   labels:
     {{- include "ocync.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:

--- a/charts/ocync/templates/job.yaml
+++ b/charts/ocync/templates/job.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "ocync.fullname" . }}
   labels:
     {{- include "ocync.labels" . | nindent 4 }}
+  {{- with .Values.jobAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   template:
     {{- include "ocync.podTemplate" . | nindent 4 }}

--- a/charts/ocync/tests/pod_template_test.yaml
+++ b/charts/ocync/tests/pod_template_test.yaml
@@ -143,3 +143,90 @@ tests:
       - notExists:
           path: spec.template.metadata.annotations
 
+  - it: deploymentAnnotations renders on the Deployment metadata (watch mode)
+    set:
+      mode: watch
+      deploymentAnnotations:
+        reloader.stakater.com/auto: "true"
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["reloader.stakater.com/auto"]
+          value: "true"
+      - notExists:
+          path: spec.template.metadata.annotations["reloader.stakater.com/auto"]
+
+  - it: cronJobAnnotations renders on the CronJob metadata (cronjob mode)
+    set:
+      mode: cronjob
+      cronJobAnnotations:
+        helm.sh/hook: post-install
+        argocd.argoproj.io/sync-wave: "5"
+    template: cronjob.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-install
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "5"
+
+  - it: jobAnnotations renders on the Job metadata (job mode)
+    set:
+      mode: job
+      jobAnnotations:
+        helm.sh/hook: post-install
+        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    template: job.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-install
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+
+  - it: per-mode values do not cross-render (deploymentAnnotations ignored in cronjob mode)
+    set:
+      mode: cronjob
+      deploymentAnnotations:
+        should-not-appear: "true"
+    template: cronjob.yaml
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: per-mode values do not cross-render (jobAnnotations ignored in watch mode)
+    set:
+      mode: watch
+      jobAnnotations:
+        should-not-appear: "true"
+    template: deployment.yaml
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: deploymentAnnotations omitted produces no metadata.annotations on Deployment
+    set:
+      mode: watch
+    template: deployment.yaml
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: cronJobAnnotations omitted produces no metadata.annotations on CronJob
+    set:
+      mode: cronjob
+    template: cronjob.yaml
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: jobAnnotations omitted produces no metadata.annotations on Job
+    set:
+      mode: job
+    template: job.yaml
+    asserts:
+      - notExists:
+          path: metadata.annotations
+

--- a/charts/ocync/values.yaml
+++ b/charts/ocync/values.yaml
@@ -72,6 +72,24 @@ extraVolumeMounts: []
 # (`linkerd.io/inject`, `sidecar.istio.io/inject`).
 podAnnotations: {}
 
+# -- Annotations applied to the Deployment's `metadata.annotations` when
+# `mode: watch`. Use for controllers that key off workload-level metadata:
+# Stakater Reloader (`reloader.stakater.com/auto`), Argo Rollouts notification
+# subscriptions, etc. Pod-template annotations belong under `podAnnotations`.
+deploymentAnnotations: {}
+
+# -- Annotations applied to the CronJob's `metadata.annotations` when
+# `mode: cronjob`. Common uses: Helm lifecycle hooks (`helm.sh/hook`), Argo CD
+# sync-wave / hook annotations, policy-controller selectors (Kyverno, Gatekeeper),
+# cost-allocation tags. Pod-template annotations belong under `podAnnotations`.
+cronJobAnnotations: {}
+
+# -- Annotations applied to the Job's `metadata.annotations` when `mode: job`.
+# Common uses: Helm lifecycle hooks (`helm.sh/hook: post-install` etc.), Argo CD
+# sync-wave / hook annotations on one-shot Jobs, policy-controller selectors.
+# Pod-template annotations belong under `podAnnotations`.
+jobAnnotations: {}
+
 # -- Pod-level labels. Composed with `workloadIdentity.podLabels` (the chart sets
 # `azure.workload.identity/use: "true"` automatically when `workloadIdentity.provider` is `azure`).
 podLabels: {}


### PR DESCRIPTION
Closes #74.

## Summary

Adds three mode-gated values rendered onto `metadata.annotations` of the top-level workload, distinct from `podAnnotations`:

| Value | Renders on | Active when |
|---|---|---|
| `deploymentAnnotations` | Deployment metadata | `mode: watch` |
| `cronJobAnnotations` | CronJob metadata | `mode: cronjob` |
| `jobAnnotations` | Job metadata | `mode: job` |

Each is independently mode-gated, so values for inactive modes never render. Pod-template annotations remain unchanged under `podAnnotations`.

## Naming and shape

The original issue proposed a single `workloadAnnotations`. After surveying mainstream charts the three-value shape is the established convention for charts that render multiple workload kinds:

- **kubernetes-sigs/descheduler** — direct precedent: same multi-mode (Deployment / CronJob) pattern, exposes `deploymentAnnotations` + `cronJobAnnotations` + `jobAnnotations` + `podAnnotations` side by side.
- **cert-manager** — `startupapicheck.jobAnnotations` defaults to `helm.sh/hook: post-install` plus `helm.sh/hook-weight` and `helm.sh/hook-delete-policy`. Helm hook annotations only function on the workload's own metadata, not the pod template.
- **bitnami/superset, devtron-labs/cronjob-chart, wiz-sec/charts**, and 800+ other `values.yaml` files in public repos use one or more of the same three keys.

`workloadAnnotations` has no precedent in any popular chart. A bare top-level `annotations:` was rejected because `serviceAccount.annotations` already exists at `values.yaml:24` and would create an ambiguous pair next to `podAnnotations`.

## Why workload-level annotations matter for Job/CronJob (not just Deployment)

Reloader does not watch Jobs or CronJobs, so its motivation does not extend. The justification for the Job/CronJob slots is independent:

- **Helm lifecycle hooks** (`helm.sh/hook: post-install`, `helm.sh/hook-delete-policy`, `helm.sh/hook-weight`) — these only function on the workload's own `metadata.annotations`. cert-manager's startupapicheck Job is the canonical example.
- **Argo CD** — `argocd.argoproj.io/sync-wave` and `argocd.argoproj.io/hook` are read from the resource's own metadata. Sync-wave on a CronJob (e.g. ordering DB migration before app rollout) is a normal Argo pattern.
- **Policy controllers** — Kyverno and OPA Gatekeeper select on workload-level annotations for cost-center tags, owner tags, and exemption markers.
- **Backup/cost tooling** — Velero, Kubecost, and similar tools key off resource-level annotations for inclusion/exclusion and rollups.

None of these need Reloader. All of them need the workload's own metadata, not the pod template's.

## Mid-sync runtime safety

Editing `metadata.annotations` does not signal the running Pod or restart any in-flight sync. For each mode:

- **`mode: watch`** — annotations on the Deployment are not part of the pod-template hash, so `kubectl patch` does not roll the workload. The exception is `reloader.stakater.com/auto: "true"` paired with a ConfigMap/Secret rotation, which causes Reloader to mutate the *pod-template* annotation and roll the Deployment. Safe-by-design: ocync's transfer state cache and digest skip-detection allow the new pod to resume work and skip already-uploaded blobs.
- **`mode: cronjob`** — annotations on the CronJob's `metadata` are independent of any spawned Job. Patching `cronJobAnnotations` while a sync runs has no effect on the running Job. Affects only Argo's reconcile view, Helm's hook lifecycle, policy controllers, etc.
- **`mode: job`** — annotations on the Job's `metadata` are read-only from the runtime's perspective. Patching mid-run does not signal the pod or restart anything.

## Example

```yaml
# values.yaml — Argo CD-managed sync Job ordered before app rollout
mode: job

jobAnnotations:
  helm.sh/hook: post-install
  helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
  argocd.argoproj.io/sync-wave: "5"
```

## Test plan

- [x] `helm-unittest` covers all three modes with positive (real annotation values: `helm.sh/hook`, `argocd.argoproj.io/sync-wave`, `reloader.stakater.com/auto`) and negative cases — 60/60 pass (added 8 new cases)
- [x] Cross-render guards: `deploymentAnnotations` is not rendered in `mode: cronjob`, `jobAnnotations` is not rendered in `mode: watch`
- [x] `helm template` end-to-end render verified for each mode with a real annotation set
- [x] `helm template` with no override produces no `metadata.annotations` block on any workload
- [x] `helm lint charts/ocync` clean
- [x] `helm-docs` regenerated; `charts/ocync/README.md` includes all three new values
