### PR TITLE
ci: always trigger PR workflows so checks report on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,13 @@
 name: CI
 
+# Always triggers on every PR so each job reports a status. Step-level `if`
+# guards skip the actual work when no Rust files changed, letting the job
+# report success without doing real work. This pattern lets these jobs be
+# named in branch protection without blocking chart-only or doc-only PRs --
+# top-level `paths:` filters do not compose with required status checks.
+
 on:
   pull_request:
-    paths:
-      - "**/*.rs"
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
-      - ".github/workflows/ci.yml"
-      - ".github/actions/setup-rust/**"
-      - "clippy.toml"
-      - "rustfmt.toml"
-      - "deny.toml"
 
 permissions:
   contents: read
@@ -24,39 +21,73 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  format:
-    name: Format
+  changes:
+    name: Detect changes
     runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/setup-rust
+      - id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            rust:
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - '**/Cargo.lock'
+              - 'clippy.toml'
+              - 'rustfmt.toml'
+              - 'deny.toml'
+              - '.github/workflows/ci.yml'
+              - '.github/actions/setup-rust/**'
+
+  format:
+    name: Format
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - if: needs.changes.outputs.rust == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - if: needs.changes.outputs.rust == 'true'
+        uses: ./.github/actions/setup-rust
         with:
           components: rustfmt
-      - run: cargo fmt --all -- --check
+      - if: needs.changes.outputs.rust == 'true'
+        run: cargo fmt --all -- --check
 
   lint:
     name: Lint
+    needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/setup-rust
+      - if: needs.changes.outputs.rust == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - if: needs.changes.outputs.rust == 'true'
+        uses: ./.github/actions/setup-rust
         with:
           components: clippy
-      - run: cargo clippy --workspace --all-targets --locked -- -D warnings
+      - if: needs.changes.outputs.rust == 'true'
+        run: cargo clippy --workspace --all-targets --locked -- -D warnings
 
   test:
     name: Test (${{ matrix.runner }})
+    needs: changes
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
         runner: [ubuntu-24.04, ubuntu-24.04-arm]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/setup-rust
-      - run: cargo test --workspace --locked
+      - if: needs.changes.outputs.rust == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - if: needs.changes.outputs.rust == 'true'
+        uses: ./.github/actions/setup-rust
+      - if: needs.changes.outputs.rust == 'true'
+        run: cargo test --workspace --locked
 
   build:
     name: Build (${{ matrix.target }})
+    needs: changes
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -66,27 +97,38 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/setup-rust
+      - if: needs.changes.outputs.rust == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - if: needs.changes.outputs.rust == 'true'
+        uses: ./.github/actions/setup-rust
       - name: Build release binary
+        if: needs.changes.outputs.rust == 'true'
         run: cargo build --release --locked
         env:
           CARGO_BUILD_RUSTFLAGS: "-C target-feature=+crt-static"
           CARGO_BUILD_TARGET: ${{ matrix.target }}
       - name: Verify static binary
+        if: needs.changes.outputs.rust == 'true'
         run: "! readelf -d target/${{ matrix.target }}/release/ocync | grep -q NEEDED"
 
   check-non-fips:
     name: Check (non-fips)
+    needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/setup-rust
-      - run: cargo check --locked --no-default-features --features non-fips
+      - if: needs.changes.outputs.rust == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - if: needs.changes.outputs.rust == 'true'
+        uses: ./.github/actions/setup-rust
+      - if: needs.changes.outputs.rust == 'true'
+        run: cargo check --locked --no-default-features --features non-fips
 
   deny:
     name: Deny
+    needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
+      - if: needs.changes.outputs.rust == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - if: needs.changes.outputs.rust == 'true'
+        uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,13 +1,13 @@
 name: Docker
 
+# Always triggers on every PR so the Build job reports a status. Step-level
+# `if` guards skip the actual work when no Dockerfile-relevant files changed,
+# letting the job report success without doing real work. This pattern lets
+# the job be named in branch protection without blocking unrelated PRs --
+# top-level `paths:` filters do not compose with required status checks.
+
 on:
   pull_request:
-    paths:
-      - "Dockerfile"
-      - "**/*.rs"
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
-      - ".github/workflows/docker.yml"
 
 permissions:
   contents: read
@@ -17,9 +17,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build
+  changes:
+    name: Detect changes
     runs-on: ubuntu-latest
+    outputs:
+      docker: ${{ steps.filter.outputs.docker }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - run: docker build .
+      - id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            docker:
+              - 'Dockerfile'
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - '**/Cargo.lock'
+              - '.github/workflows/docker.yml'
+
+  build:
+    name: Build
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - if: needs.changes.outputs.docker == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - if: needs.changes.outputs.docker == 'true'
+        run: docker build .

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,15 @@
 name: Docs
 
+# On PRs, always triggers so the Build job reports a status. Step-level `if`
+# guards skip the actual work when no doc files changed, letting the job
+# report success without doing real work. This pattern lets the job be
+# named in branch protection without blocking Rust-only or chart-only PRs --
+# top-level `paths:` filters do not compose with required status checks.
+#
+# On pushes to main, `paths:` is preserved so the Pages deploy only fires
+# when docs actually change. Push events are not branch-protected and don't
+# need the always-trigger treatment.
+
 on:
   push:
     branches: [main]
@@ -7,9 +17,6 @@ on:
       - "docs/**"
       - ".github/workflows/docs.yml"
   pull_request:
-    paths:
-      - "docs/**"
-      - ".github/workflows/docs.yml"
 
 permissions:
   contents: read
@@ -21,37 +28,57 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build
+  changes:
+    name: Detect changes
     runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - '.github/workflows/docs.yml'
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+  build:
+    name: Build
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - if: needs.changes.outputs.docs == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - if: needs.changes.outputs.docs == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: latest
           cache: npm
           cache-dependency-path: docs/package-lock.json
 
       - name: Install dependencies
+        if: needs.changes.outputs.docs == 'true'
         working-directory: docs
         run: npm ci
 
       - name: Build site
+        if: needs.changes.outputs.docs == 'true'
         working-directory: docs
         env:
           NODE_ENV: production
         run: npm run build
 
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && needs.changes.outputs.docs == 'true'
         with:
           path: docs/dist
 
   deploy:
     name: Deploy
-    if: github.event_name == 'push'
-    needs: build
+    if: github.event_name == 'push' && needs.changes.outputs.docs == 'true'
+    needs: [changes, build]
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,10 +1,13 @@
 name: Helm
 
+# Always triggers on every PR so the Lint job reports a status. Step-level
+# `if` guards skip the actual work when no chart files changed, letting the
+# job report success without doing real work. This pattern lets the job be
+# named in branch protection without blocking Rust-only or doc-only PRs --
+# top-level `paths:` filters do not compose with required status checks.
+
 on:
   pull_request:
-    paths:
-      - "charts/**"
-      - ".github/workflows/helm.yml"
 
 permissions:
   contents: read
@@ -14,16 +17,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    name: Lint
+  changes:
+    name: Detect changes
     runs-on: ubuntu-latest
+    outputs:
+      helm: ${{ steps.filter.outputs.helm }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - run: helm lint charts/ocync
-      - run: helm template ocync charts/ocync
+      - id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            helm:
+              - 'charts/**'
+              - '.github/workflows/helm.yml'
+
+  lint:
+    name: Lint
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - if: needs.changes.outputs.helm == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - if: needs.changes.outputs.helm == 'true'
+        run: helm lint charts/ocync
+      - if: needs.changes.outputs.helm == 'true'
+        run: helm template ocync charts/ocync
       - name: Install helm-unittest
         # helm-unittest is a helm plugin (not a standalone binary). `helm plugin
         # install --version <ref>` selects a specific git tag of the plugin repo.
+        if: needs.changes.outputs.helm == 'true'
         env:
           HELM_UNITTEST_VERSION: v1.0.3
         run: |
@@ -36,11 +59,13 @@ jobs:
         # Tier 2 conditional rendering, workloadIdentity per-provider, watch-
         # vs-cronjob-vs-job pod spec). New tests in charts/ocync/tests/*.yaml
         # are picked up automatically.
+        if: needs.changes.outputs.helm == 'true'
         run: helm unittest charts/ocync
       - name: Install helm-docs
         # Pinned binary + sha256. helm-docs reads `# --` comments in values.yaml
         # and regenerates the chart README. CI verifies the committed README
         # matches what helm-docs would generate.
+        if: needs.changes.outputs.helm == 'true'
         env:
           HELM_DOCS_VERSION: v1.14.2
           HELM_DOCS_SHA256: a8cf72ada34fad93285ba2a452b38bdc5bd52cc9a571236244ec31022928d6cc
@@ -56,6 +81,7 @@ jobs:
         # If a contributor changed values.yaml without regenerating README.md,
         # this step fails with a diff. Regenerate locally with:
         #   helm-docs --chart-search-root charts
+        if: needs.changes.outputs.helm == 'true'
         run: |
           set -euo pipefail
           helm-docs --chart-search-root charts
@@ -67,6 +93,7 @@ jobs:
         # Pinned binary + sha256 verification. kubeconform validates against
         # bundled JSON schemas offline - kubectl apply --dry-run=client requires
         # API discovery from a live cluster, which we don't have in CI.
+        if: needs.changes.outputs.helm == 'true'
         env:
           KUBECONFORM_VERSION: v0.6.7
           KUBECONFORM_SHA256: 95f14e87aa28c09d5941f11bd024c1d02fdc0303ccaa23f61cef67bc92619d73
@@ -84,6 +111,7 @@ jobs:
         # picked up automatically. -ignore-missing-schemas accepts CRDs whose
         # schemas are not bundled (added in later steps: ExternalSecret,
         # SecretProviderClass); -strict rejects unknown fields on core types.
+        if: needs.changes.outputs.helm == 'true'
         run: |
           set -euo pipefail
           shopt -s nullglob


### PR DESCRIPTION
## Why

GitHub treats path-filtered workflows as "expected but not present" on PRs that do not touch the filtered paths. The moment any of these jobs is named in branch protection's required status checks, **chart-only and doc-only PRs become unmergeable** — the required check never reports because the workflow never triggered.

This is dormant today (`main` has no branch protection), but it would bite the day branch protection is turned on. Better to fix it before the rules go in than after open PRs are stuck.

## What

All four PR-relevant workflows (`ci.yml`, `helm.yml`, `docs.yml`, `docker.yml`) now follow the same pattern:

1. Drop the top-level `paths:` filter on `pull_request:` triggers.
2. Add a `changes` job using `dorny/paths-filter` (pinned to `v4.0.1` by SHA, matching the repo's action-pin convention) that computes a boolean per workflow (`rust`, `helm`, `docs`, `docker`).
3. Gate every substantive step with `if: needs.changes.outputs.<key> == 'true'`.

The job always runs, always reports green, and only does real work when files in the filtered set changed. Each skipped job costs about 15 seconds of runner time (checkout + filter, no other work).

`docs.yml` preserves its `push: paths:` filter so the Pages deploy only fires when docs change on main. Push events are not branch-protected and do not need the always-trigger treatment.

## Why this pattern (and not the alternatives)

- **Aggregator job** (one always-run "CI Gate" check that depends on the others): hides the per-job names from branch protection, makes the gate harder to read, and `workflow_run` cross-workflow dependencies are fiddly.
- **Drop path filters entirely** (let everything run on every PR): wall-clock and runner-minute cost go up significantly — a doc typo would run the full Rust matrix (Test x2, Build x2, Deny, Format, Lint, Check non-fips).
- **Wait until branch protection is needed**: cheap today, painful when it's wired up under time pressure.

The chosen pattern preserves per-job granularity in branch protection settings, keeps actual job names readable, and has a small, predictable per-skip cost.

## Test plan

This PR itself is the regression test: it touches only `.github/workflows/`, which is in the `rust` filter set (`.github/workflows/ci.yml`) and the `docker` filter set (`.github/workflows/docker.yml`), so:

- [ ] CI workflow's jobs (Format, Lint, Test x2, Build x2, Check non-fips, Deny) should run real work because `ci.yml` was modified
- [ ] Docker workflow's Build should run real work because `docker.yml` was modified
- [ ] Helm workflow's Lint should run, all steps skipped (no chart files changed) → green in <1 minute
- [ ] Docs workflow's Build should run, all steps skipped → green in <1 minute
- [ ] No `paths:` filter remains on any `pull_request:` trigger across the four workflows

Once this lands, a follow-up chart-only or doc-only PR will exercise the inverse path: Rust/Docker workflows skip-but-report, Helm/Docs workflows do real work.

## Notes for reviewers

- Repetitive `if: needs.changes.outputs.<key> == 'true'` on every step is the cost of preserving per-job names. The alternative (one `if` at the job level) would mark the job as "skipped" rather than "success", which does not satisfy required-status-check semantics.
- `dorny/paths-filter@v4.0.1` is the only new action dependency. It is widely used in the GitHub Actions ecosystem.
