### PR TITLE
fix(chart): bind watch-mode health server to 0.0.0.0 for kubelet probes

### DIFF
--- a/charts/ocync/README.md
+++ b/charts/ocync/README.md
@@ -45,7 +45,7 @@ See the [Helm chart documentation](https://clowdhaus.github.io/ocync/helm) and [
 | fullnameOverride | string | `""` | Override the fully-qualified release name (overrides `<release>-<chartname>`). |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | image.repository | string | `"public.ecr.aws/clowdhaus/ocync"` | Container image repository. |
-| image.tag | string | `<chart-app-version>-fips` | Container image tag. |
+| image.tag | string | `<chart-app-version>-fips` | Container image tag. Overriding to a tag older than the chart's appVersion is not recommended: the chart may pass binary flags that older images do not recognize, causing the container to fail at startup. |
 | imagePullSecrets | list | `[]` | Image pull secrets for the workload pods. |
 | jobAnnotations | object | `{}` | Annotations applied to the Job's `metadata.annotations` when `mode: job`. Common uses: Helm lifecycle hooks (`helm.sh/hook: post-install` etc.), Argo CD sync-wave / hook annotations on one-shot Jobs, policy-controller selectors. Pod-template annotations belong under `podAnnotations`. |
 | mode | string | `"watch"` | Deployment mode: `watch` (Deployment with sync interval), `cronjob` (CronJob), or `job` (one-shot Job). |

--- a/charts/ocync/README.md
+++ b/charts/ocync/README.md
@@ -64,6 +64,7 @@ See the [Helm chart documentation](https://clowdhaus.github.io/ocync/helm) and [
 | serviceAccount.create | bool | `true` | Whether the chart should create a ServiceAccount for the workload. |
 | serviceAccount.name | string | `""` | Override the ServiceAccount name (defaults to the chart fullname). |
 | tolerations | list | `[]` | Tolerations for the pod. |
+| watch.healthBind | string | `"0.0.0.0"` | Health server bind address (watch mode only). Defaults to `0.0.0.0` so kubelet probes (which target the pod IP) succeed without override. Set to `::` for IPv6-only clusters. |
 | watch.healthPort | int | `8080` | Health check port (watch mode only). Exposed via Service and used by liveness/readiness probes. |
 | watch.interval | int | `300` | Sync interval in seconds (watch mode only). |
 | workloadIdentity.aws.roleArn | string | `""` | IAM role ARN to assume via IRSA. Sets `eks.amazonaws.com/role-arn` on the ServiceAccount. |

--- a/charts/ocync/templates/_pod.tpl
+++ b/charts/ocync/templates/_pod.tpl
@@ -55,9 +55,11 @@ spec:
         - {{ .Values.watch.interval | quote }}
         - --health-port
         - {{ .Values.watch.healthPort | quote }}
-        {{- /* Required override: binary default 127.0.0.1 is unreachable from kubelet (probes pod IP). See #77. */}}
+        {{- /* Yield to extraArgs override; clap would resolve last-wins anyway, but skipping avoids duplicate flags in the rendered Deployment. */}}
+        {{- if not (has "--health-bind" .Values.extraArgs) }}
         - --health-bind
-        - "0.0.0.0"
+        - {{ .Values.watch.healthBind | quote }}
+        {{- end }}
         {{- else }}
         - sync
         - --config

--- a/charts/ocync/templates/_pod.tpl
+++ b/charts/ocync/templates/_pod.tpl
@@ -55,6 +55,9 @@ spec:
         - {{ .Values.watch.interval | quote }}
         - --health-port
         - {{ .Values.watch.healthPort | quote }}
+        {{- /* Required override: binary default 127.0.0.1 is unreachable from kubelet (probes pod IP). See #77. */}}
+        - --health-bind
+        - 0.0.0.0
         {{- else }}
         - sync
         - --config

--- a/charts/ocync/templates/_pod.tpl
+++ b/charts/ocync/templates/_pod.tpl
@@ -57,7 +57,7 @@ spec:
         - {{ .Values.watch.healthPort | quote }}
         {{- /* Required override: binary default 127.0.0.1 is unreachable from kubelet (probes pod IP). See #77. */}}
         - --health-bind
-        - 0.0.0.0
+        - "0.0.0.0"
         {{- else }}
         - sync
         - --config

--- a/charts/ocync/tests/pod_template_test.yaml
+++ b/charts/ocync/tests/pod_template_test.yaml
@@ -9,12 +9,7 @@ templates:
   - job.yaml
 
 tests:
-  - it: watch mode renders the full container args list (regression guard for #77)
-    # Asserts the exact ordered args. Substring `contains` would pass if
-    # --health-bind drifted away from its 0.0.0.0 value or if any flag/value
-    # pair separated; full-list equality catches both. Probes target the pod
-    # IP and the binary defaults to 127.0.0.1, so --health-bind 0.0.0.0 is
-    # load-bearing and must stay paired.
+  - it: watch mode renders the full container args list
     set:
       mode: watch
     template: deployment.yaml
@@ -30,7 +25,7 @@ tests:
             - --health-port
             - "8080"
             - --health-bind
-            - 0.0.0.0
+            - "0.0.0.0"
 
   - it: cronjob mode renders the full container args list
     set:

--- a/charts/ocync/tests/pod_template_test.yaml
+++ b/charts/ocync/tests/pod_template_test.yaml
@@ -9,50 +9,52 @@ templates:
   - job.yaml
 
 tests:
-  - it: watch mode renders container args [watch, --config, ..., --interval, --health-port]
+  - it: watch mode renders the full container args list (regression guard for #77)
+    # Asserts the exact ordered args. Substring `contains` would pass if
+    # --health-bind drifted away from its 0.0.0.0 value or if any flag/value
+    # pair separated; full-list equality catches both. Probes target the pod
+    # IP and the binary defaults to 127.0.0.1, so --health-bind 0.0.0.0 is
+    # load-bearing and must stay paired.
     set:
       mode: watch
     template: deployment.yaml
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].args[0]
-          value: watch
-      - equal:
-          path: spec.template.spec.containers[0].args[1]
-          value: --config
-      - contains:
           path: spec.template.spec.containers[0].args
-          content: --interval
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: --health-port
+          value:
+            - watch
+            - --config
+            - /etc/ocync/config.yaml
+            - --interval
+            - "300"
+            - --health-port
+            - "8080"
+            - --health-bind
+            - 0.0.0.0
 
-  - it: cronjob mode renders container args [sync, --config, ...]
+  - it: cronjob mode renders the full container args list
     set:
       mode: cronjob
     template: cronjob.yaml
     asserts:
       - equal:
-          path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
-          value: sync
-      - notContains:
           path: spec.jobTemplate.spec.template.spec.containers[0].args
-          content: watch
-      - notContains:
-          path: spec.jobTemplate.spec.template.spec.containers[0].args
-          content: --interval
+          value:
+            - sync
+            - --config
+            - /etc/ocync/config.yaml
 
-  - it: job mode renders container args [sync, --config, ...]
+  - it: job mode renders the full container args list
     set:
       mode: job
     template: job.yaml
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].args[0]
-          value: sync
-      - notContains:
           path: spec.template.spec.containers[0].args
-          content: watch
+          value:
+            - sync
+            - --config
+            - /etc/ocync/config.yaml
 
   - it: watch mode has health port and probes
     set:

--- a/charts/ocync/tests/pod_template_test.yaml
+++ b/charts/ocync/tests/pod_template_test.yaml
@@ -27,6 +27,33 @@ tests:
             - --health-bind
             - "0.0.0.0"
 
+  - it: watch.healthBind override flows through to container args
+    set:
+      mode: watch
+      watch:
+        healthBind: "::"
+    template: deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "::"
+
+  - it: extraArgs --health-bind suppresses the chart's own --health-bind to avoid duplicate flags
+    set:
+      mode: watch
+      extraArgs:
+        - --health-bind
+        - 127.0.0.1
+    template: deployment.yaml
+    asserts:
+      # Total args = 7 watch defaults (no --health-bind) + 2 extraArgs.
+      - lengthEqual:
+          path: spec.template.spec.containers[0].args
+          count: 9
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "127.0.0.1"
+
   - it: cronjob mode renders the full container args list
     set:
       mode: cronjob

--- a/charts/ocync/values.yaml
+++ b/charts/ocync/values.yaml
@@ -4,7 +4,9 @@ mode: watch
 image:
   # -- Container image repository.
   repository: public.ecr.aws/clowdhaus/ocync
-  # -- Container image tag.
+  # -- Container image tag. Overriding to a tag older than the chart's appVersion
+  # is not recommended: the chart may pass binary flags that older images do not
+  # recognize, causing the container to fail at startup.
   # @default -- `<chart-app-version>-fips`
   tag: ""
   # -- Image pull policy.

--- a/charts/ocync/values.yaml
+++ b/charts/ocync/values.yaml
@@ -38,6 +38,9 @@ watch:
   interval: 300
   # -- Health check port (watch mode only). Exposed via Service and used by liveness/readiness probes.
   healthPort: 8080
+  # -- Health server bind address (watch mode only). Defaults to `0.0.0.0` so kubelet probes
+  # (which target the pod IP) succeed without override. Set to `::` for IPv6-only clusters.
+  healthBind: "0.0.0.0"
 
 cronjob:
   # -- Cron schedule expression (cronjob mode only).

--- a/docs/src/content/cli-reference.md
+++ b/docs/src/content/cli-reference.md
@@ -91,6 +91,7 @@ ocync watch -c config.yaml --interval 600 --health-port 8080
 | `-c`, `--config` | (required) | Path to sync config file |
 | `--interval` | `300` | Seconds between sync runs (minimum: 1) |
 | `--health-port` | `8080` | Port for `/healthz` and `/readyz` endpoints |
+| `--health-bind` | `127.0.0.1` | IP for the health endpoint to bind on. Set to `0.0.0.0` for container hosts where probes originate externally. The Helm chart sets this automatically in `watch` mode |
 | `--json` | | Output sync reports as JSON |
 
 See [observability](/observability) for health endpoint details.

--- a/docs/src/content/cli-reference.md
+++ b/docs/src/content/cli-reference.md
@@ -91,7 +91,7 @@ ocync watch -c config.yaml --interval 600 --health-port 8080
 | `-c`, `--config` | (required) | Path to sync config file |
 | `--interval` | `300` | Seconds between sync runs (minimum: 1) |
 | `--health-port` | `8080` | Port for `/healthz` and `/readyz` endpoints |
-| `--health-bind` | `127.0.0.1` | IP for the health endpoint to bind on. Set to `0.0.0.0` for container hosts where probes originate externally. The Helm chart sets this automatically in `watch` mode |
+| `--health-bind` | `127.0.0.1` | IP for the health endpoint to bind on. Set to `0.0.0.0` for container hosts where probes originate externally |
 | `--json` | | Output sync reports as JSON |
 
 See [observability](/observability) for health endpoint details.

--- a/docs/src/content/helm.md
+++ b/docs/src/content/helm.md
@@ -80,6 +80,8 @@ watch:
 
 Exposes `/healthz` (liveness) and `/readyz` (readiness) endpoints. See [observability](/observability) for logging configuration.
 
+The chart binds the health server to `0.0.0.0` so kubelet probes (which target the pod IP) succeed without user override. Clusters with non-IPv4 pod networking need to pass an appropriate bind address via `extraArgs`.
+
 ## Job mode
 
 ```yaml

--- a/docs/src/content/helm.md
+++ b/docs/src/content/helm.md
@@ -80,7 +80,7 @@ watch:
 
 Exposes `/healthz` (liveness) and `/readyz` (readiness) endpoints. See [observability](/observability) for logging configuration.
 
-The chart binds the health server to `0.0.0.0` so kubelet probes (which target the pod IP) succeed without user override. Clusters with non-IPv4 pod networking need to pass an appropriate bind address via `extraArgs`.
+`watch.healthBind` defaults to `0.0.0.0` so kubelet probes (which target the pod IP) succeed without user override. Set `watch.healthBind: "::"` on IPv6-only clusters.
 
 ## Job mode
 

--- a/docs/src/content/observability.md
+++ b/docs/src/content/observability.md
@@ -98,4 +98,6 @@ watch:
   healthPort: 8080
 ```
 
+The Helm chart binds the health server to `0.0.0.0` so kubelet probes (which target the pod IP) succeed without user override. Clusters with non-IPv4 pod networking need to pass an appropriate bind address via `extraArgs`.
+
 See [CLI reference](/cli-reference#watch) for all `watch` flags including `--interval` and `--json`.

--- a/docs/src/content/observability.md
+++ b/docs/src/content/observability.md
@@ -98,6 +98,4 @@ watch:
   healthPort: 8080
 ```
 
-The Helm chart binds the health server to `0.0.0.0` so kubelet probes (which target the pod IP) succeed without user override. Clusters with non-IPv4 pod networking need to pass an appropriate bind address via `extraArgs`.
-
 See [CLI reference](/cli-reference#watch) for all `watch` flags including `--interval` and `--json`.


### PR DESCRIPTION
## Summary

- Add `watch.healthBind` chart value (default `0.0.0.0`) so kubelet probes (which target the pod IP) reach the health server. Fixes the CrashLoopBackOff reported in #77 where probes failed with `connection refused` because the binary defaulted to `127.0.0.1`. IPv6-only clusters set `watch.healthBind: "::"`.
- The chart yields to `extraArgs` when the user sets `--health-bind` there, avoiding duplicate flags in the rendered Deployment that clap would otherwise resolve via last-wins. Existing users with the workaround `extraArgs: ["--health-bind", "0.0.0.0"]` get a clean upgrade with no duplicated flags.
- Refactor the per-mode args tests in `pod_template_test.yaml` from positional/`contains` checks to full-list `equal`, aligning with the rest of the test suite. Add tests for `watch.healthBind` override flow-through and `extraArgs` dedupe.
- Document `--health-bind` in the CLI reference; document `watch.healthBind` and the IPv6-only override in the Helm page.
- Warn in `values.yaml` that overriding `image.tag` to a version older than the chart's appVersion may cause the container to fail at startup if the older binary does not recognize newer chart-rendered flags.

The binary's `127.0.0.1` default is intentionally safe for local CLI use and stays. The fix is at the chart layer where the K8s probe contract lives.

Closes #77

## Test plan

- [x] `helm unittest charts/ocync` — 62/62 pass (60 prior + override flow-through + extraArgs dedupe)
- [x] `helm lint charts/ocync` — clean
- [x] `helm-docs --chart-search-root charts` — README adds `watch.healthBind` row and the `image.tag` warning
- [x] `helm template` against all 5 `charts/ocync/ci/*-values.yaml` fixtures — render successfully; default render unchanged from before this PR's fix beyond the new flag
- [x] Manual render with `extraArgs: ["--health-bind", "127.0.0.1"]` — chart's own `--health-bind` is suppressed, only the user's flag appears
- [x] `npm run build` in `docs/` — 21 pages built, no internal-link errors
- [ ] Reviewer to verify rendered Deployment in a real cluster: probes succeed, container does not enter CrashLoopBackOff