### PR TITLE
fix(release): unify version bump across workspace and chart

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -20,7 +20,10 @@ Local flow uses [`cargo-release`](https://github.com/crate-ci/cargo-release) to 
 
 ```
 cargo install cargo-release
+brew install norwoodj/tap/helm-docs   # or follow the upstream installer
 ```
+
+`helm-docs` is invoked as a `pre-release-hook` during the bump to regenerate `charts/ocync/README.md` against the new chart version. Without it, cargo-release fails fast with a clear error before producing any commit or tag.
 
 Then, on a clean `main` checkout:
 
@@ -33,56 +36,55 @@ cargo release 0.2.0 --execute    # explicit version
 
 `cargo-release` will:
 
-1. Bump `[package].version` in the root `Cargo.toml` (the `ocync` binary crate).
-2. Regenerate `Cargo.lock` so `cargo build --locked` keeps working.
-3. Create a single commit with the bump.
-4. Tag it `v<version>` (matches the `v*` pattern the release workflow watches).
-5. Push the commit and tag to the remote.
+1. Bump `[workspace.package].version` in the root `Cargo.toml`. All five workspace crates (`ocync`, `ocync-distribution`, `ocync-sync`, `bench-proxy`, `xtask`) inherit via `version.workspace = true` and move together.
+2. Rewrite `version` and `appVersion` in `charts/ocync/Chart.yaml` to the new value (driven by `pre-release-replacements` in the root `[package.metadata.release]`).
+3. Run `helm-docs --chart-search-root charts` to regenerate `charts/ocync/README.md` against the new chart version (driven by `pre-release-hook`).
+4. Regenerate `Cargo.lock` so `cargo build --locked` keeps working.
+5. Create a single commit with all of the above.
+6. Tag it `v<version>` (matches the `v*` pattern the release workflow watches).
+7. Push the commit and tag to the remote.
 
 The pushed tag fires `workflows/release.yml` and the rest is automated.
+
+The four non-binary crates carry `[package.metadata.release] release = false` so cargo-release skips them entirely (no per-crate tags, no publish attempts). They still receive the version bump because their `[package].version` inherits from the workspace.
 
 ### Manual fallback
 
 If `cargo-release` is unavailable, the same outcome by hand:
 
 ```
-sed -i '' 's/^version = "0.1.0"/version = "0.2.0"/' Cargo.toml
+sed -i '' 's/^version = "0.3.0"/version = "0.4.0"/' Cargo.toml
+sed -i '' 's/^version: 0.3.0/version: 0.4.0/' charts/ocync/Chart.yaml
+sed -i '' 's/^appVersion: "0.3.0"/appVersion: "0.4.0"/' charts/ocync/Chart.yaml
+helm-docs --chart-search-root charts
 cargo generate-lockfile
-git commit -am "chore(release): v0.2.0"
-git tag v0.2.0
-git push origin main v0.2.0
+git commit -am "chore(release): v0.4.0"
+git tag v0.4.0
+git push origin main v0.4.0
 ```
 
-The validate job (`release.yml:23-37`) gates on `[package].version` matching the tag, so a mismatch fails fast before any artifact is built.
+The validate job (`release.yml`) gates the tag against `[workspace.package].version`, `Chart.yaml` `version`, and `Chart.yaml` `appVersion`. Any mismatch fails fast before artifacts are built.
 
 ### Workspace versioning
 
-Three crates live in this workspace: `ocync` (root, the binary), `ocync-distribution`, and `ocync-sync`. Only the root crate's version is gated by the release workflow, and only the root crate's version drives the released artifacts (Docker image tag, Helm `appVersion`, GitHub Release name). The library crates can stay at `0.1.0` indefinitely; they are not published to crates.io.
+The workspace has one version, defined once at `[workspace.package].version` and inherited by every crate. The five crates always carry the same number. None of them publish to crates.io; the version is the released-artifact identity (Docker tag, Helm chart version, GitHub Release name).
 
-On the first `cargo release` run, do a dry run (no `--execute`) and confirm only the root `Cargo.toml` is touched. If `cargo-release` proposes bumping the library crates, opt them out by adding to each library `Cargo.toml`:
-
-```toml
-[package.metadata.release]
-release = false
-```
-
-Library crates can opt back in later if we ever publish them.
+If a library crate ever needs to publish independently, drop `version.workspace = true` from its `[package]`, set an explicit version, and remove `release = false` from its `[package.metadata.release]`.
 
 ## What you do NOT need to touch
 
-- `charts/ocync/Chart.yaml` `version` / `appVersion`. `helm package --version $TAG --app-version $TAG` overrides them at release time. The committed `0.1.0` is a placeholder for `helm lint` / `helm template` in CI; do not chase it.
-- `charts/ocync/values.yaml` `image.tag`. Left empty on purpose. The chart's `ocync.image` helper (`templates/_helpers.tpl`) defaults the tag to `<.Chart.AppVersion>-fips`, which is whatever was passed to `helm package`. Tag bump moves chart and image together.
+- `charts/ocync/values.yaml` `image.tag`. Left empty on purpose. The chart's `ocync.image` helper (`templates/_helpers.tpl`) defaults the tag to `<.Chart.AppVersion>-fips`, which now equals the bumped chart `appVersion`. Tag bump moves chart and image together.
 
 If you ever need to override the image tag for a one-off install, that is a `helm install --set image.tag=...` decision, not a chart edit.
 
 ## Workflow steps
 
-1. **validate**: fails fast unless the tag (minus `v`) matches `Cargo.toml` `[package].version`. This is the only version gate; `Chart.yaml` is not checked because it is overridden during packaging.
+1. **validate**: fails fast unless the tag (minus `v`) matches `[workspace.package].version` in `Cargo.toml`, `version` in `charts/ocync/Chart.yaml`, AND `appVersion` in `charts/ocync/Chart.yaml`. Any mismatch is reported with `::error file=...::` against the offending file.
 2. **build-linux** (matrix amd64/arm64): builds with `RUSTFLAGS="-C target-feature=+crt-static"` for fully static FIPS binaries; `readelf -d` confirms no `NEEDED` entries.
 3. **build-macos** / **build-windows**: non-FIPS builds (the `aws-lc-rs` FIPS provider is Linux-only).
 4. **docker** (matrix amd64/arm64): assumes `ECR_PUBLIC_ROLE_ARN`, builds the Dockerfile, pushes the per-arch tag.
 5. **docker-manifest**: composes the per-arch images into `<version>-fips` and `latest-fips` manifests, signs both with cosign keyless.
-6. **helm**: `helm package` with `--version` / `--app-version` set to the tag, then `helm push` to ECR Public over OCI. Chart version and app version both equal the tag.
+6. **helm**: `helm package charts/ocync` (no flag overrides; chart version and appVersion come straight from `Chart.yaml`), then `helm push` to ECR Public over OCI.
 7. **release**: downloads all binary artifacts, generates `sha256sums.txt`, attests build provenance, runs `git-cliff` (config in `cliff.toml`) for release notes filtered by conventional-commit type, and creates the GitHub Release.
 
 The `helm` job depends on `docker-manifest`, so a failed image build short-circuits the chart push. The chart will never reference an image that does not exist.

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -71,6 +71,12 @@ The workspace has one version, defined once at `[workspace.package].version` and
 
 If a library crate ever needs to publish independently, drop `version.workspace = true` from its `[package]`, set an explicit version, and remove `release = false` from its `[package.metadata.release]`.
 
+### Chart-only changes
+
+Chart-only fixes (templates, values, helpers — no Rust changes) ride with the next bundled release. Run `cargo release patch --execute` when the chart fix needs to ship; the binary gets rebuilt and re-tagged at the new version even though no Rust code changed. The Docker image is reproducible from `Cargo.lock`, so the new `<version>-fips` tag is identical bytes apart from the version stamp. There is no separate chart-only release path, by design — chart and binary versions stay locked so the chart's rendered flags always match a binary that recognizes them.
+
+If a chart bug ever genuinely cannot wait for the next bundled release and you don't want to consume a binary patch version, the escape hatch is a one-off `helm package charts/ocync` + `helm push` run by hand against ECR Public, with `--version` overriding `Chart.yaml`. That path is unsupported and bypasses the validate gate; prefer the bundled release.
+
 ## What you do NOT need to touch
 
 - `charts/ocync/values.yaml` `image.tag`. Left empty on purpose. The chart's `ocync.image` helper (`templates/_helpers.tpl`) defaults the tag to `<.Chart.AppVersion>-fips`, which now equals the bumped chart `appVersion`. Tag bump moves chart and image together.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,16 +25,29 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Check tag matches Cargo.toml
+      - name: Check tag matches Cargo.toml and Chart.yaml
         env:
           TAG_VERSION: ${{ github.ref_name }}
         run: |
-          CARGO_VERSION="$(sed -n '/^\[package\]/,/^\[/{s/^version = "\(.*\)"/\1/p}' Cargo.toml)"
+          set -euo pipefail
           TAG_VERSION="${TAG_VERSION#v}"
+          CARGO_VERSION="$(sed -n '/^\[workspace\.package\]/,/^\[/{s/^version = "\(.*\)"/\1/p}' Cargo.toml)"
+          CHART_VERSION="$(sed -n 's/^version: //p' charts/ocync/Chart.yaml)"
+          CHART_APP_VERSION="$(sed -n 's/^appVersion: "\(.*\)"/\1/p' charts/ocync/Chart.yaml)"
+          fail=0
           if [ "$CARGO_VERSION" != "$TAG_VERSION" ]; then
-            echo "::error::Tag v${TAG_VERSION} does not match Cargo.toml version ${CARGO_VERSION}"
-            exit 1
+            echo "::error file=Cargo.toml::workspace.package.version is ${CARGO_VERSION}, tag is v${TAG_VERSION}"
+            fail=1
           fi
+          if [ "$CHART_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error file=charts/ocync/Chart.yaml::version is ${CHART_VERSION}, tag is v${TAG_VERSION}"
+            fail=1
+          fi
+          if [ "$CHART_APP_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error file=charts/ocync/Chart.yaml::appVersion is ${CHART_APP_VERSION}, tag is v${TAG_VERSION}"
+            fail=1
+          fi
+          [ $fail -eq 0 ]
 
   build-linux:
     name: Build Linux (${{ matrix.artifact }})
@@ -188,11 +201,8 @@ jobs:
           aws-region: us-east-1
       - name: Login to ECR Public (Helm)
         run: aws ecr-public get-login-password --region us-east-1 | helm registry login --username AWS --password-stdin public.ecr.aws
-      - name: Extract version
-        id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
       - name: Package Helm chart
-        run: helm package charts/ocync --version "${{ steps.version.outputs.VERSION }}" --app-version "${{ steps.version.outputs.VERSION }}"
+        run: helm package charts/ocync
       - name: Push Helm chart
         env:
           REGISTRY: ${{ env.ECR_REGISTRY }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "bench-proxy"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "clap",
@@ -2239,7 +2239,7 @@ dependencies = [
 
 [[package]]
 name = "ocync-distribution"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aws-config",
  "aws-lc-rs",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "ocync-sync"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -4316,7 +4316,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xtask"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aws-config",
  "aws-sdk-ecr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = ["bench/proxy", "crates/*", "xtask"]
 
 [workspace.package]
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.94"
 license = "Apache-2.0"
@@ -48,7 +49,7 @@ doc_markdown = "warn"
 
 [package]
 name = "ocync"
-version = "0.3.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -57,6 +58,11 @@ description = "OCI registry sync tool"
 
 [package.metadata.release]
 publish = false
+pre-release-replacements = [
+  { file = "charts/ocync/Chart.yaml", search = "^version: .*$", replace = "version: {{version}}", exactly = 1 },
+  { file = "charts/ocync/Chart.yaml", search = '^appVersion: ".*"$', replace = 'appVersion: "{{version}}"', exactly = 1 },
+]
+pre-release-hook = ["helm-docs", "--chart-search-root", "charts"]
 
 [features]
 default = ["fips"]

--- a/bench/proxy/Cargo.toml
+++ b/bench/proxy/Cargo.toml
@@ -1,12 +1,15 @@
 [package]
 name = "bench-proxy"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "MITM HTTPS forward proxy for ocync benchmark traffic capture"
 publish = false
+
+[package.metadata.release]
+release = false
 
 [lints]
 workspace = true

--- a/charts/ocync/Chart.yaml
+++ b/charts/ocync/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: ocync
 description: OCI container image sync tool
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.3.0
+appVersion: "0.3.0"
 home: https://github.com/clowdhaus/ocync
 sources:
   - https://github.com/clowdhaus/ocync

--- a/charts/ocync/README.md
+++ b/charts/ocync/README.md
@@ -2,10 +2,10 @@
 
 OCI container image sync tool
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
 
 ```bash
-helm install ocync oci://public.ecr.aws/clowdhaus/ocync --version 0.1.0
+helm install ocync oci://public.ecr.aws/clowdhaus/ocync --version 0.3.0
 ```
 
 See the [Helm chart documentation](https://clowdhaus.github.io/ocync/helm) and [`docs/src/content/registries/secrets.md`](../../docs/src/content/registries/secrets.md) for configuration, deployment modes, and the four supported secret-injection patterns.

--- a/crates/ocync-distribution/Cargo.toml
+++ b/crates/ocync-distribution/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
 name = "ocync-distribution"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "OCI Distribution client library"
+publish = false
+
+[package.metadata.release]
+release = false
 
 [features]
 default = ["fips"]

--- a/crates/ocync-sync/Cargo.toml
+++ b/crates/ocync-sync/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
 name = "ocync-sync"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "OCI registry sync orchestration"
+publish = false
+
+[package.metadata.release]
+release = false
 
 [lints]
 workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "xtask"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 publish = false
+
+[package.metadata.release]
+release = false
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

- `cargo release` previously bumped only the root binary's version. The Helm `Chart.yaml` (`version` / `appVersion`) and the four other workspace crates stayed at `0.1.0` indefinitely. Released chart artifacts were correct because CI overrode `--version`/`--app-version` at packaging time, but `helm template` from a source checkout produced stale image tags (`0.1.0-fips`), and the source-of-truth diverged from what shipped.
- Centralize the version at `[workspace.package].version`. All five workspace crates (`ocync`, `ocync-distribution`, `ocync-sync`, `bench-proxy`, `xtask`) inherit via `version.workspace = true` and bump together.
- Add cargo-release `pre-release-replacements` to rewrite `Chart.yaml` `version` and `appVersion`, and a `pre-release-hook` that runs `helm-docs` so `charts/ocync/README.md` regenerates against the new chart version. Both land in the same atomic release commit.
- Library / tool crates carry `[package.metadata.release] release = false` so cargo-release skips them entirely (no per-crate tags, no publish attempts) while still inheriting the workspace bump. `ocync-distribution` and `ocync-sync` also gain `[package].publish = false` so a stray `cargo publish` can't push them to crates.io.
- Drop the `--version`/`--app-version` overrides in the release workflow (Chart.yaml is now authoritative) and broaden the `validate` job to gate the tag against `[workspace.package].version`, `Chart.yaml` `version`, AND `Chart.yaml` `appVersion`. Any mismatch fails fast with `::error file=...::`.
- Update `.github/RELEASING.md` to reflect the new flow and drop the "do not chase the Chart.yaml placeholder" carve-out.

After this PR, `cargo release minor --execute` produces one commit touching `Cargo.toml` + `Cargo.lock` + `Chart.yaml` + `README.md`, one tag, all five crates moving in lockstep, and no in-tree lies about the chart version.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 1241 passed, 1 ignored
- [x] `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- [x] `helm lint charts/ocync` — clean
- [x] `helm unittest charts/ocync` — 62/62 passed
- [x] `helm-docs --chart-search-root charts` — README regenerated, version 0.3.0
- [x] `helm template ocync charts/ocync --values charts/ocync/ci/watch-default-values.yaml` — renders `image: public.ecr.aws/clowdhaus/ocync:0.3.0-fips` (was `0.1.0-fips`)
- [x] `cargo metadata` — all five crates report `0.3.0`
- [x] `cargo release minor` (dry run) — bumps workspace once, all five crates inherit, rewrites `Chart.yaml`, runs `helm-docs`, single `v0.4.0` tag, only `ocync` is "managed" (publish skipped via `publish = false`)
- [ ] Reviewer to verify `release.yml` still parses on GitHub Actions side
- [ ] Reviewer to verify the next real release (`cargo release patch --execute` post-merge) behaves as documented in `RELEASING.md`