### PR TITLE
docs: add recipes section and artifacts configuration reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Sync OCI container images across registries - efficiently.
 
 ocync copies container images between OCI registries with blob deduplication, cross-repo mounting, and streaming transfers. On real-world workloads it completes cold syncs 4x faster than comparable tools, with up to 30% fewer API requests, zero duplicate blob fetches across the run, and zero 429s on every benchmarked registry. See [Performance](https://clowdhaus.github.io/ocync/performance) for the full comparison.
 
-ocync is purpose-built for one job: efficiently mirroring images from upstream registries (Docker Hub, GHCR, GAR, Chainguard) to a private registry (ECR, GAR, ACR). It is not a build tool, a registry, or a content rewriter - it copies bytes verbatim and lets the registry do its job.
+ocync is purpose-built for one job: efficiently mirroring images from upstream registries (Docker Hub, GHCR, GAR, Chainguard) to a private registry (ECR, GAR, ACR). It is not a build tool, a registry, or a content rewriter - it copies bytes verbatim and lets the registry do its job. Multi-architecture indexes, manifests, blobs, and OCI 1.1 referrers (signatures, SBOMs, attestations) all flow through bit-for-bit.
 
 ## Features
 
@@ -40,17 +40,60 @@ ocync copy cgr.dev/chainguard/nginx:latest \
     123456789012.dkr.ecr.us-east-1.amazonaws.com/nginx:latest
 ```
 
-Sync from a config file:
+For repeated syncs, use a config file. Two starting points cover most cases.
+
+### Full-fidelity mirror (default)
+
+Multi-arch indexes, signatures, and SBOMs are preserved bit-for-bit. Use this for compliance and any workload that cares about supply-chain provenance.
+
+```yaml
+registries:
+  source: { url: ghcr.io }
+  ecr:    { url: 123456789012.dkr.ecr.us-east-1.amazonaws.com }
+
+defaults:
+  source: source
+  targets: ecr
+
+mappings:
+  - from: my-org/my-app
+    to: my-app
+    tags:
+      semver: ">=1.0"
+      sort: semver
+      latest: 5
+```
+
+### Minimum bytes
+
+Use this for CI mirrors and air-gapped fleets that do not verify signatures. Skip the OCI 1.1 referrers and narrow to the tags you actually need; multi-arch indexes still flow through verbatim.
+
+```yaml
+registries:
+  source: { url: cgr.dev }
+  ecr:    { url: 123456789012.dkr.ecr.us-east-1.amazonaws.com }
+
+defaults:
+  source: source
+  targets: ecr
+  artifacts:
+    enabled: false       # skip cosign signatures, SBOMs, attestations
+  tags:
+    glob: ["latest"]
+
+mappings:
+  - from: chainguard/curl
+    to: curl
+```
+
+Run a sync, or preview what would change:
 
 ```bash
 ocync sync -c config.yaml
-```
-
-Preview what would sync:
-
-```bash
 ocync sync -c config.yaml --dry-run
 ```
+
+See [Recipes](https://clowdhaus.github.io/ocync/recipes/production-mirror) for variant-only mirrors, helm-chart-and-images patterns (ArgoCD, cert-manager, Karpenter), semver release tracking, and more.
 
 ## Installation
 
@@ -113,6 +156,7 @@ Full documentation at [clowdhaus.github.io/ocync](https://clowdhaus.github.io/oc
 
 - [Getting started](https://clowdhaus.github.io/ocync/getting-started) - installation, first sync, key concepts
 - [Configuration](https://clowdhaus.github.io/ocync/configuration) - config file reference
+- [Recipes](https://clowdhaus.github.io/ocync/recipes/production-mirror) - common mirror patterns (production, minimum bytes, helm + images, variant filtering, semver tracking)
 - [CLI reference](https://clowdhaus.github.io/ocync/cli-reference) - commands, flags, exit codes
 - [Registry guides](https://clowdhaus.github.io/ocync/registries/ecr) - ECR, Docker Hub, GHCR, GAR, ACR, Chainguard
 - [Helm chart](https://clowdhaus.github.io/ocync/helm) - Kubernetes deployment

--- a/docs/src/content/configuration.md
+++ b/docs/src/content/configuration.md
@@ -55,7 +55,7 @@ defaults:
     - linux/arm64
   tags:
     semver: ">=1.0"
-    semver_prerelease: exclude
+    semver_prerelease: include   # cgr.dev tags carry -rN build suffixes
     sort: semver
     latest: 10
 
@@ -154,7 +154,9 @@ Applied to all mappings unless overridden at the mapping level:
 defaults:
   source: chainguard           # Default source registry
   targets: prod                # Default target group
-  platforms:                   # Platform filter
+  artifacts:                   # OCI 1.1 referrer handling (default: enabled)
+    enabled: true
+  platforms:                   # Platform filter (omit to preserve multi-arch)
     - linux/amd64
     - linux/arm64
   tags:
@@ -172,7 +174,8 @@ defaults:
 |---|---|---|
 | `source` | None | Default source registry name for all mappings |
 | `targets` | None | Default target group name or inline list |
-| `platforms` | All platforms | Platform filter applied to all mappings. Each entry must be `os/arch` or `os/arch/variant` (e.g., `linux/amd64`, `linux/arm/v7`). List must not be empty |
+| `artifacts` | `enabled: true` | OCI 1.1 referrer handling (signatures, SBOMs, attestations). See [Artifacts](#artifacts) |
+| `platforms` | All platforms | Platform filter. Each entry must be `os/arch` or `os/arch/variant` (e.g., `linux/amd64`, `linux/arm/v7`). When set, multi-arch indexes are rewritten at the target with a different digest than the source - bit-for-bit divergence. Omit to preserve multi-arch verbatim |
 | `tags` | None | Tag filtering pipeline (see [Tag filtering](#tag-filtering)) |
 
 ## Mappings
@@ -201,6 +204,64 @@ mappings:
 | `targets` | No | Override target group or inline list for this mapping |
 | `tags` | No | Override tag filtering for this mapping |
 | `platforms` | No | Override platform filter for this mapping. List must not be empty if provided |
+| `artifacts` | No | Override artifact handling for this mapping. See [Artifacts](#artifacts) |
+
+## Artifacts
+
+Controls whether OCI 1.1 referrers (cosign signatures, SBOMs, attestations) are discovered and transferred alongside their parent image manifests. Default: enabled.
+
+```yaml
+defaults:
+  artifacts:
+    enabled: true                  # Default; set to false to skip referrers
+    include:                       # When non-empty, only artifacts whose
+      - application/vnd.dev.cosign.simplesigning.v1+json   # artifact_type matches one of these
+      - application/vnd.cyclonedx+json
+    exclude:                       # Always-skip artifacts whose type matches
+      - application/vnd.in-toto+json
+    require_artifacts: false       # When true, fail the sync if a parent has zero referrers
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `enabled` | `true` | When `true`, after each image manifest is synced, `ocync` queries the source's `/v2/<repo>/referrers/<digest>` endpoint and transfers each referrer manifest plus its blobs to the target. Set to `false` to skip referrer discovery entirely |
+| `include` | All types | If non-empty, only referrers whose `artifact_type` matches one of these MIME types are transferred. Empty means all types pass |
+| `exclude` | None | Referrers whose `artifact_type` matches one of these are skipped, even if `include` matches |
+| `require_artifacts` | `false` | When `true`, an image with zero discovered referrers fails the sync with an error. Use to enforce that every mirrored image carries provenance |
+
+### Why default-on
+
+Defaulting `enabled: true` is the only setting consistent with `ocync`'s bit-for-bit promise. If `enabled: false` were the default, the mirror would look correct (every image present, every digest valid) but `cosign verify` against the source's signature would fail at deployment time, because the signature lives on a referrer that was never copied. The opt-out is there for users who deliberately want unsigned mirrors: testing setups, isolated networks, or hard byte budgets.
+
+### Opt-out
+
+```yaml
+defaults:
+  artifacts:
+    enabled: false              # Skip all referrer discovery and transfer
+```
+
+### Type filtering
+
+Mirror only SBOMs:
+
+```yaml
+defaults:
+  artifacts:
+    enabled: true
+    include:
+      - application/vnd.cyclonedx+json
+      - application/spdx+json
+```
+
+### Hard-fail on missing signatures
+
+```yaml
+defaults:
+  artifacts:
+    enabled: true
+    require_artifacts: true     # Fail sync if any image lacks referrers
+```
 
 ## Tag filtering
 
@@ -225,10 +286,13 @@ All filters are optional. Without any filters, all tags are synced.
 | `sort` | string | Sort order for remaining tags: `semver` or `alpha` |
 | `latest` | integer | Keep only the N most recent tags after sorting |
 | `min_tags` | integer | Minimum number of tags that must survive the filtering pipeline. If fewer tags remain, the sync for this mapping fails with an error |
+| `immutable_tags` | string | Glob pattern marking tags that never change content (e.g. `"v?[0-9]*.[0-9]*.[0-9]*"`). When a tag matches AND already exists in **every** target's tag list, the sync skips it with zero source and target requests. Useful for long-running mirrors of registries that publish many semver-pinned tags |
 
 **Validation constraints:**
 - `semver_prerelease` requires `semver` to be set
 - `latest` requires `sort` to be set
+
+**Override semantics:** when a mapping defines `tags:`, the entire block replaces `defaults.tags` - fields are not merged. If you want a mapping to inherit some default fields and override others, repeat the inherited fields in the mapping's `tags:` block.
 
 ## Environment variables
 
@@ -252,7 +316,7 @@ The `DOCKER_CONFIG` environment variable controls the Docker config file locatio
 
 ### Chainguard to ECR
 
-Single region. Sync a curated set of Chainguard base images to ECR, keeping only the latest 5 semver-stable tags for `linux/amd64` and `linux/arm64`:
+Single region. Sync a curated set of Chainguard base images to ECR, keeping the latest 5 semver-pinned tags for `linux/amd64` and `linux/arm64`. Chainguard tags carry a `-rN` build-revision suffix (`1.25.5-r0`, `1.25.5-r1`); the SemVer spec treats anything after `-` as a prerelease, so `semver_prerelease: include` is required for any `cgr.dev` tag to survive a `semver:` range:
 
 ```yaml
 registries:
@@ -269,6 +333,7 @@ defaults:
     - linux/arm64
   tags:
     semver: ">=1.0"
+    semver_prerelease: include
     sort: semver
     latest: 5
 
@@ -325,9 +390,15 @@ mappings:
   - from: library/postgres
     to: postgres
     tags:
+      # Mapping tags: replaces defaults.tags entirely. Repeat the
+      # inherited fields explicitly when a mapping needs both.
       semver: ">=15"
+      exclude:
+        - "*-debug"
+        - "*-rc*"
       sort: semver
       latest: 3
+      min_tags: 1
 ```
 
 ### GHCR to ECR with glob filtering

--- a/docs/src/content/getting-started.md
+++ b/docs/src/content/getting-started.md
@@ -116,6 +116,7 @@ ocync sync -c config.yaml --dry-run
 
 ## Next steps
 
+- [Recipes](/recipes/production-mirror) for common mirror patterns: production fidelity, minimum bytes, helm + images, variant filtering, semver tracking
 - [Configuration reference](/configuration) for full config file syntax and options
 - [CLI reference](/cli-reference) for all commands, flags, and exit codes
 - [Helm chart](/helm) for Kubernetes deployment (CronJob, Deployment, or Job)

--- a/docs/src/content/recipes/helm-chart-and-images.md
+++ b/docs/src/content/recipes/helm-chart-and-images.md
@@ -1,0 +1,75 @@
+---
+title: Helm chart and images
+description: Mirror an operator's Helm chart together with its dependent container images. ArgoCD as the canonical example.
+order: 4
+---
+
+Operators are typically distributed as a Helm chart plus several container images that the chart references. To run the operator from your mirror, both have to land at the target. List the chart and each image as separate mappings.
+
+## When to use
+
+- Mirroring a Helm-distributed operator whose chart is published as an OCI artifact
+- Air-gapped Kubernetes clusters that need both chart and images locally
+- Multi-source mirrors where the chart and images live in different upstream registries
+
+## Config
+
+ArgoCD as the canonical example - the chart on `ghcr.io`, the controller image on `quay.io`, both fanning out to ECR:
+
+```yaml
+registries:
+  ghcr:
+    url: ghcr.io
+  quay:
+    url: quay.io
+  ecr:
+    url: ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
+
+defaults:
+  targets: ecr
+
+mappings:
+  # Chart artifact (single OCI artifact, not multi-arch)
+  - from: argoproj/argo-helm/argo-cd
+    source: ghcr
+    to: argo/argo-cd
+    tags:
+      glob: ["7.6.0"]
+
+  # Controller image (multi-arch index, preserved bit-for-bit).
+  # ApplicationSet, the Notifications controller, and the Repo Server
+  # are all bundled into this single image since ArgoCD v2.5; older
+  # split-image charts referenced them separately.
+  - from: argoproj/argocd
+    source: quay
+    to: argo/argocd
+    tags:
+      glob: ["v2.13.0"]
+```
+
+## Variations
+
+The same shape applies to any operator that publishes its Helm chart as an OCI artifact alongside its container images. A few examples:
+
+- **cert-manager**: chart `quay.io/jetstack/charts/cert-manager` plus images `quay.io/jetstack/cert-manager-controller`, `quay.io/jetstack/cert-manager-webhook`, `quay.io/jetstack/cert-manager-cainjector`
+- **Karpenter**: chart `public.ecr.aws/karpenter/karpenter` plus image `public.ecr.aws/karpenter/controller`
+
+Operators whose Helm charts are still distributed only via classic Helm repositories (HTTP `index.yaml`, e.g. AWS Load Balancer Controller and the AWS EBS CSI driver from `aws.github.io/eks-charts`) are out of scope for `ocync` - their container images can be mirrored, but the charts need a Helm-repo mirror. Mirror the images with `ocync` and serve the chart from a separate Helm repository in those cases.
+
+## Caveats
+
+`ocync` mirrors what you tell it to mirror. It does not parse Helm chart values to discover and follow image references; you list the chart and the images yourself.
+
+That means the mirrored chart's `values.yaml` still references the upstream image registry after sync. Consumers have to override `image.repository` at install time:
+
+```bash
+helm install argocd <your-mirror>/argo/argo-cd \
+  --set global.image.repository=<your-mirror>/argo/argocd
+```
+
+This is the bit-for-bit promise in action. The chart at your mirror is byte-identical to the source; auto-rewriting registry references would change the chart digest and break signature verification. The design tradeoff is tracked in [issue #80](https://github.com/clowdhaus/ocync/issues/80).
+
+## Related
+
+- [Production mirror](/recipes/production-mirror) for the full-fidelity defaults
+- [Issue #80](https://github.com/clowdhaus/ocync/issues/80) for the registry URL rewriting investigation

--- a/docs/src/content/recipes/minimum-bytes.md
+++ b/docs/src/content/recipes/minimum-bytes.md
@@ -1,0 +1,69 @@
+---
+title: Minimum bytes
+description: Mirror just the container images you need - skip signatures, SBOMs, and historical tags - while preserving multi-arch indexes bit-for-bit.
+order: 2
+---
+
+There are two levers for cutting bytes without sacrificing content integrity: skip the supply-chain referrers and tighten the tag set. Multi-arch stays intact.
+
+## When to use
+
+- CI mirrors that do not need supply-chain provenance
+- Air-gapped fleets that do not run `cosign verify`
+- Egress-sensitive environments where every megabyte counts
+
+## Config
+
+```yaml
+registries:
+  source:
+    url: cgr.dev
+  ecr:
+    url: ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
+
+defaults:
+  source: source
+  targets: ecr
+  artifacts:
+    enabled: false       # skip referrers (signatures, SBOMs, attestations)
+  tags:
+    glob: ["latest"]     # one specific tag (or use a tight semver range)
+
+mappings:
+  - from: chainguard/curl
+    to: curl
+```
+
+## Fields
+
+`artifacts.enabled: false` skips the OCI 1.1 referrer discovery and transfer that runs after each parent manifest, dropping cosign signatures, SBOMs, and attestations from the mirror.
+
+`tags.glob` (or `tags.semver`) limits the candidate set. The single cheapest case is an all-literal `glob` (no `*`, `?`, `[`): `ocync` recognizes it and skips the source `list-tags` API call entirely, going straight to one HEAD per pinned tag. Any non-literal pattern, any `semver:` constraint, any `sort`/`latest`/`exclude`/`min_tags` field forces the full tag listing; the filter then narrows in memory.
+
+There is deliberately no `platforms:` filter. Multi-arch indexes flow verbatim and the target index digest matches the source - filtering platforms would rewrite the index, change its digest, break `cosign verify`, break pin-by-digest workflows, and fail pulls from excluded architectures. Dropping referrers and tightening tags typically saves one to two orders of magnitude in bytes; dropping platforms saves another 2x to 4x but at the cost of bit-for-bit divergence. See [single architecture](/recipes/single-architecture) if that tradeoff is on the table.
+
+## Variations
+
+Pinning multiple floating tags as literals (preserves the listing-skip optimization):
+
+```yaml
+tags:
+  glob: ["latest", "latest-dev"]
+  # See pin-literals-only for the full discussion of the literal-pin pattern.
+```
+
+Tracking the latest five releases of a major version. Chainguard tags carry a `-rN` build-revision suffix (`1.25.5-r0`, `1.25.5-r1`) which the SemVer spec treats as a prerelease, so `semver_prerelease: include` is required against `cgr.dev` for any tag to survive the range filter:
+
+```yaml
+tags:
+  semver: ">=1.0.0, <2.0.0"
+  semver_prerelease: include
+  sort: semver
+  latest: 5
+```
+
+## Related
+
+- [Production mirror](/recipes/production-mirror) when you need full provenance
+- [Pin literals only](/recipes/pin-literals-only) for the rate-limit-friendly literal-tag pattern
+- [Configuration reference](/configuration#tag-filtering) for the full tag pipeline

--- a/docs/src/content/recipes/pin-literals-only.md
+++ b/docs/src/content/recipes/pin-literals-only.md
@@ -1,0 +1,71 @@
+---
+title: Pin literals only
+description: Mirror a small set of named tags without listing the source registry - the rate-limit-friendly pattern for floating tags and explicit version pins.
+order: 3
+---
+
+When you already know the exact tag names you want, list them as literals. `ocync` skips the `list-tags` API call entirely and HEAD-checks each pinned tag directly. This is the rate-limit-friendly pattern for sources like Docker Hub.
+
+## When to use
+
+- Floating tags (`latest`, `stable`, `nightly`)
+- Explicit pinned releases when you do not need automatic discovery
+- Mirrors of low-tag-volume repos where one HEAD per tag beats listing
+
+## Config
+
+```yaml
+registries:
+  source:
+    url: ghcr.io
+  ecr:
+    url: ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
+
+defaults:
+  source: source
+  targets: ecr
+
+mappings:
+  - from: argoproj/argocd
+    to: argocd
+    tags:
+      glob: ["v2.13.0", "v2.13.1", "stable"]
+```
+
+## Fields
+
+When every entry in `glob:` is wildcard-free (no `*`, `?`, `[`) and no other tag fields are set (`semver`, `sort`, `latest`, `exclude`, `min_tags`), `ocync` recognizes the entries as literals and skips the source `list-tags` walk entirely. Each pinned tag becomes one HEAD against the source instead of a paginated listing of every tag in the repository.
+
+For sources with thousands of tags this matters even when listing is not separately rate-limited: several round trips of pagination turn into zero. For Docker Hub specifically, the cap that bites is the manifest GET budget (10 per hour anonymous), and the HEAD checks issued for pinned tags do count against it - the saving here is the avoided listing cost, not a different rate-limit bucket.
+
+## Variations
+
+Multiple literal pins OR-match within a single `glob:` list, and the all-literal optimization still applies as long as every entry is wildcard-free:
+
+```yaml
+tags:
+  glob: ["latest", "v2.13.0", "v2.13.1"]
+```
+
+Adding any wildcard entry to the same list (e.g. `"v2.*"`) disables the optimization for the whole list - the listing is then performed and the filter narrows in memory.
+
+Mixing literal pins with the minimum-bytes pattern:
+
+```yaml
+defaults:
+  artifacts:
+    enabled: false
+  tags:
+    glob: ["latest"]
+```
+
+## Caveats
+
+- "Latest five versions" needs ordering, not pinning - use `semver` + `sort` + `latest` instead.
+- A tag pattern (`v2.*`) is a glob, not a literal - either accept the listing cost or list each version explicitly.
+- Pinned tags and a filtered range cannot share a single mapping today; split into two mappings (one literal-only, one filtered) targeting the same `to:` repository.
+
+## Related
+
+- [Minimum bytes](/recipes/minimum-bytes) for the broader cost-sensitive pattern
+- [Configuration reference](/configuration#tag-filtering) for the tag pipeline

--- a/docs/src/content/recipes/production-mirror.md
+++ b/docs/src/content/recipes/production-mirror.md
@@ -1,0 +1,47 @@
+---
+title: Production mirror
+description: Full-fidelity OCI mirror with multi-arch indexes, signatures, and SBOMs preserved bit-for-bit.
+order: 1
+---
+
+A production mirror keeps every byte the upstream published: multi-architecture indexes, image manifests, blobs, and any OCI 1.1 referrers (signatures, SBOMs, attestations) attached to those images. This is what `ocync` does by default. The config below is the minimum you need to write down to get there.
+
+## When to use
+
+- Compliance or regulated environments where signed-image provenance matters
+- Air-gapped clusters that need to run `cosign verify` against the source's signature
+- Any mirror where consumers may pin by digest
+
+## Config
+
+```yaml
+registries:
+  source:
+    url: ghcr.io
+  ecr:
+    url: ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
+
+defaults:
+  source: source
+  targets: ecr
+
+mappings:
+  - from: my-org/my-app
+    to: my-app
+    tags:
+      semver: ">=1.0"
+      sort: semver
+      latest: 5
+```
+
+## Fields
+
+`artifacts.enabled` defaults to `true`, so cosign signatures, SBOMs, and attestations transfer alongside their parent images. With no `platforms:` filter, multi-arch indexes flow verbatim and the index digest at the target matches the source's index digest. The `semver` + `sort` + `latest` block lists every tag from the source and then narrows in memory to the five newest semver-stable releases; the listing cost is paid once per sync, after which only the surviving tags drive HEAD checks and pulls.
+
+Once a sync completes, `cosign verify --certificate-identity-regexp ... <target>/my-app@sha256:<index-digest>` works against the same digest the source published, because nothing was rewritten on the way through.
+
+## Related
+
+- [Minimum bytes](/recipes/minimum-bytes) when you do not need the supply-chain artifacts
+- [Helm chart and images](/recipes/helm-chart-and-images) for operator-shaped deployments
+- [Configuration reference](/configuration#artifacts) for `artifacts.enabled`, `include`, `exclude`, `require_artifacts`

--- a/docs/src/content/recipes/semver-tracking.md
+++ b/docs/src/content/recipes/semver-tracking.md
@@ -1,0 +1,96 @@
+---
+title: Semver release tracking
+description: Track the latest N versions of an upstream release stream while controlling pre-release inclusion - the long-running mirror pattern.
+order: 6
+---
+
+For a mirror that follows an upstream's active release stream, you typically want the most recent N stable versions and explicit control over pre-releases. Three fields work together: `semver` for the version range, `sort` for ordering, and `latest` for the cap.
+
+## When to use
+
+- Long-running mirror that should pick up new releases automatically
+- Want a hard cap on the number of versions kept (storage and egress control)
+- Need explicit control over whether pre-release tags are included
+
+## Config
+
+```yaml
+registries:
+  source:
+    url: ghcr.io
+  ecr:
+    url: ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
+
+defaults:
+  source: source
+  targets: ecr
+
+mappings:
+  - from: my-org/my-app
+    to: my-app
+    tags:
+      semver: ">=2.0"
+      semver_prerelease: exclude
+      sort: semver
+      latest: 10
+      min_tags: 1
+```
+
+## Fields
+
+`semver: ">=2.0"` drops everything below 2.0. Non-semver tags like `latest` and `nightly` are also dropped at this stage, since they cannot be parsed as semver.
+
+`semver_prerelease: exclude` drops `2.0.0-rc.1`, `2.0.0-alpha`, and any other prerelease identifier. This is the default - it is spelled out here so the intent is obvious in the config.
+
+`sort: semver` orders the surviving tags by semantic version, highest first.
+
+`latest: 10` keeps only the top 10 after sorting. This requires `sort:` to be set.
+
+`min_tags: 1` is a safety net for long-running mirrors. If upstream renames their tag scheme or drops below your range, the sync fails loudly rather than silently producing an empty mirror.
+
+## Variations
+
+The default `exclude` matches npm, cargo, and Masterminds semver. To include pre-releases:
+
+```yaml
+tags:
+  semver: ">=2.0"
+  semver_prerelease: include    # 2.0.0-rc.1 matches >=2.0.0
+  sort: semver
+  latest: 10
+```
+
+`include` mode compares the base version (`2.0.0` for `2.0.0-rc.1`) against the range. So `2.0.0-rc.1` matches `>=2.0.0` but not `<2.0.0`.
+
+To mirror only pre-releases:
+
+```yaml
+tags:
+  semver: ">=2.0"
+  semver_prerelease: only
+```
+
+Chainguard and Wolfi tags use a `-rN` build-revision suffix (`1.25.5-r0`, `1.25.5-r1`). Per the SemVer spec, anything after `-` is a prerelease identifier, so the default `exclude` drops them. To keep the `-rN` revisions while still rejecting the actual release-candidate prereleases:
+
+```yaml
+tags:
+  semver: ">=1.25.0"
+  semver_prerelease: include
+  exclude: ["*-rc*", "*-beta*", "*-alpha*"]
+  sort: semver
+  latest: 10
+```
+
+`semver_prerelease: include` keeps the `-rN` tags, and the `exclude:` patterns drop the named prerelease channels. Most Chainguard mirrors converge on this shape.
+
+## Related
+
+The default-`exclude` choice plus the `include`-with-deny pattern addresses long-running issues elsewhere:
+
+- ArgoCD [#353](https://github.com/argoproj/argo-cd/issues/353), [#426](https://github.com/argoproj/argo-cd/issues/426) - prerelease handling
+- Harbor [#16131](https://github.com/goharbor/harbor/issues/16131), [#19328](https://github.com/goharbor/harbor/issues/19328) - prerelease drops
+
+See also:
+
+- [Variant filtering](/recipes/variant-filtering) for variant-specific narrowing
+- [Configuration reference](/configuration#tag-filtering) for the full pipeline

--- a/docs/src/content/recipes/single-architecture.md
+++ b/docs/src/content/recipes/single-architecture.md
@@ -1,0 +1,75 @@
+---
+title: Single architecture
+description: Mirror one architecture only - the only ocync recipe that opts out of bit-for-bit content integrity. Read the warnings before adopting.
+order: 7
+---
+
+<div class="callout callout-warning">
+
+<span class="callout-title">Warning</span>
+
+This recipe rewrites multi-arch index manifests at the target. It opts out of `ocync`'s bit-for-bit content integrity for affected mappings. Read the caveats below before using.
+
+</div>
+
+The single-architecture recipe trades content integrity for storage and egress savings. This is the only place in the engine where pushed content does not match source content byte-for-byte.
+
+## When to use
+
+- Every consumer of the target uses `linux/amd64` exclusively (no arm64 nodes, no Mac developer pulls, no future migration planned)
+- You are not running `cosign verify` against the source's signatures
+- You are not pinning by the source's index digest
+- Egress and storage savings are large enough to justify the integrity loss
+
+## Config
+
+```yaml
+registries:
+  source:
+    url: cgr.dev
+  ecr:
+    url: ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
+
+defaults:
+  source: source
+  targets: ecr
+  platforms: ["linux/amd64"]
+  artifacts:
+    enabled: false
+  tags:
+    glob: ["latest"]
+
+mappings:
+  - from: chainguard/curl
+    to: curl
+```
+
+## Fields
+
+When `platforms:` is set, `ocync`:
+
+1. Pulls the multi-arch index from the source.
+2. Drops child descriptors for non-matching platforms.
+3. Re-serializes the index with only the kept descriptors.
+4. Pushes the rewritten index, which has a different SHA-256 than the source.
+
+`artifacts.enabled: false` and `tags.glob: ["latest"]` are not required for platform filtering, but they are usually paired with it: a recipe willing to give up bit-for-bit integrity is usually also willing to drop referrers and narrow the tag set.
+
+## Caveats
+
+A typical multi-arch image has 2x to 4x layer surface across architectures. Skipping artifacts and narrowing tags typically saves 10x to 100x. Platform filtering is the smallest of the byte-saving levers and the only one with correctness consequences - if every other lever is already pulled and platform filtering is the next one, this recipe is for you. Most mirrors should not need it.
+
+The integrity tradeoffs:
+
+- `cosign verify` against the source index digest fails because the target index has a different digest, and cosign signatures sign the source's index digest.
+- Pin-by-digest workflows that reference the source's index break for the same reason.
+- Consumers on the excluded architecture pull the tag, get an index that says "no manifest for your platform," and fail.
+- OCI 1.1 referrers attached to the original index reference the source digest, so they no longer apply to the rewritten artifact.
+
+If any of those matters - any arm64 consumers (developers on Apple Silicon, Graviton nodes, Raspberry Pi), any `cosign verify` against source signatures, any pipeline pinning by source-index digest, or simply uncertainty - use [minimum bytes](/recipes/minimum-bytes) instead. It preserves multi-arch and gives up only the supply-chain referrers.
+
+## Related
+
+- [Minimum bytes](/recipes/minimum-bytes) for the multi-arch-preserving alternative
+- [Production mirror](/recipes/production-mirror) for full bit-for-bit fidelity
+- [Configuration reference](/configuration#defaults) for `platforms:` syntax

--- a/docs/src/content/recipes/variant-filtering.md
+++ b/docs/src/content/recipes/variant-filtering.md
@@ -1,0 +1,72 @@
+---
+title: Variant filtering
+description: Mirror only the alpine, slim, or distroless variants of an image using glob include or exclude patterns.
+order: 5
+---
+
+Many upstream images publish multiple variants of the same version: `1.25.5`, `1.25.5-alpine`, `1.25.5-slim`, `1.25.5-debug`. Variant selection is a string-pattern question, so the lever is `glob` (include) or `exclude` (deny). Pick whichever expresses the intent more directly.
+
+## When to use
+
+- Mirror only one flavor of an image (alpine, slim, distroless) and drop the rest
+- Mirror only the bare-version tags and drop every suffixed variant
+- Combine a variant filter with the rest of the tag pipeline in the same mapping
+
+## Config
+
+To keep one variant and drop the rest, glob-include the suffix:
+
+```yaml
+registries:
+  dockerhub:
+    url: docker.io
+  ecr:
+    url: ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
+
+defaults:
+  source: dockerhub
+  targets: ecr
+  artifacts:
+    enabled: false
+
+mappings:
+  - from: library/postgres
+    to: postgres
+    tags:
+      glob: ["*-alpine"]
+```
+
+To keep the bare-version tags and drop the suffixed variants, invert the pattern with `exclude`:
+
+```yaml
+tags:
+  exclude: ["*-alpine", "*-slim", "*-bookworm", "*-bullseye"]
+```
+
+## Fields
+
+`glob:` is OR-include - a tag survives if it matches any pattern. `exclude:` is OR-deny - a tag is dropped if it matches any pattern. Both stages run in the same pipeline; combining them lets you express "variants of this flavor only, except a deny-listed sub-set."
+
+## Variations
+
+Adding a numeric range cutoff (e.g. "alpine variants of 15 and newer") on top of a variant glob does not work cleanly today. Tags like `15.10-alpine` are not parseable by the strict SemVer parser `ocync` currently uses, so they are dropped at the `semver:` stage with a warning. If you need a version floor on a suffixed tag set, enumerate the major versions in the glob:
+
+```yaml
+tags:
+  glob: ["15.*-alpine", "16.*-alpine", "17.*-alpine"]
+```
+
+A more permissive version parser that handles `X.Y-suffix` tags is on the roadmap; once it lands, `glob + semver` will combine without enumeration.
+
+## Related
+
+The variant-include and variant-exclude shapes here cover long-running feature requests in comparable tools:
+
+- dregsy [#72](https://github.com/xelalexv/dregsy/issues/72) - "semver range AND substring filter"
+- skopeo [#852](https://github.com/containers/skopeo/issues/852) - "deny-list on top of include"
+- regclient [#1041](https://github.com/regclient/regclient/issues/1041) - `semverRange + allow + deny`
+
+See also:
+
+- [Semver tracking](/recipes/semver-tracking) for the latest-N release-window pattern
+- [Configuration reference](/configuration#tag-filtering) for the full pipeline

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -39,6 +39,9 @@ const isDocsActive =
 const isRegistriesActive = pathname.startsWith(
   `${base}registries`.replace(/\/$/, ""),
 );
+const isRecipesActive = pathname.startsWith(
+  `${base}recipes`.replace(/\/$/, ""),
+);
 const isDesignActive = pathname.startsWith(
   `${base}design/`.replace(/\/$/, ""),
 );
@@ -124,6 +127,12 @@ const isDesignActive = pathname.startsWith(
               href={`${base}registries/ecr`}
               aria-current={isRegistriesActive ? "true" : undefined}
             >Registries</a>
+          </li>
+          <li>
+            <a
+              href={`${base}recipes/production-mirror`}
+              aria-current={isRecipesActive ? "true" : undefined}
+            >Recipes</a>
           </li>
           <li>
             <a

--- a/docs/src/layouts/DocLayout.astro
+++ b/docs/src/layouts/DocLayout.astro
@@ -41,6 +41,19 @@ const navSections = {
       { href: `${base}registries/secrets`, label: "Kubernetes secrets" },
     ],
   },
+  recipes: {
+    label: "Recipes",
+    href: `${base}recipes/production-mirror`,
+    links: [
+      { href: `${base}recipes/production-mirror`, label: "Production mirror" },
+      { href: `${base}recipes/minimum-bytes`, label: "Minimum bytes" },
+      { href: `${base}recipes/pin-literals-only`, label: "Pin literals only" },
+      { href: `${base}recipes/helm-chart-and-images`, label: "Helm chart and images" },
+      { href: `${base}recipes/variant-filtering`, label: "Variant filtering" },
+      { href: `${base}recipes/semver-tracking`, label: "Semver release tracking" },
+      { href: `${base}recipes/single-architecture`, label: "Single architecture" },
+    ],
+  },
   design: {
     label: "Design",
     href: `${base}design/overview`,

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -489,6 +489,35 @@
       font-style: italic;
     }
 
+    & .callout {
+      margin-block: var(--space-6);
+      padding: var(--space-4) var(--space-6);
+      border-radius: var(--radius-md);
+      border: 1px solid var(--color-border);
+      border-inline-start-width: 4px;
+      background-color: var(--color-bg-surface);
+
+      & > * + * {
+        margin-block-start: var(--space-3);
+      }
+    }
+
+    & .callout-warning {
+      border-color: color-mix(in srgb, var(--pink) 35%, var(--color-border));
+      border-inline-start-color: var(--pink);
+      background-color: color-mix(in srgb, var(--pink) 8%, var(--color-bg));
+    }
+
+    & .callout-title {
+      display: block;
+      font-weight: 800;
+      font-size: var(--text-sm);
+      text-transform: uppercase;
+      letter-spacing: var(--tracking-label);
+      color: var(--pink);
+      margin-block-end: var(--space-2);
+    }
+
     & details {
       background-color: var(--color-bg-surface);
       border: 1px solid var(--color-border);


### PR DESCRIPTION
## Summary

PR 4 of the tag-filter + artifacts rollout. Pure docs — no code touched. Surfaces existing knobs as named patterns so users can find them without reading the configuration reference end to end.

- Adds a **Recipes** top-level section with seven pages: production-mirror, minimum-bytes, pin-literals-only, helm-chart-and-images, variant-filtering, semver-tracking, single-architecture.
- Adds an **Artifacts** configuration section (`enabled` / `include` / `exclude` / `require_artifacts`) with rationale for default-on.
- Adds a **dual quickstart** to `README.md` distinguishing full-fidelity from minimum-bytes, and surfaces the bit-for-bit framing in the tagline.
- The single-architecture recipe lives behind a prominent warning header documenting digest divergence, broken `cosign verify`, and arm64-consumer failure — the only ocync recipe that opts out of bit-for-bit.

Multi-arch is preserved in every standard recipe. The `platforms:` filter is documented as the single existing exception to bit-for-bit and isolated to the advanced recipe.

Linked: #80 (registry URL rewriting investigation, referenced from helm-chart-and-images).

## Test plan

- [x] `npm run --prefix docs build` — 28 pages built, no errors
- [x] All seven recipe pages render at expected paths under `/recipes/`
- [x] Cross-page links use root-absolute slugs per `docs/CLAUDE.md` convention
- [x] Astro nav (top header + sidebar) shows the new "Recipes" tab and links
- [ ] Manual: load `npm run --prefix docs preview` and click through the dual quickstart and one recipe
- [ ] Manual: confirm `gh-pages` deploy renders correctly under the `/ocync/` base path