### PR TITLE
feat: lenient tag-version parser, include field, default-exclude

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2277,7 +2277,6 @@ dependencies = [
  "postcard",
  "reqwest",
  "schemars 0.8.22",
- "semver",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ecr"
-version = "1.115.0"
+version = "1.115.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b97059a7e76b122096f333cf06cf109bfe8e763ee04ced2315f68ee2a6e0ed0"
+checksum = "5e30c797e7df731ba0c9d051b2f82a95526fd1fb3905185908d1b77d6e0a1386"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -610,12 +610,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -698,7 +692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "async-stream",
- "base64 0.22.1",
+ "base64",
  "bitflags",
  "bollard-buildkit-proto",
  "bollard-stubs",
@@ -755,7 +749,7 @@ version = "1.52.1-rc.29.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bollard-buildkit-proto",
  "bytes",
  "prost",
@@ -1098,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -1121,11 +1115,11 @@ dependencies = [
 
 [[package]]
 name = "docker_credential"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+checksum = "a4564c274ebf369f501de192b02a0b81a5c4bda375abfe526aa70fc702fa6fa0"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "serde",
  "serde_json",
 ]
@@ -1401,7 +1395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54a26c047222f874ea87177368ad07c65a9f66534ad3a3f9401f1322c802ccac"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "chrono",
  "google-cloud-gax",
@@ -1427,7 +1421,7 @@ version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dc387965cc2efc28d73896d6707125815c16792c23c33a0c67794f3d6e31cc8"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures",
  "google-cloud-rpc",
@@ -1460,7 +1454,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b30ccefdb9276269bb0336afe207c5e0ba1a544a5eb0034763af051f2b9eb63"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "serde",
  "serde_json",
@@ -1472,9 +1466,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1694,7 +1688,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2245,7 +2239,7 @@ dependencies = [
  "aws-lc-rs",
  "aws-sdk-ecr",
  "aws-sdk-ecrpublic",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-util",
  "google-cloud-auth",
@@ -2352,7 +2346,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde_core",
 ]
 
@@ -2364,18 +2358,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2632,9 +2626,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -2699,7 +2693,7 @@ name = "reqwest"
 version = "0.13.2"
 source = "git+https://github.com/seanmonstar/reqwest?rev=5f9c231502d827bdd19864277187b133bb746f2f#5f9c231502d827bdd19864277187b133bb746f2f"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3048,11 +3042,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3067,9 +3061,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3387,9 +3381,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -3454,7 +3448,7 @@ checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "h2",
  "http 1.4.0",
@@ -3643,7 +3637,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "log",
  "percent-encoding",
  "rustls",
@@ -3658,7 +3652,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "http 1.4.0",
  "httparse",
  "log",
@@ -4163,7 +4157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64 0.22.1",
+ "base64",
  "deadpool",
  "futures",
  "http 1.4.0",

--- a/crates/ocync-sync/Cargo.toml
+++ b/crates/ocync-sync/Cargo.toml
@@ -23,7 +23,6 @@ http.workspace = true
 ocync-distribution.workspace = true
 postcard = { version = "1", default-features = false, features = ["alloc"] }
 reqwest.workspace = true
-semver = { version = "1", default-features = false, features = ["std"] }
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/ocync-sync/src/error.rs
+++ b/crates/ocync-sync/src/error.rs
@@ -15,9 +15,9 @@ pub enum Error {
         reason: String,
     },
 
-    /// A semver version range could not be parsed.
-    #[error("invalid semver range '{range}': {reason}")]
-    InvalidSemverRange {
+    /// A version range could not be parsed.
+    #[error("invalid version range '{range}': {reason}")]
+    InvalidVersionRange {
         /// The range string that failed to parse.
         range: String,
         /// Why the range is invalid.
@@ -118,8 +118,8 @@ mod tests {
     }
 
     #[test]
-    fn display_invalid_semver_range() {
-        let err = Error::InvalidSemverRange {
+    fn display_invalid_version_range() {
+        let err = Error::InvalidVersionRange {
             range: ">= oops".into(),
             reason: "unexpected character".into(),
         };

--- a/crates/ocync-sync/src/filter.rs
+++ b/crates/ocync-sync/src/filter.rs
@@ -225,106 +225,42 @@ mod tests {
     #[test]
     fn semver_range_filter() {
         let tags = vec!["1.18.0", "1.19.0", "1.20.0", "1.17.0"];
-        let result = filter_semver(&tags, ">=1.18.0", SemverPrerelease::Exclude).unwrap();
+        let result = filter_semver(&tags, ">=1.18.0").unwrap();
         assert_eq!(result, vec!["1.18.0", "1.19.0", "1.20.0"]);
     }
 
     #[test]
     fn semver_v_prefix_stripped() {
         let tags = vec!["v1.0.0", "v2.0.0", "v3.0.0"];
-        let result = filter_semver(&tags, ">=2.0.0", SemverPrerelease::Exclude).unwrap();
+        let result = filter_semver(&tags, ">=2.0.0").unwrap();
         assert_eq!(result, vec!["v2.0.0", "v3.0.0"]);
     }
 
     #[test]
     fn semver_two_part_normalised() {
         let tags = vec!["1.18", "1.19", "1.20"];
-        let result = filter_semver(&tags, ">=1.19.0", SemverPrerelease::Exclude).unwrap();
+        let result = filter_semver(&tags, ">=1.19.0").unwrap();
         assert_eq!(result, vec!["1.19", "1.20"]);
     }
 
     #[test]
     fn semver_invalid_range_returns_error() {
         let tags = vec!["1.0.0"];
-        let err = filter_semver(&tags, ">= not_a_version", SemverPrerelease::Exclude).unwrap_err();
-        assert!(matches!(err, Error::InvalidSemverRange { .. }));
+        let err = filter_semver(&tags, ">= not_a_version").unwrap_err();
+        assert!(matches!(err, Error::InvalidVersionRange { .. }));
     }
 
     #[test]
     fn semver_non_parseable_tags_dropped() {
         let tags = vec!["latest", "nightly", "1.0.0", "2.0.0"];
-        let result = filter_semver(&tags, ">=1.0.0", SemverPrerelease::Exclude).unwrap();
+        let result = filter_semver(&tags, ">=1.0.0").unwrap();
         assert_eq!(result, vec!["1.0.0", "2.0.0"]);
     }
 
     #[test]
     fn semver_empty_tags() {
-        let result = filter_semver(&[], ">=1.0.0", SemverPrerelease::Exclude).unwrap();
+        let result = filter_semver(&[], ">=1.0.0").unwrap();
         assert!(result.is_empty());
-    }
-
-    // - prerelease tests --------------------------------------------------
-
-    #[test]
-    fn prerelease_include() {
-        let tags = vec!["1.0.0", "1.1.0-rc1", "1.2.0"];
-        let result = filter_semver(&tags, ">=1.0.0", SemverPrerelease::Include).unwrap();
-        assert_eq!(result, vec!["1.0.0", "1.1.0-rc1", "1.2.0"]);
-    }
-
-    #[test]
-    fn prerelease_exclude() {
-        let tags = vec!["1.0.0", "1.1.0-rc1", "1.2.0"];
-        let result = filter_semver(&tags, ">=1.0.0", SemverPrerelease::Exclude).unwrap();
-        assert_eq!(result, vec!["1.0.0", "1.2.0"]);
-    }
-
-    #[test]
-    fn prerelease_only() {
-        let tags = vec!["1.0.0", "1.1.0-rc1", "1.2.0-beta2"];
-        let result = filter_semver(&tags, ">=1.0.0", SemverPrerelease::Only).unwrap();
-        assert_eq!(result, vec!["1.1.0-rc1", "1.2.0-beta2"]);
-    }
-
-    /// Docker convention: `1.0.0-alpine` parses as a semver pre-release.
-    /// `SemverPrerelease::Exclude` drops these. Users who want to keep
-    /// variant suffixes like `-alpine` or `-slim` while excluding actual
-    /// pre-releases (`-rc1`, `-beta2`) should leave prerelease as `Include`
-    /// and use the exclude stage with globs like `*-rc*`.
-    #[test]
-    fn prerelease_alpine_suffix_treated_as_prerelease() {
-        let tags = vec!["1.0.0", "1.0.0-alpine", "1.0.0-slim"];
-        let result = filter_semver(&tags, ">=1.0.0", SemverPrerelease::Exclude).unwrap();
-        assert_eq!(result, vec!["1.0.0"]);
-    }
-
-    /// `1.1.0-rc1` matches `>=1.1.0` with `Include` because the base
-    /// version `1.1.0` satisfies the range.
-    #[test]
-    fn prerelease_include_matches_base_range() {
-        let tags = vec!["1.0.0", "1.1.0-rc1", "1.2.0-beta1"];
-        let result = filter_semver(&tags, ">=1.1.0", SemverPrerelease::Include).unwrap();
-        assert_eq!(result, vec!["1.1.0-rc1", "1.2.0-beta1"]);
-    }
-
-    /// `1.0.9-rc1` does NOT match `>=1.1.0` even with `Include`, because
-    /// the base version `1.0.9` is below the range.
-    #[test]
-    fn prerelease_include_below_range_excluded() {
-        let tags = vec!["1.0.9-rc1", "1.1.0-rc1"];
-        let result = filter_semver(&tags, ">=1.1.0", SemverPrerelease::Include).unwrap();
-        assert_eq!(result, vec!["1.1.0-rc1"]);
-    }
-
-    /// Pre-release matching uses base-version comparison: `2.0.0-rc1` has
-    /// base `2.0.0` which does NOT match `<2.0.0`, so it is excluded.
-    /// This is consistent with regsync and dregsy behavior. Users who need
-    /// `2.0.0-rc1` can use `<2.1.0` or add it via a separate glob pattern.
-    #[test]
-    fn prerelease_include_upper_bound_uses_base_version() {
-        let tags = vec!["1.9.0", "2.0.0-rc1", "2.0.0"];
-        let result = filter_semver(&tags, "<2.0.0", SemverPrerelease::Include).unwrap();
-        assert_eq!(result, vec!["1.9.0"]);
     }
 
     // - exclude tests -----------------------------------------------------
@@ -409,64 +345,11 @@ mod tests {
         assert_eq!(tags, vec!["2.0.0", "v1.5.0", "v1.0.0"]);
     }
 
-    // - prerelease + range edge cases -------------------------------------
-
-    /// `Only` mode with a narrowing range drops pre-releases whose base
-    /// version is below the range AND drops stable versions.
-    #[test]
-    fn prerelease_only_with_narrowing_range() {
-        let tags = vec!["1.0.0-rc1", "1.2.0-rc1", "1.3.0"];
-        let result = filter_semver(&tags, ">=1.2.0", SemverPrerelease::Only).unwrap();
-        assert_eq!(result, vec!["1.2.0-rc1"]);
-    }
-
-    // - recommended workflow: Include + exclude globs ---------------------
-
-    /// The documented workflow for keeping `-alpine`/`-slim` while excluding
-    /// actual pre-releases: use `SemverPrerelease::Include` with exclude
-    /// globs for `*-rc*`, `*-beta*`, etc.
-    #[test]
-    fn pipeline_include_prerelease_exclude_rc() {
-        let tags = vec![
-            "1.0.0",
-            "1.0.0-alpine",
-            "1.0.0-slim",
-            "1.1.0-rc1",
-            "1.1.0-beta1",
-        ];
-        let config = FilterConfig {
-            semver: Some(">=1.0.0".into()),
-            semver_prerelease: Some(SemverPrerelease::Include),
-            exclude: vec!["*-rc*".into(), "*-beta*".into()],
-            ..FilterConfig::default()
-        };
-        let result = config.apply(&tags).unwrap();
-        assert_eq!(result, vec!["1.0.0", "1.0.0-alpine", "1.0.0-slim"]);
-    }
-
-    // - parse_semver edge cases -------------------------------------------
-
-    /// Date-based tags like `20240101` are not valid semver and are dropped.
-    #[test]
-    fn semver_date_tags_dropped() {
-        let tags = vec!["20240101", "1.0.0"];
-        let result = filter_semver(&tags, ">=1.0.0", SemverPrerelease::Exclude).unwrap();
-        assert_eq!(result, vec!["1.0.0"]);
-    }
-
-    /// Build metadata (`+build`) is valid semver and is preserved.
-    #[test]
-    fn semver_build_metadata_parsed() {
-        let tags = vec!["1.0.0+build123", "2.0.0"];
-        let result = filter_semver(&tags, ">=1.0.0", SemverPrerelease::Exclude).unwrap();
-        assert_eq!(result, vec!["1.0.0+build123", "2.0.0"]);
-    }
-
-    /// Empty string and bare `v` are not parseable semver.
+    /// Empty string and bare `v` are not parseable as a version.
     #[test]
     fn semver_empty_and_bare_v_dropped() {
         let tags = vec!["", "v", "1.0.0"];
-        let result = filter_semver(&tags, ">=1.0.0", SemverPrerelease::Exclude).unwrap();
+        let result = filter_semver(&tags, ">=1.0.0").unwrap();
         assert_eq!(result, vec!["1.0.0"]);
     }
 
@@ -494,11 +377,11 @@ mod tests {
         let config = FilterConfig {
             glob: vec!["1.*".into()],
             semver: Some(">=1.18.0".into()),
-            semver_prerelease: Some(SemverPrerelease::Exclude),
-            exclude: vec![],
+            exclude: vec!["*-rc*".into()],
             sort: Some(SortOrder::Semver),
             latest: Some(2),
             min_tags: None,
+            ..FilterConfig::default()
         };
         let result = config.apply(&tags).unwrap();
         assert_eq!(result, vec!["1.20.0", "1.19.0"]);
@@ -531,7 +414,7 @@ mod tests {
             ..FilterConfig::default()
         };
         let err = config.apply(&["1.0.0"]).unwrap_err();
-        assert!(matches!(err, Error::InvalidSemverRange { .. }));
+        assert!(matches!(err, Error::InvalidVersionRange { .. }));
     }
 
     #[test]
@@ -655,5 +538,74 @@ mod tests {
     fn glob_set_invalid_pattern() {
         let err = build_glob_set(&["[bad".into()]).unwrap_err();
         assert!(matches!(err, Error::InvalidGlob { .. }));
+    }
+
+    // - lenient-parser regression tests ----------------------------------
+
+    /// Headline regression: `15.10-alpine` survives `>=15.0` under the
+    /// lenient parser. Today's strict-SemVer parser drops it.
+    #[test]
+    fn filter_semver_keeps_alpine_with_two_part_range() {
+        let tags = vec!["15.10-alpine", "15.10", "14.0-alpine"];
+        let result = filter_semver(&tags, ">=15.0").unwrap();
+        assert_eq!(result, vec!["15.10-alpine", "15.10"]);
+        // Negative assertion: 14.0-alpine drops (below range).
+        assert!(!result.contains(&"14.0-alpine"));
+    }
+
+    /// Chainguard `-rN` build revisions survive `>=N.M.K` directly.
+    #[test]
+    fn filter_semver_keeps_chainguard_revisions() {
+        let tags = vec!["1.25.5-r0", "1.25.5", "1.24.0-r5"];
+        let result = filter_semver(&tags, ">=1.25.0").unwrap();
+        assert_eq!(result, vec!["1.25.5-r0", "1.25.5"]);
+        assert!(!result.contains(&"1.24.0-r5"));
+    }
+
+    /// Eclipse Temurin underscore build is treated as a numeric prefix component.
+    #[test]
+    fn filter_semver_keeps_temurin_underscore_build() {
+        let tags = vec!["25.0.3_9-jre-alpine-3.23", "24.0.1-jre", "25.0.0"];
+        let result = filter_semver(&tags, ">=25.0").unwrap();
+        assert_eq!(result, vec!["25.0.3_9-jre-alpine-3.23", "25.0.0"]);
+        assert!(!result.contains(&"24.0.1-jre"));
+    }
+
+    /// EKS Distro compound suffix sorts numerically on the trailing components.
+    #[test]
+    fn sort_semver_eks_distro_compound_suffix() {
+        let mut tags = vec![
+            "v1.27.6-eks-1-27-9",
+            "v1.27.6-eks-1-27-14",
+            "v1.27.6-eks-1-27-12",
+        ];
+        sort_tags_in_place(&mut tags, SortOrder::Semver);
+        assert_eq!(
+            tags,
+            vec![
+                "v1.27.6-eks-1-27-14",
+                "v1.27.6-eks-1-27-12",
+                "v1.27.6-eks-1-27-9",
+            ]
+        );
+    }
+
+    /// Letter-digit split makes `rc10` sort above `rc9`.
+    #[test]
+    fn sort_semver_rc_above_9() {
+        let mut tags = vec!["1.0.0-rc9", "1.0.0-rc10", "1.0.0-rc1"];
+        sort_tags_in_place(&mut tags, SortOrder::Semver);
+        assert_eq!(tags, vec!["1.0.0-rc10", "1.0.0-rc9", "1.0.0-rc1"]);
+    }
+
+    /// Date-style tags now parse as N-component prefixes (replaces the old
+    /// `semver_date_tags_dropped` test which asserted the opposite).
+    #[test]
+    fn semver_date_tags_parse_as_components() {
+        let tags = vec!["2024.01.15", "2023.12.31", "1.0.0"];
+        let result = filter_semver(&tags, ">=2024.0.0").unwrap();
+        assert_eq!(result, vec!["2024.01.15"]);
+        assert!(!result.contains(&"2023.12.31"));
+        assert!(!result.contains(&"1.0.0"));
     }
 }

--- a/crates/ocync-sync/src/filter.rs
+++ b/crates/ocync-sync/src/filter.rs
@@ -1,6 +1,6 @@
 //! Tag filtering pipeline: glob -> semver -> exclude -> sort + latest.
 
-use globset::{Glob, GlobSet, GlobSetBuilder};
+use globset::{Glob, GlobBuilder, GlobSet, GlobSetBuilder};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
@@ -28,12 +28,44 @@ pub enum SortOrder {
     Alpha,
 }
 
+/// Glob patterns excluded from the `glob:`/`semver:` pipeline by default.
+/// Common prerelease markers, matched case-insensitively. Users override
+/// per-tag via `include:`.
+const SYSTEM_EXCLUDE: &[&str] = &[
+    "*-rc*",
+    "*-alpha*",
+    "*-beta*",
+    "*-pre*",
+    "*-snapshot*",
+    "*-nightly*",
+];
+
+fn build_system_exclude_set() -> GlobSet {
+    let mut builder = GlobSetBuilder::new();
+    for pat in SYSTEM_EXCLUDE {
+        let g = GlobBuilder::new(pat)
+            .case_insensitive(true)
+            .build()
+            .expect("system-exclude pattern is statically valid");
+        builder.add(g);
+    }
+    builder.build().expect("system-exclude GlobSet is statically valid")
+}
+
 /// Configuration for the tag filter pipeline.
 ///
 /// All stages are AND (narrowing). Each stage reduces the set:
 /// `glob → semver → exclude → sort → latest → min_tags`.
+/// Tags matching `include:` bypass the glob/semver pipeline (but are still
+/// subject to user `exclude:`).
 #[derive(Debug, Default)]
 pub struct FilterConfig {
+    /// Always-include glob patterns. Tags matching any pattern survive
+    /// `glob:`/`semver:` filters and the system-exclude defaults. Not
+    /// subject to `sort:` or `latest:` truncation (those only cap the
+    /// `glob:`/`semver:` pipeline side). Subject to user `exclude:`. Same
+    /// syntax as `exclude:`.
+    pub include: Vec<String>,
     /// Glob patterns (OR semantics). An empty list passes all tags through.
     pub glob: Vec<String>,
     /// Semver version range constraint (e.g. `>=1.18.0`).
@@ -58,49 +90,76 @@ impl FilterConfig {
     /// `sort`, or fewer tags survive than [`min_tags`](Self::min_tags)
     /// requires.
     pub fn apply(&self, tags: &[&str]) -> Result<Vec<String>, Error> {
-        // 0. Config validation
+        // 0. Config validation.
         if self.latest.is_some() && self.sort.is_none() {
             return Err(Error::LatestWithoutSort);
         }
 
-        // 1. Glob include
-        let mut current: Vec<&str> = if self.glob.is_empty() {
+        // Build user-exclude (optional) and system-exclude.
+        let user_exclude_set = if self.exclude.is_empty() {
+            None
+        } else {
+            Some(build_glob_set(&self.exclude)?)
+        };
+        let system_exclude_set = build_system_exclude_set();
+
+        // 1. include_set: tags matching any include: pattern, minus user-exclude.
+        let include_kept: Vec<&str> = if self.include.is_empty() {
+            Vec::new()
+        } else {
+            let inc_set = build_glob_set(&self.include)?;
+            tags.iter()
+                .copied()
+                .filter(|t| inc_set.is_match(t))
+                .filter(|t| user_exclude_set.as_ref().is_none_or(|s| !s.is_match(t)))
+                .collect()
+        };
+
+        // 2. pipeline_input: glob (default *) AND semver.
+        let mut pipeline: Vec<&str> = if self.glob.is_empty() {
             tags.to_vec()
         } else {
             filter_glob(tags, &self.glob)?
         };
-
-        // 2. Semver filter
         if let Some(ref range) = self.semver {
-            current = filter_semver(&current, range)?;
+            pipeline = filter_semver(&pipeline, range)?;
         }
 
-        // 3. Exclude
-        if !self.exclude.is_empty() {
-            current = filter_exclude(&current, &self.exclude)?;
+        // 3. pipeline minus user-exclude minus system-exclude.
+        if let Some(ref s) = user_exclude_set {
+            pipeline.retain(|t| !s.is_match(t));
         }
+        pipeline.retain(|t| !system_exclude_set.is_match(t));
 
-        // 4. Sort
+        // 4. sort + latest cap (pipeline only).
         if let Some(order) = self.sort {
-            sort_tags_in_place(&mut current, order);
+            sort_tags_in_place(&mut pipeline, order);
         }
-
-        // 5. Latest
         if let Some(n) = self.latest {
-            current.truncate(n);
+            pipeline.truncate(n);
         }
 
-        // 6. Min tags validation
+        // 5. Union: include first (preserves include input order), then
+        //    pipeline tags not already in include.
+        let mut seen: std::collections::HashSet<&str> = include_kept.iter().copied().collect();
+        let mut final_set: Vec<&str> = include_kept.clone();
+        for t in pipeline {
+            if seen.insert(t) {
+                final_set.push(t);
+            }
+        }
+
+        // 6. min_tags validation against the union.
         if let Some(min) = self.min_tags {
-            if current.len() < min {
+            if final_set.len() < min {
                 return Err(Error::BelowMinTags {
-                    matched: current.len(),
+                    matched: final_set.len(),
                     minimum: min,
                 });
             }
         }
 
-        Ok(current.into_iter().map(String::from).collect())
+        Ok(final_set.into_iter().map(String::from).collect())
     }
 }
 
@@ -152,11 +211,6 @@ fn filter_semver<'a>(tags: &[&'a str], range: &str) -> Result<Vec<&'a str>, Erro
         .collect())
 }
 
-/// Exclude tags matching any of the given glob patterns.
-fn filter_exclude<'a>(tags: &[&'a str], patterns: &[String]) -> Result<Vec<&'a str>, Error> {
-    let set = build_glob_set(patterns)?;
-    Ok(tags.iter().copied().filter(|t| !set.is_match(t)).collect())
-}
 
 /// Sort tags in-place in descending order (highest first).
 fn sort_tags_in_place(tags: &mut [&str], order: SortOrder) {
@@ -268,21 +322,22 @@ mod tests {
     #[test]
     fn exclude_basic() {
         let tags = vec!["1.0-alpine", "1.0-slim", "1.0", "1.1-alpine"];
-        let result = filter_exclude(&tags, &["*-alpine".into()]).unwrap();
+        let set = build_glob_set(&["*-alpine".into()]).unwrap();
+        let result: Vec<&str> = tags.into_iter().filter(|t| !set.is_match(t)).collect();
         assert_eq!(result, vec!["1.0-slim", "1.0"]);
     }
 
     #[test]
     fn exclude_multiple_patterns() {
         let tags = vec!["1.0-alpine", "1.0-slim", "1.0", "nightly"];
-        let result = filter_exclude(&tags, &["*-alpine".into(), "nightly".into()]).unwrap();
+        let set = build_glob_set(&["*-alpine".into(), "nightly".into()]).unwrap();
+        let result: Vec<&str> = tags.into_iter().filter(|t| !set.is_match(t)).collect();
         assert_eq!(result, vec!["1.0-slim", "1.0"]);
     }
 
     #[test]
     fn exclude_invalid_pattern_returns_error() {
-        let tags = vec!["1.0"];
-        let err = filter_exclude(&tags, &["[bad".into()]).unwrap_err();
+        let err = build_glob_set(&["[bad".into()]).unwrap_err();
         assert!(matches!(err, Error::InvalidGlob { .. }));
     }
 

--- a/crates/ocync-sync/src/filter.rs
+++ b/crates/ocync-sync/src/filter.rs
@@ -366,9 +366,10 @@ mod tests {
         assert_eq!(tags, vec!["v3.0.0", "v2.0.0", "v1.0.0"]);
     }
 
-    /// Pre-release tags sort below their base version: `1.0.0-rc1 < 1.0.0`.
+    /// Tags with `-rc1`/`-alpha`/`-beta` suffixes sort below their base
+    /// version and in descending suffix order within the same base.
     #[test]
-    fn sort_semver_prerelease_ordering() {
+    fn sort_semver_suffix_tags_descending() {
         let mut tags = vec!["1.0.0", "1.0.0-rc1", "1.0.0-alpha", "1.1.0-beta1", "1.1.0"];
         sort_tags_in_place(&mut tags, SortOrder::Semver);
         assert_eq!(
@@ -813,5 +814,19 @@ mod tests {
         };
         let result = config.apply(&tags).unwrap();
         assert_eq!(result.len(), 5);
+    }
+
+    /// `HashiCorp` `alpha20241016` tags drop via system-exclude `*-alpha*`
+    /// (the wildcard catches the embedded date stamp).
+    #[test]
+    fn system_exclude_drops_alpha_with_date_stamp() {
+        let tags = vec!["1.10.0", "1.10.0-alpha20241016", "1.9.0-alpha20240501"];
+        let config = FilterConfig {
+            semver: Some(">=1.0".into()),
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert_eq!(result, vec!["1.10.0"]);
+        assert!(!result.contains(&"1.10.0-alpha20241016".to_string()));
     }
 }

--- a/crates/ocync-sync/src/filter.rs
+++ b/crates/ocync-sync/src/filter.rs
@@ -28,18 +28,21 @@ const SYSTEM_EXCLUDE: &[&str] = &[
     "*-nightly*",
 ];
 
-fn build_system_exclude_set() -> GlobSet {
-    let mut builder = GlobSetBuilder::new();
-    for pat in SYSTEM_EXCLUDE {
-        let g = GlobBuilder::new(pat)
-            .case_insensitive(true)
+fn system_exclude_set() -> &'static GlobSet {
+    static SET: std::sync::OnceLock<GlobSet> = std::sync::OnceLock::new();
+    SET.get_or_init(|| {
+        let mut builder = GlobSetBuilder::new();
+        for pat in SYSTEM_EXCLUDE {
+            let g = GlobBuilder::new(pat)
+                .case_insensitive(true)
+                .build()
+                .expect("system-exclude pattern is statically valid");
+            builder.add(g);
+        }
+        builder
             .build()
-            .expect("system-exclude pattern is statically valid");
-        builder.add(g);
-    }
-    builder
-        .build()
-        .expect("system-exclude GlobSet is statically valid")
+            .expect("system-exclude GlobSet is statically valid")
+    })
 }
 
 /// Configuration for the tag filter pipeline.
@@ -88,7 +91,7 @@ impl FilterConfig {
         } else {
             Some(build_glob_set(&self.exclude)?)
         };
-        let system_exclude_set = build_system_exclude_set();
+        let sys_exclude = system_exclude_set();
 
         // 1. include_set: tags matching any include: pattern, minus user-exclude.
         let include_kept: Vec<&str> = if self.include.is_empty() {
@@ -116,7 +119,7 @@ impl FilterConfig {
         if let Some(ref s) = user_exclude_set {
             pipeline.retain(|t| !s.is_match(t));
         }
-        pipeline.retain(|t| !system_exclude_set.is_match(t));
+        pipeline.retain(|t| !sys_exclude.is_match(t));
 
         // 4. sort + latest cap (pipeline only).
         if let Some(order) = self.sort {

--- a/crates/ocync-sync/src/filter.rs
+++ b/crates/ocync-sync/src/filter.rs
@@ -6,18 +6,6 @@ use tracing::warn;
 
 use crate::Error;
 
-/// How to handle semver pre-release tags.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, schemars::JsonSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum SemverPrerelease {
-    /// Include pre-release tags in results.
-    Include,
-    /// Exclude pre-release tags from results.
-    Exclude,
-    /// Return only pre-release tags.
-    Only,
-}
-
 /// Sort order for the final tag list.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
@@ -70,9 +58,6 @@ pub struct FilterConfig {
     pub glob: Vec<String>,
     /// Semver version range constraint (e.g. `>=1.18.0`).
     pub semver: Option<String>,
-    /// Pre-release handling. Defaults to [`SemverPrerelease::Exclude`] when
-    /// a `semver` range is set.
-    pub semver_prerelease: Option<SemverPrerelease>,
     /// Exclude patterns (OR deny).
     pub exclude: Vec<String>,
     /// Sort order.

--- a/crates/ocync-sync/src/filter.rs
+++ b/crates/ocync-sync/src/filter.rs
@@ -72,11 +72,7 @@ impl FilterConfig {
 
         // 2. Semver filter
         if let Some(ref range) = self.semver {
-            current = filter_semver(
-                &current,
-                range,
-                self.semver_prerelease.unwrap_or(SemverPrerelease::Exclude),
-            )?;
+            current = filter_semver(&current, range)?;
         }
 
         // 3. Exclude
@@ -134,24 +130,11 @@ fn filter_glob<'a>(tags: &[&'a str], patterns: &[String]) -> Result<Vec<&'a str>
     Ok(tags.iter().copied().filter(|t| set.is_match(t)).collect())
 }
 
-/// Filter tags by a semver version range, with pre-release handling.
+/// Filter tags by a version range.
 ///
-/// Tags that cannot be parsed as semver are dropped with a warning.
-///
-/// # Pre-release matching
-///
-/// When `prerelease` is [`SemverPrerelease::Include`] or
-/// [`SemverPrerelease::Only`], pre-release tags are matched by comparing
-/// their **base version** (major.minor.patch) against the range. This means
-/// `1.0.0-rc1` matches `>=1.0.0` (base `1.0.0` satisfies the range), but
-/// `2.0.0-rc1` does NOT match `<2.0.0` (base `2.0.0` fails the range).
-/// This is consistent with how regsync and dregsy handle pre-releases.
-fn filter_semver<'a>(
-    tags: &[&'a str],
-    range: &str,
-    prerelease: SemverPrerelease,
-) -> Result<Vec<&'a str>, Error> {
-    let req = semver::VersionReq::parse(range).map_err(|e| Error::InvalidSemverRange {
+/// Tags that cannot be parsed as a version are dropped with a warning.
+fn filter_semver<'a>(tags: &[&'a str], range: &str) -> Result<Vec<&'a str>, Error> {
+    let req = crate::version::Range::parse(range).map_err(|e| Error::InvalidVersionRange {
         range: range.to_owned(),
         reason: e.to_string(),
     })?;
@@ -160,25 +143,11 @@ fn filter_semver<'a>(
         .iter()
         .copied()
         .filter(|tag| {
-            let Some(ver) = parse_semver(tag) else {
-                warn!(tag, "tag is not parseable as semver, dropping");
+            let Some(ver) = crate::version::TagVersion::parse(tag) else {
+                warn!(tag, "tag is not parseable as a version, dropping");
                 return false;
             };
-            let has_pre = !ver.pre.is_empty();
-            match prerelease {
-                SemverPrerelease::Exclude if has_pre => return false,
-                SemverPrerelease::Only if !has_pre => return false,
-                _ => {}
-            }
-            // The semver crate doesn't match pre-releases against ranges
-            // without pre-release specifiers, so compare the base version
-            // when the user wants to include them.
-            if has_pre && prerelease != SemverPrerelease::Exclude {
-                let base = semver::Version::new(ver.major, ver.minor, ver.patch);
-                req.matches(&base)
-            } else {
-                req.matches(&ver)
-            }
+            req.matches(&ver)
         })
         .collect())
 }
@@ -191,43 +160,26 @@ fn filter_exclude<'a>(tags: &[&'a str], patterns: &[String]) -> Result<Vec<&'a s
 
 /// Sort tags in-place in descending order (highest first).
 fn sort_tags_in_place(tags: &mut [&str], order: SortOrder) {
+    use crate::version::TagVersion;
+    use std::cmp::Ordering;
+
     match order {
         SortOrder::Semver => {
             tags.sort_by(|a, b| {
-                let va = parse_semver(a);
-                let vb = parse_semver(b);
+                let va = TagVersion::parse(a);
+                let vb = TagVersion::parse(b);
                 match (va, vb) {
-                    (Some(va), Some(vb)) => vb.cmp(&va), // descending
-                    (Some(_), None) => std::cmp::Ordering::Less,
-                    (None, Some(_)) => std::cmp::Ordering::Greater,
+                    (Some(va), Some(vb)) => TagVersion::compare(&vb, &va), // descending
+                    (Some(_), None) => Ordering::Less,
+                    (None, Some(_)) => Ordering::Greater,
                     (None, None) => b.cmp(a), // alpha-descending fallback
                 }
             });
         }
         SortOrder::Alpha => {
-            tags.sort_by(|a, b| b.cmp(a)); // descending
+            tags.sort_by(|a, b| b.cmp(a));
         }
     }
-}
-
-// ---------------------------------------------------------------------------
-// Semver parse helper
-// ---------------------------------------------------------------------------
-
-/// Parse a tag as semver, stripping an optional `v` prefix and normalising
-/// two-part versions (`X.Y` -> `X.Y.0`).
-fn parse_semver(tag: &str) -> Option<semver::Version> {
-    let s = tag.strip_prefix('v').unwrap_or(tag);
-    if let Ok(v) = semver::Version::parse(s) {
-        return Some(v);
-    }
-    // Try X.Y -> X.Y.0 (only pure numeric two-part, no pre-release suffix).
-    let parts: Vec<&str> = s.splitn(3, '.').collect();
-    if parts.len() == 2 {
-        let normalised = format!("{}.{}.0", parts[0], parts[1]);
-        return semver::Version::parse(&normalised).ok();
-    }
-    None
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ocync-sync/src/filter.rs
+++ b/crates/ocync-sync/src/filter.rs
@@ -37,7 +37,9 @@ fn build_system_exclude_set() -> GlobSet {
             .expect("system-exclude pattern is statically valid");
         builder.add(g);
     }
-    builder.build().expect("system-exclude GlobSet is statically valid")
+    builder
+        .build()
+        .expect("system-exclude GlobSet is statically valid")
 }
 
 /// Configuration for the tag filter pipeline.
@@ -195,7 +197,6 @@ fn filter_semver<'a>(tags: &[&'a str], range: &str) -> Result<Vec<&'a str>, Erro
         })
         .collect())
 }
-
 
 /// Sort tags in-place in descending order (highest first).
 fn sort_tags_in_place(tags: &mut [&str], order: SortOrder) {
@@ -683,12 +684,7 @@ mod tests {
 
     #[test]
     fn system_exclude_keeps_dev_and_r_revisions() {
-        let tags = vec![
-            "1.0.0-dev",
-            "1.0.0-r0",
-            "1.0.0-edge",
-            "1.0.0-final",
-        ];
+        let tags = vec!["1.0.0-dev", "1.0.0-r0", "1.0.0-edge", "1.0.0-final"];
         let config = FilterConfig {
             semver: Some(">=1.0".into()),
             ..FilterConfig::default()
@@ -771,8 +767,13 @@ mod tests {
         // Pipeline has 5 candidates; latest:2 should keep only the top 2 of
         // the pipeline side. Includes pass through uncapped.
         let tags = vec![
-            "latest", "latest-dev",
-            "1.5.0", "1.4.0", "1.3.0", "1.2.0", "1.1.0",
+            "latest",
+            "latest-dev",
+            "1.5.0",
+            "1.4.0",
+            "1.3.0",
+            "1.2.0",
+            "1.1.0",
         ];
         let config = FilterConfig {
             include: vec!["latest".into(), "latest-dev".into()],

--- a/crates/ocync-sync/src/filter.rs
+++ b/crates/ocync-sync/src/filter.rs
@@ -1,5 +1,7 @@
 //! Tag filtering pipeline: glob -> semver -> exclude -> sort + latest.
 
+use std::sync::OnceLock;
+
 use globset::{Glob, GlobBuilder, GlobSet, GlobSetBuilder};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
@@ -29,7 +31,7 @@ const SYSTEM_EXCLUDE: &[&str] = &[
 ];
 
 fn system_exclude_set() -> &'static GlobSet {
-    static SET: std::sync::OnceLock<GlobSet> = std::sync::OnceLock::new();
+    static SET: OnceLock<GlobSet> = OnceLock::new();
     SET.get_or_init(|| {
         let mut builder = GlobSetBuilder::new();
         for pat in SYSTEM_EXCLUDE {
@@ -132,7 +134,7 @@ impl FilterConfig {
         // 5. Union: include first (preserves include input order), then
         //    pipeline tags not already in include.
         let mut seen: std::collections::HashSet<&str> = include_kept.iter().copied().collect();
-        let mut final_set: Vec<&str> = include_kept.clone();
+        let mut final_set: Vec<&str> = include_kept;
         for t in pipeline {
             if seen.insert(t) {
                 final_set.push(t);
@@ -208,16 +210,18 @@ fn sort_tags_in_place(tags: &mut [&str], order: SortOrder) {
 
     match order {
         SortOrder::Semver => {
-            tags.sort_by(|a, b| {
-                let va = TagVersion::parse(a);
-                let vb = TagVersion::parse(b);
-                match (va, vb) {
-                    (Some(va), Some(vb)) => TagVersion::compare(&vb, &va), // descending
-                    (Some(_), None) => Ordering::Less,
-                    (None, Some(_)) => Ordering::Greater,
-                    (None, None) => b.cmp(a), // alpha-descending fallback
-                }
+            // Parse each tag once, sort on the parsed value, then write back.
+            let mut decorated: Vec<(Option<TagVersion>, &str)> =
+                tags.iter().map(|t| (TagVersion::parse(t), *t)).collect();
+            decorated.sort_by(|(va, ta), (vb, tb)| match (va, vb) {
+                (Some(a), Some(b)) => TagVersion::compare(b, a), // descending
+                (Some(_), None) => Ordering::Less,
+                (None, Some(_)) => Ordering::Greater,
+                (None, None) => tb.cmp(ta), // alpha-descending fallback
             });
+            for (i, (_, tag)) in decorated.into_iter().enumerate() {
+                tags[i] = tag;
+            }
         }
         SortOrder::Alpha => {
             tags.sort_by(|a, b| b.cmp(a));

--- a/crates/ocync-sync/src/filter.rs
+++ b/crates/ocync-sync/src/filter.rs
@@ -663,4 +663,162 @@ mod tests {
         assert!(!result.contains(&"2023.12.31"));
         assert!(!result.contains(&"1.0.0"));
     }
+
+    // - system-exclude tests ---------------------------------------------
+
+    #[test]
+    fn system_exclude_drops_rc_by_default() {
+        let tags = vec![
+            "1.0.0",
+            "1.0.0-rc1",
+            "1.0.0-alpha",
+            "1.0.0-beta",
+            "1.0.0-snapshot",
+            "1.0.0-nightly",
+            "1.0.0-pre",
+        ];
+        let config = FilterConfig {
+            semver: Some(">=1.0".into()),
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert_eq!(result, vec!["1.0.0"]);
+    }
+
+    #[test]
+    fn system_exclude_case_insensitive() {
+        let tags = vec!["5.0.0-SNAPSHOT", "5.0.0-RC1", "5.0.0-BETA1", "5.0.0"];
+        let config = FilterConfig {
+            semver: Some(">=1.0".into()),
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert_eq!(result, vec!["5.0.0"]);
+    }
+
+    #[test]
+    fn system_exclude_keeps_dev_and_r_revisions() {
+        let tags = vec![
+            "1.0.0-dev",
+            "1.0.0-r0",
+            "1.0.0-edge",
+            "1.0.0-final",
+        ];
+        let config = FilterConfig {
+            semver: Some(">=1.0".into()),
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        // Order matches input; none of these match the default-exclude list.
+        assert!(result.contains(&"1.0.0-dev".to_string()));
+        assert!(result.contains(&"1.0.0-r0".to_string()));
+        assert!(result.contains(&"1.0.0-edge".to_string()));
+        assert!(result.contains(&"1.0.0-final".to_string()));
+        assert_eq!(result.len(), 4);
+    }
+
+    // - include tests -----------------------------------------------------
+
+    #[test]
+    fn include_pin_overrides_system_exclude() {
+        let tags = vec!["1.25.0-rc1", "1.0.0-rc2", "1.25.0"];
+        let config = FilterConfig {
+            include: vec!["1.25.0-rc1".into()],
+            semver: Some(">=1.0".into()),
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        // 1.25.0-rc1 survives via include; 1.0.0-rc2 drops via system-exclude;
+        // 1.25.0 survives via the pipeline.
+        assert!(result.contains(&"1.25.0-rc1".to_string()));
+        assert!(result.contains(&"1.25.0".to_string()));
+        assert!(!result.contains(&"1.0.0-rc2".to_string()));
+    }
+
+    /// `include` survives even when the tag would fail the `semver:` filter
+    /// (e.g., literal `latest` has no numeric prefix).
+    #[test]
+    fn include_pin_overrides_semver() {
+        let tags = vec!["latest", "1.0.0", "0.9.0"];
+        let config = FilterConfig {
+            include: vec!["latest".into()],
+            semver: Some(">=1.0".into()),
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert!(result.contains(&"latest".to_string()));
+        assert!(result.contains(&"1.0.0".to_string()));
+        assert!(!result.contains(&"0.9.0".to_string()));
+    }
+
+    /// `include` survives even when the tag doesn't match `glob:` (which
+    /// would otherwise restrict the pool).
+    #[test]
+    fn include_pin_overrides_glob() {
+        // glob restricts pool to alpine variants; "latest" wouldn't match.
+        let tags = vec!["latest", "1.0.0-alpine", "1.0.0"];
+        let config = FilterConfig {
+            include: vec!["latest".into()],
+            glob: vec!["*-alpine".into()],
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert!(result.contains(&"latest".to_string()));
+        assert!(result.contains(&"1.0.0-alpine".to_string()));
+        // 1.0.0 fails glob; not in include; not kept.
+        assert!(!result.contains(&"1.0.0".to_string()));
+    }
+
+    #[test]
+    fn user_exclude_wins_over_include() {
+        let tags = vec!["latest", "1.0.0"];
+        let config = FilterConfig {
+            include: vec!["latest".into()],
+            exclude: vec!["latest".into()],
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert!(!result.contains(&"latest".to_string()));
+    }
+
+    #[test]
+    fn latest_n_does_not_cap_include() {
+        // Pipeline has 5 candidates; latest:2 should keep only the top 2 of
+        // the pipeline side. Includes pass through uncapped.
+        let tags = vec![
+            "latest", "latest-dev",
+            "1.5.0", "1.4.0", "1.3.0", "1.2.0", "1.1.0",
+        ];
+        let config = FilterConfig {
+            include: vec!["latest".into(), "latest-dev".into()],
+            semver: Some(">=1.0".into()),
+            sort: Some(SortOrder::Semver),
+            latest: Some(2),
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        // 2 includes + top 2 of pipeline = 4 tags.
+        assert_eq!(result.len(), 4);
+        assert!(result.contains(&"latest".to_string()));
+        assert!(result.contains(&"latest-dev".to_string()));
+        // Top 2 of pipeline kept; lower versions dropped by latest:N truncation.
+        assert!(result.contains(&"1.5.0".to_string()));
+        assert!(result.contains(&"1.4.0".to_string()));
+        assert!(!result.contains(&"1.3.0".to_string()));
+        assert!(!result.contains(&"1.2.0".to_string()));
+        assert!(!result.contains(&"1.1.0".to_string()));
+    }
+
+    #[test]
+    fn min_tags_counts_include_and_pipeline() {
+        let tags = vec!["latest", "1.0.0", "1.1.0", "1.2.0", "1.3.0"];
+        let config = FilterConfig {
+            include: vec!["latest".into()],
+            semver: Some(">=1.0".into()),
+            min_tags: Some(5),
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert_eq!(result.len(), 5);
+    }
 }

--- a/crates/ocync-sync/src/filter.rs
+++ b/crates/ocync-sync/src/filter.rs
@@ -1,5 +1,6 @@
 //! Tag filtering pipeline: glob -> semver -> exclude -> sort + latest.
 
+use std::collections::HashSet;
 use std::sync::OnceLock;
 
 use globset::{Glob, GlobBuilder, GlobSet, GlobSetBuilder};
@@ -117,11 +118,10 @@ impl FilterConfig {
             pipeline = filter_semver(&pipeline, range)?;
         }
 
-        // 3. pipeline minus user-exclude minus system-exclude.
-        if let Some(ref s) = user_exclude_set {
-            pipeline.retain(|t| !s.is_match(t));
-        }
-        pipeline.retain(|t| !sys_exclude.is_match(t));
+        // 3. pipeline minus user-exclude minus system-exclude (one pass).
+        pipeline.retain(|t| {
+            user_exclude_set.as_ref().is_none_or(|s| !s.is_match(t)) && !sys_exclude.is_match(t)
+        });
 
         // 4. sort + latest cap (pipeline only).
         if let Some(order) = self.sort {
@@ -133,7 +133,7 @@ impl FilterConfig {
 
         // 5. Union: include first (preserves include input order), then
         //    pipeline tags not already in include.
-        let mut seen: std::collections::HashSet<&str> = include_kept.iter().copied().collect();
+        let mut seen: HashSet<&str> = include_kept.iter().copied().collect();
         let mut final_set: Vec<&str> = include_kept;
         for t in pipeline {
             if seen.insert(t) {
@@ -211,7 +211,7 @@ fn sort_tags_in_place(tags: &mut [&str], order: SortOrder) {
     match order {
         SortOrder::Semver => {
             // Parse each tag once, sort on the parsed value, then write back.
-            let mut decorated: Vec<(Option<TagVersion>, &str)> =
+            let mut decorated: Vec<(Option<TagVersion<'_>>, &str)> =
                 tags.iter().map(|t| (TagVersion::parse(t), *t)).collect();
             decorated.sort_by(|(va, ta), (vb, tb)| match (va, vb) {
                 (Some(a), Some(b)) => TagVersion::compare(b, a), // descending

--- a/crates/ocync-sync/src/lib.rs
+++ b/crates/ocync-sync/src/lib.rs
@@ -9,6 +9,8 @@ pub mod error;
 pub mod filter;
 /// Sync planning and transfer ordering.
 pub mod plan;
+/// Tag-version parser, comparator, and range matcher.
+pub(crate) mod version;
 /// Progress reporting trait and types.
 pub mod progress;
 /// Retry configuration and backoff logic.

--- a/crates/ocync-sync/src/lib.rs
+++ b/crates/ocync-sync/src/lib.rs
@@ -9,12 +9,12 @@ pub mod error;
 pub mod filter;
 /// Sync planning and transfer ordering.
 pub mod plan;
-/// Tag-version parser, comparator, and range matcher.
-pub(crate) mod version;
 /// Progress reporting trait and types.
 pub mod progress;
 /// Retry configuration and backoff logic.
 pub mod retry;
+/// Tag-version parser, comparator, and range matcher.
+pub(crate) mod version;
 
 /// Sync engine - pipelined concurrent orchestration of image transfers.
 pub mod engine;

--- a/crates/ocync-sync/src/version.rs
+++ b/crates/ocync-sync/src/version.rs
@@ -1,8 +1,9 @@
 //! Tag-version parser, comparator, and range matcher.
 //!
-//! Replaces the strict-SemVer parser previously used by the filter pipeline.
-//! See `docs/superpowers/specs/2026-05-04-tag-version-parser-design.md`
-//! for the design rationale.
+//! Lenient prefix-based parser for OCI registry tag patterns.
+//! Handles real-world variants (alpine, Chainguard `-rN`, Eclipse Temurin
+//! `_<digits>`, EKS Distro compound suffixes) by treating the suffix as
+//! opaque tokens for ordering only. Range matching is prefix-only.
 
 use std::cmp::Ordering;
 
@@ -31,13 +32,11 @@ impl TagVersion {
             return None;
         }
 
-        // Optional leading 'v' is stripped before prefix parsing.
         let s = tag.strip_prefix('v').unwrap_or(tag);
         if s.is_empty() {
             return None;
         }
 
-        // Prefix region: everything before the first '-'.
         let (prefix_str, suffix_str) = match s.find('-') {
             Some(i) => (&s[..i], Some(&s[i + 1..])),
             None => (s, None),
@@ -62,7 +61,7 @@ impl TagVersion {
     /// Equal) is incompatible with `Ord`'s contract that
     /// `cmp(a, b) == Equal` implies `a == b`.
     pub(crate) fn compare(a: &Self, b: &Self) -> Ordering {
-        // Step 1: numeric prefix, zero-padded to the longer length.
+        // Step 1: numeric prefix (zero-padded).
         let max_len = a.prefix.len().max(b.prefix.len());
         for i in 0..max_len {
             let ai = a.prefix.get(i).copied().unwrap_or(0);
@@ -73,7 +72,7 @@ impl TagVersion {
             }
         }
 
-        // Step 2: suffix presence. Empty suffix wins.
+        // Step 2: suffix presence (empty suffix wins).
         match (a.suffix.is_empty(), b.suffix.is_empty()) {
             (true, true) => return Ordering::Equal,
             (true, false) => return Ordering::Greater,
@@ -81,7 +80,7 @@ impl TagVersion {
             (false, false) => {}
         }
 
-        // Step 3: token-by-token comparison.
+        // Step 3: token-by-token.
         for (at, bt) in a.suffix.iter().zip(b.suffix.iter()) {
             let ord = compare_tokens(at, bt);
             if ord != Ordering::Equal {
@@ -94,7 +93,8 @@ impl TagVersion {
     }
 }
 
-/// Compare two suffix tokens. Numeric < Alpha at the same position (`SemVer` rule).
+/// Compare two suffix tokens. Numeric is less than Alpha at the same
+/// position; tokens of the same kind compare by their inner value.
 fn compare_tokens(a: &Token, b: &Token) -> Ordering {
     match (a, b) {
         (Token::Numeric(x), Token::Numeric(y)) => x.cmp(y),
@@ -110,10 +110,6 @@ fn parse_prefix(s: &str) -> Option<Vec<u64>> {
     let mut components = Vec::new();
     for part in s.split(['.', '_']) {
         if part.is_empty() {
-            return None;
-        }
-        // Reject if any non-digit character is present.
-        if !part.chars().all(|c| c.is_ascii_digit()) {
             return None;
         }
         let n: u64 = part.parse().ok()?;
@@ -226,7 +222,9 @@ impl Range {
         Ok(Range { constraints })
     }
 
-    /// Returns `true` if `v` satisfies all constraints in the range.
+    /// `true` if every constraint matches against `v.prefix`. Constraints
+    /// zero-pad both sides to the longer length before comparing, so a
+    /// two-part bound (`>=15.0`) matches a three-part prefix (`15.10.5`).
     pub(crate) fn matches(&self, v: &TagVersion) -> bool {
         self.constraints.iter().all(|c| c.matches(&v.prefix))
     }
@@ -301,18 +299,20 @@ fn parse_bound(s: &str) -> Result<Vec<u64>, RangeParseError> {
 impl Constraint {
     fn matches(&self, prefix: &[u64]) -> bool {
         let max_len = prefix.len().max(self.bound.len());
-        let lhs: Vec<u64> = (0..max_len)
-            .map(|i| prefix.get(i).copied().unwrap_or(0))
-            .collect();
-        let rhs: Vec<u64> = (0..max_len)
-            .map(|i| self.bound.get(i).copied().unwrap_or(0))
-            .collect();
+        let cmp = (0..max_len)
+            .map(|i| {
+                let l = prefix.get(i).copied().unwrap_or(0);
+                let r = self.bound.get(i).copied().unwrap_or(0);
+                l.cmp(&r)
+            })
+            .find(|o| *o != Ordering::Equal)
+            .unwrap_or(Ordering::Equal);
         match self.op {
-            Op::Ge => lhs >= rhs,
-            Op::Le => lhs <= rhs,
-            Op::Gt => lhs > rhs,
-            Op::Lt => lhs < rhs,
-            Op::Eq => lhs == rhs,
+            Op::Ge => cmp != Ordering::Less,
+            Op::Le => cmp != Ordering::Greater,
+            Op::Gt => cmp == Ordering::Greater,
+            Op::Lt => cmp == Ordering::Less,
+            Op::Eq => cmp == Ordering::Equal,
         }
     }
 }
@@ -567,60 +567,60 @@ mod compare_tests {
         TagVersion::parse(s).expect("valid tag")
     }
 
-    fn cmp(a: &str, b: &str) -> Ordering {
+    fn compare(a: &str, b: &str) -> Ordering {
         TagVersion::compare(&p(a), &p(b))
     }
 
     #[test]
     fn three_part_numeric_descending() {
-        assert_eq!(cmp("1.0.0", "2.0.0"), Ordering::Less);
-        assert_eq!(cmp("2.0.0", "1.0.0"), Ordering::Greater);
-        assert_eq!(cmp("1.21.5", "1.21.5"), Ordering::Equal);
+        assert_eq!(compare("1.0.0", "2.0.0"), Ordering::Less);
+        assert_eq!(compare("2.0.0", "1.0.0"), Ordering::Greater);
+        assert_eq!(compare("1.21.5", "1.21.5"), Ordering::Equal);
     }
 
     #[test]
     fn zero_pad_one_dot_zero_equals_one_zero_zero() {
-        assert_eq!(cmp("1.0", "1.0.0"), Ordering::Equal);
+        assert_eq!(compare("1.0", "1.0.0"), Ordering::Equal);
     }
 
     #[test]
     fn zero_pad_three_part_beats_two_part() {
         // 1.0.5 > 1.0 (which pads to 1.0.0)
-        assert_eq!(cmp("1.0.5", "1.0"), Ordering::Greater);
+        assert_eq!(compare("1.0.5", "1.0"), Ordering::Greater);
     }
 
     #[test]
     fn suffix_less_wins() {
-        assert_eq!(cmp("1.0.0", "1.0.0-rc1"), Ordering::Greater);
-        assert_eq!(cmp("1.0.0-alpha", "1.0.0"), Ordering::Less);
+        assert_eq!(compare("1.0.0", "1.0.0-rc1"), Ordering::Greater);
+        assert_eq!(compare("1.0.0-alpha", "1.0.0"), Ordering::Less);
     }
 
     #[test]
     fn temurin_underscore_build_orders() {
-        assert_eq!(cmp("25.0.3_10", "25.0.3_9"), Ordering::Greater);
+        assert_eq!(compare("25.0.3_10", "25.0.3_9"), Ordering::Greater);
         // 25.0.3 > 25.0.2_999: prefix [25,0,3,0] > [25,0,2,999] after padding.
-        assert_eq!(cmp("25.0.3", "25.0.2_999"), Ordering::Greater);
+        assert_eq!(compare("25.0.3", "25.0.2_999"), Ordering::Greater);
     }
 
     #[test]
     fn rc10_above_rc9_via_letter_digit_split() {
-        assert_eq!(cmp("1.0.0-rc10", "1.0.0-rc9"), Ordering::Greater);
+        assert_eq!(compare("1.0.0-rc10", "1.0.0-rc9"), Ordering::Greater);
     }
 
     #[test]
     fn rc1_and_rc_dot_1_compare_equal() {
-        assert_eq!(cmp("1.0.0-rc1", "1.0.0-rc.1"), Ordering::Equal);
+        assert_eq!(compare("1.0.0-rc1", "1.0.0-rc.1"), Ordering::Equal);
     }
 
     #[test]
     fn rc_dot_2_above_rc_dot_1() {
-        assert_eq!(cmp("1.0.0-rc.1", "1.0.0-rc.2"), Ordering::Less);
+        assert_eq!(compare("1.0.0-rc.1", "1.0.0-rc.2"), Ordering::Less);
     }
 
     #[test]
     fn eks_distro_compound_suffix_orders() {
         assert_eq!(
-            cmp("v1.27.6-eks-1-27-14", "v1.27.6-eks-1-27-9"),
+            compare("v1.27.6-eks-1-27-14", "v1.27.6-eks-1-27-9"),
             Ordering::Greater
         );
     }
@@ -628,7 +628,7 @@ mod compare_tests {
     #[test]
     fn bitnami_release_counter_orders() {
         assert_eq!(
-            cmp("1.31.3-debian-12-r3", "1.31.3-debian-12-r2"),
+            compare("1.31.3-debian-12-r3", "1.31.3-debian-12-r2"),
             Ordering::Greater
         );
     }
@@ -636,7 +636,7 @@ mod compare_tests {
     #[test]
     fn case_significant_alpha() {
         // ASCII: 'R' (0x52) < 'r' (0x72), so RC1 sorts before rc1.
-        assert_eq!(cmp("1.0.0-RC1", "1.0.0-rc1"), Ordering::Less);
+        assert_eq!(compare("1.0.0-RC1", "1.0.0-rc1"), Ordering::Less);
     }
 
     #[test]
@@ -652,8 +652,11 @@ mod compare_tests {
         // Exercises the length tie-breaker: [rc, 1] vs [rc, 1, "hotfix"].
         // Tokens compare equal at positions 0 and 1; falls through to
         // length comparison.
-        assert_eq!(cmp("1.0.0-rc.1", "1.0.0-rc.1.hotfix"), Ordering::Less);
+        assert_eq!(compare("1.0.0-rc.1", "1.0.0-rc.1.hotfix"), Ordering::Less);
         // Antisymmetry: the reverse comparison must yield Greater.
-        assert_eq!(cmp("1.0.0-rc.1.hotfix", "1.0.0-rc.1"), Ordering::Greater);
+        assert_eq!(
+            compare("1.0.0-rc.1.hotfix", "1.0.0-rc.1"),
+            Ordering::Greater
+        );
     }
 }

--- a/crates/ocync-sync/src/version.rs
+++ b/crates/ocync-sync/src/version.rs
@@ -179,6 +179,154 @@ fn split_letter_digit(s: &str) -> Vec<&str> {
     splits
 }
 
+/// A parsed version range: one or more constraints joined by AND.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) struct Range {
+    constraints: Vec<Constraint>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Constraint {
+    op: Op,
+    bound: Vec<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Op {
+    Ge,
+    Le,
+    Gt,
+    Lt,
+    Eq,
+}
+
+/// Error returned when a version range string cannot be parsed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RangeParseError {
+    pub(crate) reason: String,
+}
+
+impl std::fmt::Display for RangeParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.reason)
+    }
+}
+
+impl std::error::Error for RangeParseError {}
+
+#[allow(dead_code)]
+impl Range {
+    /// Parse a range string into a `Range`.
+    ///
+    /// Accepts comma-joined constraints of the form `>=1.0, <2.0`.
+    /// Supported operators: `>=`, `<=`, `>`, `<`, `=`, and bare (implies `=`).
+    /// Caret (`^`), tilde (`~`), and wildcards (`x`, `X`, `*`) are rejected.
+    pub(crate) fn parse(s: &str) -> Result<Self, RangeParseError> {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            return Err(RangeParseError {
+                reason: "empty range".into(),
+            });
+        }
+        let mut constraints = Vec::new();
+        for part in trimmed.split(',') {
+            constraints.push(parse_constraint(part.trim())?);
+        }
+        Ok(Range { constraints })
+    }
+
+    /// Returns `true` if `v` satisfies all constraints in the range.
+    pub(crate) fn matches(&self, v: &TagVersion) -> bool {
+        self.constraints.iter().all(|c| c.matches(&v.prefix))
+    }
+}
+
+fn parse_constraint(s: &str) -> Result<Constraint, RangeParseError> {
+    if s.is_empty() {
+        return Err(RangeParseError {
+            reason: "empty constraint".into(),
+        });
+    }
+    if s.starts_with('^')
+        || s.starts_with('~')
+        || s.contains('x')
+        || s.contains('X')
+        || s.contains('*')
+    {
+        return Err(RangeParseError {
+            reason: format!(
+                "unsupported range syntax '{}'; use a comma-joined combination of >=, <=, >, <, =",
+                s
+            ),
+        });
+    }
+
+    let (op, rest) = if let Some(r) = s.strip_prefix(">=") {
+        (Op::Ge, r.trim_start())
+    } else if let Some(r) = s.strip_prefix("<=") {
+        (Op::Le, r.trim_start())
+    } else if let Some(r) = s.strip_prefix('>') {
+        (Op::Gt, r.trim_start())
+    } else if let Some(r) = s.strip_prefix('<') {
+        (Op::Lt, r.trim_start())
+    } else if let Some(r) = s.strip_prefix('=') {
+        (Op::Eq, r.trim_start())
+    } else {
+        (Op::Eq, s)
+    };
+
+    let bound_str = rest.strip_prefix('v').unwrap_or(rest);
+    let bound = parse_bound(bound_str)?;
+    Ok(Constraint { op, bound })
+}
+
+fn parse_bound(s: &str) -> Result<Vec<u64>, RangeParseError> {
+    if s.contains('-') {
+        return Err(RangeParseError {
+            reason: format!("prerelease suffix not allowed in range bound: '{}'", s),
+        });
+    }
+    let mut components = Vec::new();
+    for part in s.split('.') {
+        if part.is_empty() {
+            return Err(RangeParseError {
+                reason: format!("malformed bound '{}'", s),
+            });
+        }
+        let n: u64 = part.parse().map_err(|_| RangeParseError {
+            reason: format!("malformed bound '{}'", s),
+        })?;
+        components.push(n);
+    }
+    if components.is_empty() {
+        Err(RangeParseError {
+            reason: format!("empty bound '{}'", s),
+        })
+    } else {
+        Ok(components)
+    }
+}
+
+impl Constraint {
+    fn matches(&self, prefix: &[u64]) -> bool {
+        let max_len = prefix.len().max(self.bound.len());
+        let lhs: Vec<u64> = (0..max_len)
+            .map(|i| prefix.get(i).copied().unwrap_or(0))
+            .collect();
+        let rhs: Vec<u64> = (0..max_len)
+            .map(|i| self.bound.get(i).copied().unwrap_or(0))
+            .collect();
+        match self.op {
+            Op::Ge => lhs >= rhs,
+            Op::Le => lhs <= rhs,
+            Op::Gt => lhs > rhs,
+            Op::Lt => lhs < rhs,
+            Op::Eq => lhs == rhs,
+        }
+    }
+}
+
 #[cfg(test)]
 mod parse_tests {
     use super::*;
@@ -331,6 +479,93 @@ mod parse_tests {
         let b = TagVersion::parse("1.0.0-rc.1").unwrap();
         assert_eq!(a.suffix, b.suffix);
         assert_eq!(a.suffix, vec![Token::Alpha("rc".into()), Token::Numeric(1)]);
+    }
+}
+
+#[cfg(test)]
+mod range_tests {
+    use super::*;
+
+    fn matches(range: &str, tag: &str) -> bool {
+        let r = Range::parse(range).expect("valid range");
+        let v = TagVersion::parse(tag).expect("valid tag");
+        r.matches(&v)
+    }
+
+    #[test]
+    fn ge_simple() {
+        assert!(matches(">=1.0", "1.0.0"));
+        assert!(matches(">=1.0", "1.5.0"));
+        assert!(!matches(">=1.0", "0.9.0"));
+    }
+
+    #[test]
+    fn lt_simple() {
+        assert!(matches("<2.0", "1.99.99"));
+        assert!(!matches("<2.0", "2.0.0"));
+        // suffix opaque: 2.0.0-rc1 has prefix [2,0,0]
+        assert!(!matches("<2.0", "2.0.0-rc1"));
+    }
+
+    #[test]
+    fn comma_joined_narrows() {
+        assert!(matches(">=1.0, <2.0", "1.5.0"));
+        assert!(!matches(">=1.0, <2.0", "2.0.0"));
+        assert!(!matches(">=1.0, <2.0", "0.9.0"));
+    }
+
+    #[test]
+    fn whitespace_tolerated() {
+        assert!(matches(" >= 1.0 , < 2.0 ", "1.5.0"));
+    }
+
+    #[test]
+    fn no_operator_implies_equal() {
+        assert!(matches("1.0", "1.0.0"));
+        assert!(matches("1.0", "1"));
+        assert!(!matches("1.0", "1.0.5"));
+    }
+
+    #[test]
+    fn equal_explicit() {
+        assert!(matches("=15.0", "15"));
+        assert!(matches("=15.0", "15.0"));
+        assert!(matches("=15.0", "15.0.0"));
+        assert!(!matches("=15.0", "15.0.5"));
+    }
+
+    #[test]
+    fn two_part_bound_matches_three_part_prefix() {
+        assert!(matches(">=15.0", "15.10.5"));
+    }
+
+    #[test]
+    fn rejects_caret() {
+        assert!(Range::parse("^2").is_err());
+    }
+
+    #[test]
+    fn rejects_tilde() {
+        assert!(Range::parse("~1").is_err());
+    }
+
+    #[test]
+    fn rejects_wildcard() {
+        assert!(Range::parse("1.x").is_err());
+        assert!(Range::parse("1.*").is_err());
+        assert!(Range::parse("1.X").is_err());
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(Range::parse("").is_err());
+    }
+
+    #[test]
+    fn rejects_prerelease_bound() {
+        assert!(Range::parse(">=1.0-rc1").is_err());
+        // Bare bound (no operator falls through to Op::Eq); same rejection path.
+        assert!(Range::parse("1.0.0-r0").is_err());
     }
 }
 

--- a/crates/ocync-sync/src/version.rs
+++ b/crates/ocync-sync/src/version.rs
@@ -8,10 +8,10 @@
 use std::cmp::Ordering;
 
 /// A token in a tokenized tag suffix.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum Token {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Token<'a> {
     Numeric(u64),
-    Alpha(String),
+    Alpha(&'a str),
 }
 
 /// A tag parsed into a numeric prefix and a tokenized suffix.
@@ -19,15 +19,15 @@ pub(crate) enum Token {
 /// Empty `suffix` means the tag had no `-suffix` region (or the suffix
 /// tokenized to nothing, e.g. `1.0-` or `1.0---`).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct TagVersion {
+pub(crate) struct TagVersion<'a> {
     pub(crate) prefix: Vec<u64>,
-    pub(crate) suffix: Vec<Token>,
+    pub(crate) suffix: Vec<Token<'a>>,
 }
 
-impl TagVersion {
+impl<'a> TagVersion<'a> {
     /// Parse a tag string into a `TagVersion`.
     /// Returns `None` if the tag has no parseable numeric prefix.
-    pub(crate) fn parse(tag: &str) -> Option<Self> {
+    pub(crate) fn parse(tag: &'a str) -> Option<Self> {
         if tag.is_empty() {
             return None;
         }
@@ -60,7 +60,7 @@ impl TagVersion {
     /// `impl Ord` because zero-padding equality (`1.0` and `1.0.0` compare
     /// Equal) is incompatible with `Ord`'s contract that
     /// `cmp(a, b) == Equal` implies `a == b`.
-    pub(crate) fn compare(a: &Self, b: &Self) -> Ordering {
+    pub(crate) fn compare(a: &TagVersion<'_>, b: &TagVersion<'_>) -> Ordering {
         // Step 1: numeric prefix (zero-padded).
         let max_len = a.prefix.len().max(b.prefix.len());
         for i in 0..max_len {
@@ -95,7 +95,7 @@ impl TagVersion {
 
 /// Compare two suffix tokens. Numeric is less than Alpha at the same
 /// position; tokens of the same kind compare by their inner value.
-fn compare_tokens(a: &Token, b: &Token) -> Ordering {
+fn compare_tokens(a: &Token<'_>, b: &Token<'_>) -> Ordering {
     match (a, b) {
         (Token::Numeric(x), Token::Numeric(y)) => x.cmp(y),
         (Token::Alpha(x), Token::Alpha(y)) => x.cmp(y),
@@ -127,8 +127,8 @@ fn parse_prefix(s: &str) -> Option<Vec<u64>> {
 ///   2. For each token, split at letter-digit boundaries.
 ///
 /// Empty strings are dropped. Each surviving string becomes Numeric(u64) if
-/// all-digit, otherwise Alpha(String).
-fn tokenize_suffix(s: &str) -> Vec<Token> {
+/// all-digit, otherwise Alpha(&str).
+fn tokenize_suffix(s: &str) -> Vec<Token<'_>> {
     let mut tokens = Vec::new();
     for part in s.split(['.', '-', '_']) {
         if part.is_empty() {
@@ -141,7 +141,7 @@ fn tokenize_suffix(s: &str) -> Vec<Token> {
             if let Ok(n) = sub.parse::<u64>() {
                 tokens.push(Token::Numeric(n));
             } else {
-                tokens.push(Token::Alpha(sub.to_string()));
+                tokens.push(Token::Alpha(sub));
             }
         }
     }
@@ -225,7 +225,7 @@ impl Range {
     /// `true` if every constraint matches against `v.prefix`. Constraints
     /// zero-pad both sides to the longer length before comparing, so a
     /// two-part bound (`>=15.0`) matches a three-part prefix (`15.10.5`).
-    pub(crate) fn matches(&self, v: &TagVersion) -> bool {
+    pub(crate) fn matches(&self, v: &TagVersion<'_>) -> bool {
         self.constraints.iter().all(|c| c.matches(&v.prefix))
     }
 }
@@ -408,14 +408,14 @@ mod parse_tests {
     fn parses_suffix_alpine() {
         let v = TagVersion::parse("15.10-alpine").unwrap();
         assert_eq!(v.prefix, vec![15, 10]);
-        assert_eq!(v.suffix, vec![Token::Alpha("alpine".into())]);
+        assert_eq!(v.suffix, vec![Token::Alpha("alpine")]);
     }
 
     #[test]
     fn parses_suffix_chainguard_revision() {
         let v = TagVersion::parse("1.25.5-r0").unwrap();
         assert_eq!(v.prefix, vec![1, 25, 5]);
-        assert_eq!(v.suffix, vec![Token::Alpha("r".into()), Token::Numeric(0)]);
+        assert_eq!(v.suffix, vec![Token::Alpha("r"), Token::Numeric(0)]);
     }
 
     #[test]
@@ -425,8 +425,8 @@ mod parse_tests {
         assert_eq!(
             v.suffix,
             vec![
-                Token::Alpha("jre".into()),
-                Token::Alpha("alpine".into()),
+                Token::Alpha("jre"),
+                Token::Alpha("alpine"),
                 Token::Numeric(3),
                 Token::Numeric(23),
             ]
@@ -440,7 +440,7 @@ mod parse_tests {
         assert_eq!(
             v.suffix,
             vec![
-                Token::Alpha("eks".into()),
+                Token::Alpha("eks"),
                 Token::Numeric(1),
                 Token::Numeric(27),
                 Token::Numeric(14),
@@ -455,7 +455,7 @@ mod parse_tests {
         assert_eq!(
             v.suffix,
             vec![
-                Token::Alpha("alpine".into()),
+                Token::Alpha("alpine"),
                 Token::Numeric(3),
                 Token::Numeric(20),
             ]
@@ -468,7 +468,7 @@ mod parse_tests {
         let a = TagVersion::parse("1.0.0-rc1").unwrap();
         let b = TagVersion::parse("1.0.0-rc.1").unwrap();
         assert_eq!(a.suffix, b.suffix);
-        assert_eq!(a.suffix, vec![Token::Alpha("rc".into()), Token::Numeric(1)]);
+        assert_eq!(a.suffix, vec![Token::Alpha("rc"), Token::Numeric(1)]);
     }
 }
 
@@ -563,7 +563,7 @@ mod range_tests {
 mod compare_tests {
     use super::*;
 
-    fn p(s: &str) -> TagVersion {
+    fn p(s: &str) -> TagVersion<'_> {
         TagVersion::parse(s).expect("valid tag")
     }
 

--- a/crates/ocync-sync/src/version.rs
+++ b/crates/ocync-sync/src/version.rs
@@ -470,6 +470,55 @@ mod parse_tests {
         assert_eq!(a.suffix, b.suffix);
         assert_eq!(a.suffix, vec![Token::Alpha("rc"), Token::Numeric(1)]);
     }
+
+    /// dotnet major-only with multi-part dashed variant: `8.0-bookworm-slim`
+    /// (mcr.microsoft.com/dotnet/aspnet).
+    #[test]
+    fn parses_suffix_dotnet_compound_variant() {
+        let v = TagVersion::parse("8.0-bookworm-slim").unwrap();
+        assert_eq!(v.prefix, vec![8, 0]);
+        assert_eq!(
+            v.suffix,
+            vec![Token::Alpha("bookworm"), Token::Alpha("slim")]
+        );
+    }
+
+    /// `HashiCorp` alpha date-stamp: `1.10.0-alpha20241016`
+    /// (terraform pre-release with embedded YYYYMMDD).
+    #[test]
+    fn parses_suffix_hashicorp_alpha_date_stamp() {
+        let v = TagVersion::parse("1.10.0-alpha20241016").unwrap();
+        assert_eq!(v.prefix, vec![1, 10, 0]);
+        assert_eq!(
+            v.suffix,
+            vec![Token::Alpha("alpha"), Token::Numeric(20241016)]
+        );
+    }
+
+    /// ARM variant suffix: `2.21.0-arm64v8` (aws-cli).
+    #[test]
+    fn parses_suffix_arm_variant() {
+        let v = TagVersion::parse("2.21.0-arm64v8").unwrap();
+        assert_eq!(v.prefix, vec![2, 21, 0]);
+        assert_eq!(
+            v.suffix,
+            vec![
+                Token::Alpha("arm"),
+                Token::Numeric(64),
+                Token::Alpha("v"),
+                Token::Numeric(8),
+            ]
+        );
+    }
+
+    /// Date as a single 8-digit integer: `20240115` (some image tag schemes).
+    /// Should parse as a one-component prefix and sort numerically.
+    #[test]
+    fn parses_date_as_single_integer() {
+        let v = TagVersion::parse("20240115").unwrap();
+        assert_eq!(v.prefix, vec![20240115]);
+        assert!(v.suffix.is_empty());
+    }
 }
 
 #[cfg(test)]
@@ -658,5 +707,25 @@ mod compare_tests {
             compare("1.0.0-rc.1.hotfix", "1.0.0-rc.1"),
             Ordering::Greater
         );
+    }
+
+    /// Maven/Java uppercase RC tokens are NOT equivalent to lowercase under
+    /// `compare` -- the suffix comparison is byte-wise. The system-exclude
+    /// glob layer is case-insensitive (handled separately), but the parse
+    /// and compare layers preserve case.
+    #[test]
+    fn maven_uppercase_rc_distinct_from_lowercase() {
+        // 'R' (0x52) < 'r' (0x72) by ASCII byte order.
+        assert_eq!(compare("5.0.0-RC1", "5.0.0-rc1"), Ordering::Less);
+        // SNAPSHOT vs snapshot: same property.
+        assert_eq!(compare("5.0.0-SNAPSHOT", "5.0.0-snapshot"), Ordering::Less);
+    }
+
+    /// Single-integer date sorts as a number, not lex: `20240115 > 2024.1.15`
+    /// (the single integer 20240115 is much greater than the [2024,1,15]
+    /// list under zero-pad).
+    #[test]
+    fn date_single_integer_sorts_above_date_components() {
+        assert_eq!(compare("20240115", "2024.01.15"), Ordering::Greater);
     }
 }

--- a/crates/ocync-sync/src/version.rs
+++ b/crates/ocync-sync/src/version.rs
@@ -4,11 +4,195 @@
 //! See `docs/superpowers/specs/2026-05-04-tag-version-parser-design.md`
 //! for the design rationale.
 
-use std::cmp::Ordering;
-
 /// A token in a tokenized tag suffix.
+#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Token {
     Numeric(u64),
     Alpha(String),
+}
+
+/// A tag parsed into a numeric prefix and a tokenized suffix.
+///
+/// Empty `suffix` means the tag had no `-suffix` region (or the suffix
+/// tokenized to nothing, e.g. `1.0-` or `1.0---`).
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TagVersion {
+    pub(crate) prefix: Vec<u64>,
+    pub(crate) suffix: Vec<Token>,
+}
+
+impl TagVersion {
+    /// Parse a tag string into a `TagVersion`.
+    /// Returns `None` if the tag has no parseable numeric prefix.
+    #[allow(dead_code)]
+    pub(crate) fn parse(tag: &str) -> Option<Self> {
+        if tag.is_empty() {
+            return None;
+        }
+
+        // Optional leading 'v' is stripped before prefix parsing.
+        let s = tag.strip_prefix('v').unwrap_or(tag);
+        if s.is_empty() {
+            return None;
+        }
+
+        // Prefix region: everything before the first '-'.
+        let (prefix_str, suffix_str) = match s.find('-') {
+            Some(i) => (&s[..i], Some(&s[i + 1..])),
+            None => (s, None),
+        };
+
+        if prefix_str.is_empty() {
+            return None;
+        }
+
+        let prefix = parse_prefix(prefix_str)?;
+
+        let suffix = match suffix_str {
+            Some(s) if !s.is_empty() => tokenize_suffix(s),
+            _ => Vec::new(),
+        };
+
+        Some(TagVersion { prefix, suffix })
+    }
+}
+
+/// Parse the prefix region: u64 components separated by '.' or '_'.
+/// Any non-digit character causes the whole tag to fail to parse.
+#[allow(dead_code)]
+fn parse_prefix(s: &str) -> Option<Vec<u64>> {
+    let mut components = Vec::new();
+    for part in s.split(['.', '_']) {
+        if part.is_empty() {
+            return None;
+        }
+        // Reject if any non-digit character is present.
+        if !part.chars().all(|c| c.is_ascii_digit()) {
+            return None;
+        }
+        let n: u64 = part.parse().ok()?;
+        components.push(n);
+    }
+    if components.is_empty() {
+        None
+    } else {
+        Some(components)
+    }
+}
+
+/// Tokenize the suffix region. Two passes:
+///   1. Split on '.', '-', '_'.
+///   2. For each token, split at letter-digit boundaries.
+///
+/// Empty strings are dropped. Each surviving string becomes Numeric(u64) if
+/// all-digit, otherwise Alpha(String).
+#[allow(dead_code)]
+fn tokenize_suffix(s: &str) -> Vec<Token> {
+    let mut tokens = Vec::new();
+    for part in s.split(['.', '-', '_']) {
+        if part.is_empty() {
+            continue;
+        }
+        for sub in split_letter_digit(part) {
+            if sub.is_empty() {
+                continue;
+            }
+            if let Ok(n) = sub.parse::<u64>() {
+                tokens.push(Token::Numeric(n));
+            } else {
+                tokens.push(Token::Alpha(sub.to_string()));
+            }
+        }
+    }
+    tokens
+}
+
+/// Split a string at every transition between digit and non-digit characters.
+#[allow(dead_code)]
+fn split_letter_digit(s: &str) -> Vec<&str> {
+    let mut splits = Vec::new();
+    let mut start = 0;
+    let mut prev_is_digit: Option<bool> = None;
+    for (i, c) in s.char_indices() {
+        let is_digit = c.is_ascii_digit();
+        if let Some(prev) = prev_is_digit {
+            if prev != is_digit {
+                splits.push(&s[start..i]);
+                start = i;
+            }
+        }
+        prev_is_digit = Some(is_digit);
+    }
+    splits.push(&s[start..]);
+    splits
+}
+
+#[cfg(test)]
+mod parse_tests {
+    use super::*;
+
+    #[test]
+    fn parses_three_part_numeric() {
+        let v = TagVersion::parse("1.21.5").unwrap();
+        assert_eq!(v.prefix, vec![1, 21, 5]);
+        assert!(v.suffix.is_empty());
+    }
+
+    #[test]
+    fn parses_two_part_numeric() {
+        let v = TagVersion::parse("15.10").unwrap();
+        assert_eq!(v.prefix, vec![15, 10]);
+        assert!(v.suffix.is_empty());
+    }
+
+    #[test]
+    fn parses_one_part_numeric() {
+        let v = TagVersion::parse("21").unwrap();
+        assert_eq!(v.prefix, vec![21]);
+        assert!(v.suffix.is_empty());
+    }
+
+    #[test]
+    fn strips_v_prefix() {
+        let v = TagVersion::parse("v1.27.6").unwrap();
+        assert_eq!(v.prefix, vec![1, 27, 6]);
+    }
+
+    #[test]
+    fn parses_v0() {
+        let v = TagVersion::parse("v0").unwrap();
+        assert_eq!(v.prefix, vec![0]);
+    }
+
+    #[test]
+    fn parses_underscore_separator() {
+        let v = TagVersion::parse("21.0.5_11").unwrap();
+        assert_eq!(v.prefix, vec![21, 0, 5, 11]);
+        assert!(v.suffix.is_empty());
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(TagVersion::parse("").is_none());
+    }
+
+    #[test]
+    fn rejects_bare_v() {
+        assert!(TagVersion::parse("v").is_none());
+    }
+
+    #[test]
+    fn rejects_non_numeric_prefix() {
+        assert!(TagVersion::parse("latest").is_none());
+        assert!(TagVersion::parse("lts-iron").is_none());
+    }
+
+    #[test]
+    fn rejects_letter_in_prefix_region() {
+        // postgres `17rc1` has 'r' in the prefix region (before any '-') -> drop.
+        assert!(TagVersion::parse("17rc1").is_none());
+        assert!(TagVersion::parse("1.24rc2").is_none());
+    }
 }

--- a/crates/ocync-sync/src/version.rs
+++ b/crates/ocync-sync/src/version.rs
@@ -195,4 +195,91 @@ mod parse_tests {
         assert!(TagVersion::parse("17rc1").is_none());
         assert!(TagVersion::parse("1.24rc2").is_none());
     }
+
+    #[test]
+    fn rejects_u64_overflow() {
+        // 25 digits exceeds u64::MAX.
+        let too_big = "1".repeat(25);
+        assert!(TagVersion::parse(&too_big).is_none());
+    }
+
+    #[test]
+    fn collapses_trailing_dash() {
+        let v = TagVersion::parse("1.0-").unwrap();
+        assert_eq!(v.prefix, vec![1, 0]);
+        assert!(v.suffix.is_empty());
+    }
+
+    #[test]
+    fn collapses_suffix_with_only_separators() {
+        let v = TagVersion::parse("1.0---").unwrap();
+        assert!(v.suffix.is_empty());
+    }
+
+    #[test]
+    fn parses_suffix_alpine() {
+        let v = TagVersion::parse("15.10-alpine").unwrap();
+        assert_eq!(v.prefix, vec![15, 10]);
+        assert_eq!(v.suffix, vec![Token::Alpha("alpine".into())]);
+    }
+
+    #[test]
+    fn parses_suffix_chainguard_revision() {
+        let v = TagVersion::parse("1.25.5-r0").unwrap();
+        assert_eq!(v.prefix, vec![1, 25, 5]);
+        assert_eq!(v.suffix, vec![Token::Alpha("r".into()), Token::Numeric(0)]);
+    }
+
+    #[test]
+    fn parses_suffix_temurin_compound() {
+        let v = TagVersion::parse("25.0.3_9-jre-alpine-3.23").unwrap();
+        assert_eq!(v.prefix, vec![25, 0, 3, 9]);
+        assert_eq!(
+            v.suffix,
+            vec![
+                Token::Alpha("jre".into()),
+                Token::Alpha("alpine".into()),
+                Token::Numeric(3),
+                Token::Numeric(23),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_suffix_eks_distro() {
+        let v = TagVersion::parse("v1.27.6-eks-1-27-14").unwrap();
+        assert_eq!(v.prefix, vec![1, 27, 6]);
+        assert_eq!(
+            v.suffix,
+            vec![
+                Token::Alpha("eks".into()),
+                Token::Numeric(1),
+                Token::Numeric(27),
+                Token::Numeric(14),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_suffix_node_alpine_compound() {
+        let v = TagVersion::parse("20.18.1-alpine3.20").unwrap();
+        assert_eq!(v.prefix, vec![20, 18, 1]);
+        assert_eq!(
+            v.suffix,
+            vec![
+                Token::Alpha("alpine".into()),
+                Token::Numeric(3),
+                Token::Numeric(20),
+            ]
+        );
+    }
+
+    #[test]
+    fn tokenization_equivalence_rc1_and_rc_dot_1() {
+        // 1.0.0-rc1 and 1.0.0-rc.1 produce identical tokens.
+        let a = TagVersion::parse("1.0.0-rc1").unwrap();
+        let b = TagVersion::parse("1.0.0-rc.1").unwrap();
+        assert_eq!(a.suffix, b.suffix);
+        assert_eq!(a.suffix, vec![Token::Alpha("rc".into()), Token::Numeric(1)]);
+    }
 }

--- a/crates/ocync-sync/src/version.rs
+++ b/crates/ocync-sync/src/version.rs
@@ -1,0 +1,14 @@
+//! Tag-version parser, comparator, and range matcher.
+//!
+//! Replaces the strict-SemVer parser previously used by the filter pipeline.
+//! See `docs/superpowers/specs/2026-05-04-tag-version-parser-design.md`
+//! for the design rationale.
+
+use std::cmp::Ordering;
+
+/// A token in a tokenized tag suffix.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Token {
+    Numeric(u64),
+    Alpha(String),
+}

--- a/crates/ocync-sync/src/version.rs
+++ b/crates/ocync-sync/src/version.rs
@@ -4,6 +4,8 @@
 //! See `docs/superpowers/specs/2026-05-04-tag-version-parser-design.md`
 //! for the design rationale.
 
+use std::cmp::Ordering;
+
 /// A token in a tokenized tag suffix.
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -56,6 +58,54 @@ impl TagVersion {
         };
 
         Some(TagVersion { prefix, suffix })
+    }
+
+    /// Total order over `TagVersion`. Free associated function rather than
+    /// `impl Ord` because zero-padding equality (`1.0` and `1.0.0` compare
+    /// Equal) is incompatible with `Ord`'s contract that
+    /// `cmp(a, b) == Equal` implies `a == b`.
+    #[allow(dead_code)]
+    pub(crate) fn compare(a: &Self, b: &Self) -> Ordering {
+        // Step 1: numeric prefix, zero-padded to the longer length.
+        let max_len = a.prefix.len().max(b.prefix.len());
+        for i in 0..max_len {
+            let ai = a.prefix.get(i).copied().unwrap_or(0);
+            let bi = b.prefix.get(i).copied().unwrap_or(0);
+            match ai.cmp(&bi) {
+                Ordering::Equal => continue,
+                ord => return ord,
+            }
+        }
+
+        // Step 2: suffix presence. Empty suffix wins.
+        match (a.suffix.is_empty(), b.suffix.is_empty()) {
+            (true, true) => return Ordering::Equal,
+            (true, false) => return Ordering::Greater,
+            (false, true) => return Ordering::Less,
+            (false, false) => {}
+        }
+
+        // Step 3: token-by-token comparison.
+        for (at, bt) in a.suffix.iter().zip(b.suffix.iter()) {
+            let ord = compare_tokens(at, bt);
+            if ord != Ordering::Equal {
+                return ord;
+            }
+        }
+
+        // Length-mismatch tie-breaker: shorter token list is less.
+        a.suffix.len().cmp(&b.suffix.len())
+    }
+}
+
+/// Compare two suffix tokens. Numeric < Alpha at the same position (`SemVer` rule).
+#[allow(dead_code)]
+fn compare_tokens(a: &Token, b: &Token) -> Ordering {
+    match (a, b) {
+        (Token::Numeric(x), Token::Numeric(y)) => x.cmp(y),
+        (Token::Alpha(x), Token::Alpha(y)) => x.cmp(y),
+        (Token::Numeric(_), Token::Alpha(_)) => Ordering::Less,
+        (Token::Alpha(_), Token::Numeric(_)) => Ordering::Greater,
     }
 }
 
@@ -281,5 +331,104 @@ mod parse_tests {
         let b = TagVersion::parse("1.0.0-rc.1").unwrap();
         assert_eq!(a.suffix, b.suffix);
         assert_eq!(a.suffix, vec![Token::Alpha("rc".into()), Token::Numeric(1)]);
+    }
+}
+
+#[cfg(test)]
+mod compare_tests {
+    use super::*;
+
+    fn p(s: &str) -> TagVersion {
+        TagVersion::parse(s).expect("valid tag")
+    }
+
+    fn cmp(a: &str, b: &str) -> Ordering {
+        TagVersion::compare(&p(a), &p(b))
+    }
+
+    #[test]
+    fn three_part_numeric_descending() {
+        assert_eq!(cmp("1.0.0", "2.0.0"), Ordering::Less);
+        assert_eq!(cmp("2.0.0", "1.0.0"), Ordering::Greater);
+        assert_eq!(cmp("1.21.5", "1.21.5"), Ordering::Equal);
+    }
+
+    #[test]
+    fn zero_pad_one_dot_zero_equals_one_zero_zero() {
+        assert_eq!(cmp("1.0", "1.0.0"), Ordering::Equal);
+    }
+
+    #[test]
+    fn zero_pad_three_part_beats_two_part() {
+        // 1.0.5 > 1.0 (which pads to 1.0.0)
+        assert_eq!(cmp("1.0.5", "1.0"), Ordering::Greater);
+    }
+
+    #[test]
+    fn suffix_less_wins() {
+        assert_eq!(cmp("1.0.0", "1.0.0-rc1"), Ordering::Greater);
+        assert_eq!(cmp("1.0.0-alpha", "1.0.0"), Ordering::Less);
+    }
+
+    #[test]
+    fn temurin_underscore_build_orders() {
+        assert_eq!(cmp("25.0.3_10", "25.0.3_9"), Ordering::Greater);
+        // 25.0.3 > 25.0.2_999: prefix [25,0,3,0] > [25,0,2,999] after padding.
+        assert_eq!(cmp("25.0.3", "25.0.2_999"), Ordering::Greater);
+    }
+
+    #[test]
+    fn rc10_above_rc9_via_letter_digit_split() {
+        assert_eq!(cmp("1.0.0-rc10", "1.0.0-rc9"), Ordering::Greater);
+    }
+
+    #[test]
+    fn rc1_and_rc_dot_1_compare_equal() {
+        assert_eq!(cmp("1.0.0-rc1", "1.0.0-rc.1"), Ordering::Equal);
+    }
+
+    #[test]
+    fn rc_dot_2_above_rc_dot_1() {
+        assert_eq!(cmp("1.0.0-rc.1", "1.0.0-rc.2"), Ordering::Less);
+    }
+
+    #[test]
+    fn eks_distro_compound_suffix_orders() {
+        assert_eq!(
+            cmp("v1.27.6-eks-1-27-14", "v1.27.6-eks-1-27-9"),
+            Ordering::Greater
+        );
+    }
+
+    #[test]
+    fn bitnami_release_counter_orders() {
+        assert_eq!(
+            cmp("1.31.3-debian-12-r3", "1.31.3-debian-12-r2"),
+            Ordering::Greater
+        );
+    }
+
+    #[test]
+    fn case_significant_alpha() {
+        // ASCII: 'R' (0x52) < 'r' (0x72), so RC1 sorts before rc1.
+        assert_eq!(cmp("1.0.0-RC1", "1.0.0-rc1"), Ordering::Less);
+    }
+
+    #[test]
+    fn numeric_lt_alpha_at_same_position() {
+        // SemVer identifier-precedence rule.
+        let a = p("1.0.0-1");
+        let b = p("1.0.0-alpha");
+        assert_eq!(TagVersion::compare(&a, &b), Ordering::Less);
+    }
+
+    #[test]
+    fn longer_suffix_beats_shorter_when_tokens_equal() {
+        // Exercises the length tie-breaker: [rc, 1] vs [rc, 1, "hotfix"].
+        // Tokens compare equal at positions 0 and 1; falls through to
+        // length comparison.
+        assert_eq!(cmp("1.0.0-rc.1", "1.0.0-rc.1.hotfix"), Ordering::Less);
+        // Antisymmetry: the reverse comparison must yield Greater.
+        assert_eq!(cmp("1.0.0-rc.1.hotfix", "1.0.0-rc.1"), Ordering::Greater);
     }
 }

--- a/crates/ocync-sync/src/version.rs
+++ b/crates/ocync-sync/src/version.rs
@@ -7,7 +7,6 @@
 use std::cmp::Ordering;
 
 /// A token in a tokenized tag suffix.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Token {
     Numeric(u64),
@@ -18,7 +17,6 @@ pub(crate) enum Token {
 ///
 /// Empty `suffix` means the tag had no `-suffix` region (or the suffix
 /// tokenized to nothing, e.g. `1.0-` or `1.0---`).
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TagVersion {
     pub(crate) prefix: Vec<u64>,
@@ -28,7 +26,6 @@ pub(crate) struct TagVersion {
 impl TagVersion {
     /// Parse a tag string into a `TagVersion`.
     /// Returns `None` if the tag has no parseable numeric prefix.
-    #[allow(dead_code)]
     pub(crate) fn parse(tag: &str) -> Option<Self> {
         if tag.is_empty() {
             return None;
@@ -64,7 +61,6 @@ impl TagVersion {
     /// `impl Ord` because zero-padding equality (`1.0` and `1.0.0` compare
     /// Equal) is incompatible with `Ord`'s contract that
     /// `cmp(a, b) == Equal` implies `a == b`.
-    #[allow(dead_code)]
     pub(crate) fn compare(a: &Self, b: &Self) -> Ordering {
         // Step 1: numeric prefix, zero-padded to the longer length.
         let max_len = a.prefix.len().max(b.prefix.len());
@@ -99,7 +95,6 @@ impl TagVersion {
 }
 
 /// Compare two suffix tokens. Numeric < Alpha at the same position (`SemVer` rule).
-#[allow(dead_code)]
 fn compare_tokens(a: &Token, b: &Token) -> Ordering {
     match (a, b) {
         (Token::Numeric(x), Token::Numeric(y)) => x.cmp(y),
@@ -111,7 +106,6 @@ fn compare_tokens(a: &Token, b: &Token) -> Ordering {
 
 /// Parse the prefix region: u64 components separated by '.' or '_'.
 /// Any non-digit character causes the whole tag to fail to parse.
-#[allow(dead_code)]
 fn parse_prefix(s: &str) -> Option<Vec<u64>> {
     let mut components = Vec::new();
     for part in s.split(['.', '_']) {
@@ -138,7 +132,6 @@ fn parse_prefix(s: &str) -> Option<Vec<u64>> {
 ///
 /// Empty strings are dropped. Each surviving string becomes Numeric(u64) if
 /// all-digit, otherwise Alpha(String).
-#[allow(dead_code)]
 fn tokenize_suffix(s: &str) -> Vec<Token> {
     let mut tokens = Vec::new();
     for part in s.split(['.', '-', '_']) {
@@ -160,7 +153,6 @@ fn tokenize_suffix(s: &str) -> Vec<Token> {
 }
 
 /// Split a string at every transition between digit and non-digit characters.
-#[allow(dead_code)]
 fn split_letter_digit(s: &str) -> Vec<&str> {
     let mut splits = Vec::new();
     let mut start = 0;
@@ -181,7 +173,6 @@ fn split_letter_digit(s: &str) -> Vec<&str> {
 
 /// A parsed version range: one or more constraints joined by AND.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)]
 pub(crate) struct Range {
     constraints: Vec<Constraint>,
 }
@@ -215,7 +206,6 @@ impl std::fmt::Display for RangeParseError {
 
 impl std::error::Error for RangeParseError {}
 
-#[allow(dead_code)]
 impl Range {
     /// Parse a range string into a `Range`.
     ///

--- a/docs/public/config.schema.json
+++ b/docs/public/config.schema.json
@@ -431,32 +431,7 @@
         }
       }
     },
-    "SemverPrerelease": {
-      "description": "How to handle semver pre-release tags.",
-      "oneOf": [
-        {
-          "description": "Include pre-release tags in results.",
-          "type": "string",
-          "enum": [
-            "include"
-          ]
-        },
-        {
-          "description": "Exclude pre-release tags from results.",
-          "type": "string",
-          "enum": [
-            "exclude"
-          ]
-        },
-        {
-          "description": "Return only pre-release tags.",
-          "type": "string",
-          "enum": [
-            "only"
-          ]
-        }
-      ]
-    },
+    "RemovedSemverPrerelease": false,
     "SortOrder": {
       "description": "Sort order for the final tag list.",
       "oneOf": [
@@ -512,6 +487,18 @@
             "null"
           ]
         },
+        "include": {
+          "description": "Always-include glob patterns. Tags matching any pattern survive `glob:`/`semver:` filters and the system-exclude defaults. Same syntax as `exclude:`. Not subject to `sort:` or `latest:` truncation.",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/GlobOrList"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "latest": {
           "description": "Keep only the N most recent tags after sorting.",
           "default": null,
@@ -541,11 +528,11 @@
           ]
         },
         "semver_prerelease": {
-          "description": "Whether to include or exclude semver pre-release tags.",
-          "default": null,
+          "description": "Removed in 2026-05; deserializing a config that still sets this field triggers a fail-loud migration error pointing at `include:`.",
+          "writeOnly": true,
           "anyOf": [
             {
-              "$ref": "#/definitions/SemverPrerelease"
+              "$ref": "#/definitions/RemovedSemverPrerelease"
             },
             {
               "type": "null"

--- a/docs/src/content/configuration.md
+++ b/docs/src/content/configuration.md
@@ -268,8 +268,8 @@ defaults:
 Tags are filtered through a pipeline in order:
 
 1. **glob**: include tags matching the glob pattern (string or list)
-2. **semver**: include tags satisfying the semver range
-3. **semver_prerelease**: control pre-release tag handling when `semver` is set
+2. **include**: always-include glob pattern(s) that override filters and system-exclude defaults
+3. **semver**: include tags satisfying the version range
 4. **exclude**: remove tags matching any exclude pattern (string or list)
 5. **sort**: order remaining tags (`semver`, `alpha`)
 6. **latest**: keep only the N most recent after sorting
@@ -280,8 +280,8 @@ All filters are optional. Without any filters, all tags are synced.
 | Field | Type | Description |
 |---|---|---|
 | `glob` | string or list | Include tags matching glob pattern(s). A single string or a list of patterns |
-| `semver` | string | Include tags satisfying a semver range (e.g., `">=1.0"`, `"^2"`, `"1.x"`) |
-| `semver_prerelease` | string | How to handle pre-release tags when `semver` is set. Values: `include`, `exclude`, `only`. Default: `exclude`. Requires `semver` to be set |
+| `include` | string or list | Always-include glob pattern(s). Tags matching any pattern survive `glob:`/`semver:` filters and the system-exclude defaults. Same syntax as `exclude:` |
+| `semver` | string | Include tags satisfying a version range. Operators: `>=`, `<=`, `>`, `<`, `=`. Comma-joined for AND-narrowing. Example: `">=1.0, <2.0"` |
 | `exclude` | string or list | Remove tags matching these glob pattern(s) |
 | `sort` | string | Sort order for remaining tags: `semver` or `alpha` |
 | `latest` | integer | Keep only the N most recent tags after sorting |
@@ -289,10 +289,29 @@ All filters are optional. Without any filters, all tags are synced.
 | `immutable_tags` | string | Glob pattern marking tags that never change content (e.g. `"v?[0-9]*.[0-9]*.[0-9]*"`). When a tag matches AND already exists in **every** target's tag list, the sync skips it with zero source and target requests. Useful for long-running mirrors of registries that publish many semver-pinned tags |
 
 **Validation constraints:**
-- `semver_prerelease` requires `semver` to be set
 - `latest` requires `sort` to be set
 
 **Override semantics:** when a mapping defines `tags:`, the entire block replaces `defaults.tags` - fields are not merged. If you want a mapping to inherit some default fields and override others, repeat the inherited fields in the mapping's `tags:` block.
+
+### Default-exclude patterns
+
+ocync drops common prerelease-marker tag patterns by default to keep mirrors focused on stable releases. The default-exclude list (case-insensitive) is:
+
+- `*-rc*`
+- `*-alpha*`
+- `*-beta*`
+- `*-pre*`
+- `*-snapshot*`
+- `*-nightly*`
+
+Patterns deliberately NOT in the default list (still admitted unless you exclude them yourself):
+
+- `*-dev*` -- Chainguard publishes `latest-dev` and `1.25.5-dev` as stable variants
+- `*-edge*` -- Alpine rolling stable channel
+- `*-final*` -- Java stable marker
+- `-r<N>` -- Chainguard/Bitnami build counters
+
+To opt back into prereleases, add them to `include:` (which overrides the default-exclude). To pin a single prerelease tag for testing, add the exact tag string to `include:`. To add custom exclude patterns on top of the defaults, use `exclude:`.
 
 ## Environment variables
 
@@ -316,7 +335,7 @@ The `DOCKER_CONFIG` environment variable controls the Docker config file locatio
 
 ### Chainguard to ECR
 
-Single region. Sync a curated set of Chainguard base images to ECR, keeping the latest 5 semver-pinned tags for `linux/amd64` and `linux/arm64`. Chainguard tags carry a `-rN` build-revision suffix (`1.25.5-r0`, `1.25.5-r1`); the SemVer spec treats anything after `-` as a prerelease, so `semver_prerelease: include` is required for any `cgr.dev` tag to survive a `semver:` range:
+Single region. Sync a curated set of Chainguard base images to ECR, keeping the latest 5 stable releases plus the `latest`/`latest-dev` floats for `linux/amd64` and `linux/arm64`. Chainguard's `-rN` build-revision suffix admits directly under the lenient parser:
 
 ```yaml
 registries:
@@ -332,8 +351,8 @@ defaults:
     - linux/amd64
     - linux/arm64
   tags:
+    include: ["latest", "latest-dev"]
     semver: ">=1.0"
-    semver_prerelease: include
     sort: semver
     latest: 5
 

--- a/docs/src/content/configuration.md
+++ b/docs/src/content/configuration.md
@@ -55,7 +55,6 @@ defaults:
     - linux/arm64
   tags:
     semver: ">=1.0"
-    semver_prerelease: include   # cgr.dev tags carry -rN build suffixes
     sort: semver
     latest: 10
 
@@ -162,7 +161,6 @@ defaults:
   tags:
     glob: "*"                  # Glob pattern
     semver: ">=1.0"            # Semver range
-    semver_prerelease: exclude # Pre-release handling
     exclude:                   # Exclude patterns
       - "*-debug"
     sort: semver               # Sort order: semver, alpha

--- a/docs/src/content/configuration.md
+++ b/docs/src/content/configuration.md
@@ -265,15 +265,14 @@ defaults:
 
 ## Tag filtering
 
-Tags are filtered through a pipeline in order:
+Tags are filtered through a pipeline:
 
-1. **glob**: include tags matching the glob pattern (string or list)
-2. **include**: always-include glob pattern(s) that override filters and system-exclude defaults
-3. **semver**: include tags satisfying the version range
-4. **exclude**: remove tags matching any exclude pattern (string or list)
-5. **sort**: order remaining tags (`semver`, `alpha`)
-6. **latest**: keep only the N most recent after sorting
-7. **min_tags**: validate at least N tags survived the pipeline (error if fewer)
+1. **glob + semver**: build the candidate pool by intersecting the glob match set (default `*`) with the version range
+2. **exclude**: remove tags matching any user `exclude` pattern OR any default-exclude pattern (see below)
+3. **sort**: order the pool (`semver` or `alpha`)
+4. **latest**: keep only the N most recent of the pool
+5. **include**: union always-include tag matches into the result (not subject to `glob`, `semver`, default-excludes, `sort`, or `latest`); still subject to user `exclude`
+6. **min_tags**: validate the final union has at least N tags (error if fewer)
 
 All filters are optional. Without any filters, all tags are synced.
 

--- a/docs/src/content/configuration.md
+++ b/docs/src/content/configuration.md
@@ -288,6 +288,10 @@ All filters are optional. Without any filters, all tags are synced.
 **Validation constraints:**
 - `latest` requires `sort` to be set
 
+### Capping output size
+
+`latest:` is optional, but mirrors with `semver:` and no `latest:` cap will sync every tag matching the version range. Under the lenient parser, popular images often publish hundreds of variant tags (`-alpine`, `-r0`, `-debian-12-rN`, `-bookworm-slim`, etc.). For long-running mirrors, set `latest: N` (with `sort: semver`) to cap output size. ocync emits a startup warning when `semver:` is set without `latest:`.
+
 **Override semantics:** when a mapping defines `tags:`, the entire block replaces `defaults.tags` - fields are not merged. If you want a mapping to inherit some default fields and override others, repeat the inherited fields in the mapping's `tags:` block.
 
 ### Default-exclude patterns

--- a/docs/src/content/recipes/minimum-bytes.md
+++ b/docs/src/content/recipes/minimum-bytes.md
@@ -52,12 +52,11 @@ tags:
   # See pin-literals-only for the full discussion of the literal-pin pattern.
 ```
 
-Tracking the latest five releases of a major version. Chainguard tags carry a `-rN` build-revision suffix (`1.25.5-r0`, `1.25.5-r1`) which the SemVer spec treats as a prerelease, so `semver_prerelease: include` is required against `cgr.dev` for any tag to survive the range filter:
+Tracking the latest five releases of a major version. The lenient parser admits Chainguard's `-rN` build-revision suffix (`1.25.5-r0`, `1.25.5-r1`) directly:
 
 ```yaml
 tags:
   semver: ">=1.0.0, <2.0.0"
-  semver_prerelease: include
   sort: semver
   latest: 5
 ```

--- a/docs/src/content/recipes/pin-literals-only.md
+++ b/docs/src/content/recipes/pin-literals-only.md
@@ -65,6 +65,14 @@ defaults:
 - A tag pattern (`v2.*`) is a glob, not a literal - either accept the listing cost or list each version explicitly.
 - Pinned tags and a filtered range cannot share a single mapping today; split into two mappings (one literal-only, one filtered) targeting the same `to:` repository.
 
+## When to use `glob:` vs `include:`
+
+`glob:` is the *filter* mechanism: it narrows the candidate pool. Use it when you want only specific tags, with no `semver:` range driving the pipeline.
+
+`include:` is the *augment* mechanism: it always-adds tags alongside a `semver:`-driven pipeline. Use it when you want literal pins (`latest`, `latest-dev`) plus a version range in the same mapping.
+
+For pin-only use cases (this recipe), `glob:` is the right field. For pin-plus-range, see [semver tracking](/recipes/semver-tracking).
+
 ## Related
 
 - [Minimum bytes](/recipes/minimum-bytes) for the broader cost-sensitive pattern

--- a/docs/src/content/recipes/semver-tracking.md
+++ b/docs/src/content/recipes/semver-tracking.md
@@ -46,6 +46,8 @@ mappings:
 
 `latest: 10` keeps only the top 10 of the pipeline side. Include-pinned floats pass through uncapped.
 
+> **Always set `latest:` for long-running mirrors.** If you omit `latest:`, every tag in the version range is synced -- popular images publish hundreds of variant tags (`-alpine`, `-bullseye-slim`, `-r0`, `-debian-12-r3`, etc.), and a `semver: ">=1.0"` mirror without a cap can sync hundreds of tags on the first run. Caps prevent the mirror from blowing up under variant proliferation.
+
 `min_tags: 1` is a safety net for long-running mirrors. Counts the union of include and pipeline.
 
 ## Variations

--- a/docs/src/content/recipes/semver-tracking.md
+++ b/docs/src/content/recipes/semver-tracking.md
@@ -29,8 +29,8 @@ mappings:
   - from: my-org/my-app
     to: my-app
     tags:
+      include: ["latest", "latest-dev"]
       semver: ">=2.0"
-      semver_prerelease: exclude
       sort: semver
       latest: 10
       min_tags: 1
@@ -38,50 +38,56 @@ mappings:
 
 ## Fields
 
-`semver: ">=2.0"` drops everything below 2.0. Non-semver tags like `latest` and `nightly` are also dropped at this stage, since they cannot be parsed as semver.
+`include: ["latest", "latest-dev"]` always pins these literal floats. They survive the `semver:` filter and the system-exclude defaults.
 
-`semver_prerelease: exclude` drops `2.0.0-rc.1`, `2.0.0-alpha`, and any other prerelease identifier. This is the default - it is spelled out here so the intent is obvious in the config.
+`semver: ">=2.0"` drops everything below 2.0 from the candidate pool. Common prerelease patterns (`*-rc*`, `*-alpha*`, `*-beta*`, `*-pre*`, `*-snapshot*`, `*-nightly*`) drop by default via the system-exclude. Variant suffixes like `-alpine` and `-r0` are admitted (suffix is opaque).
 
-`sort: semver` orders the surviving tags by semantic version, highest first.
+`sort: semver` orders the surviving pipeline tags by version, highest first.
 
-`latest: 10` keeps only the top 10 after sorting. This requires `sort:` to be set.
+`latest: 10` keeps only the top 10 of the pipeline side. Include-pinned floats pass through uncapped.
 
-`min_tags: 1` is a safety net for long-running mirrors. If upstream renames their tag scheme or drops below your range, the sync fails loudly rather than silently producing an empty mirror.
+`min_tags: 1` is a safety net for long-running mirrors. Counts the union of include and pipeline.
 
 ## Variations
 
-The default `exclude` matches npm, cargo, and Masterminds semver. To include pre-releases:
+The default already drops `*-rc*`, `*-alpha*`, `*-beta*`, `*-pre*`, `*-snapshot*`, `*-nightly*` via the system-exclude -- no extra config needed for stable-only:
 
 ```yaml
 tags:
   semver: ">=2.0"
-  semver_prerelease: include    # 2.0.0-rc.1 matches >=2.0.0
   sort: semver
   latest: 10
 ```
 
-`include` mode compares the base version (`2.0.0` for `2.0.0-rc.1`) against the range. So `2.0.0-rc.1` matches `>=2.0.0` but not `<2.0.0`.
-
-To mirror only pre-releases:
+To opt back into all prereleases, add the patterns to `include:` (which overrides the system default):
 
 ```yaml
 tags:
+  include: ["*-rc*", "*-alpha*", "*-beta*", "*-pre*", "*-snapshot*", "*-nightly*"]
   semver: ">=2.0"
-  semver_prerelease: only
+  sort: semver
+  latest: 10
 ```
 
-Chainguard and Wolfi tags use a `-rN` build-revision suffix (`1.25.5-r0`, `1.25.5-r1`). Per the SemVer spec, anything after `-` is a prerelease identifier, so the default `exclude` drops them. To keep the `-rN` revisions while still rejecting the actual release-candidate prereleases:
+To pin a specific RC alongside stable releases:
 
 ```yaml
 tags:
+  include: ["1.25.0-rc1"]
   semver: ">=1.25.0"
-  semver_prerelease: include
-  exclude: ["*-rc*", "*-beta*", "*-alpha*"]
   sort: semver
   latest: 10
 ```
 
-`semver_prerelease: include` keeps the `-rN` tags, and the `exclude:` patterns drop the named prerelease channels. Most Chainguard mirrors converge on this shape.
+Chainguard `-rN` build revisions admit by default; no special configuration:
+
+```yaml
+tags:
+  include: ["latest", "latest-dev"]
+  semver: ">=1.25.0"
+  sort: semver
+  latest: 10
+```
 
 ## Related
 

--- a/docs/src/content/recipes/variant-filtering.md
+++ b/docs/src/content/recipes/variant-filtering.md
@@ -49,14 +49,28 @@ tags:
 
 ## Variations
 
-Adding a numeric range cutoff (e.g. "alpine variants of 15 and newer") on top of a variant glob does not work cleanly today. Tags like `15.10-alpine` are not parseable by the strict SemVer parser `ocync` currently uses, so they are dropped at the `semver:` stage with a warning. If you need a version floor on a suffixed tag set, enumerate the major versions in the glob:
+Combine a variant glob with a numeric range cutoff. The lenient parser admits `15.10-alpine` directly (prefix `[15, 10]`), so a `glob` plus `semver` bound work in the same mapping:
 
 ```yaml
 tags:
-  glob: ["15.*-alpine", "16.*-alpine", "17.*-alpine"]
+  glob: ["*-alpine"]
+  semver: ">=15.0"
+  sort: semver
+  latest: 5
 ```
 
-A more permissive version parser that handles `X.Y-suffix` tags is on the roadmap; once it lands, `glob + semver` will combine without enumeration.
+### Match only base versions
+
+To keep plain-numeric tags (`15.10`, `16.0`, `17.1.2`) and drop every dashed-suffix variant in one move, exclude any tag that contains a dash:
+
+```yaml
+tags:
+  semver: ">=15.0"
+  exclude: ["*-*"]
+  sort: semver
+```
+
+The `semver:` stage continues to drop non-version tags like `latest`, `lts-iron`, and `nightly`. The `exclude` patterns drop `15.10-alpine`, `15.10-bullseye-slim`, and any other variant.
 
 ## Related
 

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -451,9 +451,9 @@ fn build_filter(tags: Option<&TagsConfig>) -> FilterConfig {
     };
 
     FilterConfig {
+        include: glob_or_list_to_vec(tags.include.as_ref()),
         glob: glob_or_list_to_vec(tags.glob.as_ref()),
         semver: tags.semver.clone(),
-        semver_prerelease: tags.semver_prerelease,
         exclude: glob_or_list_to_vec(tags.exclude.as_ref()),
         sort: tags.sort,
         latest: tags.latest,
@@ -634,22 +634,23 @@ mod tests {
 
     #[test]
     fn build_filter_full() {
-        use ocync_sync::filter::{SemverPrerelease, SortOrder};
+        use ocync_sync::filter::SortOrder;
 
         let tags = TagsConfig {
+            include: Some(GlobOrList::List(vec!["latest".into()])),
             glob: Some(GlobOrList::Single("*".into())),
             semver: Some(">=1.0.0".into()),
-            semver_prerelease: Some(SemverPrerelease::Exclude),
             exclude: Some(GlobOrList::Single("*-alpine".into())),
             sort: Some(SortOrder::Semver),
             latest: Some(5),
             min_tags: Some(1),
             immutable_tags: None,
+            ..Default::default()
         };
         let filter = build_filter(Some(&tags));
+        assert_eq!(filter.include, vec!["latest"]);
         assert_eq!(filter.glob, vec!["*"]);
         assert_eq!(filter.semver.as_deref(), Some(">=1.0.0"));
-        assert_eq!(filter.semver_prerelease, Some(SemverPrerelease::Exclude));
         assert_eq!(filter.exclude, vec!["*-alpine"]);
         assert_eq!(filter.sort, Some(SortOrder::Semver));
         assert_eq!(filter.latest, Some(5));

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -657,6 +657,55 @@ mod tests {
         assert_eq!(filter.min_tags, Some(1));
     }
 
+    /// End-to-end: a `TagsConfig` with `include:` + `semver:` builds a
+    /// `FilterConfig` that, when applied to a tag list, returns both the
+    /// pinned literals and the version-range matches.
+    #[test]
+    fn build_filter_include_pin_plus_range_full_flow() {
+        let tags_yaml = r#"
+include: ["latest", "latest-dev"]
+semver: ">=1.25.0"
+sort: semver
+latest: 5
+"#;
+        let tags: TagsConfig = serde_yaml::from_str(tags_yaml).expect("yaml parses");
+        let filter = build_filter(Some(&tags));
+
+        // Confirm the FilterConfig was built with the right include patterns.
+        assert_eq!(
+            filter.include,
+            vec!["latest".to_string(), "latest-dev".to_string()]
+        );
+
+        // Apply against a synthesized tag list and verify both arms work.
+        let candidate_tags = vec![
+            "latest",
+            "latest-dev",
+            "1.25.5-r0",
+            "1.25.4",
+            "1.25.3",
+            "1.25.2",
+            "1.25.1",
+            "1.25.0",
+            "1.24.0",     // below range, drops
+            "1.25.5-rc1", // RC, dropped by system-exclude
+        ];
+        let result = filter.apply(&candidate_tags).expect("filter applies");
+
+        // Floats survive via include.
+        assert!(result.contains(&"latest".to_string()));
+        assert!(result.contains(&"latest-dev".to_string()));
+        // Top 5 of the version range (1.25.5-r0 sorts above 1.25.5-rc1 if rc1
+        // weren't dropped, but rc1 IS dropped, so we expect 1.25.0..1.25.5-r0).
+        assert!(result.contains(&"1.25.5-r0".to_string()));
+        // Below range: dropped.
+        assert!(!result.contains(&"1.24.0".to_string()));
+        // RC: dropped by system-exclude.
+        assert!(!result.contains(&"1.25.5-rc1".to_string()));
+        // 5 versions + 2 floats = 7.
+        assert_eq!(result.len(), 7);
+    }
+
     #[test]
     fn glob_or_list_to_vec_none() {
         assert!(glob_or_list_to_vec(None).is_empty());

--- a/src/cli/commands/tags.rs
+++ b/src/cli/commands/tags.rs
@@ -34,11 +34,11 @@ pub(crate) async fn run(args: &TagsArgs) -> Result<ExitCode, CliError> {
     let filter = FilterConfig {
         glob: args.glob.clone(),
         semver: args.semver.clone(),
-        semver_prerelease: None,
         exclude: args.exclude.clone(),
         sort: args.sort.map(|s| s.into()),
         latest: args.latest,
         min_tags: None,
+        ..FilterConfig::default()
     };
 
     let tag_refs: Vec<&str> = all_tags.iter().map(String::as_str).collect();

--- a/src/cli/commands/tags.rs
+++ b/src/cli/commands/tags.rs
@@ -37,7 +37,6 @@ pub(crate) async fn run(args: &TagsArgs) -> Result<ExitCode, CliError> {
         exclude: args.exclude.clone(),
         sort: args.sort.map(|s| s.into()),
         latest: args.latest,
-        min_tags: None,
         ..FilterConfig::default()
     };
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -409,9 +409,17 @@ pub(crate) struct TagsConfig {
     #[serde(default)]
     pub semver: Option<String>,
 
-    /// Whether to include or exclude semver pre-release tags.
+    /// Always-include glob patterns. Tags matching any pattern survive
+    /// `glob:`/`semver:` filters and the system-exclude defaults. Same syntax
+    /// as `exclude:`. Not subject to `sort:` or `latest:` truncation.
     #[serde(default)]
-    pub semver_prerelease: Option<SemverPrerelease>,
+    pub include: Option<GlobOrList>,
+
+    /// Removed in 2026-05; deserializing a config that still sets this field
+    /// triggers a fail-loud migration error pointing at `include:`.
+    #[serde(default, skip_serializing)]
+    #[allow(dead_code)]
+    pub semver_prerelease: Option<RemovedSemverPrerelease>,
 
     /// Exclude tags matching one or more glob patterns.
     #[serde(default)]
@@ -480,7 +488,36 @@ pub(crate) enum GlobOrList {
     List(Vec<String>),
 }
 
-use ocync_sync::filter::{SemverPrerelease, SortOrder};
+use ocync_sync::filter::SortOrder;
+
+/// Placeholder type for the removed `tags.semver_prerelease` field. Triggers
+/// a custom Deserialize error if the field appears in user config, with a
+/// migration hint pointing at the new `include:` mechanism.
+#[derive(Debug)]
+pub(crate) struct RemovedSemverPrerelease;
+
+impl<'de> Deserialize<'de> for RemovedSemverPrerelease {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Consume the value so the deserializer is in a clean state.
+        let _: serde::de::IgnoredAny = Deserialize::deserialize(deserializer)?;
+        Err(<D::Error as serde::de::Error>::custom(
+            "tags.semver_prerelease has been removed. The default behavior matches the old 'exclude' mode (system-exclude drops *-rc*, *-alpha*, *-beta*, *-pre*, *-snapshot*, *-nightly*). To restore 'include' mode, add: include: [\"*-rc*\", \"*-alpha*\", \"*-beta*\", \"*-pre*\", \"*-snapshot*\", \"*-nightly*\"]",
+        ))
+    }
+}
+
+impl JsonSchema for RemovedSemverPrerelease {
+    fn schema_name() -> String {
+        "RemovedSemverPrerelease".to_owned()
+    }
+
+    fn json_schema(_gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        schemars::schema::Schema::Bool(false)
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Environment variable expansion
@@ -726,11 +763,6 @@ fn validate_tags(tags: &TagsConfig) -> Result<(), ConfigError> {
             "tags.latest requires tags.sort to be set".to_string(),
         ));
     }
-    if tags.semver_prerelease.is_some() && tags.semver.is_none() {
-        return Err(ConfigError::Validation(
-            "tags.semver_prerelease requires tags.semver to be set".to_string(),
-        ));
-    }
     Ok(())
 }
 
@@ -932,7 +964,7 @@ mappings:
     tags:
       glob: "18.*"
       semver: ">=18.0.0"
-      semver_prerelease: exclude
+      include: "*-rc*"
       exclude: "*-alpine"
       sort: semver
       latest: 5
@@ -941,10 +973,24 @@ mappings:
         let tags = config.mappings[0].tags.as_ref().unwrap();
         assert!(matches!(tags.sort, Some(SortOrder::Semver)));
         assert_eq!(tags.latest, Some(5));
-        assert!(matches!(
-            tags.semver_prerelease,
-            Some(SemverPrerelease::Exclude)
-        ));
+        assert!(matches!(&tags.include, Some(GlobOrList::Single(s)) if s == "*-rc*"));
+    }
+
+    #[test]
+    fn deserialize_semver_prerelease_removed_errors() {
+        let yaml = r#"
+mappings:
+  - from: library/node
+    tags:
+      glob: "18.*"
+      semver_prerelease: exclude
+"#;
+        let err = serde_yaml::from_str::<Config>(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("semver_prerelease has been removed"),
+            "expected migration hint in error, got: {msg}"
+        );
     }
 
     #[test]

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -36,12 +36,12 @@ pub(crate) fn load_config(path: &Path) -> Result<Config, ConfigError> {
     for mapping in &config.mappings {
         validate_mapping(mapping, has_default_tags)?;
         if let Some(ref tags) = mapping.tags {
-            validate_tags(tags)?;
+            validate_tags(&format!("mapping '{}'", mapping.from), tags)?;
         }
     }
     if let Some(ref defaults) = config.defaults {
         if let Some(ref tags) = defaults.tags {
-            validate_tags(tags)?;
+            validate_tags("defaults", tags)?;
         }
         if let Some(ref platforms) = defaults.platforms {
             validate_platforms("defaults", platforms)?;
@@ -762,11 +762,19 @@ fn validate_artifacts(context: &str, artifacts: &ArtifactsConfig) -> Result<(), 
     Ok(())
 }
 
-fn validate_tags(tags: &TagsConfig) -> Result<(), ConfigError> {
+fn validate_tags(context: &str, tags: &TagsConfig) -> Result<(), ConfigError> {
     if tags.latest.is_some() && tags.sort.is_none() {
         return Err(ConfigError::Validation(
             "tags.latest requires tags.sort to be set".to_string(),
         ));
+    }
+    if tags.semver.is_some() && tags.latest.is_none() {
+        tracing::warn!(
+            context,
+            "tags.semver is set without tags.latest: every tag matching the version range will sync. \
+             For long-running mirrors of images with many tags, consider adding 'latest: N' (with 'sort: semver') \
+             to cap output size and reduce bytes transferred"
+        );
     }
     Ok(())
 }
@@ -1250,7 +1258,7 @@ mappings:
             sort: None,
             ..Default::default()
         };
-        let err = validate_tags(&tags).unwrap_err();
+        let err = validate_tags("test", &tags).unwrap_err();
         assert!(matches!(err, ConfigError::Validation(_)));
     }
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -505,7 +505,11 @@ impl<'de> Deserialize<'de> for RemovedSemverPrerelease {
         // Consume the value so the deserializer is in a clean state.
         let _: serde::de::IgnoredAny = Deserialize::deserialize(deserializer)?;
         Err(<D::Error as serde::de::Error>::custom(
-            "tags.semver_prerelease has been removed. The default behavior matches the old 'exclude' mode (system-exclude drops *-rc*, *-alpha*, *-beta*, *-pre*, *-snapshot*, *-nightly*). To restore 'include' mode, add: include: [\"*-rc*\", \"*-alpha*\", \"*-beta*\", \"*-pre*\", \"*-snapshot*\", \"*-nightly*\"]",
+            "tags.semver_prerelease has been removed. \
+             For the previous 'exclude' default (the common case), simply delete this field; \
+             the system-exclude default drops *-rc*, *-alpha*, *-beta*, *-pre*, *-snapshot*, *-nightly* automatically. \
+             For 'include' mode, replace this field with: include: [\"*-rc*\", \"*-alpha*\", \"*-beta*\", \"*-pre*\", \"*-snapshot*\", \"*-nightly*\"]. \
+             For 'only' mode, restrict via glob: e.g., glob: [\"*-rc*\", \"*-alpha*\", \"*-beta*\"] plus include: with the same patterns.",
         ))
     }
 }
@@ -991,6 +995,14 @@ mappings:
         assert!(
             msg.contains("semver_prerelease has been removed"),
             "expected migration hint in error, got: {msg}"
+        );
+        assert!(
+            msg.contains("delete this field"),
+            "expected delete-this-field guidance in error, got: {msg}"
+        );
+        assert!(
+            msg.contains("system-exclude default"),
+            "expected system-exclude default mention in error, got: {msg}"
         );
         assert!(
             msg.contains("include:"),

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -451,8 +451,8 @@ impl TagsConfig {
     ///
     /// Returns `Some` when `glob` contains only literal strings (no wildcard
     /// characters) and no other filter fields (`semver`, `latest`, `sort`,
-    /// `min_tags`) are set. In this case the tags can be used directly
-    /// without listing all tags from the registry.
+    /// `min_tags`, `exclude`, `include`) are set. In this case the tags can
+    /// be used directly without listing all tags from the registry.
     pub(crate) fn exact_tags(&self) -> Option<Vec<String>> {
         // Any field that requires the full tag list forces enumeration.
         if self.semver.is_some()
@@ -460,6 +460,7 @@ impl TagsConfig {
             || self.sort.is_some()
             || self.min_tags.is_some()
             || self.exclude.is_some()
+            || self.include.is_some()
         {
             return None;
         }
@@ -2041,6 +2042,16 @@ mappings:
         let tags = TagsConfig {
             glob: Some(GlobOrList::List(vec!["v1.0".into(), "v2.0".into()])),
             exclude: Some(GlobOrList::Single("v2.0".into())),
+            ..Default::default()
+        };
+        assert!(tags.exact_tags().is_none());
+    }
+
+    #[test]
+    fn exact_tags_with_include_returns_none() {
+        let tags = TagsConfig {
+            glob: Some(GlobOrList::List(vec!["v2.13.0".into()])),
+            include: Some(GlobOrList::Single("latest".into())),
             ..Default::default()
         };
         assert!(tags.exact_tags().is_none());

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -991,6 +991,33 @@ mappings:
             msg.contains("semver_prerelease has been removed"),
             "expected migration hint in error, got: {msg}"
         );
+        assert!(
+            msg.contains("include:"),
+            "expected include: recommendation in error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn accepts_include_field() {
+        let yaml = r#"
+registries:
+  src: { url: docker.io }
+defaults:
+  source: src
+mappings:
+  - from: lib/redis
+    tags:
+      include: ["latest", "latest-dev"]
+      semver: ">=1.0"
+"#;
+        let cfg = serde_yaml::from_str::<Config>(yaml).expect("config parses");
+        let mapping = &cfg.mappings[0];
+        let include = mapping.tags.as_ref().unwrap().include.as_ref().unwrap();
+        let list = match include {
+            GlobOrList::List(l) => l,
+            GlobOrList::Single(s) => panic!("expected list, got single: {}", s),
+        };
+        assert_eq!(list, &vec!["latest".to_string(), "latest-dev".to_string()]);
     }
 
     #[test]


### PR DESCRIPTION
Closes #82

## Summary

Replaces the `semver` crate with an in-tree lenient parser handling real OCI tag patterns the strict parser drops: `15.10-alpine` (postgres), `1.25.5-r0` (Chainguard), `25.0.3_9-jre-alpine-3.23` (Eclipse Temurin), `v1.27.6-eks-1-27-14` (EKS Distro), `17.1.0-debian-12-r0` (Bitnami), `20.18.1-alpine3.20` (node), `8.0-bookworm-slim` (dotnet), `1.10.0-alpha20241016` (terraform), `2.21.0-arm64v8` (aws-cli). Suffix content is opaque to range matching, so `>=1.0` admits `1.25.5-r0` and `15.10-alpine` without extra config.

Adds `tags.include:` for always-include glob patterns (literal pins like `latest`/`latest-dev` plus a `semver:` range in one mapping). Adds a hardcoded system-exclude default (`*-rc*`, `*-alpha*`, `*-beta*`, `*-pre*`, `*-snapshot*`, `*-nightly*`, case-insensitive) so the lenient parser does not silently start syncing prereleases. Four-layer precedence: user `exclude` is final, `include` overrides system-exclude and `glob`/`semver`, system-exclude only applies to the pipeline side, `sort:`/`latest:` only cap the pipeline side.

Removes `tags.semver_prerelease:` with a fail-loud migration error pointing at `include:` and explaining all three legacy modes (Exclude/Include/Only). Drops the `semver` crate dependency.

Emits a `tracing::warn!` at config-load when `tags.semver:` is set without `tags.latest:` — under the lenient parser, popular images publish hundreds of variant tags and an uncapped mirror can balloon. Documented in the recipe and configuration reference.

## Behavior changes for users

- Mirrors using `semver:` will start syncing variant tags they previously silently dropped (`-alpine`, `-r0`, `-bookworm`, `-debian-12-rN`, etc.). Users who want only base versions add `exclude: ["*-*"]` (see `recipes/variant-filtering.md`).
- Default-exclude drops common prerelease patterns at the pipeline side. Users who pinned specific RCs add them to `include:`. Users who want all prereleases add `include: ["*-rc*", "*-alpha*", "*-beta*", "*-pre*", "*-snapshot*", "*-nightly*"]`.
- Comma required between range constraints: `>=8.0.0, <9.0.0`. Removed: `^N`, `~N`, `1.x` syntax (use comma-joined `>=`/`<` instead).
- Configs that still set `semver_prerelease:` fail at config-load with a migration error covering all three legacy modes.
- Mirrors with `semver:` and no `latest:` cap now emit a startup warning recommending a cap.

## Test plan

- [x] `cargo test --workspace` (1300 passed, 1 ignored)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo deny check`
- [x] `npm run --prefix docs build` (28 pages)
- [x] Config with legacy `semver_prerelease:` field surfaces the migration error covering Exclude/Include/Only modes
- [x] Config with `include: ["latest", "latest-dev"]` plus `semver: ">=N"` syncs both the floats and the version-range matches (covered by `build_filter_include_pin_plus_range_full_flow`)
- [x] `semver: ">=15.0"` admits `15.10`, `15.10-alpine`; drops `latest`, `17rc1`
- [x] System-exclude case-insensitive: `5.0.0-SNAPSHOT`, `5.0.0-RC1`, `5.0.0-BETA1` all drop
- [x] Real-world patterns: Bitnami release counter, EKS Distro compound suffix, Temurin underscore build, Hashicorp alpha date-stamp, ARM variant suffix, single-integer date all parse and sort correctly
- [x] Config with `semver:` but no `latest:` emits a `tracing::warn!` at load
- [x] `exact_tags` fast-path correctly returns `None` when `include:` is set (so the literal-only optimization doesn't silently skip include matches)

## Implementation notes

- `version::TagVersion<'a>` carries a borrowed lifetime; `Token::Alpha(&'a str)` avoids per-token `String` allocations on parse.
- `compare` is a free function (not `impl Ord`) because zero-pad equality (`1.0` == `1.0.0`) is incompatible with `Ord`'s `cmp == Equal => a == b` contract.
- Sort uses Schwartzian decoration to parse each tag once instead of O(n log n) parses inside the comparator.
- `Constraint::matches` walks lexicographically without allocating intermediate `Vec<u64>`s.
- `SYSTEM_EXCLUDE` GlobSet is built once via `OnceLock`, not per `apply()` call.
- Pipeline merges user-exclude and system-exclude into a single `retain` pass.

## References

- Spec: `docs/superpowers/specs/2026-05-04-tag-version-parser-design.md`
- Plan: `docs/superpowers/plans/2026-05-04-tag-version-parser.md`
- Issue: #82