### PR TITLE
feat(dry-run): tag-selection observability

### DIFF
--- a/charts/ocync/README.md
+++ b/charts/ocync/README.md
@@ -48,6 +48,7 @@ See the [Helm chart documentation](https://clowdhaus.github.io/ocync/helm) and [
 | image.tag | string | `<chart-app-version>-fips` | Container image tag. Overriding to a tag older than the chart's appVersion is not recommended: the chart may pass binary flags that older images do not recognize, causing the container to fail at startup. |
 | imagePullSecrets | list | `[]` | Image pull secrets for the workload pods. |
 | jobAnnotations | object | `{}` | Annotations applied to the Job's `metadata.annotations` when `mode: job`. Common uses: Helm lifecycle hooks (`helm.sh/hook: post-install` etc.), Argo CD sync-wave / hook annotations on one-shot Jobs, policy-controller selectors. Pod-template annotations belong under `podAnnotations`. |
+| logging.format | string | `"text"` | Log output format: `text` (human-readable, the default) or `json` (structured fields). Most operators read syncs via `kubectl logs`, where text is easier to scan. Set to `json` if you pipe ocync's stdout into a structured log store that parses JSON. |
 | mode | string | `"watch"` | Deployment mode: `watch` (Deployment with sync interval), `cronjob` (CronJob), or `job` (one-shot Job). |
 | nameOverride | string | `""` | Override the chart name used in resource names and labels. |
 | nodeSelector | object | `{}` | Node selector for the pod. |

--- a/charts/ocync/templates/NOTES.txt
+++ b/charts/ocync/templates/NOTES.txt
@@ -1,0 +1,29 @@
+ocync {{ .Chart.AppVersion }} installed in mode: {{ .Values.mode }}
+
+Log format: {{ .Values.logging.format }}
+{{- if eq .Values.logging.format "text" }}
+
+  The chart now defaults to `text` (human-readable) for `kubectl logs`.
+  Earlier chart versions auto-detected Kubernetes via
+  `KUBERNETES_SERVICE_HOST` and emitted JSON. If your log pipeline parses
+  structured fields, set `logging.format: json` in your helm values.
+{{- end }}
+
+Documentation:
+  https://clowdhaus.github.io/ocync/
+
+{{- if eq .Values.mode "watch" }}
+
+Tail the watch loop:
+  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "ocync.name" . }} -f
+{{- else if eq .Values.mode "cronjob" }}
+
+CronJob schedule: {{ .Values.cronjob.schedule }}
+
+Trigger an out-of-cycle run:
+  kubectl create job -n {{ .Release.Namespace }} --from=cronjob/{{ include "ocync.fullname" . }} {{ include "ocync.fullname" . }}-manual
+{{- else if eq .Values.mode "job" }}
+
+Watch the one-shot Job:
+  kubectl logs -n {{ .Release.Namespace }} job/{{ include "ocync.fullname" . }} -f
+{{- end }}

--- a/charts/ocync/templates/_pod.tpl
+++ b/charts/ocync/templates/_pod.tpl
@@ -65,6 +65,8 @@ spec:
         - --config
         - /etc/ocync/config.yaml
         {{- end }}
+        - --log-format
+        - {{ .Values.logging.format | quote }}
         {{- range .Values.extraArgs }}
         - {{ . | quote }}
         {{- end }}

--- a/charts/ocync/tests/pod_template_test.yaml
+++ b/charts/ocync/tests/pod_template_test.yaml
@@ -26,6 +26,8 @@ tests:
             - "8080"
             - --health-bind
             - "0.0.0.0"
+            - --log-format
+            - text
 
   - it: watch.healthBind override flows through to container args
     set:
@@ -46,10 +48,10 @@ tests:
         - 127.0.0.1
     template: deployment.yaml
     asserts:
-      # Total args = 7 watch defaults (no --health-bind) + 2 extraArgs.
+      # Total args = 9 watch defaults including --log-format (no --health-bind) + 2 extraArgs.
       - lengthEqual:
           path: spec.template.spec.containers[0].args
-          count: 9
+          count: 11
       - contains:
           path: spec.template.spec.containers[0].args
           content: "127.0.0.1"
@@ -65,6 +67,8 @@ tests:
             - sync
             - --config
             - /etc/ocync/config.yaml
+            - --log-format
+            - text
 
   - it: job mode renders the full container args list
     set:
@@ -77,6 +81,8 @@ tests:
             - sync
             - --config
             - /etc/ocync/config.yaml
+            - --log-format
+            - text
 
   - it: watch mode has health port and probes
     set:
@@ -253,4 +259,30 @@ tests:
     asserts:
       - notExists:
           path: metadata.annotations
+
+  - it: logging.format json renders the full args list with --log-format json
+    set:
+      mode: watch
+      logging:
+        format: json
+    template: deployment.yaml
+    asserts:
+      # Tight assertion (full args list with `equal`) so a regression that
+      # appended `json` somewhere else, or omitted `--log-format`, would fail.
+      # Default-text coverage lives in "watch mode renders the full container
+      # args list" above; no need for a redundant text-default assertion here.
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - watch
+            - --config
+            - /etc/ocync/config.yaml
+            - --interval
+            - "300"
+            - --health-port
+            - "8080"
+            - --health-bind
+            - "0.0.0.0"
+            - --log-format
+            - json
 

--- a/charts/ocync/values.yaml
+++ b/charts/ocync/values.yaml
@@ -52,6 +52,13 @@ cronjob:
   # -- CronJob concurrency policy: `Allow` | `Forbid` | `Replace`.
   concurrencyPolicy: Forbid
 
+# Logging configuration applied via `--log-format` on the container args.
+logging:
+  # -- Log output format: `text` (human-readable, the default) or `json` (structured fields).
+  # Most operators read syncs via `kubectl logs`, where text is easier to scan. Set to `json`
+  # if you pipe ocync's stdout into a structured log store that parses JSON.
+  format: text
+
 # -- Additional CLI arguments appended to the container args after the mode-specific defaults.
 extraArgs: []
 

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -230,6 +230,11 @@ pub struct ResolvedMapping {
     pub immutable_glob: Option<globset::GlobSet>,
     /// Artifact sync configuration (shared across all tasks for this mapping).
     pub artifacts_config: Rc<ResolvedArtifacts>,
+    /// Number of source tags considered before filtering. `None` on the
+    /// exact-tag fast path where source tags are not enumerated.
+    pub candidates: Option<usize>,
+    /// Filter pipeline trace. `Some` only when `--dry-run` requested a report.
+    pub filter_report: Option<crate::filter::FilterReport>,
 }
 
 impl ResolvedMapping {
@@ -329,6 +334,18 @@ impl TagPair {
         Self {
             source: source.into(),
             target: target.into(),
+        }
+    }
+}
+
+impl fmt::Display for TagPair {
+    /// Renders as the bare tag when source and target match, otherwise
+    /// `source -> target`. Suitable for human-facing tag lists.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.source == self.target {
+            f.write_str(&self.source)
+        } else {
+            write!(f, "{} -> {}", self.source, self.target)
         }
     }
 }

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -231,8 +231,10 @@ pub struct ResolvedMapping {
     /// Artifact sync configuration (shared across all tasks for this mapping).
     pub artifacts_config: Rc<ResolvedArtifacts>,
     /// Number of source tags considered before filtering. `None` on the
-    /// exact-tag fast path where source tags are not enumerated.
-    pub candidates: Option<usize>,
+    /// exact-tag fast path where source tags are not enumerated. Populated
+    /// on both real-sync and dry-run paths; `filter_report` is only Some on
+    /// dry-run.
+    pub candidate_count: Option<usize>,
     /// Filter pipeline trace. `Some` only when `--dry-run` requested a report.
     pub filter_report: Option<crate::filter::FilterReport>,
 }

--- a/crates/ocync-sync/src/filter.rs
+++ b/crates/ocync-sync/src/filter.rs
@@ -87,37 +87,39 @@ impl FilterConfig {
     pub fn apply(&self, tags: &[&str]) -> Result<Vec<String>, Error> {
         // The hot path skips drop attribution to avoid allocating per-stage
         // `Vec<String>` of dropped tag names every watch-mode cycle.
-        let outcome = self.run_pipeline(tags, false)?;
+        let filtered = self.run_pipeline(tags, false)?;
         if let Some(min) = self.min_tags {
-            if outcome.kept.len() < min {
+            if filtered.kept.len() < min {
                 return Err(Error::BelowMinTags {
-                    matched: outcome.kept.len(),
+                    matched: filtered.kept.len(),
                     minimum: min,
                 });
             }
         }
-        Ok(outcome.kept)
+        Ok(filtered.kept)
     }
 
     /// Run the full filter pipeline and return both the kept tags and a
     /// trace of how the pipeline arrived at them.
     ///
     /// Does NOT enforce [`min_tags`](Self::min_tags); the caller checks it
-    /// against `outcome.kept.len()`. This lets `--dry-run` show what survived
-    /// even when `min_tags` would otherwise turn the run into an error.
-    pub fn apply_with_report(&self, tags: &[&str]) -> Result<Outcome, Error> {
+    /// against `filtered.kept.len()`. This lets `--dry-run` show what
+    /// survived even when `min_tags` would otherwise turn the run into an
+    /// error. The report carries `min_tags` so callers can render the
+    /// configured limit alongside the actual count.
+    pub fn apply_with_report(&self, tags: &[&str]) -> Result<Filtered, Error> {
         self.run_pipeline(tags, true)
     }
 
     /// Shared pipeline implementation. When `track` is false (the real-sync
     /// hot path), per-stage `StageDelta` and per-reason `DropReason` are not
-    /// constructed; the resulting `Outcome.report` carries empty vectors.
-    fn run_pipeline(&self, tags: &[&str], track: bool) -> Result<Outcome, Error> {
+    /// constructed; the resulting `Filtered.report` carries empty vectors.
+    fn run_pipeline(&self, tags: &[&str], track: bool) -> Result<Filtered, Error> {
         if self.latest.is_some() && self.sort.is_none() {
             return Err(Error::LatestWithoutSort);
         }
 
-        let candidates = tags.len();
+        let candidate_count = tags.len();
         let mut pipeline_stages: Vec<StageDelta> = Vec::new();
         let mut drop_reasons: Vec<DropReason> = Vec::new();
 
@@ -128,7 +130,7 @@ impl FilterConfig {
         };
         let sys_exclude = system_exclude_set();
 
-        let include_kept: Vec<&str> = if self.include.is_empty() {
+        let include_kept_refs: Vec<&str> = if self.include.is_empty() {
             Vec::new()
         } else {
             let inc_set = build_glob_set(&self.include)?;
@@ -142,54 +144,53 @@ impl FilterConfig {
         let mut pipeline: Vec<&str> = if self.glob.is_empty() {
             tags.to_vec()
         } else {
-            let kept = filter_glob(tags, &self.glob)?;
-            if track {
-                let kept_set: HashSet<&str> = kept.iter().copied().collect();
-                let dropped: Vec<String> = tags
-                    .iter()
-                    .filter(|t| !kept_set.contains(*t))
-                    .map(|t| (*t).to_owned())
-                    .collect();
-                if !dropped.is_empty() {
-                    drop_reasons.push(DropReason {
-                        kind: DropKind::Glob {
-                            patterns: self.glob.clone(),
-                        },
-                        count: dropped.len(),
-                        samples: dropped,
-                    });
-                }
-            }
+            let glob_set = build_glob_set(&self.glob)?;
+            let (kept, dropped) = partition_with_drop(tags, track, |t| glob_set.is_match(t));
+            push_drop_reason(
+                &mut drop_reasons,
+                track,
+                DropKind::Glob {
+                    patterns: self.glob.clone(),
+                },
+                dropped,
+            );
             kept
         };
         if track && !self.glob.is_empty() {
             pipeline_stages.push(StageDelta {
                 label: format!("glob {}", patterns_label(&self.glob)),
-                count_in: candidates,
+                count_in: candidate_count,
                 count_out: pipeline.len(),
             });
         }
 
         if let Some(ref range) = self.semver {
             let before = pipeline.len();
-            let kept = filter_semver(&pipeline, range)?;
-            if track {
-                let kept_set: HashSet<&str> = kept.iter().copied().collect();
-                let dropped: Vec<String> = pipeline
-                    .iter()
-                    .filter(|t| !kept_set.contains(*t))
-                    .map(|t| (*t).to_owned())
-                    .collect();
-                if !dropped.is_empty() {
-                    drop_reasons.push(DropReason {
-                        kind: DropKind::Semver {
-                            range: range.clone(),
-                        },
-                        count: dropped.len(),
-                        samples: dropped,
-                    });
-                }
-            }
+            let req =
+                crate::version::Range::parse(range).map_err(|e| Error::InvalidVersionRange {
+                    range: range.to_owned(),
+                    reason: e.to_string(),
+                })?;
+            let (kept, dropped) =
+                partition_with_drop(
+                    &pipeline,
+                    track,
+                    |t| match crate::version::TagVersion::parse(t) {
+                        Some(ver) => req.matches(&ver),
+                        None => {
+                            warn!(tag = t, "tag is not parseable as a version, dropping");
+                            false
+                        }
+                    },
+                );
+            push_drop_reason(
+                &mut drop_reasons,
+                track,
+                DropKind::Semver {
+                    range: range.clone(),
+                },
+                dropped,
+            );
             pipeline = kept;
             if track {
                 pipeline_stages.push(StageDelta {
@@ -280,8 +281,8 @@ impl FilterConfig {
         // Union: include first (preserves include input order), then pipeline
         // tags not already in include. The order matters for the dry-run
         // formatter's "include first, then pipeline" header.
-        let mut seen: HashSet<&str> = include_kept.iter().copied().collect();
-        let mut final_set: Vec<&str> = include_kept.clone();
+        let mut seen: HashSet<&str> = include_kept_refs.iter().copied().collect();
+        let mut final_set: Vec<&str> = include_kept_refs.clone();
         for t in pipeline {
             if seen.insert(t) {
                 final_set.push(t);
@@ -292,13 +293,21 @@ impl FilterConfig {
             drop_reasons.sort_by(|a, b| b.count.cmp(&a.count));
         }
 
-        Ok(Outcome {
+        // Track-only: hot path discards the report, so don't allocate names.
+        let include_kept: Vec<String> = if track {
+            include_kept_refs.iter().map(|s| (*s).to_owned()).collect()
+        } else {
+            Vec::new()
+        };
+
+        Ok(Filtered {
             kept: final_set.into_iter().map(String::from).collect(),
             report: FilterReport {
-                candidates,
-                include_kept: include_kept.len(),
+                candidate_count,
+                include_kept,
                 pipeline: pipeline_stages,
                 dropped: drop_reasons,
+                min_tags: self.min_tags,
             },
         })
     }
@@ -309,7 +318,7 @@ impl FilterConfig {
 /// `kept` is the same `Vec<String>` that [`FilterConfig::apply`] returns.
 /// `report` describes how the pipeline arrived at it.
 #[derive(Debug)]
-pub struct Outcome {
+pub struct Filtered {
     /// Tags that survive the full pipeline.
     pub kept: Vec<String>,
     /// Stage-by-stage attrition and per-reason drop attribution.
@@ -318,24 +327,32 @@ pub struct Outcome {
 
 /// Per-mapping filter pipeline trace.
 ///
-/// `candidates` is the source-tag count fed in. `pipeline` lists each stage
-/// (label + `count_in` -> `count_out`). `dropped` is Pareto-sorted by drop
-/// count across all stages, suitable for "where did most of my tags go"
-/// output.
+/// `candidate_count` is the source-tag count fed in. `pipeline` lists each
+/// stage (label + `count_in` -> `count_out`). `dropped` is Pareto-sorted by
+/// drop count across all stages, suitable for "where did most of my tags go"
+/// output. `include_kept` carries the names of tags rescued via the
+/// `include:` path so the formatter can call them out by name.
 ///
 /// Distinct from `ocync_sync::SyncReport` (the run-level engine report);
 /// this is the per-mapping filter trace consumed by `--dry-run`.
 #[derive(Debug)]
 pub struct FilterReport {
     /// Number of source tags fed into the pipeline.
-    pub candidates: usize,
-    /// Number of tags admitted via the `include:` path. `0` when `include:`
-    /// is not configured.
-    pub include_kept: usize,
+    pub candidate_count: usize,
+    /// Tag names admitted via the `include:` path. Empty when `include:` is
+    /// not configured or no tag matched. These tags bypass the
+    /// glob/semver/sort/latest pipeline (but are still subject to user
+    /// `exclude:`).
+    pub include_kept: Vec<String>,
     /// Stage-by-stage attrition along the pipeline (top-down order).
     pub pipeline: Vec<StageDelta>,
     /// Drop reasons sorted by count descending (Pareto).
     pub dropped: Vec<DropReason>,
+    /// Configured `min_tags:` value, if set. The dry-run formatter compares
+    /// this against `kept.len()` so the user sees whether real-sync would
+    /// fail with `BelowMinTags`. `apply()` enforces this directly;
+    /// `apply_with_report()` does not (the report is the point of dry-run).
+    pub min_tags: Option<usize>,
 }
 
 /// One pipeline stage's count delta.
@@ -417,6 +434,45 @@ fn patterns_label(patterns: &[String]) -> String {
     }
 }
 
+/// Single-pass partition of `input` into kept references and (when `track`)
+/// owned dropped names. The `else if track` skips `to_owned` allocation on
+/// the watch-mode hot path. Used by the glob and semver stages; the exclude
+/// stage is structured differently because it splits drops between
+/// user- and system-attributed buckets.
+fn partition_with_drop<'a>(
+    input: &[&'a str],
+    track: bool,
+    keep: impl Fn(&'a str) -> bool,
+) -> (Vec<&'a str>, Vec<String>) {
+    let mut kept = Vec::new();
+    let mut dropped: Vec<String> = Vec::new();
+    for &t in input {
+        if keep(t) {
+            kept.push(t);
+        } else if track {
+            dropped.push(t.to_owned());
+        }
+    }
+    (kept, dropped)
+}
+
+/// Append a `DropReason` to `drop_reasons` when both `track` is true and
+/// at least one tag was dropped at this stage.
+fn push_drop_reason(
+    drop_reasons: &mut Vec<DropReason>,
+    track: bool,
+    kind: DropKind,
+    samples: Vec<String>,
+) {
+    if track && !samples.is_empty() {
+        drop_reasons.push(DropReason {
+            count: samples.len(),
+            kind,
+            samples,
+        });
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Individual stages
 // ---------------------------------------------------------------------------
@@ -438,6 +494,11 @@ pub fn build_glob_set(patterns: &[String]) -> Result<GlobSet, Error> {
 }
 
 /// Filter tags by glob patterns (OR: any pattern match keeps the tag).
+///
+/// Test-only convenience over [`build_glob_set`] + [`Iterator::filter`].
+/// Production callers go through [`FilterConfig::apply`], which inlines
+/// the same logic with single-pass drop attribution.
+#[cfg(test)]
 fn filter_glob<'a>(tags: &[&'a str], patterns: &[String]) -> Result<Vec<&'a str>, Error> {
     let set = build_glob_set(patterns)?;
     Ok(tags.iter().copied().filter(|t| set.is_match(t)).collect())
@@ -446,6 +507,9 @@ fn filter_glob<'a>(tags: &[&'a str], patterns: &[String]) -> Result<Vec<&'a str>
 /// Filter tags by a version range.
 ///
 /// Tags that cannot be parsed as a version are dropped with a warning.
+/// Test-only; production callers go through [`FilterConfig::apply`], which
+/// inlines the same logic with single-pass drop attribution.
+#[cfg(test)]
 fn filter_semver<'a>(tags: &[&'a str], range: &str) -> Result<Vec<&'a str>, Error> {
     let req = crate::version::Range::parse(range).map_err(|e| Error::InvalidVersionRange {
         range: range.to_owned(),
@@ -1112,11 +1176,11 @@ mod tests {
             latest: Some(2),
             ..FilterConfig::default()
         };
-        let outcome = config.apply_with_report(&tags).unwrap();
-        let total_dropped: usize = outcome.report.dropped.iter().map(|d| d.count).sum();
+        let filtered = config.apply_with_report(&tags).unwrap();
+        let total_dropped: usize = filtered.report.dropped.iter().map(|d| d.count).sum();
         assert_eq!(
-            outcome.kept.len() + total_dropped,
-            outcome.report.candidates
+            filtered.kept.len() + total_dropped,
+            filtered.report.candidate_count
         );
     }
 
@@ -1130,44 +1194,45 @@ mod tests {
             latest: Some(2),
             ..FilterConfig::default()
         };
-        let outcome = config.apply_with_report(&tags).unwrap();
+        let filtered = config.apply_with_report(&tags).unwrap();
 
-        assert_eq!(outcome.report.include_kept, 1);
+        // include_kept now carries names: just `latest` was rescued.
+        assert_eq!(filtered.report.include_kept, vec!["latest".to_string()]);
 
         // Pipeline accounting (closed): every candidate either survives the
         // pipeline or appears in `dropped`. Tags rescued only via `include:`
         // still count as dropped here -- they reach `kept` via the include
         // path, not the pipeline.
-        let total_dropped: usize = outcome.report.dropped.iter().map(|d| d.count).sum();
-        let pipeline_survivors = outcome.report.candidates - total_dropped;
+        let total_dropped: usize = filtered.report.dropped.iter().map(|d| d.count).sum();
+        let pipeline_survivors = filtered.report.candidate_count - total_dropped;
 
         // Union semantics: final kept is `include_kept + pipeline_survivors`
         // minus their overlap (tags that both include and the pipeline kept).
         // So `kept` is bounded above by the unduplicated sum and below by
         // pipeline survivors alone.
         assert!(
-            outcome.kept.len() <= outcome.report.include_kept + pipeline_survivors,
+            filtered.kept.len() <= filtered.report.include_kept.len() + pipeline_survivors,
             "kept={} > include_kept={} + pipeline_survivors={}",
-            outcome.kept.len(),
-            outcome.report.include_kept,
+            filtered.kept.len(),
+            filtered.report.include_kept.len(),
             pipeline_survivors,
         );
         assert!(
-            outcome.kept.len() >= pipeline_survivors,
+            filtered.kept.len() >= pipeline_survivors,
             "kept={} < pipeline_survivors={}",
-            outcome.kept.len(),
+            filtered.kept.len(),
             pipeline_survivors,
         );
 
         // Concrete shape for this fixture: latest is dropped by semver but
         // rescued by include; 1.0.0 falls off via latest=2; 0.9.0-rc1 fails
         // semver. Final kept = {latest, 1.2.0, 1.1.0}.
-        assert_eq!(outcome.kept.len(), 3);
-        assert!(outcome.kept.contains(&"latest".to_string()));
-        assert!(outcome.kept.contains(&"1.2.0".to_string()));
-        assert!(outcome.kept.contains(&"1.1.0".to_string()));
-        assert!(!outcome.kept.contains(&"1.0.0".to_string()));
-        assert!(!outcome.kept.contains(&"0.9.0-rc1".to_string()));
+        assert_eq!(filtered.kept.len(), 3);
+        assert!(filtered.kept.contains(&"latest".to_string()));
+        assert!(filtered.kept.contains(&"1.2.0".to_string()));
+        assert!(filtered.kept.contains(&"1.1.0".to_string()));
+        assert!(!filtered.kept.contains(&"1.0.0".to_string()));
+        assert!(!filtered.kept.contains(&"0.9.0-rc1".to_string()));
     }
 
     #[test]
@@ -1182,19 +1247,19 @@ mod tests {
             latest: Some(3),
             ..FilterConfig::default()
         };
-        let outcome = config.apply_with_report(&tag_refs).unwrap();
-        for window in outcome.report.dropped.windows(2) {
+        let filtered = config.apply_with_report(&tag_refs).unwrap();
+        for window in filtered.report.dropped.windows(2) {
             assert!(
                 window[0].count >= window[1].count,
                 "not Pareto-sorted: {:?}",
-                outcome.report.dropped
+                filtered.report.dropped
             );
         }
     }
 
     #[test]
     fn report_min_tags_does_not_block_apply_with_report() {
-        // apply() returns BelowMinTags; apply_with_report() returns Outcome anyway.
+        // apply() returns BelowMinTags; apply_with_report() returns Filtered anyway.
         let tags = vec!["1.0.0", "1.1.0"];
         let config = FilterConfig {
             sort: Some(SortOrder::Semver),
@@ -1206,9 +1271,36 @@ mod tests {
             config.apply(&tags),
             Err(Error::BelowMinTags { .. })
         ));
-        // apply_with_report succeeds with partial data:
-        let outcome = config.apply_with_report(&tags).unwrap();
-        assert_eq!(outcome.kept.len(), 2);
+        // apply_with_report succeeds with partial data, and surfaces min_tags
+        // in the report so the caller can render the gap to the user.
+        let filtered = config.apply_with_report(&tags).unwrap();
+        assert_eq!(filtered.kept.len(), 2);
+        assert_eq!(filtered.report.min_tags, Some(10));
+    }
+
+    #[test]
+    fn report_min_tags_satisfied_round_trip() {
+        // When min_tags is satisfied, apply_with_report still surfaces the
+        // configured value so the formatter can show "satisfied" status.
+        let tags = vec!["1.0.0", "1.1.0", "1.2.0"];
+        let config = FilterConfig {
+            sort: Some(SortOrder::Semver),
+            min_tags: Some(2),
+            ..FilterConfig::default()
+        };
+        let filtered = config.apply_with_report(&tags).unwrap();
+        assert_eq!(filtered.report.min_tags, Some(2));
+        assert!(filtered.kept.len() >= 2);
+        // And apply() succeeds (kept >= min):
+        assert!(config.apply(&tags).is_ok());
+    }
+
+    #[test]
+    fn report_min_tags_absent_when_not_configured() {
+        let tags = vec!["1.0.0", "1.1.0"];
+        let config = FilterConfig::default();
+        let filtered = config.apply_with_report(&tags).unwrap();
+        assert_eq!(filtered.report.min_tags, None);
     }
 
     #[test]
@@ -1219,8 +1311,8 @@ mod tests {
             semver: Some(">=1.0".into()),
             ..FilterConfig::default()
         };
-        let outcome = config.apply_with_report(&tags).unwrap();
-        let kinds: Vec<&DropKind> = outcome.report.dropped.iter().map(|d| &d.kind).collect();
+        let filtered = config.apply_with_report(&tags).unwrap();
+        let kinds: Vec<&DropKind> = filtered.report.dropped.iter().map(|d| &d.kind).collect();
         assert!(
             kinds
                 .iter()
@@ -1231,5 +1323,59 @@ mod tests {
             kinds.iter().any(|k| matches!(k, DropKind::SystemExclude)),
             "missing SystemExclude in {kinds:?}"
         );
+    }
+
+    /// `include_kept` carries the actual rescued tag names so the dry-run
+    /// formatter can call them out by name. Order matches input order
+    /// (preserved by the union step).
+    #[test]
+    fn report_include_kept_carries_rescued_names() {
+        let tags = vec!["latest", "latest-dev", "1.0.0", "1.1.0", "0.9.0-rc1"];
+        let config = FilterConfig {
+            include: vec!["latest".into(), "latest-dev".into()],
+            semver: Some(">=1.0".into()),
+            ..FilterConfig::default()
+        };
+        let filtered = config.apply_with_report(&tags).unwrap();
+        assert_eq!(
+            filtered.report.include_kept,
+            vec!["latest".to_string(), "latest-dev".to_string()]
+        );
+    }
+
+    /// Tags matched by user-exclude do not show up in `include_kept` even
+    /// when an include pattern would have rescued them: user-exclude wins.
+    #[test]
+    fn report_include_kept_omits_user_excluded() {
+        let tags = vec!["latest", "1.0.0"];
+        let config = FilterConfig {
+            include: vec!["latest".into()],
+            exclude: vec!["latest".into()],
+            ..FilterConfig::default()
+        };
+        let filtered = config.apply_with_report(&tags).unwrap();
+        assert!(filtered.report.include_kept.is_empty());
+    }
+
+    /// Single-pass attribution invariant: every drop attributed to a stage
+    /// has a non-zero count. A stage that drops nothing must not appear in
+    /// `dropped` at all.
+    #[test]
+    fn report_drop_reasons_have_non_zero_counts() {
+        let tags = vec!["1.0.0", "1.1.0", "1.2.0"];
+        let config = FilterConfig {
+            glob: vec!["*".into()],
+            semver: Some(">=1.0".into()),
+            ..FilterConfig::default()
+        };
+        let filtered = config.apply_with_report(&tags).unwrap();
+        // Nothing dropped: no entries.
+        assert!(filtered.report.dropped.is_empty());
+        // Sanity: nothing dropped means counts add up to candidate_count.
+        assert_eq!(filtered.kept.len(), filtered.report.candidate_count);
+        for reason in &filtered.report.dropped {
+            assert!(reason.count > 0, "stage attributed zero drops: {reason:?}");
+            assert_eq!(reason.count, reason.samples.len());
+        }
     }
 }

--- a/crates/ocync-sync/src/filter.rs
+++ b/crates/ocync-sync/src/filter.rs
@@ -1,6 +1,7 @@
 //! Tag filtering pipeline: glob -> semver -> exclude -> sort + latest.
 
 use std::collections::HashSet;
+use std::fmt;
 use std::sync::OnceLock;
 
 use globset::{Glob, GlobBuilder, GlobSet, GlobSetBuilder};
@@ -81,14 +82,45 @@ impl FilterConfig {
     ///
     /// Returns an error if any pattern is invalid, `latest` is set without
     /// `sort`, or fewer tags survive than [`min_tags`](Self::min_tags)
-    /// requires.
+    /// requires. For per-stage attribution and drop reasons (used by
+    /// `--dry-run`), call [`apply_with_report`](Self::apply_with_report).
     pub fn apply(&self, tags: &[&str]) -> Result<Vec<String>, Error> {
-        // 0. Config validation.
+        // The hot path skips drop attribution to avoid allocating per-stage
+        // `Vec<String>` of dropped tag names every watch-mode cycle.
+        let outcome = self.run_pipeline(tags, false)?;
+        if let Some(min) = self.min_tags {
+            if outcome.kept.len() < min {
+                return Err(Error::BelowMinTags {
+                    matched: outcome.kept.len(),
+                    minimum: min,
+                });
+            }
+        }
+        Ok(outcome.kept)
+    }
+
+    /// Run the full filter pipeline and return both the kept tags and a
+    /// trace of how the pipeline arrived at them.
+    ///
+    /// Does NOT enforce [`min_tags`](Self::min_tags); the caller checks it
+    /// against `outcome.kept.len()`. This lets `--dry-run` show what survived
+    /// even when `min_tags` would otherwise turn the run into an error.
+    pub fn apply_with_report(&self, tags: &[&str]) -> Result<Outcome, Error> {
+        self.run_pipeline(tags, true)
+    }
+
+    /// Shared pipeline implementation. When `track` is false (the real-sync
+    /// hot path), per-stage `StageDelta` and per-reason `DropReason` are not
+    /// constructed; the resulting `Outcome.report` carries empty vectors.
+    fn run_pipeline(&self, tags: &[&str], track: bool) -> Result<Outcome, Error> {
         if self.latest.is_some() && self.sort.is_none() {
             return Err(Error::LatestWithoutSort);
         }
 
-        // Build user-exclude (optional) and system-exclude.
+        let candidates = tags.len();
+        let mut pipeline_stages: Vec<StageDelta> = Vec::new();
+        let mut drop_reasons: Vec<DropReason> = Vec::new();
+
         let user_exclude_set = if self.exclude.is_empty() {
             None
         } else {
@@ -96,7 +128,6 @@ impl FilterConfig {
         };
         let sys_exclude = system_exclude_set();
 
-        // 1. include_set: tags matching any include: pattern, minus user-exclude.
         let include_kept: Vec<&str> = if self.include.is_empty() {
             Vec::new()
         } else {
@@ -108,50 +139,281 @@ impl FilterConfig {
                 .collect()
         };
 
-        // 2. pipeline_input: glob (default *) AND semver.
         let mut pipeline: Vec<&str> = if self.glob.is_empty() {
             tags.to_vec()
         } else {
-            filter_glob(tags, &self.glob)?
+            let kept = filter_glob(tags, &self.glob)?;
+            if track {
+                let kept_set: HashSet<&str> = kept.iter().copied().collect();
+                let dropped: Vec<String> = tags
+                    .iter()
+                    .filter(|t| !kept_set.contains(*t))
+                    .map(|t| (*t).to_owned())
+                    .collect();
+                if !dropped.is_empty() {
+                    drop_reasons.push(DropReason {
+                        kind: DropKind::Glob {
+                            patterns: self.glob.clone(),
+                        },
+                        count: dropped.len(),
+                        samples: dropped,
+                    });
+                }
+            }
+            kept
         };
-        if let Some(ref range) = self.semver {
-            pipeline = filter_semver(&pipeline, range)?;
+        if track && !self.glob.is_empty() {
+            pipeline_stages.push(StageDelta {
+                label: format!("glob {}", patterns_label(&self.glob)),
+                count_in: candidates,
+                count_out: pipeline.len(),
+            });
         }
 
-        // 3. pipeline minus user-exclude minus system-exclude (one pass).
-        pipeline.retain(|t| {
-            user_exclude_set.as_ref().is_none_or(|s| !s.is_match(t)) && !sys_exclude.is_match(t)
-        });
+        if let Some(ref range) = self.semver {
+            let before = pipeline.len();
+            let kept = filter_semver(&pipeline, range)?;
+            if track {
+                let kept_set: HashSet<&str> = kept.iter().copied().collect();
+                let dropped: Vec<String> = pipeline
+                    .iter()
+                    .filter(|t| !kept_set.contains(*t))
+                    .map(|t| (*t).to_owned())
+                    .collect();
+                if !dropped.is_empty() {
+                    drop_reasons.push(DropReason {
+                        kind: DropKind::Semver {
+                            range: range.clone(),
+                        },
+                        count: dropped.len(),
+                        samples: dropped,
+                    });
+                }
+            }
+            pipeline = kept;
+            if track {
+                pipeline_stages.push(StageDelta {
+                    label: format!("semver \"{range}\""),
+                    count_in: before,
+                    count_out: pipeline.len(),
+                });
+            }
+        }
 
-        // 4. sort + latest cap (pipeline only).
+        let before_exclude = pipeline.len();
+        let mut user_dropped: Vec<String> = Vec::new();
+        let mut sys_dropped: Vec<String> = Vec::new();
+        pipeline.retain(|t| {
+            if let Some(ref s) = user_exclude_set {
+                if s.is_match(t) {
+                    if track {
+                        user_dropped.push((*t).to_owned());
+                    }
+                    return false;
+                }
+            }
+            if sys_exclude.is_match(t) {
+                if track {
+                    sys_dropped.push((*t).to_owned());
+                }
+                return false;
+            }
+            true
+        });
+        if track {
+            if !user_dropped.is_empty() {
+                drop_reasons.push(DropReason {
+                    kind: DropKind::UserExclude {
+                        patterns: self.exclude.clone(),
+                    },
+                    count: user_dropped.len(),
+                    samples: user_dropped,
+                });
+            }
+            if !sys_dropped.is_empty() {
+                drop_reasons.push(DropReason {
+                    kind: DropKind::SystemExclude,
+                    count: sys_dropped.len(),
+                    samples: sys_dropped,
+                });
+            }
+            if before_exclude != pipeline.len() {
+                pipeline_stages.push(StageDelta {
+                    label: "exclude (user + system)".to_string(),
+                    count_in: before_exclude,
+                    count_out: pipeline.len(),
+                });
+            }
+        }
+
         if let Some(order) = self.sort {
             sort_tags_in_place(&mut pipeline, order);
         }
         if let Some(n) = self.latest {
-            pipeline.truncate(n);
+            let before = pipeline.len();
+            if pipeline.len() > n {
+                if track {
+                    let dropped: Vec<String> =
+                        pipeline[n..].iter().map(|t| (*t).to_owned()).collect();
+                    drop_reasons.push(DropReason {
+                        kind: DropKind::LatestCap { limit: n },
+                        count: dropped.len(),
+                        samples: dropped,
+                    });
+                }
+                pipeline.truncate(n);
+            }
+            if track {
+                let label = match self.sort {
+                    Some(SortOrder::Semver) => format!("sort semver desc, latest {n}"),
+                    Some(SortOrder::Alpha) => format!("sort alpha desc, latest {n}"),
+                    None => format!("latest {n}"),
+                };
+                pipeline_stages.push(StageDelta {
+                    label,
+                    count_in: before,
+                    count_out: pipeline.len(),
+                });
+            }
         }
 
-        // 5. Union: include first (preserves include input order), then
-        //    pipeline tags not already in include.
+        // Union: include first (preserves include input order), then pipeline
+        // tags not already in include. The order matters for the dry-run
+        // formatter's "include first, then pipeline" header.
         let mut seen: HashSet<&str> = include_kept.iter().copied().collect();
-        let mut final_set: Vec<&str> = include_kept;
+        let mut final_set: Vec<&str> = include_kept.clone();
         for t in pipeline {
             if seen.insert(t) {
                 final_set.push(t);
             }
         }
 
-        // 6. min_tags validation against the union.
-        if let Some(min) = self.min_tags {
-            if final_set.len() < min {
-                return Err(Error::BelowMinTags {
-                    matched: final_set.len(),
-                    minimum: min,
-                });
-            }
+        if track {
+            drop_reasons.sort_by(|a, b| b.count.cmp(&a.count));
         }
 
-        Ok(final_set.into_iter().map(String::from).collect())
+        Ok(Outcome {
+            kept: final_set.into_iter().map(String::from).collect(),
+            report: FilterReport {
+                candidates,
+                include_kept: include_kept.len(),
+                pipeline: pipeline_stages,
+                dropped: drop_reasons,
+            },
+        })
+    }
+}
+
+/// Result of applying a [`FilterConfig`] with reporting attached.
+///
+/// `kept` is the same `Vec<String>` that [`FilterConfig::apply`] returns.
+/// `report` describes how the pipeline arrived at it.
+#[derive(Debug)]
+pub struct Outcome {
+    /// Tags that survive the full pipeline.
+    pub kept: Vec<String>,
+    /// Stage-by-stage attrition and per-reason drop attribution.
+    pub report: FilterReport,
+}
+
+/// Per-mapping filter pipeline trace.
+///
+/// `candidates` is the source-tag count fed in. `pipeline` lists each stage
+/// (label + `count_in` -> `count_out`). `dropped` is Pareto-sorted by drop
+/// count across all stages, suitable for "where did most of my tags go"
+/// output.
+///
+/// Distinct from `ocync_sync::SyncReport` (the run-level engine report);
+/// this is the per-mapping filter trace consumed by `--dry-run`.
+#[derive(Debug)]
+pub struct FilterReport {
+    /// Number of source tags fed into the pipeline.
+    pub candidates: usize,
+    /// Number of tags admitted via the `include:` path. `0` when `include:`
+    /// is not configured.
+    pub include_kept: usize,
+    /// Stage-by-stage attrition along the pipeline (top-down order).
+    pub pipeline: Vec<StageDelta>,
+    /// Drop reasons sorted by count descending (Pareto).
+    pub dropped: Vec<DropReason>,
+}
+
+/// One pipeline stage's count delta.
+#[derive(Debug)]
+pub struct StageDelta {
+    /// Human-readable label, e.g. `glob "3.*"` or `semver ">=3.18"`.
+    pub label: String,
+    /// Tag count entering this stage.
+    pub count_in: usize,
+    /// Tag count leaving this stage.
+    pub count_out: usize,
+}
+
+/// What rejected the dropped tags. Carries enough structure for both human
+/// rendering and downstream pattern-matching (e.g., the dry-run formatter
+/// prefixes most reasons with "by " but renders [`LatestCap`](Self::LatestCap)
+/// as a self-contained clause).
+#[derive(Debug, Clone)]
+pub enum DropKind {
+    /// Tag did not match any configured `glob:` pattern.
+    Glob {
+        /// Configured glob patterns (one or more).
+        patterns: Vec<String>,
+    },
+    /// Tag did not satisfy the configured `semver:` range.
+    Semver {
+        /// The configured version range string, e.g. `">=1.18.0"`.
+        range: String,
+    },
+    /// Tag matched a user-configured `exclude:` pattern.
+    UserExclude {
+        /// User-configured exclude patterns (one or more).
+        patterns: Vec<String>,
+    },
+    /// Tag matched the built-in prerelease exclude list.
+    SystemExclude,
+    /// Tag fell off the end of the `latest: N` truncation.
+    LatestCap {
+        /// The configured `latest: N` value.
+        limit: usize,
+    },
+}
+
+impl fmt::Display for DropKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Glob { patterns } => write!(f, "glob {}", patterns_label(patterns)),
+            Self::Semver { range } => write!(f, "semver \"{range}\""),
+            Self::UserExclude { patterns } => {
+                write!(f, "user-exclude {}", patterns_label(patterns))
+            }
+            Self::SystemExclude => f.write_str("system-exclude"),
+            Self::LatestCap { limit } => write!(f, "over latest={limit} limit"),
+        }
+    }
+}
+
+/// One drop reason with sample tag names.
+#[derive(Debug)]
+pub struct DropReason {
+    /// Which pipeline stage rejected these tags.
+    pub kind: DropKind,
+    /// How many tags this stage dropped.
+    pub count: usize,
+    /// All dropped tag names. Stored uncapped so `--dry-run -v` can render
+    /// the full list; the default formatter caps display at 5 (display-only,
+    /// not stored).
+    pub samples: Vec<String>,
+}
+
+/// Format a list of patterns for stage/drop labels.
+fn patterns_label(patterns: &[String]) -> String {
+    match patterns.len() {
+        1 => format!("\"{}\"", patterns[0]),
+        _ => {
+            let quoted: Vec<String> = patterns.iter().map(|p| format!("\"{p}\"")).collect();
+            quoted.join(", ")
+        }
     }
 }
 
@@ -828,5 +1090,146 @@ mod tests {
         let result = config.apply(&tags).unwrap();
         assert_eq!(result, vec!["1.10.0"]);
         assert!(!result.contains(&"1.10.0-alpha20241016".to_string()));
+    }
+
+    // - apply_with_report tests --------------------------------------------
+
+    #[test]
+    fn report_invariant_kept_plus_dropped_equals_candidates() {
+        let tags = vec![
+            "1.18.0",
+            "1.19.0",
+            "1.20.0",
+            "1.20.1-rc1",
+            "1.17.0",
+            "latest",
+            "nightly",
+        ];
+        let config = FilterConfig {
+            glob: vec!["1.*".into()],
+            semver: Some(">=1.18.0".into()),
+            sort: Some(SortOrder::Semver),
+            latest: Some(2),
+            ..FilterConfig::default()
+        };
+        let outcome = config.apply_with_report(&tags).unwrap();
+        let total_dropped: usize = outcome.report.dropped.iter().map(|d| d.count).sum();
+        assert_eq!(
+            outcome.kept.len() + total_dropped,
+            outcome.report.candidates
+        );
+    }
+
+    #[test]
+    fn report_invariant_with_include_path() {
+        let tags = vec!["latest", "1.0.0", "1.1.0", "1.2.0", "0.9.0-rc1"];
+        let config = FilterConfig {
+            include: vec!["latest".into()],
+            semver: Some(">=1.0".into()),
+            sort: Some(SortOrder::Semver),
+            latest: Some(2),
+            ..FilterConfig::default()
+        };
+        let outcome = config.apply_with_report(&tags).unwrap();
+
+        assert_eq!(outcome.report.include_kept, 1);
+
+        // Pipeline accounting (closed): every candidate either survives the
+        // pipeline or appears in `dropped`. Tags rescued only via `include:`
+        // still count as dropped here -- they reach `kept` via the include
+        // path, not the pipeline.
+        let total_dropped: usize = outcome.report.dropped.iter().map(|d| d.count).sum();
+        let pipeline_survivors = outcome.report.candidates - total_dropped;
+
+        // Union semantics: final kept is `include_kept + pipeline_survivors`
+        // minus their overlap (tags that both include and the pipeline kept).
+        // So `kept` is bounded above by the unduplicated sum and below by
+        // pipeline survivors alone.
+        assert!(
+            outcome.kept.len() <= outcome.report.include_kept + pipeline_survivors,
+            "kept={} > include_kept={} + pipeline_survivors={}",
+            outcome.kept.len(),
+            outcome.report.include_kept,
+            pipeline_survivors,
+        );
+        assert!(
+            outcome.kept.len() >= pipeline_survivors,
+            "kept={} < pipeline_survivors={}",
+            outcome.kept.len(),
+            pipeline_survivors,
+        );
+
+        // Concrete shape for this fixture: latest is dropped by semver but
+        // rescued by include; 1.0.0 falls off via latest=2; 0.9.0-rc1 fails
+        // semver. Final kept = {latest, 1.2.0, 1.1.0}.
+        assert_eq!(outcome.kept.len(), 3);
+        assert!(outcome.kept.contains(&"latest".to_string()));
+        assert!(outcome.kept.contains(&"1.2.0".to_string()));
+        assert!(outcome.kept.contains(&"1.1.0".to_string()));
+        assert!(!outcome.kept.contains(&"1.0.0".to_string()));
+        assert!(!outcome.kept.contains(&"0.9.0-rc1".to_string()));
+    }
+
+    #[test]
+    fn report_pareto_sorted_by_drop_count() {
+        let tags: Vec<String> = (0..20).map(|i| format!("1.{i}.0")).collect();
+        let mut tag_refs: Vec<&str> = tags.iter().map(String::as_str).collect();
+        tag_refs.extend(["edge", "latest", "nightly", "1.0.0-rc1", "1.0.0-alpha"]);
+        let config = FilterConfig {
+            glob: vec!["1.*".into()],
+            semver: Some(">=1.10".into()),
+            sort: Some(SortOrder::Semver),
+            latest: Some(3),
+            ..FilterConfig::default()
+        };
+        let outcome = config.apply_with_report(&tag_refs).unwrap();
+        for window in outcome.report.dropped.windows(2) {
+            assert!(
+                window[0].count >= window[1].count,
+                "not Pareto-sorted: {:?}",
+                outcome.report.dropped
+            );
+        }
+    }
+
+    #[test]
+    fn report_min_tags_does_not_block_apply_with_report() {
+        // apply() returns BelowMinTags; apply_with_report() returns Outcome anyway.
+        let tags = vec!["1.0.0", "1.1.0"];
+        let config = FilterConfig {
+            sort: Some(SortOrder::Semver),
+            min_tags: Some(10),
+            ..FilterConfig::default()
+        };
+        // apply errors:
+        assert!(matches!(
+            config.apply(&tags),
+            Err(Error::BelowMinTags { .. })
+        ));
+        // apply_with_report succeeds with partial data:
+        let outcome = config.apply_with_report(&tags).unwrap();
+        assert_eq!(outcome.kept.len(), 2);
+    }
+
+    #[test]
+    fn report_drop_reasons_split_user_and_system_exclude() {
+        let tags = vec!["1.0.0", "1.0.0-musl", "1.1.0-rc1", "1.2.0"];
+        let config = FilterConfig {
+            exclude: vec!["*-musl".into()],
+            semver: Some(">=1.0".into()),
+            ..FilterConfig::default()
+        };
+        let outcome = config.apply_with_report(&tags).unwrap();
+        let kinds: Vec<&DropKind> = outcome.report.dropped.iter().map(|d| &d.kind).collect();
+        assert!(
+            kinds
+                .iter()
+                .any(|k| matches!(k, DropKind::UserExclude { .. })),
+            "missing UserExclude in {kinds:?}"
+        );
+        assert!(
+            kinds.iter().any(|k| matches!(k, DropKind::SystemExclude)),
+            "missing SystemExclude in {kinds:?}"
+        );
     }
 }

--- a/crates/ocync-sync/tests/helpers/fixtures.rs
+++ b/crates/ocync-sync/tests/helpers/fixtures.rs
@@ -104,6 +104,8 @@ pub fn resolved_mapping(
         head_first: false,
         immutable_glob: None,
         artifacts_config: Rc::new(ResolvedArtifacts::default()),
+        candidates: None,
+        filter_report: None,
     }
 }
 

--- a/crates/ocync-sync/tests/helpers/fixtures.rs
+++ b/crates/ocync-sync/tests/helpers/fixtures.rs
@@ -104,7 +104,7 @@ pub fn resolved_mapping(
         head_first: false,
         immutable_glob: None,
         artifacts_config: Rc::new(ResolvedArtifacts::default()),
-        candidates: None,
+        candidate_count: None,
         filter_report: None,
     }
 }

--- a/docs/src/content/cli-reference.md
+++ b/docs/src/content/cli-reference.md
@@ -26,7 +26,7 @@ ocync version                           Print version and build info
 |---|---|
 | `-v` / `--verbose` | Increase log verbosity (`-v` debug, `-vv` or higher trace) |
 | `-q`, `--quiet` | Suppress all output except errors |
-| `--log-format` | Set log format: `text` (default) or `json` (auto-detected in Kubernetes) |
+| `--log-format` | Set log format: `text` (default) or `json` |
 
 ## sync
 

--- a/docs/src/content/cli-reference.md
+++ b/docs/src/content/cli-reference.md
@@ -44,6 +44,17 @@ ocync sync -c config.yaml --json
 | `--dry-run` | Preview what would sync without making changes |
 | `--json` | Output sync report as JSON to stdout |
 
+### Dry-run output
+
+`--dry-run` runs the full filter pipeline against each mapping's source tags and prints, per mapping:
+
+- **`source candidates: N`** -- the number of tags fetched from the source.
+- **`include path:`** -- tags rescued via `include:` (bypasses `glob:`/`semver:` and the system-exclude defaults). Default cap is 5 names; `-v` removes the cap.
+- **`pipeline:`** -- per-stage attrition (`glob`, `semver`, `exclude`, `latest`). Each row shows count_in -> count_out and the drop count.
+- **`kept (N):`** -- the final tags. When `include:` is used, rescued tags are listed first and tagged `[via include]` so the rescue path is visible.
+- **`dropped N:`** -- Pareto-sorted drop attribution (largest cause first), with sample tag names per reason. Default cap is 5 names per reason; `-v` removes the cap.
+- **`min_tags: N`** -- when `min_tags:` is configured, the line prints `kept M, satisfied` or `kept M, real sync will FAIL with BelowMinTags`. Real-sync (no `--dry-run`) errors out below `min_tags`; dry-run shows the report and surfaces the gap so the configuration can be fixed before running.
+
 ## copy
 
 Copy a single image between registries:

--- a/docs/src/content/observability.md
+++ b/docs/src/content/observability.md
@@ -67,6 +67,8 @@ Control verbosity with `-v` flags:
 | Trace | `-vv` | HTTP requests, detailed internals |
 | Error | `-q` / `--quiet` | Errors only |
 
+`-v` also uncaps the per-reason sample list in `--dry-run` output (default cap: 5 tags per drop reason and per include rescue).
+
 ### Log format
 
 ```bash

--- a/docs/src/content/observability.md
+++ b/docs/src/content/observability.md
@@ -70,14 +70,14 @@ Control verbosity with `-v` flags:
 ### Log format
 
 ```bash
-# Human-readable (default)
+# Human-readable (default everywhere, including Kubernetes)
 ocync sync -c config.yaml -vv
 
-# JSON (auto-detected in Kubernetes, or explicit)
+# JSON for log-aggregation pipelines that parse structured fields
 ocync sync -c config.yaml -vv --log-format json
 ```
 
-JSON log format is auto-detected when running inside Kubernetes (via `KUBERNETES_SERVICE_HOST` environment variable).
+When deployed via the chart, set `logging.format: json` in helm values to opt into JSON output.
 
 Override with the `RUST_LOG` environment variable for fine-grained filter directives.
 

--- a/src/cli/commands/analyze.rs
+++ b/src/cli/commands/analyze.rs
@@ -66,10 +66,11 @@ pub(crate) async fn run(
             break;
         }
 
-        let resolved = match resolve_mapping(mapping, &config, &clients, &no_checkers).await? {
-            Some(r) => r,
-            None => continue,
-        };
+        let resolved =
+            match resolve_mapping(mapping, &config, &clients, &no_checkers, false).await? {
+                Some(r) => r,
+                None => continue,
+            };
 
         for tag_pair in &resolved.tags {
             if shutdown.is_triggered() {

--- a/src/cli/commands/copy.rs
+++ b/src/cli/commands/copy.rs
@@ -82,7 +82,7 @@ pub(crate) async fn run(
             enabled: false,
             ..ResolvedArtifacts::default()
         }),
-        candidates: None,
+        candidate_count: None,
         filter_report: None,
     };
 

--- a/src/cli/commands/copy.rs
+++ b/src/cli/commands/copy.rs
@@ -82,6 +82,8 @@ pub(crate) async fn run(
             enabled: false,
             ..ResolvedArtifacts::default()
         }),
+        candidates: None,
+        filter_report: None,
     };
 
     let engine = SyncEngine::new(RetryConfig::default(), DEFAULT_MAX_CONCURRENT_TRANSFERS);

--- a/src/cli/commands/dry_run.rs
+++ b/src/cli/commands/dry_run.rs
@@ -1,12 +1,16 @@
-//! Pretty-printer for `--dry-run`. Renders per-mapping stage attrition and
-//! Pareto-sorted drop attribution from a `filter::FilterReport`.
+//! Pretty-printer for `--dry-run`. Renders per-mapping stage attrition,
+//! Pareto-sorted drop attribution, include-rescue listing, and `min_tags`
+//! status from a `filter::FilterReport`.
 
+use std::collections::HashSet;
 use std::io::{self, Write};
 
 use ocync_sync::engine::{ResolvedMapping, TagPair};
 use ocync_sync::filter::{DropKind, FilterReport};
 
-/// Default sample cap per drop reason. Removed when verbose.
+/// Default sample cap per drop reason and per include-rescue list. Removed
+/// when verbose. Five lines is enough to spot the pattern (rc1..rc5,
+/// 1.20.0..1.20.4) without flooding the terminal.
 const SAMPLE_CAP: usize = 5;
 
 /// Print dry-run output for the resolved mappings to stdout.
@@ -16,10 +20,17 @@ const SAMPLE_CAP: usize = 5;
 pub(crate) fn print(mappings: &[ResolvedMapping], verbose: bool) {
     let stdout = io::stdout();
     let mut handle = stdout.lock();
+    // Stdout write errors during dry-run are almost always SIGPIPE (e.g.
+    // `ocync sync --dry-run | head`). Swallow them: the user explicitly
+    // asked us to stop writing.
     let _ = write_to(&mut handle, mappings, verbose);
 }
 
-fn write_to<W: Write>(w: &mut W, mappings: &[ResolvedMapping], verbose: bool) -> io::Result<()> {
+pub(crate) fn write_to<W: Write>(
+    w: &mut W,
+    mappings: &[ResolvedMapping],
+    verbose: bool,
+) -> io::Result<()> {
     if mappings.is_empty() {
         writeln!(w, "dry-run: no mappings to sync")?;
         return Ok(());
@@ -50,21 +61,22 @@ fn write_mapping<W: Write>(w: &mut W, m: &ResolvedMapping, verbose: bool) -> io:
         return write_simple_tag_list(w, &m.tags);
     };
 
-    writeln!(w, "  source candidates: {}", report.candidates)?;
+    writeln!(w, "  source candidates: {}", report.candidate_count)?;
     writeln!(w)?;
 
-    if report.include_kept > 0 {
-        write_include_path(w, report)?;
+    if !report.include_kept.is_empty() {
+        write_include_path(w, report, verbose)?;
         writeln!(w)?;
     }
 
     write_pipeline(w, report)?;
     writeln!(w)?;
 
-    write_kept(w, m, report)?;
+    write_kept(w, &m.tags, &report.include_kept)?;
     writeln!(w)?;
 
-    write_dropped(w, report, verbose)?;
+    let any_drops = write_dropped(w, report, verbose)?;
+    write_min_tags_status(w, m.tags.len(), report.min_tags, any_drops)?;
     Ok(())
 }
 
@@ -84,13 +96,13 @@ fn write_tag_pairs<W: Write>(w: &mut W, tags: &[TagPair]) -> io::Result<()> {
     Ok(())
 }
 
-fn write_include_path<W: Write>(w: &mut W, report: &FilterReport) -> io::Result<()> {
+/// Render the include-rescue section: count + sample tag names, with a
+/// `, ...` ellipsis when truncated under `SAMPLE_CAP`.
+fn write_include_path<W: Write>(w: &mut W, report: &FilterReport, verbose: bool) -> io::Result<()> {
     writeln!(w, "  include path:")?;
-    writeln!(
-        w,
-        "    include kept                 -> {}",
-        report.include_kept
-    )?;
+    let count = report.include_kept.len();
+    let display = render_samples(&report.include_kept, verbose);
+    writeln!(w, "    rescued ({count}):  {display}")?;
     Ok(())
 }
 
@@ -112,29 +124,35 @@ fn write_pipeline<W: Write>(w: &mut W, report: &FilterReport) -> io::Result<()> 
     Ok(())
 }
 
-fn write_kept<W: Write>(w: &mut W, m: &ResolvedMapping, report: &FilterReport) -> io::Result<()> {
-    let header = if report.include_kept > 0 {
-        format!("  kept ({}):  include first, then pipeline", m.tags.len())
+fn write_kept<W: Write>(w: &mut W, tags: &[TagPair], include_kept: &[String]) -> io::Result<()> {
+    let header = if include_kept.is_empty() {
+        format!("  kept ({}):", tags.len())
     } else {
-        format!("  kept ({}):", m.tags.len())
+        format!("  kept ({}):  include first, then pipeline", tags.len())
     };
     writeln!(w, "{header}")?;
-    write_tag_pairs(w, &m.tags)
+    let include_set: HashSet<&str> = include_kept.iter().map(String::as_str).collect();
+    for tag_pair in tags {
+        if include_set.contains(tag_pair.source.as_str()) {
+            writeln!(w, "    {tag_pair}  [via include]")?;
+        } else {
+            writeln!(w, "    {tag_pair}")?;
+        }
+    }
+    Ok(())
 }
 
-fn write_dropped<W: Write>(w: &mut W, report: &FilterReport, verbose: bool) -> io::Result<()> {
+/// Render the `dropped` section. Returns `true` when at least one row was
+/// emitted, so the caller can decide whether `min_tags` status needs an
+/// extra leading blank line.
+fn write_dropped<W: Write>(w: &mut W, report: &FilterReport, verbose: bool) -> io::Result<bool> {
     let total: usize = report.dropped.iter().map(|d| d.count).sum();
     if total == 0 {
-        return Ok(());
+        return Ok(false);
     }
     writeln!(w, "  dropped {total}:")?;
     for reason in &report.dropped {
-        let samples_display: String = if verbose || reason.samples.len() <= SAMPLE_CAP {
-            reason.samples.join(", ")
-        } else {
-            let head = reason.samples[..SAMPLE_CAP].join(", ");
-            format!("{head}, ...")
-        };
+        let samples_display = render_samples(&reason.samples, verbose);
         // `LatestCap` reads as a complete clause ("over latest=N limit"); every
         // other reason gets a "by " preposition so the line reads as English.
         let display_label = match reason.kind {
@@ -154,7 +172,45 @@ fn write_dropped<W: Write>(w: &mut W, report: &FilterReport, verbose: bool) -> i
             )?;
         }
     }
+    Ok(true)
+}
+
+/// Render `min_tags` status when configured. When `kept < min_tags`, surface
+/// a clear warning that real-sync will fail with `BelowMinTags`. When the
+/// config is absent, render nothing.
+fn write_min_tags_status<W: Write>(
+    w: &mut W,
+    kept: usize,
+    min_tags: Option<usize>,
+    any_drops: bool,
+) -> io::Result<()> {
+    let Some(min) = min_tags else {
+        return Ok(());
+    };
+    if any_drops {
+        writeln!(w)?;
+    }
+    if kept < min {
+        writeln!(
+            w,
+            "  min_tags: {min}  (kept {kept}, real sync will FAIL with BelowMinTags)"
+        )?;
+    } else {
+        writeln!(w, "  min_tags: {min}  (kept {kept}, satisfied)")?;
+    }
     Ok(())
+}
+
+/// Format a sample list with the default cap of `SAMPLE_CAP`, joining with
+/// `, ` and appending `, ...` when truncated. With `verbose`, all samples
+/// are printed without truncation.
+fn render_samples(samples: &[String], verbose: bool) -> String {
+    if verbose || samples.len() <= SAMPLE_CAP {
+        samples.join(", ")
+    } else {
+        let head = samples[..SAMPLE_CAP].join(", ");
+        format!("{head}, ...")
+    }
 }
 
 #[cfg(test)]
@@ -164,8 +220,8 @@ mod tests {
 
     fn report_fixture() -> FilterReport {
         FilterReport {
-            candidates: 50,
-            include_kept: 0,
+            candidate_count: 50,
+            include_kept: Vec::new(),
             pipeline: vec![
                 StageDelta {
                     label: "glob \"3.*\"".into(),
@@ -197,6 +253,7 @@ mod tests {
                     samples: vec!["3.18.0-rc.1".into(), "3.19.0-beta.1".into()],
                 },
             ],
+            min_tags: None,
         }
     }
 
@@ -212,7 +269,10 @@ mod tests {
     #[test]
     fn sample_cap_default_truncates_with_ellipsis() {
         let report = report_fixture();
-        let out = capture(|w| write_dropped(w, &report, false));
+        let out = capture(|w| {
+            write_dropped(w, &report, false)?;
+            Ok(())
+        });
         // 6 samples -> first 5 listed + ", ..."
         assert!(
             out.contains("3.20.3, 3.20.2, 3.20.1, 3.20.0, 3.19.7, ..."),
@@ -225,7 +285,10 @@ mod tests {
     #[test]
     fn sample_cap_verbose_prints_all_samples() {
         let report = report_fixture();
-        let out = capture(|w| write_dropped(w, &report, true));
+        let out = capture(|w| {
+            write_dropped(w, &report, true)?;
+            Ok(())
+        });
         // All 6 samples present, no trailing ellipsis.
         assert!(out.contains("3.19.6"), "{out}");
         assert!(!out.contains(", ..."), "{out}");
@@ -234,34 +297,14 @@ mod tests {
     #[test]
     fn system_exclude_emits_override_hint() {
         let report = report_fixture();
-        let out = capture(|w| write_dropped(w, &report, false));
+        let out = capture(|w| {
+            write_dropped(w, &report, false)?;
+            Ok(())
+        });
         assert!(
             out.contains("to keep prereleases, list patterns under include:"),
             "{out}"
         );
-    }
-
-    #[test]
-    fn pareto_section_orders_by_count_descending() {
-        let report = report_fixture();
-        let out = capture(|w| write_dropped(w, &report, false));
-        let latest_pos = out
-            .find("over latest=3 limit")
-            .expect("latest line present");
-        let sys_pos = out
-            .find("system-exclude")
-            .expect("system-exclude line present");
-        assert!(latest_pos < sys_pos, "{out}");
-    }
-
-    #[test]
-    fn drop_labels_prefix_by_except_over() {
-        let report = report_fixture();
-        let out = capture(|w| write_dropped(w, &report, false));
-        // "over latest=N limit" reads naturally without prefix.
-        assert!(out.contains("over latest=3 limit"), "{out}");
-        // Other labels get "by " prefix.
-        assert!(out.contains("by system-exclude"), "{out}");
     }
 
     #[test]
@@ -271,32 +314,72 @@ mod tests {
     }
 
     #[test]
-    fn include_path_renders_count_and_header() {
+    fn include_path_renders_count_and_rescued_names() {
         let report = FilterReport {
-            candidates: 50,
-            include_kept: 3,
+            candidate_count: 50,
+            include_kept: vec!["latest".into(), "latest-dev".into(), "edge".into()],
             pipeline: vec![],
             dropped: vec![],
+            min_tags: None,
         };
-        let out = capture(|w| write_include_path(w, &report));
+        let out = capture(|w| write_include_path(w, &report, false));
         assert!(out.contains("include path:"), "{out}");
-        assert!(out.contains("include kept"), "{out}");
-        assert!(out.contains("-> 3"), "{out}");
+        // Count and the actual rescued tag names appear together.
+        assert!(out.contains("rescued (3):"), "{out}");
+        assert!(out.contains("latest, latest-dev, edge"), "{out}");
+    }
+
+    #[test]
+    fn include_path_truncates_long_rescue_list_under_default() {
+        let names: Vec<String> = (0..10).map(|i| format!("pin-{i}")).collect();
+        let report = FilterReport {
+            candidate_count: 50,
+            include_kept: names,
+            pipeline: vec![],
+            dropped: vec![],
+            min_tags: None,
+        };
+        let out = capture(|w| write_include_path(w, &report, false));
+        // First 5 names appear, ellipsis present.
+        assert!(out.contains("pin-0, pin-1, pin-2, pin-3, pin-4"), "{out}");
+        assert!(out.contains(", ..."), "{out}");
+        // Sixth name is truncated.
+        assert!(!out.contains("pin-5"), "{out}");
+    }
+
+    #[test]
+    fn include_path_verbose_shows_all_rescued() {
+        let names: Vec<String> = (0..10).map(|i| format!("pin-{i}")).collect();
+        let report = FilterReport {
+            candidate_count: 50,
+            include_kept: names,
+            pipeline: vec![],
+            dropped: vec![],
+            min_tags: None,
+        };
+        let out = capture(|w| write_include_path(w, &report, true));
+        assert!(out.contains("pin-0"), "{out}");
+        assert!(out.contains("pin-9"), "{out}");
+        assert!(!out.contains(", ..."), "{out}");
     }
 
     #[test]
     fn dropped_section_omitted_when_total_is_zero() {
         let report = FilterReport {
-            candidates: 5,
-            include_kept: 0,
+            candidate_count: 5,
+            include_kept: Vec::new(),
             pipeline: vec![StageDelta {
                 label: "glob \"*\"".into(),
                 count_in: 5,
                 count_out: 5,
             }],
             dropped: vec![],
+            min_tags: None,
         };
-        let out = capture(|w| write_dropped(w, &report, false));
+        let out = capture(|w| {
+            write_dropped(w, &report, false)?;
+            Ok(())
+        });
         assert!(
             out.is_empty(),
             "expected no output when no drops; got: {out:?}"
@@ -324,5 +407,153 @@ mod tests {
         let out = capture(|w| write_simple_tag_list(w, &renamed));
         assert!(out.contains("    v1.0.0 -> stable\n"), "{out}");
         assert!(out.contains("    latest\n"), "{out}");
+    }
+
+    /// `min_tags: N` configured with kept >= N renders a "satisfied" line.
+    #[test]
+    fn min_tags_status_satisfied_renders_satisfied() {
+        let out = capture(|w| write_min_tags_status(w, 5, Some(3), false));
+        assert!(out.contains("min_tags: 3"), "{out}");
+        assert!(out.contains("kept 5"), "{out}");
+        assert!(out.contains("satisfied"), "{out}");
+        assert!(!out.contains("FAIL"), "{out}");
+    }
+
+    /// `min_tags: N` configured with kept < N renders a hard FAIL warning so
+    /// the user knows real-sync will reject this configuration.
+    #[test]
+    fn min_tags_status_unsatisfied_warns_real_sync_will_fail() {
+        let out = capture(|w| write_min_tags_status(w, 3, Some(10), false));
+        assert!(out.contains("min_tags: 10"), "{out}");
+        assert!(out.contains("kept 3"), "{out}");
+        assert!(out.contains("FAIL"), "{out}");
+        assert!(out.contains("BelowMinTags"), "{out}");
+    }
+
+    /// `min_tags` not configured: no line emitted.
+    #[test]
+    fn min_tags_status_absent_when_not_configured() {
+        let out = capture(|w| write_min_tags_status(w, 5, None, false));
+        assert!(
+            out.is_empty(),
+            "expected nothing when min_tags is None: {out:?}"
+        );
+    }
+
+    /// When the dropped section emitted rows, the `min_tags` line gets a
+    /// leading blank to separate it visually.
+    #[test]
+    fn min_tags_status_blank_separator_after_drops() {
+        let with_drops = capture(|w| write_min_tags_status(w, 5, Some(3), true));
+        assert!(with_drops.starts_with('\n'), "{with_drops:?}");
+        let without_drops = capture(|w| write_min_tags_status(w, 5, Some(3), false));
+        assert!(!without_drops.starts_with('\n'), "{without_drops:?}");
+    }
+
+    /// End-to-end: a mapping with `min_tags` configured but unsatisfied
+    /// renders the FAIL warning in the full mapping output. This is the
+    /// scenario that motivated the fix -- dry-run silently passing what
+    /// real-sync would reject.
+    #[test]
+    fn full_mapping_render_surfaces_min_tags_failure() {
+        let report = FilterReport {
+            candidate_count: 10,
+            include_kept: Vec::new(),
+            pipeline: vec![StageDelta {
+                label: "semver \">=2.0\"".into(),
+                count_in: 10,
+                count_out: 2,
+            }],
+            dropped: vec![DropReason {
+                kind: DropKind::Semver {
+                    range: ">=2.0".into(),
+                },
+                count: 8,
+                samples: (0..8).map(|i| format!("1.{i}.0")).collect(),
+            }],
+            min_tags: Some(5),
+        };
+        let mapping = mapping_with_kept_and_report(2, Some(report));
+        let out = capture(|w| write_mapping(w, &mapping, false));
+        assert!(out.contains("min_tags: 5"), "{out}");
+        assert!(out.contains("kept 2"), "{out}");
+        assert!(out.contains("FAIL"), "{out}");
+        assert!(out.contains("BelowMinTags"), "{out}");
+    }
+
+    /// End-to-end: kept tags rescued via include get a `[via include]`
+    /// marker so the operator can visually verify what each include pattern
+    /// is rescuing.
+    #[test]
+    fn full_mapping_render_marks_include_rescued_tags() {
+        let report = FilterReport {
+            candidate_count: 5,
+            include_kept: vec!["latest".into()],
+            pipeline: vec![StageDelta {
+                label: "semver \">=1.0\"".into(),
+                count_in: 5,
+                count_out: 1,
+            }],
+            dropped: vec![],
+            min_tags: None,
+        };
+        let mapping = mapping_with_tags_and_report(
+            vec![TagPair::same("latest"), TagPair::same("1.0.0")],
+            Some(report),
+        );
+        let out = capture(|w| write_mapping(w, &mapping, false));
+        // latest came through include path, so it is marked.
+        assert!(out.contains("    latest  [via include]"), "{out}");
+        // 1.0.0 came through pipeline, no marker.
+        assert!(out.contains("    1.0.0\n"), "{out}");
+        assert!(!out.contains("1.0.0  [via include]"), "{out}");
+    }
+
+    // -- Test fixture builders -----------------------------------------------
+
+    fn mapping_with_kept_and_report(n: usize, report: Option<FilterReport>) -> ResolvedMapping {
+        let tags: Vec<TagPair> = (0..n).map(|i| TagPair::same(format!("v{i}"))).collect();
+        mapping_with_tags_and_report(tags, report)
+    }
+
+    fn mapping_with_tags_and_report(
+        tags: Vec<TagPair>,
+        filter_report: Option<FilterReport>,
+    ) -> ResolvedMapping {
+        use ocync_distribution::spec::{RegistryAuthority, RepositoryName};
+        use ocync_sync::engine::{RegistryAlias, ResolvedArtifacts, TargetEntry};
+        use std::collections::HashSet;
+        use std::rc::Rc;
+        use std::sync::Arc;
+
+        // Build a minimal mock client. We never issue requests in formatter
+        // tests; the client is a placeholder for the type system.
+        let client = Arc::new(
+            ocync_distribution::RegistryClientBuilder::new(
+                url::Url::parse("http://127.0.0.1").unwrap(),
+            )
+            .build()
+            .unwrap(),
+        );
+
+        ResolvedMapping {
+            source_authority: RegistryAuthority::new("source.test:443"),
+            source_client: client.clone(),
+            source_repo: RepositoryName::new("repo").unwrap(),
+            target_repo: RepositoryName::new("repo").unwrap(),
+            targets: vec![TargetEntry {
+                name: RegistryAlias::new("target"),
+                client,
+                batch_checker: None,
+                existing_tags: HashSet::new(),
+            }],
+            tags,
+            platforms: None,
+            head_first: false,
+            immutable_glob: None,
+            artifacts_config: Rc::new(ResolvedArtifacts::default()),
+            candidate_count: filter_report.as_ref().map(|r| r.candidate_count),
+            filter_report,
+        }
     }
 }

--- a/src/cli/commands/dry_run.rs
+++ b/src/cli/commands/dry_run.rs
@@ -1,0 +1,328 @@
+//! Pretty-printer for `--dry-run`. Renders per-mapping stage attrition and
+//! Pareto-sorted drop attribution from a `filter::FilterReport`.
+
+use std::io::{self, Write};
+
+use ocync_sync::engine::{ResolvedMapping, TagPair};
+use ocync_sync::filter::{DropKind, FilterReport};
+
+/// Default sample cap per drop reason. Removed when verbose.
+const SAMPLE_CAP: usize = 5;
+
+/// Print dry-run output for the resolved mappings to stdout.
+///
+/// `verbose` is the global `cli.verbose >= 1` toggle; when true, all
+/// rejected tags per drop reason are printed (no sample cap).
+pub(crate) fn print(mappings: &[ResolvedMapping], verbose: bool) {
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    let _ = write_to(&mut handle, mappings, verbose);
+}
+
+fn write_to<W: Write>(w: &mut W, mappings: &[ResolvedMapping], verbose: bool) -> io::Result<()> {
+    if mappings.is_empty() {
+        writeln!(w, "dry-run: no mappings to sync")?;
+        return Ok(());
+    }
+
+    for (i, m) in mappings.iter().enumerate() {
+        if i > 0 {
+            writeln!(w)?;
+        }
+        write_mapping(w, m, verbose)?;
+    }
+    Ok(())
+}
+
+fn write_mapping<W: Write>(w: &mut W, m: &ResolvedMapping, verbose: bool) -> io::Result<()> {
+    let target_names: Vec<&str> = m.targets.iter().map(|t| &*t.name).collect();
+    writeln!(
+        w,
+        "dry-run: {} -> {}  =>  [{}]",
+        m.source_repo,
+        m.target_repo,
+        target_names.join(", ")
+    )?;
+
+    let Some(report) = m.filter_report.as_ref() else {
+        // Exact-tag fast path: no report available. Fall back to a simple
+        // tag list (matches the pre-Thread-2 print_dry_run behavior).
+        return write_simple_tag_list(w, &m.tags);
+    };
+
+    writeln!(w, "  source candidates: {}", report.candidates)?;
+    writeln!(w)?;
+
+    if report.include_kept > 0 {
+        write_include_path(w, report)?;
+        writeln!(w)?;
+    }
+
+    write_pipeline(w, report)?;
+    writeln!(w)?;
+
+    write_kept(w, m, report)?;
+    writeln!(w)?;
+
+    write_dropped(w, report, verbose)?;
+    Ok(())
+}
+
+/// Render a flat tag list (used on the exact-tag fast path where no
+/// `FilterReport` is available because source tags were never enumerated).
+fn write_simple_tag_list<W: Write>(w: &mut W, tags: &[TagPair]) -> io::Result<()> {
+    writeln!(w, "  tags ({}):", tags.len())?;
+    write_tag_pairs(w, tags)
+}
+
+/// Render one indented line per [`TagPair`]. Shared by the exact-tag fast
+/// path and the `kept (N):` section.
+fn write_tag_pairs<W: Write>(w: &mut W, tags: &[TagPair]) -> io::Result<()> {
+    for tag_pair in tags {
+        writeln!(w, "    {tag_pair}")?;
+    }
+    Ok(())
+}
+
+fn write_include_path<W: Write>(w: &mut W, report: &FilterReport) -> io::Result<()> {
+    writeln!(w, "  include path:")?;
+    writeln!(
+        w,
+        "    include kept                 -> {}",
+        report.include_kept
+    )?;
+    Ok(())
+}
+
+fn write_pipeline<W: Write>(w: &mut W, report: &FilterReport) -> io::Result<()> {
+    writeln!(w, "  pipeline:")?;
+    for stage in &report.pipeline {
+        let delta = stage.count_in as isize - stage.count_out as isize;
+        let delta_str = if delta != 0 {
+            format!("    (-{})", delta.abs())
+        } else {
+            String::new()
+        };
+        writeln!(
+            w,
+            "    {:<28} {:>4} -> {:<4}{}",
+            stage.label, stage.count_in, stage.count_out, delta_str
+        )?;
+    }
+    Ok(())
+}
+
+fn write_kept<W: Write>(w: &mut W, m: &ResolvedMapping, report: &FilterReport) -> io::Result<()> {
+    let header = if report.include_kept > 0 {
+        format!("  kept ({}):  include first, then pipeline", m.tags.len())
+    } else {
+        format!("  kept ({}):", m.tags.len())
+    };
+    writeln!(w, "{header}")?;
+    write_tag_pairs(w, &m.tags)
+}
+
+fn write_dropped<W: Write>(w: &mut W, report: &FilterReport, verbose: bool) -> io::Result<()> {
+    let total: usize = report.dropped.iter().map(|d| d.count).sum();
+    if total == 0 {
+        return Ok(());
+    }
+    writeln!(w, "  dropped {total}:")?;
+    for reason in &report.dropped {
+        let samples_display: String = if verbose || reason.samples.len() <= SAMPLE_CAP {
+            reason.samples.join(", ")
+        } else {
+            let head = reason.samples[..SAMPLE_CAP].join(", ");
+            format!("{head}, ...")
+        };
+        // `LatestCap` reads as a complete clause ("over latest=N limit"); every
+        // other reason gets a "by " preposition so the line reads as English.
+        let display_label = match reason.kind {
+            DropKind::LatestCap { .. } => reason.kind.to_string(),
+            _ => format!("by {}", reason.kind),
+        };
+        writeln!(
+            w,
+            "    {:>4}  {:<28}{}",
+            reason.count, display_label, samples_display
+        )?;
+        if matches!(reason.kind, DropKind::SystemExclude) {
+            writeln!(
+                w,
+                "          {:<28}to keep prereleases, list patterns under include: (globs supported)",
+                ""
+            )?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ocync_sync::filter::{DropReason, FilterReport, StageDelta};
+
+    fn report_fixture() -> FilterReport {
+        FilterReport {
+            candidates: 50,
+            include_kept: 0,
+            pipeline: vec![
+                StageDelta {
+                    label: "glob \"3.*\"".into(),
+                    count_in: 50,
+                    count_out: 48,
+                },
+                StageDelta {
+                    label: "semver \">=3.18\"".into(),
+                    count_in: 48,
+                    count_out: 40,
+                },
+            ],
+            dropped: vec![
+                DropReason {
+                    kind: DropKind::LatestCap { limit: 3 },
+                    count: 32,
+                    samples: vec![
+                        "3.20.3".into(),
+                        "3.20.2".into(),
+                        "3.20.1".into(),
+                        "3.20.0".into(),
+                        "3.19.7".into(),
+                        "3.19.6".into(),
+                    ],
+                },
+                DropReason {
+                    kind: DropKind::SystemExclude,
+                    count: 2,
+                    samples: vec!["3.18.0-rc.1".into(), "3.19.0-beta.1".into()],
+                },
+            ],
+        }
+    }
+
+    fn capture<F>(f: F) -> String
+    where
+        F: FnOnce(&mut Vec<u8>) -> io::Result<()>,
+    {
+        let mut buf = Vec::new();
+        f(&mut buf).expect("write into Vec never fails");
+        String::from_utf8(buf).expect("formatter output is utf8")
+    }
+
+    #[test]
+    fn sample_cap_default_truncates_with_ellipsis() {
+        let report = report_fixture();
+        let out = capture(|w| write_dropped(w, &report, false));
+        // 6 samples -> first 5 listed + ", ..."
+        assert!(
+            out.contains("3.20.3, 3.20.2, 3.20.1, 3.20.0, 3.19.7, ..."),
+            "{out}"
+        );
+        // The 6th sample must NOT appear.
+        assert!(!out.contains("3.19.6"), "{out}");
+    }
+
+    #[test]
+    fn sample_cap_verbose_prints_all_samples() {
+        let report = report_fixture();
+        let out = capture(|w| write_dropped(w, &report, true));
+        // All 6 samples present, no trailing ellipsis.
+        assert!(out.contains("3.19.6"), "{out}");
+        assert!(!out.contains(", ..."), "{out}");
+    }
+
+    #[test]
+    fn system_exclude_emits_override_hint() {
+        let report = report_fixture();
+        let out = capture(|w| write_dropped(w, &report, false));
+        assert!(
+            out.contains("to keep prereleases, list patterns under include:"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn pareto_section_orders_by_count_descending() {
+        let report = report_fixture();
+        let out = capture(|w| write_dropped(w, &report, false));
+        let latest_pos = out
+            .find("over latest=3 limit")
+            .expect("latest line present");
+        let sys_pos = out
+            .find("system-exclude")
+            .expect("system-exclude line present");
+        assert!(latest_pos < sys_pos, "{out}");
+    }
+
+    #[test]
+    fn drop_labels_prefix_by_except_over() {
+        let report = report_fixture();
+        let out = capture(|w| write_dropped(w, &report, false));
+        // "over latest=N limit" reads naturally without prefix.
+        assert!(out.contains("over latest=3 limit"), "{out}");
+        // Other labels get "by " prefix.
+        assert!(out.contains("by system-exclude"), "{out}");
+    }
+
+    #[test]
+    fn empty_mappings_emits_no_mappings_message() {
+        let out = capture(|w| write_to(w, &[], false));
+        assert_eq!(out, "dry-run: no mappings to sync\n");
+    }
+
+    #[test]
+    fn include_path_renders_count_and_header() {
+        let report = FilterReport {
+            candidates: 50,
+            include_kept: 3,
+            pipeline: vec![],
+            dropped: vec![],
+        };
+        let out = capture(|w| write_include_path(w, &report));
+        assert!(out.contains("include path:"), "{out}");
+        assert!(out.contains("include kept"), "{out}");
+        assert!(out.contains("-> 3"), "{out}");
+    }
+
+    #[test]
+    fn dropped_section_omitted_when_total_is_zero() {
+        let report = FilterReport {
+            candidates: 5,
+            include_kept: 0,
+            pipeline: vec![StageDelta {
+                label: "glob \"*\"".into(),
+                count_in: 5,
+                count_out: 5,
+            }],
+            dropped: vec![],
+        };
+        let out = capture(|w| write_dropped(w, &report, false));
+        assert!(
+            out.is_empty(),
+            "expected no output when no drops; got: {out:?}"
+        );
+    }
+
+    #[test]
+    fn exact_tag_fast_path_lists_tags_without_pipeline() {
+        // Same source and target tags: print just the tag.
+        let same = vec![TagPair::same("v1.0.0"), TagPair::same("v1.1.0")];
+        let out = capture(|w| write_simple_tag_list(w, &same));
+        assert!(out.contains("tags (2):"), "{out}");
+        assert!(out.contains("    v1.0.0\n"), "{out}");
+        assert!(out.contains("    v1.1.0\n"), "{out}");
+        // No pipeline/kept/dropped sections appear.
+        assert!(!out.contains("pipeline:"), "{out}");
+        assert!(!out.contains("kept ("), "{out}");
+        assert!(!out.contains("dropped"), "{out}");
+    }
+
+    #[test]
+    fn exact_tag_fast_path_renders_rename_arrow() {
+        // source != target: render with `source -> target`.
+        let renamed = vec![TagPair::retag("v1.0.0", "stable"), TagPair::same("latest")];
+        let out = capture(|w| write_simple_tag_list(w, &renamed));
+        assert!(out.contains("    v1.0.0 -> stable\n"), "{out}");
+        assert!(out.contains("    latest\n"), "{out}");
+    }
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -3,6 +3,7 @@
 pub(crate) mod analyze;
 pub(crate) mod auth;
 pub(crate) mod copy;
+pub(crate) mod dry_run;
 pub(crate) mod expand;
 pub(crate) mod synchronize;
 pub(crate) mod tags;

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -353,24 +353,12 @@ pub(crate) async fn resolve_mapping(
     // enumerating all tags from the source registry. This avoids
     // hundreds of paginated tags/list requests for repos with thousands
     // of tags.
-    let (filtered, candidates, filter_report) =
+    let (filtered, candidate_count, filter_report) =
         if let Some(exact) = tags_config.and_then(|t| t.exact_tags()) {
             (exact, None, None)
         } else {
             let all_tags = source_client.list_tags(&source_repo_path).await?;
-            let candidates_count = all_tags.len();
-            let filter = build_filter(tags_config);
-            let tag_refs: Vec<&str> = all_tags.iter().map(String::as_str).collect();
-            if with_report {
-                // Dry-run path: do NOT enforce min_tags here. The report is the
-                // point of dry-run; failing here would suppress it. The user
-                // compares `kept` against their `min_tags:` setting themselves.
-                // Real-sync (`with_report = false`) below still enforces via apply().
-                let outcome = filter.apply_with_report(&tag_refs)?;
-                (outcome.kept, Some(candidates_count), Some(outcome.report))
-            } else {
-                (filter.apply(&tag_refs)?, Some(candidates_count), None)
-            }
+            select_filtered_tags(tags_config, all_tags, with_report)?
         };
 
     if filtered.is_empty() {
@@ -456,7 +444,7 @@ pub(crate) async fn resolve_mapping(
         head_first,
         immutable_glob,
         artifacts_config: Rc::new(artifacts),
-        candidates,
+        candidate_count,
         filter_report,
     }))
 }
@@ -487,18 +475,54 @@ fn glob_or_list_to_vec(g: Option<&GlobOrList>) -> Vec<String> {
     }
 }
 
+/// Result of [`select_filtered_tags`]: kept tags, candidate count, and the
+/// optional filter trace consumed by `--dry-run`.
+type SelectionResult = (
+    Vec<String>,
+    Option<usize>,
+    Option<ocync_sync::filter::FilterReport>,
+);
+
+/// Apply the filter pipeline to `all_tags` from `tags_config`, returning the
+/// kept tags, the candidate count, and an optional `FilterReport`.
+///
+/// `with_report = true` (dry-run) calls
+/// [`FilterConfig::apply_with_report`], which does NOT enforce `min_tags` --
+/// the report carries the configured value so the formatter can render the
+/// gap to the user. `with_report = false` (real-sync) calls
+/// [`FilterConfig::apply`], which enforces `min_tags` and returns a
+/// `BelowMinTags` error when violated.
+///
+/// Extracted from [`resolve_mapping`] so the report wire-up is testable
+/// without spinning up a registry mock.
+fn select_filtered_tags(
+    tags_config: Option<&TagsConfig>,
+    all_tags: Vec<String>,
+    with_report: bool,
+) -> Result<SelectionResult, CliError> {
+    let n_candidates = all_tags.len();
+    let filter = build_filter(tags_config);
+    let tag_refs: Vec<&str> = all_tags.iter().map(String::as_str).collect();
+    if with_report {
+        let result = filter.apply_with_report(&tag_refs)?;
+        Ok((result.kept, Some(n_candidates), Some(result.report)))
+    } else {
+        Ok((filter.apply(&tag_refs)?, Some(n_candidates), None))
+    }
+}
+
 /// Format one per-mapping plan line for `INFO`-level emission.
 ///
-/// `{source} -> {target}: {kept} of {candidates} tags  =>  [t1, t2]` when
-/// candidates is known, or `{kept} tags` on the exact-tag fast path.
+/// `{source} -> {target}: {kept} of {N} tags  =>  [t1, t2]` when the
+/// candidate count is known, or `{kept} tags` on the exact-tag fast path.
 fn format_plan_line(
     source_repo: &str,
     target_repo: &str,
     kept: usize,
-    candidates: Option<usize>,
+    candidate_count: Option<usize>,
     target_names: &[&str],
 ) -> String {
-    let count_phrase = match candidates {
+    let count_phrase = match candidate_count {
         Some(n) => format!("{kept} of {n} tags"),
         None => format!("{kept} tags"),
     };
@@ -519,7 +543,7 @@ fn log_resolved_mappings(mappings: &[ResolvedMapping]) {
                 m.source_repo.as_str(),
                 m.target_repo.as_str(),
                 m.tags.len(),
-                m.candidates,
+                m.candidate_count,
                 &target_names,
             )
         );
@@ -826,5 +850,159 @@ latest: 5
             line,
             "src/repo -> dst/repo: 5 of 80 tags  =>  [only-target]"
         );
+    }
+
+    // -- select_filtered_tags wire-up tests ---------------------------------
+
+    /// `with_report = true` produces a `Some(FilterReport)` whose
+    /// `min_tags` and `include_kept` match the configured input. This is
+    /// the wire-up that `--dry-run` depends on; a regression where
+    /// `with_report` is hardcoded to `false` would fail this test.
+    #[test]
+    fn select_filtered_tags_with_report_populates_min_tags_and_include() {
+        use ocync_sync::filter::SortOrder;
+
+        let tags_config = TagsConfig {
+            include: Some(GlobOrList::List(vec!["latest".into()])),
+            semver: Some(">=1.0".into()),
+            sort: Some(SortOrder::Semver),
+            latest: Some(2),
+            min_tags: Some(5),
+            ..Default::default()
+        };
+        let all_tags = vec![
+            "latest".into(),
+            "1.0.0".into(),
+            "1.1.0".into(),
+            "1.2.0".into(),
+            "0.9.0-rc1".into(),
+        ];
+        let (kept, candidate_count, report) =
+            select_filtered_tags(Some(&tags_config), all_tags, true).unwrap();
+
+        // Wire-up: candidate count flows through.
+        assert_eq!(candidate_count, Some(5));
+        // Wire-up: report is Some.
+        let report = report.expect("report present when with_report=true");
+        // Report carries min_tags so the formatter can render the gap.
+        assert_eq!(report.min_tags, Some(5));
+        // Include rescued by name (latest fails semver but is in include:).
+        assert_eq!(report.include_kept, vec!["latest".to_string()]);
+        // Kept reflects union semantics: include + top-2 of pipeline
+        // (1.2.0 and 1.1.0). 1.0.0 falls off via latest=2; 0.9.0-rc1 fails
+        // semver and is dropped. 3 < min_tags=5, so real-sync would error.
+        assert_eq!(kept.len(), 3);
+        assert!(kept.contains(&"latest".to_string()));
+    }
+
+    /// `with_report = false` (real-sync hot path) produces `None` for the
+    /// report so we don't pay drop-attribution cost on every watch cycle.
+    #[test]
+    fn select_filtered_tags_without_report_returns_none() {
+        let tags_config = TagsConfig {
+            glob: Some(GlobOrList::Single("*".into())),
+            ..Default::default()
+        };
+        let all_tags = vec!["1.0".into(), "2.0".into()];
+        let (kept, candidate_count, report) =
+            select_filtered_tags(Some(&tags_config), all_tags, false).unwrap();
+        assert_eq!(candidate_count, Some(2));
+        assert_eq!(kept.len(), 2);
+        assert!(report.is_none());
+    }
+
+    /// `with_report = false` enforces `min_tags` (real-sync errors when
+    /// the filter doesn't yield enough tags). The dry-run path does NOT
+    /// (covered separately).
+    #[test]
+    fn select_filtered_tags_without_report_enforces_min_tags() {
+        let tags_config = TagsConfig {
+            min_tags: Some(10),
+            ..Default::default()
+        };
+        let all_tags = vec!["1.0".into(), "2.0".into()];
+        let result = select_filtered_tags(Some(&tags_config), all_tags, false);
+        assert!(
+            result.is_err(),
+            "expected BelowMinTags error from real-sync path"
+        );
+    }
+
+    /// `with_report = true` does NOT enforce `min_tags`. The dry-run formatter
+    /// surfaces the gap in its output instead of suppressing the report.
+    #[test]
+    fn select_filtered_tags_with_report_does_not_enforce_min_tags() {
+        let tags_config = TagsConfig {
+            min_tags: Some(10),
+            ..Default::default()
+        };
+        let all_tags = vec!["1.0".into(), "2.0".into()];
+        let (kept, candidate_count, report) =
+            select_filtered_tags(Some(&tags_config), all_tags, true).unwrap();
+        assert_eq!(kept.len(), 2);
+        assert_eq!(candidate_count, Some(2));
+        let report = report.expect("dry-run path returns report even when min_tags would error");
+        assert_eq!(report.min_tags, Some(10));
+    }
+
+    /// Full wire-up: `select_filtered_tags` + `ResolvedMapping` construction +
+    /// `dry_run::write_to`, ensuring the report flows from filter through to
+    /// printed output. A regression where `filter_report` drops on the floor
+    /// between `resolve_mapping` and the formatter would fail this test.
+    #[test]
+    fn dry_run_full_wire_up_renders_min_tags_failure() {
+        use ocync_distribution::spec::RegistryAuthority;
+        use ocync_sync::engine::{RegistryAlias, ResolvedArtifacts, ResolvedMapping, TargetEntry};
+        use std::collections::HashSet as Set;
+
+        let tags_config = TagsConfig {
+            semver: Some(">=2.0".into()),
+            min_tags: Some(5),
+            ..Default::default()
+        };
+        let all_tags: Vec<String> = (0..10).map(|i| format!("1.{i}.0")).collect();
+        let (kept, candidate_count, filter_report) =
+            select_filtered_tags(Some(&tags_config), all_tags, true).unwrap();
+        assert_eq!(kept.len(), 0); // all dropped by semver >=2.0
+        assert!(filter_report.is_some());
+
+        let client = Arc::new(
+            ocync_distribution::RegistryClientBuilder::new(
+                url::Url::parse("http://127.0.0.1").unwrap(),
+            )
+            .build()
+            .unwrap(),
+        );
+        let mapping = ResolvedMapping {
+            source_authority: RegistryAuthority::new("source.test:443"),
+            source_client: client.clone(),
+            source_repo: RepositoryName::new("repo").unwrap(),
+            target_repo: RepositoryName::new("repo").unwrap(),
+            targets: vec![TargetEntry {
+                name: RegistryAlias::new("target"),
+                client,
+                batch_checker: None,
+                existing_tags: Set::new(),
+            }],
+            tags: kept.into_iter().map(TagPair::same).collect(),
+            platforms: None,
+            head_first: false,
+            immutable_glob: None,
+            artifacts_config: Rc::new(ResolvedArtifacts::default()),
+            candidate_count,
+            filter_report,
+        };
+
+        let mut buf: Vec<u8> = Vec::new();
+        crate::cli::commands::dry_run::write_to(&mut buf, &[mapping], false).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+
+        // The end-to-end output surfaces the BelowMinTags warning.
+        assert!(out.contains("min_tags: 5"), "{out}");
+        assert!(out.contains("FAIL"), "{out}");
+        assert!(out.contains("BelowMinTags"), "{out}");
+        // And carries the full pipeline trace.
+        assert!(out.contains("source candidates: 10"), "{out}");
+        assert!(out.contains("dropped 10:"), "{out}");
     }
 }

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -77,6 +77,7 @@ pub(crate) async fn run(
     progress: &dyn ocync_sync::progress::ProgressReporter,
     shutdown: Option<&ShutdownSignal>,
     external_cache: Option<Rc<RefCell<TransferStateCache>>>,
+    verbose: bool,
 ) -> Result<ExitCode, CliError> {
     let config = load_config(&args.config)?;
 
@@ -85,15 +86,17 @@ pub(crate) async fn run(
 
     let mut mappings = Vec::new();
     for mapping in &config.mappings {
-        match resolve_mapping(mapping, &config, &clients, &batch_checkers).await {
+        match resolve_mapping(mapping, &config, &clients, &batch_checkers, args.dry_run).await {
             Ok(Some(resolved)) => mappings.push(resolved),
             Ok(None) => {} // no tags after filtering, logged inside
             Err(err) => return Err(err),
         }
     }
 
+    log_resolved_mappings(&mappings);
+
     if args.dry_run {
-        print_dry_run(&mappings);
+        crate::cli::commands::dry_run::print(&mappings, verbose);
         return Ok(ExitCode::Success);
     }
 
@@ -280,6 +283,7 @@ pub(crate) async fn resolve_mapping(
     config: &Config,
     clients: &HashMap<String, Arc<RegistryClient>>,
     batch_checkers: &HashMap<String, Rc<dyn BatchBlobChecker>>,
+    with_report: bool,
 ) -> Result<Option<ResolvedMapping>, CliError> {
     // --- Source registry ---
     let source_name = mapping
@@ -349,14 +353,25 @@ pub(crate) async fn resolve_mapping(
     // enumerating all tags from the source registry. This avoids
     // hundreds of paginated tags/list requests for repos with thousands
     // of tags.
-    let filtered = if let Some(exact) = tags_config.and_then(|t| t.exact_tags()) {
-        exact
-    } else {
-        let all_tags = source_client.list_tags(&source_repo_path).await?;
-        let filter = build_filter(tags_config);
-        let tag_refs: Vec<&str> = all_tags.iter().map(String::as_str).collect();
-        filter.apply(&tag_refs)?
-    };
+    let (filtered, candidates, filter_report) =
+        if let Some(exact) = tags_config.and_then(|t| t.exact_tags()) {
+            (exact, None, None)
+        } else {
+            let all_tags = source_client.list_tags(&source_repo_path).await?;
+            let candidates_count = all_tags.len();
+            let filter = build_filter(tags_config);
+            let tag_refs: Vec<&str> = all_tags.iter().map(String::as_str).collect();
+            if with_report {
+                // Dry-run path: do NOT enforce min_tags here. The report is the
+                // point of dry-run; failing here would suppress it. The user
+                // compares `kept` against their `min_tags:` setting themselves.
+                // Real-sync (`with_report = false`) below still enforces via apply().
+                let outcome = filter.apply_with_report(&tag_refs)?;
+                (outcome.kept, Some(candidates_count), Some(outcome.report))
+            } else {
+                (filter.apply(&tag_refs)?, Some(candidates_count), None)
+            }
+        };
 
     if filtered.is_empty() {
         tracing::warn!(
@@ -441,6 +456,8 @@ pub(crate) async fn resolve_mapping(
         head_first,
         immutable_glob,
         artifacts_config: Rc::new(artifacts),
+        candidates,
+        filter_report,
     }))
 }
 
@@ -470,29 +487,42 @@ fn glob_or_list_to_vec(g: Option<&GlobOrList>) -> Vec<String> {
     }
 }
 
-/// Print dry-run output showing what would be synced.
-fn print_dry_run(mappings: &[ResolvedMapping]) {
-    if mappings.is_empty() {
-        println!("dry-run: no mappings to sync");
-        return;
-    }
+/// Format one per-mapping plan line for `INFO`-level emission.
+///
+/// `{source} -> {target}: {kept} of {candidates} tags  =>  [t1, t2]` when
+/// candidates is known, or `{kept} tags` on the exact-tag fast path.
+fn format_plan_line(
+    source_repo: &str,
+    target_repo: &str,
+    kept: usize,
+    candidates: Option<usize>,
+    target_names: &[&str],
+) -> String {
+    let count_phrase = match candidates {
+        Some(n) => format!("{kept} of {n} tags"),
+        None => format!("{kept} tags"),
+    };
+    format!(
+        "{source_repo} -> {target_repo}: {count_phrase}  =>  [{}]",
+        target_names.join(", ")
+    )
+}
 
-    for mapping in mappings {
-        let target_names: Vec<&str> = mapping.targets.iter().map(|t| &*t.name).collect();
-        println!(
-            "dry-run: {} -> {} ({} tag(s)) => [{}]",
-            mapping.source_repo,
-            mapping.target_repo,
-            mapping.tags.len(),
-            target_names.join(", "),
+/// Emit one INFO log line per resolved mapping summarizing kept/considered
+/// tag counts and target list.
+fn log_resolved_mappings(mappings: &[ResolvedMapping]) {
+    for m in mappings {
+        let target_names: Vec<&str> = m.targets.iter().map(|t| &*t.name).collect();
+        tracing::info!(
+            "{}",
+            format_plan_line(
+                m.source_repo.as_str(),
+                m.target_repo.as_str(),
+                m.tags.len(),
+                m.candidates,
+                &target_names,
+            )
         );
-        for tag_pair in &mapping.tags {
-            if tag_pair.source == tag_pair.target {
-                println!("  {}", tag_pair.source);
-            } else {
-                println!("  {} -> {}", tag_pair.source, tag_pair.target);
-            }
-        }
     }
 }
 
@@ -766,5 +796,35 @@ latest: 5
     fn parse_size_trims_whitespace() {
         assert_eq!(parse_size("  500MB  "), Some(500_000_000));
         assert_eq!(parse_size(" 2GB "), Some(2_000_000_000));
+    }
+
+    #[test]
+    fn format_plan_line_filtered_path_includes_of_n() {
+        let line = format_plan_line(
+            "docker.io/library/alpine",
+            "alpine",
+            3,
+            Some(50),
+            &["ecr-prod", "ghcr-mirror"],
+        );
+        assert_eq!(
+            line,
+            "docker.io/library/alpine -> alpine: 3 of 50 tags  =>  [ecr-prod, ghcr-mirror]"
+        );
+    }
+
+    #[test]
+    fn format_plan_line_exact_tag_path_omits_of_n() {
+        let line = format_plan_line("ghcr.io/foo/bar", "bar", 3, None, &["ghcr-mirror"]);
+        assert_eq!(line, "ghcr.io/foo/bar -> bar: 3 tags  =>  [ghcr-mirror]");
+    }
+
+    #[test]
+    fn format_plan_line_single_target() {
+        let line = format_plan_line("src/repo", "dst/repo", 5, Some(80), &["only-target"]);
+        assert_eq!(
+            line,
+            "src/repo -> dst/repo: 5 of 80 tags  =>  [only-target]"
+        );
     }
 }

--- a/src/cli/commands/watch.rs
+++ b/src/cli/commands/watch.rs
@@ -20,6 +20,7 @@ pub(crate) async fn run(
     args: &WatchArgs,
     progress: &dyn ocync_sync::progress::ProgressReporter,
     shutdown: ShutdownSignal,
+    verbose: bool,
 ) -> Result<ExitCode, CliError> {
     let interval = Duration::from_secs(args.interval);
     tracing::info!(interval_secs = args.interval, "starting watch mode");
@@ -143,6 +144,7 @@ pub(crate) async fn run(
                     progress,
                     Some(&shutdown),
                     Some(Rc::clone(&cache)),
+                    verbose,
                 )
                 .await
                 {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -344,14 +344,13 @@ pub(crate) async fn build_registry_client(
 // Logging setup
 // ---------------------------------------------------------------------------
 
-/// Initialize the tracing subscriber based on CLI flags and environment.
+/// Initialize the tracing subscriber based on CLI flags.
 ///
-/// Priority: `RUST_LOG` env var > CLI flags > auto-detection (Kubernetes → JSON).
-/// Sensitive HTTP transport crates are capped at `warn` to prevent credential
-/// leakage in request/response headers at trace level.
+/// Priority: `RUST_LOG` env var > `--log-format` > text default. Sensitive
+/// HTTP transport crates are capped at `warn` to prevent credential leakage
+/// in request/response headers at trace level.
 pub(crate) fn setup_logging(cli: &Cli) {
-    let detected = detect_log_format();
-    let format = cli.log_format.or(detected).unwrap_or(LogFormat::Text);
+    let format = cli.log_format.unwrap_or(LogFormat::Text);
 
     let filter = verbosity_filter(cli.quiet, cli.verbose);
 
@@ -393,18 +392,6 @@ fn verbosity_filter(quiet: bool, verbose: u8) -> &'static str {
     }
 }
 
-/// Auto-detect log format from the environment.
-///
-/// Returns `Some(LogFormat::Json)` when running inside Kubernetes
-/// (detected via `KUBERNETES_SERVICE_HOST`).
-fn detect_log_format() -> Option<LogFormat> {
-    if std::env::var("KUBERNETES_SERVICE_HOST").is_ok() {
-        Some(LogFormat::Json)
-    } else {
-        None
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -429,18 +416,6 @@ mod tests {
     fn verbosity_two_plus_is_trace() {
         assert_eq!(verbosity_filter(false, 2), "trace");
         assert_eq!(verbosity_filter(false, 3), "trace");
-    }
-
-    #[test]
-    fn detect_log_format_no_kubernetes() {
-        let original = std::env::var("KUBERNETES_SERVICE_HOST").ok();
-        // SAFETY: test is single-threaded and restores the original value.
-        unsafe { std::env::remove_var("KUBERNETES_SERVICE_HOST") };
-        assert!(detect_log_format().is_none());
-        if let Some(val) = original {
-            // SAFETY: restoring original value.
-            unsafe { std::env::set_var("KUBERNETES_SERVICE_HOST", val) };
-        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ pub(crate) struct Cli {
     #[arg(short, long, global = true, help_heading = "Global options")]
     pub(crate) quiet: bool,
 
-    /// Set the log output format (auto-detected in Kubernetes).
+    /// Set the log output format. Defaults to `text`.
     #[arg(long, global = true, value_enum, help_heading = "Global options")]
     pub(crate) log_format: Option<LogFormat>,
 }
@@ -338,9 +338,13 @@ async fn main() -> std::process::ExitCode {
         ))
     };
 
+    // Dry-run / log-emission verbose toggle: any -v level removes the sample
+    // cap. Distinct from `effective_verbosity` above which drives progress
+    // detail level.
+    let verbose = cli.verbose >= 1;
     let result = match cli.command {
         Commands::Sync(args) => {
-            cli::commands::synchronize::run(&args, &*progress, Some(&shutdown), None).await
+            cli::commands::synchronize::run(&args, &*progress, Some(&shutdown), None, verbose).await
         }
         Commands::Copy(args) => cli::commands::copy::run(&args, &*progress, Some(&shutdown)).await,
         Commands::Tags(args) => cli::commands::tags::run(&args).await,
@@ -350,7 +354,7 @@ async fn main() -> std::process::ExitCode {
         Commands::Validate(args) => cli::commands::validate::run(&args),
         Commands::Expand(args) => cli::commands::expand::run(&args),
         Commands::Watch(args) => {
-            cli::commands::watch::run(&args, &*progress, shutdown.clone()).await
+            cli::commands::watch::run(&args, &*progress, shutdown.clone(), verbose).await
         }
         Commands::Analyze(args) => cli::commands::analyze::run(&args, &shutdown).await,
         Commands::Version => Ok(cli::commands::version::run()),


### PR DESCRIPTION
## Summary

- Each resolved mapping emits one INFO line per sync run: `{source} -> {target}: {kept} of {N} tags  =>  [t1, t2]`. Operators see at a glance which tags survived filtering and where they're going.
- `--dry-run` now renders the full filter trace per mapping: `source candidates`, `include path` (rescued tag names with sample cap), `pipeline` stages with attrition, `kept` tags (with `[via include]` markers on rescued tags), `dropped` Pareto-sorted by reason with samples, and `min_tags` status. When `min_tags` is configured but unsatisfied, the formatter prints `(kept M, real sync will FAIL with BelowMinTags)` so the configuration can be fixed before running. `-v` removes the per-reason sample cap.
- Default log format is now `text` everywhere (was JSON-by-default in Kubernetes via `KUBERNETES_SERVICE_HOST` auto-detection). The chart's `logging.format` value (default `text`) drives `--log-format`, and a new `templates/NOTES.txt` shows a one-time upgrade hint when the default is in use. Set `logging.format: json` to keep structured logs.
- Internal: filter pipeline gets `apply_with_report()` returning `Filtered { kept, report }`. The report carries `candidate_count`, `include_kept` (rescued tag names), pipeline stages, Pareto-sorted drop reasons, and `min_tags`. Hot-path `apply()` skips drop attribution to avoid per-cycle allocations on the watch loop. `partition_with_drop` and `push_drop_reason` helpers consolidate the per-stage single-pass tracking.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (1333 passed)
- [x] `cargo deny check`
- [x] `npm run --prefix docs build`
- [x] `helm unittest charts/ocync` (63 tests passed)
- [x] `helm install --dry-run` confirms `NOTES.txt` renders with the upgrade hint when `logging.format=text` and suppresses it when `logging.format=json`
- [x] New filter.rs tests cover the kept+dropped invariant, include rescue by name, `min_tags` round-trip (configured/satisfied/absent), and the single-pass attribution invariant
- [x] New synchronize.rs E2E tests exercise the full path through `select_filtered_tags` -> `ResolvedMapping` -> `dry_run::write_to`, catching wire-up regressions
- [x] New dry_run.rs tests cover `min_tags` status (satisfied / FAIL / absent / blank-separator), include-rescue rendering and verbose-uncap, and the full mapping render with both `[via include]` markers and the FAIL warning