### PR TITLE
ci(release): publish homebrew formula on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,3 +246,87 @@ jobs:
           files: |
             artifacts/ocync-*
             artifacts/sha256sums.txt
+
+  homebrew:
+    name: Homebrew tap
+    runs-on: ubuntu-24.04
+    needs: release
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: clowdhaus/homebrew-taps
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      - name: Extract version
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Download checksums from release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: gh release download "$TAG" --repo "$REPO" --pattern sha256sums.txt
+      - name: Render formula
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          set -euo pipefail
+          macos_arm=$(awk '$2 == "ocync-macos-arm64" { print $1 }' sha256sums.txt)
+          linux_amd64=$(awk '$2 == "ocync-fips-linux-amd64" { print $1 }' sha256sums.txt)
+          linux_arm64=$(awk '$2 == "ocync-fips-linux-arm64" { print $1 }' sha256sums.txt)
+          for sha in "$macos_arm" "$linux_amd64" "$linux_arm64"; do
+            [ -n "$sha" ] || { echo "missing sha in sha256sums.txt" >&2; exit 1; }
+          done
+          cat > Formula/ocync.rb <<EOF
+          class Ocync < Formula
+            desc "OCI registry sync tool"
+            homepage "https://github.com/clowdhaus/ocync"
+            version "${VERSION}"
+            license "Apache-2.0"
+
+            if OS.mac? && Hardware::CPU.arm?
+              url "https://github.com/clowdhaus/ocync/releases/download/v#{version}/ocync-macos-arm64"
+              sha256 "${macos_arm}"
+            end
+
+            if OS.linux? && Hardware::CPU.intel?
+              url "https://github.com/clowdhaus/ocync/releases/download/v#{version}/ocync-fips-linux-amd64"
+              sha256 "${linux_amd64}"
+            end
+
+            if OS.linux? && Hardware::CPU.arm?
+              url "https://github.com/clowdhaus/ocync/releases/download/v#{version}/ocync-fips-linux-arm64"
+              sha256 "${linux_arm64}"
+            end
+
+            def install
+              if OS.mac? && Hardware::CPU.arm?
+                bin.install "ocync-macos-arm64" => "ocync"
+              elsif OS.linux? && Hardware::CPU.intel?
+                bin.install "ocync-fips-linux-amd64" => "ocync"
+              elsif OS.linux? && Hardware::CPU.arm?
+                bin.install "ocync-fips-linux-arm64" => "ocync"
+              end
+            end
+
+            def caveats
+              <<~CAVEATS
+                Linux builds use FIPS-validated AWS-LC.
+              CAVEATS
+            end
+          end
+          EOF
+          rm sha256sums.txt
+      - name: Commit and push
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/ocync.rb
+          if git diff --cached --quiet; then
+            echo "Formula unchanged, skipping commit"
+            exit 0
+          fi
+          git commit -m "ocync: ${VERSION}"
+          git push

--- a/README.md
+++ b/README.md
@@ -114,6 +114,17 @@ Linux binaries are statically linked with FIPS 140-3 validated cryptography.
 </details>
 
 <details>
+<summary>Homebrew</summary>
+
+```bash
+brew install clowdhaus/taps/ocync
+```
+
+macOS (arm64) and Linux (amd64, arm64). Linux builds use FIPS-validated AWS-LC.
+
+</details>
+
+<details>
 <summary>Docker</summary>
 
 ```bash

--- a/docs/src/content/getting-started.md
+++ b/docs/src/content/getting-started.md
@@ -19,6 +19,14 @@ Download from [GitHub Releases](https://github.com/clowdhaus/ocync/releases):
 
 Linux binaries are statically linked with FIPS 140-3 validated cryptography. macOS and Windows use aws-lc-rs without FIPS mode.
 
+### Homebrew
+
+```bash
+brew install clowdhaus/taps/ocync
+```
+
+macOS (arm64) and Linux (amd64, arm64). Linux builds use FIPS-validated AWS-LC.
+
 ### Docker
 
 ```bash


### PR DESCRIPTION
## Summary

- New `homebrew` job at the end of `release.yml`, gated on `release` succeeding.
- On `v*` tag push, downloads `sha256sums.txt` from the freshly-published GitHub Release, renders `Formula/ocync.rb`, commits and pushes it to `clowdhaus/homebrew-taps`.
- Adds Homebrew section to `README.md` install block and `docs/src/content/getting-started.md`.

Install becomes:

```bash
brew install clowdhaus/taps/ocync
```

## Setup required

Repo secret `HOMEBREW_TAP_TOKEN` (already configured) — fine-grained PAT scoped to `clowdhaus/homebrew-taps` with `Contents: read/write`. PAT expiry will silently fail the homebrew step on a future release without affecting the binary release itself.

## Design notes

- **Re-fetches `sha256sums.txt` from the GitHub Release** rather than re-uploading it as a workflow artifact. Proves the file actually shipped to the release before trusting its SHAs, and avoids editing the existing `release` job.
- **Raw-binary install** with platform-conditional `bin.install "filename" => "ocync"`. Other formulas in the tap (`eksup`, `cookiecluster`, `ktime`) use the tarball pattern via `update_sha256.sh`; ocync's release artifacts are raw binaries with `-fips` suffix on Linux and no macOS Intel build, so it gets a self-contained renderer in the workflow rather than extending that script.
- **Skips empty commits** via `git diff --cached --quiet` so re-tagging the same version is idempotent.
- **Caveats block** mentions Linux uses FIPS-validated AWS-LC since the `-fips` suffix in the URL is invisible to brew users.

## Coverage

| Platform | Source artifact | Formula handling |
|---|---|---|
| macOS arm64 | `ocync-macos-arm64` | yes |
| macOS Intel | (not built) | not supported |
| Linux amd64 | `ocync-fips-linux-amd64` | yes |
| Linux arm64 | `ocync-fips-linux-arm64` | yes |
| Windows | `ocync-windows-amd64.exe` | not applicable (Homebrew) |

## Test plan

- [ ] Cut a tag (or manually invoke release.yml on a test tag) and verify the homebrew job runs after `release` succeeds.
- [ ] Confirm `Formula/ocync.rb` lands on `clowdhaus/homebrew-taps:main` with correct version, SHAs, and URLs.
- [ ] `brew tap clowdhaus/taps && brew install ocync && ocync --version` on macOS arm64.
- [ ] `brew install clowdhaus/taps/ocync && ocync --version` on Linux (amd64 or arm64).
- [ ] Re-tag the same version and confirm the homebrew job exits cleanly without an empty commit.