### PR TITLE
fix(filter): glob include respects the pipeline

### DIFF
--- a/crates/ocync-sync/src/filter.rs
+++ b/crates/ocync-sync/src/filter.rs
@@ -200,10 +200,25 @@ impl FilterConfig {
         };
         let sys_exclude = system_exclude_set();
 
-        let include_kept_refs: Vec<&str> = if self.include.is_empty() {
+        // Partition include patterns by shape. Literals bypass the entire
+        // pipeline (union after). Globs rescue from `glob:` and the soft-tier
+        // excludes, then run through the rest of the pipeline.
+        let (include_literals, include_globs): (Vec<String>, Vec<String>) = self
+            .include
+            .iter()
+            .cloned()
+            .partition(|p| is_literal_pattern(p));
+
+        let include_glob_set = if include_globs.is_empty() {
+            None
+        } else {
+            Some(build_glob_set(&include_globs)?)
+        };
+
+        let include_kept_refs: Vec<&str> = if include_literals.is_empty() {
             Vec::new()
         } else {
-            let inc_set = build_glob_set(&self.include)?;
+            let inc_set = build_glob_set(&include_literals)?;
             tags.iter()
                 .copied()
                 .filter(|t| inc_set.is_match(t))
@@ -215,7 +230,9 @@ impl FilterConfig {
             tags.to_vec()
         } else {
             let glob_set = build_glob_set(&self.glob)?;
-            let (kept, dropped) = partition_with_drop(tags, track, |t| glob_set.is_match(t));
+            let (kept, dropped) = partition_with_drop(tags, track, |t| {
+                glob_set.is_match(t) || include_glob_set.as_ref().is_some_and(|s| s.is_match(t))
+            });
             push_drop_reason(
                 &mut drop_reasons,
                 track,
@@ -281,6 +298,8 @@ impl FilterConfig {
         let mut defaults_dropped: Vec<String> = Vec::new();
         let mut builtin_dropped: Vec<String> = Vec::new();
         pipeline.retain(|t| {
+            // Hard tier (mapping `exclude:`) always applies, including to
+            // include-glob matches. Most-specific user intent wins.
             if let Some(ref s) = user_exclude_set {
                 if s.is_match(t) {
                     if track {
@@ -289,19 +308,25 @@ impl FilterConfig {
                     return false;
                 }
             }
-            if let Some(ref s) = defaults_exclude_set {
-                if s.is_match(t) {
+            // Soft tier (defaults + built-in) is bypassed when a glob `include:`
+            // pattern matches. Literal `include:` matches never reach this path
+            // (they bypass the pipeline entirely via the literal union).
+            let rescued_from_soft_tier = include_glob_set.as_ref().is_some_and(|s| s.is_match(t));
+            if !rescued_from_soft_tier {
+                if let Some(ref s) = defaults_exclude_set {
+                    if s.is_match(t) {
+                        if track {
+                            defaults_dropped.push((*t).to_owned());
+                        }
+                        return false;
+                    }
+                }
+                if sys_exclude.is_match(t) {
                     if track {
-                        defaults_dropped.push((*t).to_owned());
+                        builtin_dropped.push((*t).to_owned());
                     }
                     return false;
                 }
-            }
-            if sys_exclude.is_match(t) {
-                if track {
-                    builtin_dropped.push((*t).to_owned());
-                }
-                return false;
             }
             true
         });
@@ -598,6 +623,12 @@ fn push_drop_reason(
 /// reintroducing a duplicate prefix check that would drift over time.
 pub fn is_referrers_fallback_tag(tag: &str) -> bool {
     tag.starts_with("sha256-") || tag.starts_with("sha512-")
+}
+
+/// Returns `true` when `pattern` contains no glob metacharacters
+/// (`*`, `?`, `[`).
+pub fn is_literal_pattern(pattern: &str) -> bool {
+    !pattern.contains(['*', '?', '['])
 }
 
 /// Build a [`GlobSet`] from patterns, returning an error on invalid patterns.
@@ -1310,6 +1341,198 @@ mod tests {
         assert_eq!(result, vec!["1.0.0".to_string()]);
     }
 
+    /// `include:` is glob-matched, not literal-matched: `include: ["*-dev"]`
+    /// rescues every `-dev` tag from a `defaults_exclude: ["*-dev"]` soft
+    /// tier. Companion to `include_overrides_defaults_exclude`, which only
+    /// covers the literal-include case.
+    #[test]
+    fn include_glob_rescues_all_matching_from_defaults_exclude() {
+        let tags = vec![
+            "latest",
+            "latest-dev",
+            "1.0.0",
+            "1.0.0-dev",
+            "2.0.0-dev",
+            "1.0.0-rc1", // built-in soft tier, not matched by `*-dev` include
+        ];
+        let config = FilterConfig {
+            include: vec!["*-dev".into()],
+            defaults_exclude: vec!["*-dev".into()],
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert!(result.contains(&"latest-dev".to_string()));
+        assert!(result.contains(&"1.0.0-dev".to_string()));
+        assert!(result.contains(&"2.0.0-dev".to_string()));
+        assert!(result.contains(&"latest".to_string()));
+        assert!(result.contains(&"1.0.0".to_string()));
+        assert!(
+            !result.contains(&"1.0.0-rc1".to_string()),
+            "soft-tier patterns the include glob does NOT match are still dropped"
+        );
+    }
+
+    /// Glob character classes work against real tag strings. `*-r[0-9]*`
+    /// drops Chainguard/Bitnami `-r<N>` build counters at any digit width.
+    /// Documents the recipe shape suggested in `configuration.md` for
+    /// suffixes deliberately absent from the built-in soft tier.
+    #[test]
+    fn defaults_exclude_character_class_drops_r_counters() {
+        let tags = vec![
+            "1.25.5",
+            "1.25.5-r0",
+            "1.25.5-r9",
+            "1.25.5-r10",
+            "1.25.5-r123",
+        ];
+        let config = FilterConfig {
+            defaults_exclude: vec!["*-r[0-9]*".into()],
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert_eq!(result, vec!["1.25.5".to_string()]);
+    }
+
+    /// Glob `include:` is constrained by the pipeline. Stable + dev tags share
+    /// one pipeline; `sort:` orders them together; `latest:` caps the union.
+    /// Same suffix-presence ordering as `version::TagVersion::compare`: empty
+    /// suffix wins, so `3.12.2` sorts before `3.12.2-dev` at the same prefix.
+    #[test]
+    fn include_glob_constrained_by_semver_sort_latest() {
+        let tags = vec![
+            "3.12.0",
+            "3.12.1",
+            "3.12.2",
+            "3.12.0-dev",
+            "3.12.1-dev",
+            "3.12.2-dev",
+            "3.12.0-r0",
+            "3.12.0-r10",
+        ];
+        let config = FilterConfig {
+            include: vec!["*-dev".into()],
+            defaults_exclude: vec!["*-dev".into(), "*-r[0-9]*".into()],
+            semver: Some(">=3.12.0".into()),
+            sort: Some(SortOrder::Semver),
+            latest: Some(2),
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        // Top 2 by semver desc with empty-suffix winning: 3.12.2 then 3.12.2-dev.
+        assert_eq!(result, vec!["3.12.2".to_string(), "3.12.2-dev".to_string()]);
+    }
+
+    /// Prescription 1: drop `*-dev` from `defaults_exclude` and let
+    /// `semver:` constrain the dev tags through the pipeline. The lenient
+    /// parser admits `8.5.0-dev` as prefix `[8,5,0]` (suffix opaque), so
+    /// the range `>=8.0.0, <9.0.0` keeps `8.5.0-dev` and rejects
+    /// `10.0.0-dev`. No `include:` involved.
+    #[test]
+    fn semver_constrains_dev_tags_when_not_in_defaults_exclude() {
+        let tags = vec!["8.0.0", "8.5.0", "8.5.0-dev", "10.0.0", "10.0.0-dev"];
+        let config = FilterConfig {
+            defaults_exclude: vec!["*-r[0-9]*".into()],
+            semver: Some(">=8.0.0, <9.0.0".into()),
+            sort: Some(SortOrder::Semver),
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert!(result.contains(&"8.0.0".to_string()));
+        assert!(result.contains(&"8.5.0".to_string()));
+        assert!(
+            result.contains(&"8.5.0-dev".to_string()),
+            "8.5.0-dev should pass: prefix [8,5,0] matches >=8.0.0, <9.0.0"
+        );
+        assert!(
+            !result.contains(&"10.0.0".to_string()),
+            "10.0.0 should be rejected by <9.0.0"
+        );
+        assert!(
+            !result.contains(&"10.0.0-dev".to_string()),
+            "10.0.0-dev should be rejected: prefix [10,0,0] fails <9.0.0"
+        );
+    }
+
+    /// `glob:` does NOT rescue from soft-tier excludes. The `glob:` stage
+    /// is upstream of the exclude stage; even when `glob:` admits a tag,
+    /// `defaults_exclude` drops it downstream. Only `include:` rescues
+    /// from soft tier (literal halves bypass the entire pipeline; glob
+    /// halves bypass `glob:` and soft tier and then run through the rest
+    /// of the pipeline).
+    #[test]
+    fn glob_does_not_rescue_dev_from_defaults_exclude() {
+        let tags = vec!["8.0.0", "8.5.0-dev", "10.0.0-dev"];
+        let config = FilterConfig {
+            defaults_exclude: vec!["*-dev".into()],
+            glob: vec!["*-dev".into()],
+            semver: Some(">=8.0.0, <9.0.0".into()),
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert!(
+            !result.contains(&"8.5.0-dev".to_string()),
+            "soft tier still drops -dev even when glob admits it"
+        );
+        assert!(
+            !result.contains(&"10.0.0-dev".to_string()),
+            "soft tier still drops -dev regardless of semver intent"
+        );
+        assert_eq!(
+            result,
+            Vec::<String>::new(),
+            "two-mapping pattern produces empty result, not a bounded -dev set"
+        );
+    }
+
+    /// End-to-end Chainguard-style mirror: stable releases + dev variants
+    /// both constrained to a semver range, with `-r<N>` build counters
+    /// always denied. The only working shape, per the surrounding tests:
+    /// `*-dev` is NOT in `defaults_exclude`, `semver:` does the work for
+    /// both stable and dev tags, and per-mapping hard-tier `exclude:` on
+    /// other mappings denies `-dev` where unwanted.
+    ///
+    /// This test models the dev-wanting mapping. The companion stable-only
+    /// mapping is covered by `defaults_and_mapping_exclude_stack` plus a
+    /// mapping-level `exclude: ["*-dev"]`.
+    #[test]
+    fn dev_constrained_by_semver_end_to_end() {
+        let tags = vec![
+            "8.0.0",
+            "8.5.0",
+            "8.9.9",
+            "8.5.0-dev",
+            "8.9.9-dev",
+            "9.0.0",
+            "9.0.0-dev",
+            "10.0.0",
+            "10.0.0-dev",
+            "8.5.0-r0",
+            "8.5.0-r12",
+        ];
+        let config = FilterConfig {
+            defaults_exclude: vec!["*-r[0-9]*".into()],
+            semver: Some(">=8.0.0, <9.0.0".into()),
+            sort: Some(SortOrder::Semver),
+            latest: Some(10),
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+
+        for t in ["8.0.0", "8.5.0", "8.9.9", "8.5.0-dev", "8.9.9-dev"] {
+            assert!(result.contains(&t.to_string()), "{t} should be kept");
+        }
+        for t in [
+            "9.0.0",
+            "9.0.0-dev",
+            "10.0.0",
+            "10.0.0-dev",
+            "8.5.0-r0",
+            "8.5.0-r12",
+        ] {
+            assert!(!result.contains(&t.to_string()), "{t} should be dropped");
+        }
+    }
+
     /// Dry-run attribution: defaults-tier drops surface as
     /// `DropKind::DefaultsExclude`, distinct from `MappingExclude` and
     /// `BuiltinExclude`. The formatter relies on the variant to render
@@ -1688,5 +1911,293 @@ mod tests {
         assert!(!is_referrers_fallback_tag("v1.0.0"));
         assert!(!is_referrers_fallback_tag("latest"));
         assert!(!is_referrers_fallback_tag("sha256")); // no dash
+    }
+
+    /// Glob `include:` rescues tags from the soft tier (built-in
+    /// `SYSTEM_EXCLUDE` plus `defaults_exclude`). Hard tier (`exclude:`) is
+    /// unchanged: it still blocks include.
+    #[test]
+    fn include_glob_rescues_from_soft_tier_only() {
+        let tags = vec!["1.0.0-rc1", "1.0.0-dev", "1.0.0-debug-dev"];
+        let config = FilterConfig {
+            // `*-rc*` is in built-in SYSTEM_EXCLUDE; `*-dev` we add as defaults.
+            defaults_exclude: vec!["*-dev".into()],
+            // Hard tier denies one specific dev variant.
+            exclude: vec!["*-debug-dev".into()],
+            include: vec!["*-rc*".into(), "*-dev".into()],
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert!(
+            result.contains(&"1.0.0-rc1".to_string()),
+            "rescued from built-in soft tier"
+        );
+        assert!(
+            result.contains(&"1.0.0-dev".to_string()),
+            "rescued from defaults soft tier"
+        );
+        assert!(
+            !result.contains(&"1.0.0-debug-dev".to_string()),
+            "hard tier still blocks include"
+        );
+    }
+
+    /// Glob `include:` rescues tags from the `glob:` positive filter. Without
+    /// this bypass, dev tags would be dropped at the `glob:` stage before
+    /// soft-tier exemption could apply.
+    #[test]
+    fn include_glob_rescues_from_glob_filter() {
+        let tags = vec!["1.0.0-alpine", "1.0.0-dev", "1.0.0"];
+        let config = FilterConfig {
+            glob: vec!["*-alpine".into()],
+            include: vec!["*-dev".into()],
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert!(result.contains(&"1.0.0-alpine".to_string()));
+        assert!(
+            result.contains(&"1.0.0-dev".to_string()),
+            "include glob bypasses the glob: positive filter"
+        );
+        assert!(
+            !result.contains(&"1.0.0".to_string()),
+            "tags matching neither glob nor include glob are dropped"
+        );
+    }
+
+    /// Partition is internal but observable through the apply path: a pure
+    /// literal include retains today's bypass-everything semantics, including
+    /// surviving a `semver:` filter that the literal does not parse against.
+    #[test]
+    fn literal_include_partition_bypasses_semver() {
+        let tags = vec!["latest", "1.0.0", "2.0.0"];
+        let config = FilterConfig {
+            include: vec!["latest".into()],
+            semver: Some(">=2.0.0".into()),
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert!(result.contains(&"latest".to_string()));
+        assert!(result.contains(&"2.0.0".to_string()));
+        assert!(!result.contains(&"1.0.0".to_string()));
+    }
+
+    /// Glob include constrained by semver: rescues tags from soft tier, then
+    /// drops them if `semver:` rejects. The case-6 fix in concrete form.
+    #[test]
+    fn include_glob_dropped_by_semver_when_out_of_range() {
+        let tags = vec!["8.5.0", "8.5.0-dev", "10.0.0", "10.0.0-dev"];
+        let config = FilterConfig {
+            defaults_exclude: vec!["*-dev".into()],
+            include: vec!["*-dev".into()],
+            semver: Some(">=8.0.0, <9.0.0".into()),
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert!(result.contains(&"8.5.0".to_string()));
+        assert!(result.contains(&"8.5.0-dev".to_string()));
+        assert!(!result.contains(&"10.0.0".to_string()));
+        assert!(
+            !result.contains(&"10.0.0-dev".to_string()),
+            "include glob is constrained by semver"
+        );
+    }
+
+    /// Mixed include: literal halves bypass everything, glob halves go
+    /// through the pipeline. The two halves union into the final result
+    /// and are handled independently from each other.
+    #[test]
+    fn mixed_include_handles_literals_and_globs_independently() {
+        let tags = vec!["latest", "8.5.0", "8.5.0-dev", "10.0.0-dev"];
+        let config = FilterConfig {
+            defaults_exclude: vec!["*-dev".into()],
+            include: vec!["latest".into(), "*-dev".into()],
+            semver: Some(">=8.0.0, <9.0.0".into()),
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert!(
+            result.contains(&"latest".to_string()),
+            "literal include bypasses semver"
+        );
+        assert!(result.contains(&"8.5.0".to_string()));
+        assert!(
+            result.contains(&"8.5.0-dev".to_string()),
+            "glob include rescued and admitted by semver"
+        );
+        assert!(
+            !result.contains(&"10.0.0-dev".to_string()),
+            "glob include rejected by semver"
+        );
+    }
+
+    /// Glob include matching a non-parseable tag is dropped at semver --
+    /// globs go through the pipeline, and the pipeline drops anything the
+    /// version parser cannot read. Companion test
+    /// `literal_include_pins_non_parseable_tag` shows how to keep such a
+    /// tag (promote to a literal).
+    #[test]
+    fn include_glob_drops_non_parseable_tag_at_semver() {
+        let tags = vec!["latest-dev", "8.5.0-dev"];
+        let config = FilterConfig {
+            defaults_exclude: vec!["*-dev".into()],
+            include: vec!["*-dev".into()],
+            semver: Some(">=2.0.0".into()),
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert!(
+            result.contains(&"8.5.0-dev".to_string()),
+            "parseable in-range tag survives"
+        );
+        assert!(
+            !result.contains(&"latest-dev".to_string()),
+            "non-parseable tag drops at semver even when matched by include glob"
+        );
+    }
+
+    /// Literal include pins a non-parseable tag through `semver:`. The
+    /// literal half of include bypasses the entire pipeline, so a tag
+    /// like `latest-dev` that the version parser cannot read still lands
+    /// in the result. Workaround for the case covered by
+    /// `include_glob_drops_non_parseable_tag_at_semver`.
+    #[test]
+    fn literal_include_pins_non_parseable_tag() {
+        let tags = vec!["latest-dev", "8.5.0-dev"];
+        let config = FilterConfig {
+            defaults_exclude: vec!["*-dev".into()],
+            include: vec!["latest-dev".into(), "*-dev".into()],
+            semver: Some(">=2.0.0".into()),
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert!(
+            result.contains(&"latest-dev".to_string()),
+            "literal include bypasses semver, pinning the non-parseable tag"
+        );
+        assert!(
+            result.contains(&"8.5.0-dev".to_string()),
+            "glob include still admits parseable in-range tags alongside the literal"
+        );
+    }
+
+    /// Literal include pins a parseable tag that `semver:` would otherwise
+    /// reject (out-of-range RC). Matches the recipe at
+    /// `recipes/semver-tracking.md` "To pin a specific RC alongside stable
+    /// releases" -- proves the literal-bypass contract for tags that DO
+    /// parse as semver but fail the range constraint.
+    #[test]
+    fn literal_include_pins_parseable_rc_against_semver_range() {
+        let tags = vec!["1.0.0-rc1", "2.5.0", "3.0.0"];
+        let config = FilterConfig {
+            include: vec!["1.0.0-rc1".into()],
+            semver: Some(">=2.0.0".into()),
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert!(
+            result.contains(&"1.0.0-rc1".to_string()),
+            "literal RC pinned via include bypasses the semver range"
+        );
+        assert!(result.contains(&"2.5.0".to_string()));
+        assert!(result.contains(&"3.0.0".to_string()));
+        // Sanity: with a glob include of the same RC pattern, the bypass is
+        // gone and the RC drops at semver.
+        let glob_config = FilterConfig {
+            include: vec!["1.0.0-*".into()],
+            semver: Some(">=2.0.0".into()),
+            ..FilterConfig::default()
+        };
+        let glob_result = glob_config.apply(&tags).unwrap();
+        assert!(
+            !glob_result.contains(&"1.0.0-rc1".to_string()),
+            "glob include runs through semver; the RC drops"
+        );
+    }
+
+    /// Glob include for prerelease patterns + `semver:` keeps in-range
+    /// prereleases and drops out-of-range ones. Matches the corrected
+    /// prose in `recipes/semver-tracking.md` ("opt back into prereleases
+    /// for in-range versions") -- the docs claim that out-of-range
+    /// prereleases drop. This test pins that claim.
+    #[test]
+    fn include_glob_drops_out_of_range_prereleases_through_semver() {
+        let tags = vec![
+            "1.5.0-rc1", // below range, even though include pattern matches
+            "2.0.0-rc1", // in range, in pattern -> kept
+            "2.5.0-alpha1",
+            "2.5.0",
+            "1.5.0",
+        ];
+        let config = FilterConfig {
+            include: vec![
+                "*-rc*".into(),
+                "*-alpha*".into(),
+                "*-beta*".into(),
+                "*-pre*".into(),
+                "*-snapshot*".into(),
+                "*-nightly*".into(),
+            ],
+            semver: Some(">=2.0".into()),
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert!(
+            result.contains(&"2.0.0-rc1".to_string()),
+            "in-range RC rescued from built-in soft tier and admitted by semver"
+        );
+        assert!(
+            result.contains(&"2.5.0-alpha1".to_string()),
+            "in-range alpha rescued and admitted"
+        );
+        assert!(result.contains(&"2.5.0".to_string()));
+        assert!(
+            !result.contains(&"1.5.0-rc1".to_string()),
+            "out-of-range RC rescued from built-in soft tier but dropped by semver"
+        );
+        assert!(
+            !result.contains(&"1.5.0".to_string()),
+            "out-of-range stable still drops as usual"
+        );
+    }
+
+    /// Empty `include:` produces no rescue and no literal union. Regression
+    /// coverage for the partition logic returning empty halves.
+    #[test]
+    fn empty_include_behaves_like_no_include() {
+        let tags = vec!["1.0.0", "1.0.0-dev"];
+        let config = FilterConfig {
+            defaults_exclude: vec!["*-dev".into()],
+            include: vec![],
+            ..FilterConfig::default()
+        };
+        let result = config.apply(&tags).unwrap();
+        assert_eq!(result, vec!["1.0.0".to_string()]);
+    }
+
+    // - is_literal_pattern ------------------------------------------------
+
+    #[test]
+    fn is_literal_pattern_detects_literals() {
+        assert!(is_literal_pattern("latest"));
+        assert!(is_literal_pattern("1.25.5"));
+        assert!(is_literal_pattern("latest-dev"));
+        assert!(is_literal_pattern("v1.2.3-rc1"));
+    }
+
+    #[test]
+    fn is_literal_pattern_detects_globs() {
+        assert!(!is_literal_pattern("*-dev"));
+        assert!(!is_literal_pattern("v?.*.*"));
+        assert!(!is_literal_pattern("*-r[0-9]*"));
+        assert!(!is_literal_pattern("foo[abc]bar"));
+    }
+
+    #[test]
+    fn is_literal_pattern_empty_is_literal() {
+        // Empty string has no glob metacharacters; treat as literal.
+        // The pipeline will never see this in practice (parser rejects empty),
+        // but pin down the contract for future edits.
+        assert!(is_literal_pattern(""));
     }
 }

--- a/docs/public/config.schema.json
+++ b/docs/public/config.schema.json
@@ -488,7 +488,7 @@
           ]
         },
         "include": {
-          "description": "Always-include glob patterns. Tags matching any pattern survive `glob:`/`semver:` filters and the system-exclude defaults. Same syntax as `exclude:`. Not subject to `sort:` or `latest:` truncation.",
+          "description": "Always-include patterns. Behavior depends on pattern shape: literals (no `*`, `?`, `[`) bypass the entire pipeline and are kept verbatim (use to pin floating tags like `latest` or specific RCs). Globs rescue matching tags from `glob:` and the soft-tier excludes (built-in defaults + `defaults.tags.exclude:`), then run through `semver:`, hard `exclude:`, `sort:`, and `latest:` like any other pipeline tag. Same syntax as `exclude:`.",
           "default": null,
           "anyOf": [
             {

--- a/docs/src/content/cli-reference.md
+++ b/docs/src/content/cli-reference.md
@@ -49,7 +49,7 @@ ocync sync -c config.yaml --json
 `--dry-run` runs the full filter pipeline against each mapping's source tags and prints, per mapping:
 
 - **`source tags: N`** -- the number of tags fetched from the source.
-- **`include path:`** -- tags rescued via `include:` (bypasses `glob:`/`semver:` and the system-exclude defaults). Default cap is 5 names; `-v` removes the cap.
+- **`include path:`** -- exact tag names from `include:` synced without going through the rest of the pipeline. Glob patterns in `include:` (like `*-dev`) flow through the regular pipeline and show up in the rows below, not here. Default cap is 5 names; `-v` removes the cap.
 - **`filter:`** -- per-stage attrition (`glob`, `semver`, `exclude`, `sort`, `keep latest`). Each row shows count_in -> count_out and the drop count.
 - **`kept (N):`** -- the final tags. When `include:` is used, rescued tags are listed first and tagged `[via include]` so the rescue path is visible.
 - **`dropped (N):`** -- Pareto-sorted drop attribution (largest cause first), with sample tag names per reason. Default cap is 5 names per reason; `-v` removes the cap.

--- a/docs/src/content/configuration.md
+++ b/docs/src/content/configuration.md
@@ -269,7 +269,7 @@ Tags are filtered through a pipeline:
 2. **exclude**: remove tags matching any of three exclude tiers -- mapping `exclude:` (hard, blocks `include:`), `defaults.tags.exclude:` (soft, bypassable by `include:`), or the built-in prerelease list (soft, bypassable by `include:`)
 3. **sort**: order the pool (`semver` or `alpha`)
 4. **latest**: keep only the N most recent of the pool
-5. **include**: union always-include tag matches into the result (not subject to `glob`, `semver`, default-excludes, `sort`, or `latest`); still subject to user `exclude`
+5. **include**: pattern-shape dispatch. Literals union into the result after the pipeline (not subject to `glob`, `semver`, default-excludes, `sort`, or `latest`; still subject to user `exclude`). Globs are rescued from `glob:` and the soft tier upstream and flow through the rest of the pipeline like any other tag; they ARE subject to `semver:`, mapping `exclude:`, `sort:`, and `latest:`.
 6. **min_tags**: validate the final union has at least N tags (error if fewer)
 
 All filters are optional. Without any filters, all tags are synced.
@@ -277,7 +277,7 @@ All filters are optional. Without any filters, all tags are synced.
 | Field | Type | Description |
 |---|---|---|
 | `glob` | string or list | Include tags matching glob pattern(s). A single string or a list of patterns |
-| `include` | string or list | Always-include glob pattern(s). Tags matching any pattern survive `glob:`/`semver:` filters and the soft exclude tier (built-in defaults + `defaults.tags.exclude:`). Subject to mapping `exclude:` (hard tier). Same syntax as `exclude:` |
+| `include` | string or list | Always-include pattern(s). Behavior depends on pattern shape: **literals** (no `*`, `?`, `[`) bypass the entire pipeline and are kept verbatim. **Globs** rescue matching tags from `glob:` and the soft exclude tier (built-in defaults + `defaults.tags.exclude:`), then run through `semver:`, hard `exclude:`, `sort:`, and `latest:` like any other pipeline tag. Same syntax as `exclude:` |
 | `semver` | string | Include tags satisfying a version range. Operators: `>=`, `<=`, `>`, `<`, `=`. Comma-joined for AND-narrowing. Example: `">=1.0, <2.0"` |
 | `exclude` | string or list | Remove tags matching these glob pattern(s) |
 | `sort` | string | Sort order for remaining tags: `semver` or `alpha` |
@@ -298,6 +298,20 @@ All filters are optional. Without any filters, all tags are synced.
 - `mapping.tags.exclude:` is the **hard tier**. It applies only to that mapping and is NOT overridden by `include:` on the same mapping. Use this for absolute per-mapping denies.
 
 Both tiers apply (concat). To rescue a tag the soft tier would drop on a specific mapping, add the tag to that mapping's `include:`.
+
+```yaml
+defaults:
+  tags:
+    exclude: ["*-rc*", "*-alpha*"]   # applies to every mapping
+
+mappings:
+  - from: my-org/auth-service
+    to: auth-service
+    tags:
+      exclude: ["*-debug"]           # also applies on this mapping
+```
+
+All four patterns drop on `auth-service`. An `include:` on this mapping could rescue `*-rc*` or `*-alpha*` (the project-wide list) but not `*-debug` (the per-mapping list).
 
 > **Behavior change.** Earlier versions replaced the whole `tags:` block when a mapping defined its own, so `defaults.tags.exclude:` was silently dropped for mappings with any per-mapping tag config. It now always applies (as the soft tier). If you were relying on `defaults.tags.exclude:` blocking an `include:` somewhere, switch that pattern to `mapping.tags.exclude:` (the hard tier, which still blocks `include:` on the same mapping).
 
@@ -320,6 +334,37 @@ Patterns deliberately NOT in the built-in list (still admitted unless your `defa
 - `-r<N>` -- Chainguard/Bitnami build counters
 
 To opt back into prereleases, add them to `include:` (which overrides the built-in list and `defaults.tags.exclude:`). To pin a single prerelease tag for testing, add the exact tag string to `include:`. To add project-wide exclude patterns, use `defaults.tags.exclude:`. To deny a tag absolutely on one mapping, use `mapping.tags.exclude:`.
+
+### Include patterns
+
+`include:` accepts exact tag names and glob patterns. The two behave differently.
+
+An exact name (no `*`, `?`, or `[`) always syncs, regardless of `glob:`, `semver:`, `sort:`, `latest:`, or any exclude. Use this to pin floating tags like `latest` and `latest-dev` that are not valid version numbers and would otherwise be skipped:
+
+```yaml
+tags:
+  include: ["latest", "latest-dev"]
+  semver: ">=2.0"
+```
+
+A glob pattern (with `*`, `?`, or `[`) acts as an opt-in that overrides `glob:` and the project-wide excludes. Tags matching the pattern still go through `semver:`, the per-mapping `exclude:`, `sort:`, and `latest:`. Use this to add a family of tags without giving up the version range:
+
+```yaml
+defaults:
+  tags:
+    exclude: ["*-dev", "*-r[0-9]*"]
+
+mappings:
+  - from: chainguard/python
+    to: python
+    tags:
+      semver: ">=3.12, <3.13"
+      include: ["latest", "latest-dev", "*-dev"]
+      sort: semver
+      latest: 10
+```
+
+On this mapping, `latest` and `latest-dev` always sync. Stable releases in the 3.12 line sync (`3.12.5`, `3.12.6`), and so do their dev variants (`3.12.5-dev`, `3.12.6-dev`). A `3.13.0-dev` drops because the version range rejects it. A `3.12.5-r3` drops because nothing in `include:` matches it.
 
 ## Environment variables
 

--- a/docs/src/content/observability.md
+++ b/docs/src/content/observability.md
@@ -67,7 +67,7 @@ Control verbosity with `-v` flags:
 | Trace | `-vv` | HTTP requests, detailed internals |
 | Error | `-q` / `--quiet` | Errors only |
 
-`-v` also uncaps the per-reason sample list in `--dry-run` output (default cap: 5 tags per drop reason and per include rescue).
+`-v` also uncaps the per-reason sample list in `--dry-run` output (default cap: 5 tags per drop reason and 5 names in the literal include path).
 
 ### Log format
 

--- a/docs/src/content/recipes/pin-literals-only.md
+++ b/docs/src/content/recipes/pin-literals-only.md
@@ -67,11 +67,11 @@ defaults:
 
 ## When to use `glob:` vs `include:`
 
-`glob:` is the *filter* mechanism: it narrows the candidate pool. Use it when you want only specific tags, with no `semver:` range driving the pipeline.
+`glob:` filters: it narrows the candidate pool. Use it when you want specific tags and no `semver:` range.
 
-`include:` is the *augment* mechanism: it always-adds tags alongside a `semver:`-driven pipeline. Use it when you want literal pins (`latest`, `latest-dev`) plus a version range in the same mapping.
+`include:` adds tags on top of whatever the rest of the pipeline produces. Exact names always sync -- use these to pin floats like `latest` or `latest-dev`. Glob patterns add a tag family while still respecting `semver:`, `sort:`, and `latest:` -- use these for paired variants like `*-dev`.
 
-For pin-only use cases (this recipe), `glob:` is the right field. For pin-plus-range, see [semver tracking](/recipes/semver-tracking).
+For pin-only use cases (this recipe), `glob:` is the right field. For pin-plus-range, see [semver tracking](/recipes/semver-tracking). For paired-variant mirrors, see [build + runtime variants](/recipes/semver-tracking#build--runtime-variants).
 
 ## Related
 

--- a/docs/src/content/recipes/semver-tracking.md
+++ b/docs/src/content/recipes/semver-tracking.md
@@ -61,7 +61,7 @@ tags:
   latest: 10
 ```
 
-To opt back into all prereleases, add the patterns to `include:` (which overrides the system default):
+To opt back into prereleases for in-range versions, add the patterns to `include:`. As glob patterns, they rescue tags from the system default and then run through `semver:` like any other pipeline tag, so prereleases below the range still drop:
 
 ```yaml
 tags:
@@ -71,7 +71,7 @@ tags:
   latest: 10
 ```
 
-To pin a specific RC alongside stable releases:
+To pin a specific RC alongside stable releases, write the exact tag as a literal in `include:`. Literal patterns bypass the pipeline entirely, so the literal is kept even if it would be rejected by `semver:`:
 
 ```yaml
 tags:
@@ -90,6 +90,27 @@ tags:
   sort: semver
   latest: 10
 ```
+
+### Build + runtime variants
+
+Some images publish a build variant alongside each release -- for example `3.12.5` and `3.12.5-dev`. To mirror both within a version range, add `include: ["*-dev"]` to the mapping:
+
+```yaml
+defaults:
+  tags:
+    exclude: ["*-dev", "*-r[0-9]*"]
+
+mappings:
+  - from: chainguard/python
+    to: python
+    tags:
+      semver: ">=3.12, <3.13"
+      include: ["*-dev"]
+      sort: semver
+      latest: 10
+```
+
+The `*-dev` glob overrides the project-wide deny, but the version range still applies, so 3.12 dev tags sync and 3.13 dev tags drop. `latest: 10` counts stable and dev tags together. Mappings without their own `include:` inherit the deny and stay stable-only.
 
 ## Related
 

--- a/docs/src/content/registries/chainguard.md
+++ b/docs/src/content/registries/chainguard.md
@@ -89,6 +89,56 @@ ocync copy \
   ghcr.io/myorg/python:3.12
 ```
 
+## Tag filtering
+
+The Chainguard catalog publishes `-dev` build variants and `-rN` build counters alongside stable releases. ocync treats these as stable artifacts, not prereleases like `-rc1`, so a default Chainguard mirror syncs every variant. Two patterns cover the common cases.
+
+### Stable releases only
+
+Deny `*-dev` and `*-rN` once at the top level. Every mapping inherits without extra config:
+
+```yaml
+defaults:
+  source: cgr
+  targets: ecr
+  tags:
+    exclude: ["*-dev", "*-r[0-9]*"]
+    sort: semver
+    latest: 10
+
+mappings:
+  - from: chainguard/static
+    to: static
+  - from: chainguard/nginx
+    to: nginx
+```
+
+### Build + runtime on one mapping
+
+For SDK and language images where you need both the runtime tag (`3.12.5`) and the build layer (`3.12.5-dev`), add an `include:` on just that mapping:
+
+```yaml
+defaults:
+  tags:
+    exclude: ["*-dev", "*-r[0-9]*"]
+    sort: semver
+    latest: 10
+
+mappings:
+  - from: chainguard/python
+    to: python
+    tags:
+      semver: ">=3.12, <3.13"
+      include: ["latest", "latest-dev", "*-dev"]
+
+  - from: chainguard/static
+    to: static                          # stable only
+```
+
+The `*-dev` glob brings dev tags back through the version filter, so 3.12 dev tags sync and 3.13 ones drop. `latest` and `latest-dev` always sync because they are not version numbers and would be skipped otherwise.
+
+See [include patterns](/configuration#include-patterns) and [build + runtime variants](/recipes/semver-tracking#build--runtime-variants).
+
 ## Kubernetes deployment
 
 The recommended K8s path is the same `auth_type: basic` flow as CI, with the pull-token's username/password injected via `envFrom`:

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -1494,6 +1494,93 @@ exclude: ["*-slim"]
         assert_eq!(kept, vec!["1.27".to_string()]);
     }
 
+    /// End-to-end YAML proof of the build+runtime case: project-wide
+    /// `defaults.tags.exclude` denies `*-dev` and `*-r[0-9]*`; one mapping
+    /// uses a glob `include:` to rescue `-dev` for a bounded semver range.
+    /// Catches regressions in either the filter pipeline or the merge layer.
+    #[test]
+    fn merge_glob_include_with_semver_yaml_e2e() {
+        let defaults_yaml = r#"
+exclude: ["*-dev", "*-r[0-9]*"]
+sort: semver
+latest: 10
+"#;
+        let mapping_yaml = r#"
+semver: ">=8.0.0, <9.0.0"
+include: ["*-dev"]
+"#;
+        let defaults: TagsConfig =
+            serde_yaml::from_str(defaults_yaml).expect("defaults yaml parses");
+        let mapping: TagsConfig = serde_yaml::from_str(mapping_yaml).expect("mapping yaml parses");
+
+        let filter = build_filter(Some(&mapping), Some(&defaults));
+
+        // Mapping include reaches the FilterConfig; defaults exclude lands
+        // in the soft tier; semver/sort/latest inherit from defaults.
+        assert_eq!(filter.include, vec!["*-dev"]);
+        assert_eq!(filter.defaults_exclude, vec!["*-dev", "*-r[0-9]*"]);
+        assert_eq!(filter.semver.as_deref(), Some(">=8.0.0, <9.0.0"));
+        assert_eq!(filter.latest, Some(10));
+
+        let tags = vec![
+            "8.0.0",
+            "8.5.0",
+            "8.5.0-dev",  // rescued by include glob, in semver range -> kept
+            "8.5.0-r3",   // not in include; soft tier drops -> dropped
+            "10.0.0",     // out of semver range -> dropped
+            "10.0.0-dev", // rescued by include glob, but out of semver -> dropped
+            "7.0.0",      // below semver -> dropped
+        ];
+        let kept = filter.apply(&tags).expect("filter applies");
+        assert!(kept.contains(&"8.0.0".to_string()));
+        assert!(kept.contains(&"8.5.0".to_string()));
+        assert!(
+            kept.contains(&"8.5.0-dev".to_string()),
+            "in-range -dev rescued from soft tier and admitted by semver"
+        );
+        assert!(
+            !kept.contains(&"8.5.0-r3".to_string()),
+            "-r counter still dropped by defaults soft tier"
+        );
+        assert!(
+            !kept.contains(&"10.0.0-dev".to_string()),
+            "out-of-range -dev rescued but dropped by semver"
+        );
+        assert!(!kept.contains(&"10.0.0".to_string()));
+        assert!(!kept.contains(&"7.0.0".to_string()));
+    }
+
+    /// Per-mapping `include:` REPLACES `defaults.tags.include`, not concat.
+    /// The merge resolution at `build_filter` picks the mapping value if
+    /// set, else falls through to defaults. This pins the field-replace
+    /// semantics so a future regression cannot quietly stack the lists.
+    #[test]
+    fn merge_mapping_include_replaces_defaults_include() {
+        let defaults_yaml = r#"
+include: ["latest", "latest-dev"]
+"#;
+        let mapping_yaml = r#"
+include: ["1.25.0-rc1"]
+"#;
+        let defaults: TagsConfig =
+            serde_yaml::from_str(defaults_yaml).expect("defaults yaml parses");
+        let mapping: TagsConfig = serde_yaml::from_str(mapping_yaml).expect("mapping yaml parses");
+
+        let filter_inherited = build_filter(None, Some(&defaults));
+        assert_eq!(
+            filter_inherited.include,
+            vec!["latest", "latest-dev"],
+            "no mapping -> defaults include flows through"
+        );
+
+        let filter_overridden = build_filter(Some(&mapping), Some(&defaults));
+        assert_eq!(
+            filter_overridden.include,
+            vec!["1.25.0-rc1"],
+            "mapping include replaces defaults include; the two are NOT concat"
+        );
+    }
+
     #[test]
     fn glob_or_list_to_vec_owned_single() {
         let g = GlobOrList::Single("pattern".into());

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -409,9 +409,13 @@ pub(crate) struct TagsConfig {
     #[serde(default)]
     pub semver: Option<String>,
 
-    /// Always-include glob patterns. Tags matching any pattern survive
-    /// `glob:`/`semver:` filters and the system-exclude defaults. Same syntax
-    /// as `exclude:`. Not subject to `sort:` or `latest:` truncation.
+    /// Always-include patterns. Behavior depends on pattern shape: literals
+    /// (no `*`, `?`, `[`) bypass the entire pipeline and are kept verbatim
+    /// (use to pin floating tags like `latest` or specific RCs). Globs
+    /// rescue matching tags from `glob:` and the soft-tier excludes
+    /// (built-in defaults + `defaults.tags.exclude:`), then run through
+    /// `semver:`, hard `exclude:`, `sort:`, and `latest:` like any other
+    /// pipeline tag. Same syntax as `exclude:`.
     #[serde(default)]
     pub include: Option<GlobOrList>,
 
@@ -469,9 +473,7 @@ impl TagsConfig {
             Some(GlobOrList::List(v)) => v.clone(),
             None => return None, // No glob = sync all tags = must enumerate.
         };
-        // A pattern is "exact" if it contains no glob metacharacters.
-        let is_exact = |s: &str| !s.contains('*') && !s.contains('?') && !s.contains('[');
-        if patterns.iter().all(|p| is_exact(p)) {
+        if patterns.iter().all(|p| is_literal_pattern(p)) {
             Some(patterns)
         } else {
             None
@@ -489,7 +491,7 @@ pub(crate) enum GlobOrList {
     List(Vec<String>),
 }
 
-use ocync_sync::filter::SortOrder;
+use ocync_sync::filter::{SortOrder, is_literal_pattern};
 
 /// Placeholder type for the removed `tags.semver_prerelease` field. Triggers
 /// a custom Deserialize error if the field appears in user config, with a


### PR DESCRIPTION
## Summary

Glob patterns in `include:` (like `*-dev`) used to bypass `semver:`, `sort:`, and `latest:`. Writing `include: ["*-dev"]` alongside a `semver:` range got every dev tag in the catalog rather than the bounded subset the range implied -- a footgun for the paired-variant mirror pattern (build + runtime tags within a version range).

Glob includes now rescue matching tags from `glob:` and the project-wide excludes and flow through the rest of the pipeline like any other tag. Literal includes (e.g. `latest`, exact tag names) keep today's bypass-everything behavior -- every existing recipe uses literals and behaves identically.

The dispatch is by pattern shape: `*`, `?`, or `[` makes it a glob; otherwise it is a literal. Mixed include lists route each pattern per its shape.

## What changed

- **Filter** (`crates/ocync-sync/src/filter.rs`): partition `include:` patterns by shape at pipeline build time. Globs bypass `glob:` and the soft-tier excludes; literals stay on the union-after-pipeline path. ~30 LOC of pipeline change.
- **Merge layer** (`src/cli/commands/synchronize.rs`): no logic changes; new integration tests pin the YAML round-trip end-to-end (parse → merge → apply).
- **Schema** (`src/cli/config.rs`, `docs/public/config.schema.json`): `TagsConfig::include` doc comment updated; schema regenerated.
- **Docs**: new "Include patterns" section in `configuration.md`, "Build + runtime variants" subsection in `recipes/semver-tracking.md`, "Tag filtering" section in `registries/chainguard.md`. Stale descriptions in `cli-reference.md`, `observability.md`, and `recipes/pin-literals-only.md` corrected.

## Tests

Filter suite 79 → 89 (1 obsolete test inverted to assert constrained behavior, plus new tests for: literal-bypass through semver, glob rescue from `glob:`, glob rescue from soft tier, hard-tier still blocks include, glob constrained by semver/sort/latest, mixed literal+glob, non-parseable tag handling, end-to-end YAML round-trip, and per-mapping `include:` field-replace semantics). Workspace 1361 → 1366.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` clean
- [x] `cargo test --workspace --locked` 1366 passed
- [x] `cargo deny check` clean
- [x] `npm run --prefix docs build` clean (anchors `#include-patterns` and `#build--runtime-variants` verified in generated HTML)
- [ ] Reviewer: spot-check the worked example in `configuration.md` (the trace through `3.12.5`, `3.12.5-dev`, `3.13.0-dev`, `3.12.5-r3`) by reading it as a first-time user.
- [ ] Reviewer: confirm the corrected prose in `recipes/semver-tracking.md` ("opt back into prereleases for in-range versions") matches expectations -- this is the one place existing recipe text adjusted for the new semantics.