### PR TITLE
fix: 100% CPU hang on many mappings; auth tokens fetch in parallel

### DIFF
--- a/crates/ocync-distribution/CLAUDE.md
+++ b/crates/ocync-distribution/CLAUDE.md
@@ -15,8 +15,9 @@ OCI Distribution Specification client library - registry auth, blob/manifest tra
 - Realm URL validation: `validate_realm_url()` in `token_exchange.rs` validates realm URLs before sending credentials. Four layers: structural (scheme, userinfo, host), IP denylist (link-local, cloud metadata, unspecified, localhost, conditional loopback, IPv4-translated/NAT64), no-redirect client, domain binding (realm host must match or share parent domain with registry). Runs on both fresh and cached challenges.
 - Parse `WWW-Authenticate` header dynamically; never hardcode token exchange endpoints.
 - Token caching: `EARLY_REFRESH_WINDOW` = 30s. Docker Hub issues 300s tokens; a 15m window was a bug that bypassed the cache entirely.
-- Per-scope tokens: format `repository:<name>:<actions>` where actions = `pull`, `push`, or `pull,push`. Per-scope caching (`scopes_cache_key` in `auth/mod.rs`) is universal across every Bearer-issuing provider (anonymous, basic, docker-config, ecr-public, gcp). It is NOT a Chainguard-specific feature.
+- Per-scope tokens: format `repository:<name>:<actions>` where actions = `pull`, `push`, or `pull,push`. Per-scope caching (`scopes_cache_key` in `auth/mod.rs`) is universal across every Bearer-issuing provider (anonymous, basic, docker-config, ecr-public, gcp, acr). It is NOT a Chainguard-specific feature.
 - cgr.dev's specific quirk is *enforcement*: it returns 403 on cross-scope token reuse where some registries silently accept it. The scope-keyed cache is what makes ocync correct against this enforcement -- but the cache itself exists for every Bearer flow.
+- Per-scope coalescing: every Bearer provider routes its cache through `TokenCache` in `auth/token_cache.rs`. The helper holds the cache mutex only for brief reads and writes; the actual token exchange runs under an `Arc<Mutex<()>>` keyed by scope, so concurrent fetches for the same scope coalesce to one exchange while distinct scopes proceed in parallel. The helper owns the contract; per-provider tests verify wiring, not the contract.
 
 ## Provider dispatch (auto-detection)
 

--- a/crates/ocync-distribution/src/auth/acr.rs
+++ b/crates/ocync-distribution/src/auth/acr.rs
@@ -12,22 +12,20 @@
 //! Sovereign clouds (China `.azurecr.cn`, US Gov `.azurecr.us`) are
 //! supported via AAD authority and resource endpoint mapping.
 
-use std::collections::HashMap;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, SystemTime};
 
-use base64::Engine;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use serde::Deserialize;
-use tokio::sync::Mutex;
-
 use super::ecr::SdkCredentialCache;
+use super::token_cache::TokenCache;
 use super::token_exchange::no_redirect_http_client;
 use super::{AuthProvider, Scope, Token, scopes_cache_key};
 use crate::error::Error;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde::Deserialize;
 
 /// Decode the payload segment of a JWT token as JSON.
 fn decode_jwt_payload(token: &str) -> Result<serde_json::Value, Error> {
@@ -554,14 +552,16 @@ const ACR_ACCESS_TOKEN_DEFAULT_TTL: Duration = Duration::from_secs(60 * 60);
 ///
 /// Acquires an Azure AD token via [`AzureTokenSource`], exchanges it for an
 /// ACR refresh token (~3h TTL), then exchanges the refresh token for a
-/// scoped ACR access token per registry scope.
+/// scoped ACR access token per registry scope. Access tokens are coalesced
+/// per scope via [`TokenCache`]: concurrent fetches for the same scope
+/// produce one exchange while distinct scopes run in parallel.
 pub struct AcrAuth {
     base_url: String,
     service: String,
     exchange_http: reqwest::Client,
     api: Box<dyn AzureTokenSource>,
     refresh_cache: SdkCredentialCache<String>,
-    token_cache: Mutex<HashMap<String, Token>>,
+    tokens: TokenCache,
 }
 
 impl fmt::Debug for AcrAuth {
@@ -583,7 +583,7 @@ impl AcrAuth {
             exchange_http: no_redirect_http_client(),
             api,
             refresh_cache: SdkCredentialCache::new(),
-            token_cache: Mutex::new(HashMap::new()),
+            tokens: TokenCache::new(),
         })
     }
 
@@ -596,7 +596,7 @@ impl AcrAuth {
             exchange_http: no_redirect_http_client(),
             api: Box::new(api),
             refresh_cache: SdkCredentialCache::new(),
-            token_cache: Mutex::new(HashMap::new()),
+            tokens: TokenCache::new(),
         }
     }
 
@@ -635,42 +635,38 @@ impl AuthProvider for AcrAuth {
         let scopes = scopes.to_vec();
         Box::pin(async move {
             let key = scopes_cache_key(&scopes);
-            let mut cache = self.token_cache.lock().await;
-            if let Some(token) = cache.get(&key).filter(|t| t.is_valid()) {
-                tracing::debug!(service = %self.service, scope = %key, "ACR token cache hit");
-                return Ok(token.clone());
-            }
-            let refresh_token = self.ensure_refresh_token().await?;
-            let scope_str = scopes
-                .iter()
-                .map(|s| s.to_string())
-                .collect::<Vec<_>>()
-                .join(" ");
-            tracing::debug!(service = %self.service, scope = %key, "ACR token cache miss, exchanging");
-            let access_token = exchange_access_token(
-                &self.exchange_http,
-                &self.base_url,
-                &self.service,
-                &refresh_token,
-                &scope_str,
-            )
-            .await?;
-            let ttl = extract_jwt_exp(&access_token)
-                .ok()
-                .map(ttl_from_unix_exp)
-                .unwrap_or(ACR_ACCESS_TOKEN_DEFAULT_TTL);
-            let token = Token::with_ttl(access_token, ttl);
-            cache.insert(key, token.clone());
-            Ok(token)
+            self.tokens
+                .get_or_fetch(key.clone(), || async {
+                    let refresh_token = self.ensure_refresh_token().await?;
+                    let scope_str = scopes
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    tracing::debug!(service = %self.service, scope = %key, "ACR token cache miss, exchanging");
+                    let access_token = exchange_access_token(
+                        &self.exchange_http,
+                        &self.base_url,
+                        &self.service,
+                        &refresh_token,
+                        &scope_str,
+                    )
+                    .await?;
+                    let ttl = extract_jwt_exp(&access_token)
+                        .ok()
+                        .map(ttl_from_unix_exp)
+                        .unwrap_or(ACR_ACCESS_TOKEN_DEFAULT_TTL);
+                    Ok(Token::with_ttl(access_token, ttl))
+                })
+                .await
         })
     }
 
     fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
-            let mut cache = self.token_cache.lock().await;
-            tracing::debug!(service = %self.service, entries = cache.len(), "invalidating ACR token cache");
-            cache.clear();
-            drop(cache);
+            let entries = self.tokens.len().await;
+            tracing::debug!(service = %self.service, entries, "invalidating ACR token cache");
+            self.tokens.clear().await;
             self.refresh_cache.clear().await;
             self.api.reset();
         })
@@ -682,6 +678,8 @@ mod tests {
     use super::*;
 
     use std::collections::VecDeque;
+
+    use tokio::sync::Mutex;
 
     /// Build a fake JWT with a given JSON payload (no signature verification).
     fn fake_jwt(payload_json: &str) -> String {

--- a/crates/ocync-distribution/src/auth/anonymous.rs
+++ b/crates/ocync-distribution/src/auth/anonymous.rs
@@ -1,12 +1,10 @@
 //! Anonymous auth provider using the Docker token-exchange flow.
 
-use std::collections::HashMap;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 
-use tokio::sync::Mutex;
-
+use super::token_cache::TokenCache;
 use super::token_exchange;
 use super::{AuthProvider, Scope, Token, scopes_cache_key};
 use crate::error::Error;
@@ -15,15 +13,15 @@ use crate::error::Error;
 ///
 /// When a registry responds with `401 Unauthorized` and a `WWW-Authenticate: Bearer ...`
 /// header, this provider extracts the realm/service and exchanges them for an anonymous
-/// token. Tokens are cached per-scope and coalesced under a mutex to prevent thundering
-/// herd.
+/// token. Tokens are coalesced per scope: concurrent fetches for the same scope produce
+/// one token exchange while distinct scopes run in parallel.
 pub struct AnonymousAuth {
     /// The registry base URL (e.g. `https://registry-1.docker.io`).
     base_url: String,
     /// HTTP client for token requests.
     http: reqwest::Client,
-    /// Cached tokens keyed by sorted scope strings.
-    cache: Mutex<HashMap<String, Token>>,
+    /// Per-scope coalescing token cache.
+    tokens: TokenCache,
     /// Cached `WWW-Authenticate` challenge to skip redundant `/v2/` pings.
     challenge_cache: token_exchange::ChallengeCache,
 }
@@ -46,7 +44,7 @@ impl AnonymousAuth {
         Self {
             base_url: format!("https://{registry}"),
             http,
-            cache: Mutex::new(HashMap::new()),
+            tokens: TokenCache::new(),
             challenge_cache: token_exchange::ChallengeCache::new(),
         }
     }
@@ -58,7 +56,7 @@ impl AnonymousAuth {
         Self {
             base_url: base_url.into(),
             http,
-            cache: Mutex::new(HashMap::new()),
+            tokens: TokenCache::new(),
             challenge_cache: token_exchange::ChallengeCache::new(),
         }
     }
@@ -76,45 +74,34 @@ impl AuthProvider for AnonymousAuth {
         let scopes = scopes.to_vec();
         Box::pin(async move {
             let key = scopes_cache_key(&scopes);
-
-            // Hold the mutex for the entire check-then-fetch to prevent thundering herd.
-            let mut cache = self.cache.lock().await;
-
-            if let Some(token) = cache.get(&key).filter(|t| t.is_valid()) {
-                tracing::debug!(base_url = %self.base_url, scope = %key, "token cache hit");
-                return Ok(token.clone());
-            }
-
-            tracing::debug!(base_url = %self.base_url, scope = %key, "token cache miss, exchanging");
-            let cached_challenge = self.challenge_cache.get().await;
-            let (token, challenge) = token_exchange::exchange(
-                &self.http,
-                &self.base_url,
-                &scopes,
-                None,
-                cached_challenge.as_ref(),
-            )
-            .await
-            .map_err(|e| {
-                tracing::warn!(base_url = %self.base_url, scope = %key, error = %e, "token exchange failed");
-                e
-            })?;
-
-            self.challenge_cache.set(challenge).await;
-
-            cache.insert(key, token.clone());
-
-            Ok(token)
+            self.tokens
+                .get_or_fetch(key.clone(), || async {
+                    tracing::debug!(base_url = %self.base_url, scope = %key, "token cache miss, exchanging");
+                    let cached_challenge = self.challenge_cache.get().await;
+                    let (token, challenge) = token_exchange::exchange(
+                        &self.http,
+                        &self.base_url,
+                        &scopes,
+                        None,
+                        cached_challenge.as_ref(),
+                    )
+                    .await
+                    .map_err(|e| {
+                        tracing::warn!(base_url = %self.base_url, scope = %key, error = %e, "token exchange failed");
+                        e
+                    })?;
+                    self.challenge_cache.set(challenge).await;
+                    Ok(token)
+                })
+                .await
         })
     }
 
     fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
-            let mut cache = self.cache.lock().await;
-            tracing::debug!(base_url = %self.base_url, entries = cache.len(), "invalidating token cache");
-            cache.clear();
-            drop(cache);
-
+            let entries = self.tokens.len().await;
+            tracing::debug!(base_url = %self.base_url, entries, "invalidating token cache");
+            self.tokens.clear().await;
             self.challenge_cache.clear().await;
         })
     }
@@ -122,7 +109,9 @@ impl AuthProvider for AnonymousAuth {
 
 #[cfg(test)]
 mod tests {
-    use wiremock::matchers::{method, path};
+    use std::sync::Arc;
+
+    use wiremock::matchers::{method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::*;
@@ -252,6 +241,64 @@ mod tests {
         assert_eq!(t1.value(), "reused");
         assert_eq!(t2.value(), "reused");
         // expect(1) on /v2/ proves the challenge was cached and reused.
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn anonymous_auth_distinct_scopes_fetch_concurrently() {
+        // Two distinct scopes must be able to fetch tokens concurrently.
+        // Each token endpoint mock sleeps 300ms; serialized fetches take
+        // ~600ms while per-scope coalescing parallelizes them at ~300ms.
+        // The 500ms threshold leaves ~200ms margin on both sides.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v2/"))
+            .respond_with(ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!(r#"Bearer realm="{}/token",service="test""#, server.uri()),
+            ))
+            .mount(&server)
+            .await;
+        let slow_for = |scope: &str, token_value: &str| {
+            Mock::given(method("GET"))
+                .and(path("/token"))
+                .and(query_param("scope", scope))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_delay(std::time::Duration::from_millis(300))
+                        .set_body_json(serde_json::json!({
+                            "token": token_value,
+                            "expires_in": 3600,
+                        })),
+                )
+                .expect(1)
+        };
+        slow_for("repository:repo-a:pull", "tok-a")
+            .mount(&server)
+            .await;
+        slow_for("repository:repo-b:pull", "tok-b")
+            .mount(&server)
+            .await;
+
+        let auth = Arc::new(AnonymousAuth::with_base_url(
+            server.uri(),
+            crate::test_http_client(),
+        ));
+        let auth_a = Arc::clone(&auth);
+        let auth_b = Arc::clone(&auth);
+
+        let start = std::time::Instant::now();
+        let (t_a, t_b) = tokio::join!(
+            async move { auth_a.get_token(&[Scope::pull("repo-a")]).await.unwrap() },
+            async move { auth_b.get_token(&[Scope::pull("repo-b")]).await.unwrap() },
+        );
+        let elapsed = start.elapsed();
+
+        assert_eq!(t_a.value(), "tok-a");
+        assert_eq!(t_b.value(), "tok-b");
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "expected concurrent fetch (~300ms), got {elapsed:?}; distinct scopes must not serialize on a shared provider mutex",
+        );
     }
 
     #[test]

--- a/crates/ocync-distribution/src/auth/basic.rs
+++ b/crates/ocync-distribution/src/auth/basic.rs
@@ -3,13 +3,11 @@
 //! Performs the same challenge-response token exchange as [`super::anonymous::AnonymousAuth`],
 //! but includes an `Authorization: Basic base64(user:pass)` header on the token request.
 
-use std::collections::HashMap;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 
-use tokio::sync::Mutex;
-
+use super::token_cache::TokenCache;
 use super::token_exchange;
 use super::{AuthProvider, Credentials, Scope, Token, scopes_cache_key};
 use crate::error::Error;
@@ -18,8 +16,8 @@ use crate::error::Error;
 ///
 /// When a registry responds with `401 Unauthorized` and a `WWW-Authenticate: Bearer ...`
 /// header, this provider extracts the realm/service and exchanges them for a token using
-/// HTTP Basic authentication. Tokens are cached per-scope and coalesced under a mutex to
-/// prevent thundering herd.
+/// HTTP Basic authentication. Tokens are coalesced per scope: concurrent fetches for the
+/// same scope produce one token exchange while distinct scopes run in parallel.
 pub struct BasicAuth {
     /// The registry base URL (e.g. `https://registry-1.docker.io`).
     base_url: String,
@@ -27,8 +25,8 @@ pub struct BasicAuth {
     http: reqwest::Client,
     /// Credentials for the Basic auth header.
     credentials: Credentials,
-    /// Cached tokens keyed by sorted scope strings.
-    cache: Mutex<HashMap<String, Token>>,
+    /// Per-scope coalescing token cache.
+    tokens: TokenCache,
     /// Cached `WWW-Authenticate` challenge to skip redundant `/v2/` pings.
     challenge_cache: token_exchange::ChallengeCache,
 }
@@ -57,7 +55,7 @@ impl BasicAuth {
             base_url: format!("https://{registry}"),
             http,
             credentials,
-            cache: Mutex::new(HashMap::new()),
+            tokens: TokenCache::new(),
             challenge_cache: token_exchange::ChallengeCache::new(),
         }
     }
@@ -74,7 +72,7 @@ impl BasicAuth {
             base_url: base_url.into(),
             http,
             credentials,
-            cache: Mutex::new(HashMap::new()),
+            tokens: TokenCache::new(),
             challenge_cache: token_exchange::ChallengeCache::new(),
         }
     }
@@ -92,45 +90,34 @@ impl AuthProvider for BasicAuth {
         let scopes = scopes.to_vec();
         Box::pin(async move {
             let key = scopes_cache_key(&scopes);
-
-            // Hold the mutex for the entire check-then-fetch to prevent thundering herd.
-            let mut cache = self.cache.lock().await;
-
-            if let Some(token) = cache.get(&key).filter(|t| t.is_valid()) {
-                tracing::debug!(base_url = %self.base_url, scope = %key, "token cache hit");
-                return Ok(token.clone());
-            }
-
-            tracing::debug!(base_url = %self.base_url, scope = %key, "token cache miss, exchanging");
-            let cached_challenge = self.challenge_cache.get().await;
-            let (token, challenge) = token_exchange::exchange(
-                &self.http,
-                &self.base_url,
-                &scopes,
-                Some(&self.credentials),
-                cached_challenge.as_ref(),
-            )
-            .await
-            .map_err(|e| {
-                tracing::warn!(base_url = %self.base_url, scope = %key, error = %e, "token exchange failed");
-                e
-            })?;
-
-            self.challenge_cache.set(challenge).await;
-
-            cache.insert(key, token.clone());
-
-            Ok(token)
+            self.tokens
+                .get_or_fetch(key.clone(), || async {
+                    tracing::debug!(base_url = %self.base_url, scope = %key, "token cache miss, exchanging");
+                    let cached_challenge = self.challenge_cache.get().await;
+                    let (token, challenge) = token_exchange::exchange(
+                        &self.http,
+                        &self.base_url,
+                        &scopes,
+                        Some(&self.credentials),
+                        cached_challenge.as_ref(),
+                    )
+                    .await
+                    .map_err(|e| {
+                        tracing::warn!(base_url = %self.base_url, scope = %key, error = %e, "token exchange failed");
+                        e
+                    })?;
+                    self.challenge_cache.set(challenge).await;
+                    Ok(token)
+                })
+                .await
         })
     }
 
     fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
-            let mut cache = self.cache.lock().await;
-            tracing::debug!(base_url = %self.base_url, entries = cache.len(), "invalidating token cache");
-            cache.clear();
-            drop(cache);
-
+            let entries = self.tokens.len().await;
+            tracing::debug!(base_url = %self.base_url, entries, "invalidating token cache");
+            self.tokens.clear().await;
             self.challenge_cache.clear().await;
         })
     }
@@ -138,6 +125,9 @@ impl AuthProvider for BasicAuth {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
     use base64::Engine;
     use base64::engine::general_purpose::STANDARD as BASE64;
     use wiremock::matchers::{header, method, path, query_param};
@@ -395,7 +385,7 @@ mod tests {
         mount_v2_challenge(&server, 1).await;
         mount_token_endpoint(&server, "single-tok", 1).await;
 
-        let auth = std::sync::Arc::new(BasicAuth::with_base_url(
+        let auth = Arc::new(BasicAuth::with_base_url(
             server.uri(),
             crate::test_http_client(),
             test_credentials(),
@@ -414,6 +404,125 @@ mod tests {
         }
         // expect(1) on /token (in mount_token_endpoint) is verified on
         // MockServer drop; fan-out without coalescing would trip it.
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn basic_auth_distinct_scopes_fetch_concurrently() {
+        // Two distinct scopes must be able to fetch tokens concurrently.
+        // The original implementation held the per-provider cache mutex
+        // for the entire check-then-fetch path, so two distinct scopes
+        // serialized through the registry even when their cache entries
+        // were independent. With per-scope coalescing they parallelize:
+        // each token endpoint mock sleeps 300ms, so sequential fetches
+        // take ~600ms and concurrent fetches take ~300ms. The 500ms
+        // threshold leaves ~200ms margin on both sides for slow CI.
+        let server = MockServer::start().await;
+        // The challenge response is not bounded by `expect` because the
+        // number of hits depends on which task wins the parallel race.
+        Mock::given(method("GET"))
+            .and(path("/v2/"))
+            .respond_with(ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!(
+                    r#"Bearer realm="{}/token",service="test-registry""#,
+                    server.uri()
+                ),
+            ))
+            .mount(&server)
+            .await;
+        let slow_for = |scope: &str, token_value: &str| {
+            Mock::given(method("GET"))
+                .and(path("/token"))
+                .and(query_param("scope", scope))
+                .and(header("Authorization", expected_basic_header().as_str()))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_delay(std::time::Duration::from_millis(300))
+                        .set_body_json(serde_json::json!({
+                            "token": token_value,
+                            "expires_in": 3600,
+                        })),
+                )
+                .expect(1)
+        };
+        slow_for("repository:repo-a:pull", "tok-a")
+            .mount(&server)
+            .await;
+        slow_for("repository:repo-b:pull", "tok-b")
+            .mount(&server)
+            .await;
+
+        let auth = Arc::new(BasicAuth::with_base_url(
+            server.uri(),
+            crate::test_http_client(),
+            test_credentials(),
+        ));
+        let auth_a = Arc::clone(&auth);
+        let auth_b = Arc::clone(&auth);
+
+        let start = std::time::Instant::now();
+        let (t_a, t_b) = tokio::join!(
+            async move { auth_a.get_token(&[Scope::pull("repo-a")]).await.unwrap() },
+            async move { auth_b.get_token(&[Scope::pull("repo-b")]).await.unwrap() },
+        );
+        let elapsed = start.elapsed();
+
+        assert_eq!(t_a.value(), "tok-a");
+        assert_eq!(t_b.value(), "tok-b");
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "expected concurrent fetch (~300ms), got {elapsed:?}; distinct scopes must not serialize on a shared provider mutex",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn basic_auth_concurrent_same_scope_share_one_error_then_retry() {
+        // Five concurrent callers for the same scope race a failing
+        // token endpoint. The first to acquire the per-scope coalescing
+        // slot fails, drops the slot, and the next caller retries; no
+        // caller is left dangling waiting on a stale slot. The
+        // challenge cache is not populated on error, so every retry
+        // re-runs the `/v2/` ping -- documenting current behavior, not
+        // asserting on the exact count.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v2/"))
+            .respond_with(ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!(
+                    r#"Bearer realm="{}/token",service="test-registry""#,
+                    server.uri()
+                ),
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/token"))
+            .and(header("Authorization", expected_basic_header().as_str()))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(&server)
+            .await;
+
+        let auth = Arc::new(BasicAuth::with_base_url(
+            server.uri(),
+            crate::test_http_client(),
+            test_credentials(),
+        ));
+
+        let mut tasks = Vec::with_capacity(5);
+        for _ in 0..5 {
+            let auth = Arc::clone(&auth);
+            tasks.push(tokio::spawn(async move {
+                auth.get_token(&[Scope::pull("repo")]).await
+            }));
+        }
+        for task in tasks {
+            let err = task
+                .await
+                .expect("task did not panic")
+                .expect_err("concurrent waiters must each surface the auth error");
+            assert!(matches!(err, Error::AuthFailed { .. }));
+        }
     }
 
     #[test]

--- a/crates/ocync-distribution/src/auth/docker.rs
+++ b/crates/ocync-distribution/src/auth/docker.rs
@@ -9,8 +9,8 @@ use std::pin::Pin;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use serde::Deserialize;
-use tokio::sync::Mutex;
 
+use super::token_cache::TokenCache;
 use super::token_exchange;
 use super::{AuthProvider, Credentials, Scope, Token, scopes_cache_key};
 use crate::error::Error;
@@ -322,8 +322,8 @@ pub struct DockerConfigAuth {
     http: reqwest::Client,
     /// Resolved credentials (None = anonymous).
     credentials: Option<Credentials>,
-    /// Cached tokens keyed by sorted scope strings.
-    cache: Mutex<HashMap<String, Token>>,
+    /// Per-scope coalescing token cache.
+    tokens: TokenCache,
     /// Cached `WWW-Authenticate` challenge to skip redundant `/v2/` pings.
     challenge_cache: token_exchange::ChallengeCache,
 }
@@ -357,7 +357,7 @@ impl DockerConfigAuth {
             base_url: format!("https://{registry}"),
             http,
             credentials,
-            cache: Mutex::new(HashMap::new()),
+            tokens: TokenCache::new(),
             challenge_cache: token_exchange::ChallengeCache::new(),
         })
     }
@@ -373,7 +373,7 @@ impl DockerConfigAuth {
             base_url: base_url.into(),
             http,
             credentials,
-            cache: Mutex::new(HashMap::new()),
+            tokens: TokenCache::new(),
             challenge_cache: token_exchange::ChallengeCache::new(),
         }
     }
@@ -391,44 +391,34 @@ impl AuthProvider for DockerConfigAuth {
         let scopes = scopes.to_vec();
         Box::pin(async move {
             let key = scopes_cache_key(&scopes);
-
-            let mut cache = self.cache.lock().await;
-
-            if let Some(token) = cache.get(&key).filter(|t| t.is_valid()) {
-                tracing::debug!(base_url = %self.base_url, scope = %key, "token cache hit");
-                return Ok(token.clone());
-            }
-
-            tracing::debug!(base_url = %self.base_url, scope = %key, "token cache miss, exchanging");
-            let cached_challenge = self.challenge_cache.get().await;
-            let (token, challenge) = token_exchange::exchange(
-                &self.http,
-                &self.base_url,
-                &scopes,
-                self.credentials.as_ref(),
-                cached_challenge.as_ref(),
-            )
-            .await
-            .map_err(|e| {
-                tracing::warn!(base_url = %self.base_url, scope = %key, error = %e, "token exchange failed");
-                e
-            })?;
-
-            self.challenge_cache.set(challenge).await;
-
-            cache.insert(key, token.clone());
-
-            Ok(token)
+            self.tokens
+                .get_or_fetch(key.clone(), || async {
+                    tracing::debug!(base_url = %self.base_url, scope = %key, "token cache miss, exchanging");
+                    let cached_challenge = self.challenge_cache.get().await;
+                    let (token, challenge) = token_exchange::exchange(
+                        &self.http,
+                        &self.base_url,
+                        &scopes,
+                        self.credentials.as_ref(),
+                        cached_challenge.as_ref(),
+                    )
+                    .await
+                    .map_err(|e| {
+                        tracing::warn!(base_url = %self.base_url, scope = %key, error = %e, "token exchange failed");
+                        e
+                    })?;
+                    self.challenge_cache.set(challenge).await;
+                    Ok(token)
+                })
+                .await
         })
     }
 
     fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
-            let mut cache = self.cache.lock().await;
-            tracing::debug!(base_url = %self.base_url, entries = cache.len(), "invalidating token cache");
-            cache.clear();
-            drop(cache);
-
+            let entries = self.tokens.len().await;
+            tracing::debug!(base_url = %self.base_url, entries, "invalidating token cache");
+            self.tokens.clear().await;
             self.challenge_cache.clear().await;
         })
     }
@@ -452,6 +442,8 @@ fn default_config_path() -> Option<PathBuf> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
 
     #[test]
@@ -1006,5 +998,64 @@ mod tests {
             .unwrap();
         let debug = format!("{auth:?}");
         assert!(debug.contains("has_credentials: false"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn docker_config_auth_distinct_scopes_fetch_concurrently() {
+        // Two distinct scopes must be able to fetch tokens concurrently.
+        // Each token endpoint mock sleeps 300ms; serialized fetches take
+        // ~600ms while per-scope coalescing parallelizes them at ~300ms.
+        // The 500ms threshold leaves ~200ms margin on both sides.
+        let mock = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/"))
+            .respond_with(wiremock::ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!(r#"Bearer realm="{}/token",service="test""#, mock.uri()),
+            ))
+            .mount(&mock)
+            .await;
+        let slow_for = |scope: &str, token_value: &str| {
+            wiremock::Mock::given(wiremock::matchers::method("GET"))
+                .and(wiremock::matchers::path("/token"))
+                .and(wiremock::matchers::query_param("scope", scope))
+                .respond_with(
+                    wiremock::ResponseTemplate::new(200)
+                        .set_delay(std::time::Duration::from_millis(300))
+                        .set_body_json(serde_json::json!({
+                            "token": token_value,
+                            "expires_in": 3600,
+                        })),
+                )
+                .expect(1)
+        };
+        slow_for("repository:repo-a:pull", "tok-a")
+            .mount(&mock)
+            .await;
+        slow_for("repository:repo-b:pull", "tok-b")
+            .mount(&mock)
+            .await;
+
+        let auth = Arc::new(DockerConfigAuth::with_base_url(
+            mock.uri(),
+            crate::test_http_client(),
+            None,
+        ));
+        let auth_a = Arc::clone(&auth);
+        let auth_b = Arc::clone(&auth);
+
+        let start = std::time::Instant::now();
+        let (t_a, t_b) = tokio::join!(
+            async move { auth_a.get_token(&[Scope::pull("repo-a")]).await.unwrap() },
+            async move { auth_b.get_token(&[Scope::pull("repo-b")]).await.unwrap() },
+        );
+        let elapsed = start.elapsed();
+
+        assert_eq!(t_a.value(), "tok-a");
+        assert_eq!(t_b.value(), "tok-b");
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "expected concurrent fetch (~300ms), got {elapsed:?}; distinct scopes must not serialize on a shared provider mutex",
+        );
     }
 }

--- a/crates/ocync-distribution/src/auth/ecr_public.rs
+++ b/crates/ocync-distribution/src/auth/ecr_public.rs
@@ -16,7 +16,6 @@
 //! when they approach expiry, matching [`super::ecr::EcrAuth`]'s
 //! behavior for long-running processes (watch mode).
 
-use std::collections::HashMap;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
@@ -24,11 +23,11 @@ use std::time::Duration;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
-use tokio::sync::Mutex;
 
 use super::ecr::{
     EcrApi, EcrTokenResponse, SdkCredentialCache, ttl_from_expiry, validate_ecr_token,
 };
+use super::token_cache::TokenCache;
 use super::token_exchange;
 use super::{AuthProvider, Credentials, Scope, Token, scopes_cache_key};
 use crate::error::Error;
@@ -138,8 +137,9 @@ fn decode_ecr_credentials(
 /// read-lock fast path / write-lock refresh pattern as
 /// [`super::ecr::EcrAuth`], supporting long-running processes (watch mode).
 ///
-/// Bearer tokens are cached per-scope with the same challenge-cache
-/// optimization as [`super::basic::BasicAuth`].
+/// Bearer tokens are coalesced per scope via [`TokenCache`]: concurrent
+/// fetches for the same scope produce one token exchange while distinct
+/// scopes run in parallel.
 pub struct EcrPublicAuth {
     /// The registry base URL.
     base_url: String,
@@ -149,8 +149,8 @@ pub struct EcrPublicAuth {
     api: Box<dyn EcrApi>,
     /// Cached SDK credentials (username/password) with TTL-based refresh.
     sdk_credential_cache: SdkCredentialCache<Credentials>,
-    /// Cached Bearer tokens keyed by sorted scope strings.
-    cache: Mutex<HashMap<String, Token>>,
+    /// Per-scope coalescing Bearer token cache.
+    tokens: TokenCache,
     /// Cached `WWW-Authenticate` challenge to skip redundant `/v2/` pings.
     challenge_cache: token_exchange::ChallengeCache,
 }
@@ -182,7 +182,7 @@ impl EcrPublicAuth {
                 client: aws_sdk_ecrpublic::Client::new(&config),
             }),
             sdk_credential_cache: SdkCredentialCache::new(),
-            cache: Mutex::new(HashMap::new()),
+            tokens: TokenCache::new(),
             challenge_cache: token_exchange::ChallengeCache::new(),
         })
     }
@@ -199,7 +199,7 @@ impl EcrPublicAuth {
             http,
             api: Box::new(api),
             sdk_credential_cache: SdkCredentialCache::new(),
-            cache: Mutex::new(HashMap::new()),
+            tokens: TokenCache::new(),
             challenge_cache: token_exchange::ChallengeCache::new(),
         }
     }
@@ -237,49 +237,37 @@ impl AuthProvider for EcrPublicAuth {
         let scopes = scopes.to_vec();
         Box::pin(async move {
             let key = scopes_cache_key(&scopes);
-
-            let mut cache = self.cache.lock().await;
-
-            if let Some(token) = cache.get(&key).filter(|t| t.is_valid()) {
-                tracing::debug!(base_url = %self.base_url, scope = %key, "token cache hit");
-                return Ok(token.clone());
-            }
-
-            // Ensure SDK credentials are fresh before token exchange.
-            let credentials = self.ensure_credentials().await?;
-
-            tracing::debug!(base_url = %self.base_url, scope = %key, "token cache miss, exchanging");
-            let cached_challenge = self.challenge_cache.get().await;
-            let (token, challenge) = token_exchange::exchange(
-                &self.http,
-                &self.base_url,
-                &scopes,
-                Some(&credentials),
-                cached_challenge.as_ref(),
-            )
-            .await
-            .map_err(|e| {
-                tracing::warn!(base_url = %self.base_url, scope = %key, error = %e, "token exchange failed");
-                e
-            })?;
-
-            self.challenge_cache.set(challenge).await;
-
-            cache.insert(key, token.clone());
-
-            Ok(token)
+            self.tokens
+                .get_or_fetch(key.clone(), || async {
+                    // Ensure SDK credentials are fresh before token exchange.
+                    let credentials = self.ensure_credentials().await?;
+                    tracing::debug!(base_url = %self.base_url, scope = %key, "token cache miss, exchanging");
+                    let cached_challenge = self.challenge_cache.get().await;
+                    let (token, challenge) = token_exchange::exchange(
+                        &self.http,
+                        &self.base_url,
+                        &scopes,
+                        Some(&credentials),
+                        cached_challenge.as_ref(),
+                    )
+                    .await
+                    .map_err(|e| {
+                        tracing::warn!(base_url = %self.base_url, scope = %key, error = %e, "token exchange failed");
+                        e
+                    })?;
+                    self.challenge_cache.set(challenge).await;
+                    Ok(token)
+                })
+                .await
         })
     }
 
     fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
-            let mut cache = self.cache.lock().await;
-            tracing::debug!(base_url = %self.base_url, entries = cache.len(), "invalidating ECR Public token cache");
-            cache.clear();
-            drop(cache);
-
+            let entries = self.tokens.len().await;
+            tracing::debug!(base_url = %self.base_url, entries, "invalidating ECR Public token cache");
+            self.tokens.clear().await;
             self.challenge_cache.clear().await;
-
             // Also clear SDK credentials so they are re-fetched on next use.
             self.sdk_credential_cache.clear().await;
         })
@@ -292,6 +280,7 @@ mod tests {
 
     use base64::Engine;
     use base64::engine::general_purpose::STANDARD as BASE64;
+    use tokio::sync::Mutex;
     use wiremock::MockServer;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, ResponseTemplate};

--- a/crates/ocync-distribution/src/auth/gcp.rs
+++ b/crates/ocync-distribution/src/auth/gcp.rs
@@ -14,15 +14,13 @@
 //! var, `~/.config/gcloud/application_default_credentials.json`, GCE/GKE
 //! metadata server. GKE Workload Identity is transparent.
 
-use std::collections::HashMap;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
 
-use tokio::sync::Mutex;
-
 use super::ecr::SdkCredentialCache;
+use super::token_cache::TokenCache;
 use super::token_exchange;
 use super::{AuthProvider, Credentials, Scope, Token, scopes_cache_key};
 use crate::error::Error;
@@ -94,8 +92,9 @@ impl GcpTokenSource for GoogleCloudTokenSource {
 /// read-lock fast path / write-lock refresh pattern as
 /// [`super::ecr::EcrAuth`], supporting long-running processes (watch mode).
 ///
-/// Bearer tokens are cached per-scope with the same challenge-cache
-/// optimization as [`super::basic::BasicAuth`].
+/// Bearer tokens are coalesced per scope via [`TokenCache`]: concurrent
+/// fetches for the same scope produce one token exchange while distinct
+/// scopes run in parallel.
 pub struct GcpAuth {
     /// The registry base URL.
     base_url: String,
@@ -105,8 +104,8 @@ pub struct GcpAuth {
     api: Box<dyn GcpTokenSource>,
     /// Cached SDK credentials (username/password) with TTL-based refresh.
     sdk_credential_cache: SdkCredentialCache<Credentials>,
-    /// Cached Bearer tokens keyed by sorted scope strings.
-    cache: Mutex<HashMap<String, Token>>,
+    /// Per-scope coalescing Bearer token cache.
+    tokens: TokenCache,
     /// Cached `WWW-Authenticate` challenge to skip redundant `/v2/` pings.
     challenge_cache: token_exchange::ChallengeCache,
 }
@@ -142,7 +141,7 @@ impl GcpAuth {
                 hostname,
             }),
             sdk_credential_cache: SdkCredentialCache::new(),
-            cache: Mutex::new(HashMap::new()),
+            tokens: TokenCache::new(),
             challenge_cache: token_exchange::ChallengeCache::new(),
         })
     }
@@ -159,7 +158,7 @@ impl GcpAuth {
             http,
             api: Box::new(api),
             sdk_credential_cache: SdkCredentialCache::new(),
-            cache: Mutex::new(HashMap::new()),
+            tokens: TokenCache::new(),
             challenge_cache: token_exchange::ChallengeCache::new(),
         }
     }
@@ -199,49 +198,37 @@ impl AuthProvider for GcpAuth {
         let scopes = scopes.to_vec();
         Box::pin(async move {
             let key = scopes_cache_key(&scopes);
-
-            let mut cache = self.cache.lock().await;
-
-            if let Some(token) = cache.get(&key).filter(|t| t.is_valid()) {
-                tracing::debug!(base_url = %self.base_url, scope = %key, "token cache hit");
-                return Ok(token.clone());
-            }
-
-            // Ensure GCP credentials are fresh before token exchange.
-            let credentials = self.ensure_credentials().await?;
-
-            tracing::debug!(base_url = %self.base_url, scope = %key, "token cache miss, exchanging");
-            let cached_challenge = self.challenge_cache.get().await;
-            let (token, challenge) = token_exchange::exchange(
-                &self.http,
-                &self.base_url,
-                &scopes,
-                Some(&credentials),
-                cached_challenge.as_ref(),
-            )
-            .await
-            .map_err(|e| {
-                tracing::warn!(base_url = %self.base_url, scope = %key, error = %e, "token exchange failed");
-                e
-            })?;
-
-            self.challenge_cache.set(challenge).await;
-
-            cache.insert(key, token.clone());
-
-            Ok(token)
+            self.tokens
+                .get_or_fetch(key.clone(), || async {
+                    // Ensure GCP credentials are fresh before token exchange.
+                    let credentials = self.ensure_credentials().await?;
+                    tracing::debug!(base_url = %self.base_url, scope = %key, "token cache miss, exchanging");
+                    let cached_challenge = self.challenge_cache.get().await;
+                    let (token, challenge) = token_exchange::exchange(
+                        &self.http,
+                        &self.base_url,
+                        &scopes,
+                        Some(&credentials),
+                        cached_challenge.as_ref(),
+                    )
+                    .await
+                    .map_err(|e| {
+                        tracing::warn!(base_url = %self.base_url, scope = %key, error = %e, "token exchange failed");
+                        e
+                    })?;
+                    self.challenge_cache.set(challenge).await;
+                    Ok(token)
+                })
+                .await
         })
     }
 
     fn invalidate(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
-            let mut cache = self.cache.lock().await;
-            tracing::debug!(base_url = %self.base_url, entries = cache.len(), "invalidating GCP token cache");
-            cache.clear();
-            drop(cache);
-
+            let entries = self.tokens.len().await;
+            tracing::debug!(base_url = %self.base_url, entries, "invalidating GCP token cache");
+            self.tokens.clear().await;
             self.challenge_cache.clear().await;
-
             // Also clear SDK credentials so they are re-fetched on next use.
             self.sdk_credential_cache.clear().await;
         })
@@ -252,6 +239,7 @@ impl AuthProvider for GcpAuth {
 mod tests {
     use std::collections::VecDeque;
 
+    use tokio::sync::Mutex;
     use wiremock::MockServer;
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, ResponseTemplate};
@@ -439,7 +427,7 @@ mod tests {
         // Clear the Bearer token cache so get_token() re-enters
         // ensure_credentials(). SDK creds are near-expiry, so
         // SdkCredentialCache triggers a refresh -> "ya29.second".
-        auth.cache.lock().await.clear();
+        auth.tokens.clear().await;
 
         auth.get_token(&[Scope::pull("repo")]).await.unwrap();
     }

--- a/crates/ocync-distribution/src/auth/mod.rs
+++ b/crates/ocync-distribution/src/auth/mod.rs
@@ -18,6 +18,8 @@ pub mod ecr_public;
 pub mod gcp;
 /// Static bearer token authentication provider.
 pub mod static_token;
+/// Coalescing token cache used by every Bearer-token auth provider.
+mod token_cache;
 /// Shared Docker v2 token-exchange protocol.
 pub(crate) mod token_exchange;
 

--- a/crates/ocync-distribution/src/auth/token_cache.rs
+++ b/crates/ocync-distribution/src/auth/token_cache.rs
@@ -1,0 +1,263 @@
+//! Coalescing token cache shared by every Bearer-token auth provider.
+//!
+//! Wraps two maps:
+//!
+//! - `cache` -- the live tokens, keyed by scope.
+//! - `inflight` -- per-scope `Arc<Mutex<()>>` slots so concurrent callers
+//!   for the same scope serialize through a single fetch while callers
+//!   for distinct scopes proceed in parallel.
+//!
+//! The double-checked cache read after the per-scope mutex is acquired
+//! makes a waiter wake to a populated cache when a peer completes
+//! successfully, so a successful fetch produces exactly one token
+//! exchange regardless of fan-out.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use super::Token;
+use crate::error::Error;
+
+/// Coalescing token cache. Same-scope fetches serialize, distinct scopes
+/// run in parallel. See module-level docs for the synchronization model.
+#[derive(Debug, Default)]
+pub(super) struct TokenCache {
+    cache: Mutex<HashMap<String, Token>>,
+    inflight: Mutex<HashMap<String, Arc<Mutex<()>>>>,
+}
+
+impl TokenCache {
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of entries currently in the token cache. Used for log
+    /// diagnostics on invalidation.
+    pub(super) async fn len(&self) -> usize {
+        self.cache.lock().await.len()
+    }
+
+    /// Look up a cached token for `key`, or invoke `fetch` to produce
+    /// one. Concurrent callers for the same `key` coalesce through a
+    /// per-scope mutex; callers for distinct keys hold distinct
+    /// mutexes and run in parallel. On a successful fetch the token
+    /// is inserted into the cache; on error the entry is left empty
+    /// so the next caller can retry.
+    pub(super) async fn get_or_fetch<F, Fut>(&self, key: String, fetch: F) -> Result<Token, Error>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<Token, Error>>,
+    {
+        if let Some(token) = self
+            .cache
+            .lock()
+            .await
+            .get(&key)
+            .filter(|t| t.is_valid())
+            .cloned()
+        {
+            return Ok(token);
+        }
+
+        let key_mutex = {
+            let mut map = self.inflight.lock().await;
+            Arc::clone(
+                map.entry(key.clone())
+                    .or_insert_with(|| Arc::new(Mutex::new(()))),
+            )
+        };
+        let _guard = key_mutex.lock().await;
+
+        // Re-check the cache after acquiring the per-scope mutex: a
+        // concurrent caller for the same scope may have populated it.
+        if let Some(token) = self
+            .cache
+            .lock()
+            .await
+            .get(&key)
+            .filter(|t| t.is_valid())
+            .cloned()
+        {
+            return Ok(token);
+        }
+
+        let token = fetch().await?;
+
+        self.cache.lock().await.insert(key, token.clone());
+
+        Ok(token)
+    }
+
+    /// Drop every cached token and every per-scope coalescing slot.
+    pub(super) async fn clear(&self) {
+        self.cache.lock().await.clear();
+        self.inflight.lock().await.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use tokio::sync::Barrier;
+
+    use super::*;
+
+    /// Trivial token builder that doesn't expire so cache hits are stable.
+    fn token(value: &str) -> Token {
+        Token::new(value)
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn same_key_coalesces_to_one_fetch() {
+        // 20 concurrent callers for the same scope must produce exactly
+        // one underlying fetch.
+        let cache = Arc::new(TokenCache::new());
+        let fetch_count = Arc::new(AtomicUsize::new(0));
+
+        let mut tasks = Vec::with_capacity(20);
+        for _ in 0..20 {
+            let cache = Arc::clone(&cache);
+            let fetch_count = Arc::clone(&fetch_count);
+            tasks.push(tokio::spawn(async move {
+                cache
+                    .get_or_fetch("scope".to_string(), || async {
+                        fetch_count.fetch_add(1, Ordering::SeqCst);
+                        // Yield once so other callers get a chance to
+                        // queue behind us before the fetch resolves.
+                        tokio::task::yield_now().await;
+                        Ok(token("shared"))
+                    })
+                    .await
+            }));
+        }
+        for t in tasks {
+            let token = t.await.unwrap().unwrap();
+            assert_eq!(token.value(), "shared");
+        }
+        assert_eq!(
+            fetch_count.load(Ordering::SeqCst),
+            1,
+            "concurrent fetches for the same key must coalesce to one"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn distinct_keys_fetch_concurrently() {
+        // A `Barrier(2)` inside each fetch deadlocks unless both
+        // fetches are in flight simultaneously. The 5s timeout
+        // distinguishes deadlock from real parallel execution.
+        let cache = TokenCache::new();
+        let barrier = Arc::new(Barrier::new(2));
+        let b1 = Arc::clone(&barrier);
+        let b2 = Arc::clone(&barrier);
+
+        let outcome = tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::join!(
+                cache.get_or_fetch("scope-a".to_string(), move || async move {
+                    b1.wait().await;
+                    Ok(token("tok-a"))
+                }),
+                cache.get_or_fetch("scope-b".to_string(), move || async move {
+                    b2.wait().await;
+                    Ok(token("tok-b"))
+                }),
+            )
+        })
+        .await;
+
+        let (a, b) = outcome.expect("distinct-scope fetches must run concurrently, not deadlock");
+        assert_eq!(a.unwrap().value(), "tok-a");
+        assert_eq!(b.unwrap().value(), "tok-b");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn fetch_error_propagates_and_releases_slot() {
+        // First caller fails; second caller for the same key must be
+        // able to retry and succeed (no leaked guard, no poisoned slot).
+        let cache = TokenCache::new();
+
+        let err = cache
+            .get_or_fetch("scope".to_string(), || async {
+                Err(Error::AuthFailed {
+                    registry: "test".into(),
+                    reason: "boom".into(),
+                })
+            })
+            .await
+            .expect_err("first fetch must propagate the error");
+        assert!(matches!(err, Error::AuthFailed { .. }));
+
+        let ok = cache
+            .get_or_fetch("scope".to_string(), || async { Ok(token("retry-tok")) })
+            .await
+            .expect("retry must succeed once the slot is released");
+        assert_eq!(ok.value(), "retry-tok");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn concurrent_same_key_callers_share_one_error() {
+        // When the first caller's fetch fails, queued waiters wake to
+        // an empty cache and each retry independently. This documents
+        // the current behaviour: errors are not shared, but no caller
+        // is left dangling.
+        let cache = Arc::new(TokenCache::new());
+        let attempts = Arc::new(AtomicUsize::new(0));
+
+        let mut tasks = Vec::with_capacity(5);
+        for _ in 0..5 {
+            let cache = Arc::clone(&cache);
+            let attempts = Arc::clone(&attempts);
+            tasks.push(tokio::spawn(async move {
+                cache
+                    .get_or_fetch("scope".to_string(), || async {
+                        attempts.fetch_add(1, Ordering::SeqCst);
+                        tokio::task::yield_now().await;
+                        Err::<Token, _>(Error::AuthFailed {
+                            registry: "test".into(),
+                            reason: "always".into(),
+                        })
+                    })
+                    .await
+            }));
+        }
+        for t in tasks {
+            assert!(t.await.unwrap().is_err());
+        }
+        // Each waiter wakes to a cache miss and runs its own fetch.
+        assert_eq!(attempts.load(Ordering::SeqCst), 5);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn clear_drops_cache_and_inflight() {
+        // Seed the cache and the inflight map.
+        let cache = TokenCache::new();
+        cache
+            .get_or_fetch("scope".to_string(), || async { Ok(token("first")) })
+            .await
+            .unwrap();
+        assert_eq!(cache.len().await, 1);
+        assert!(!cache.inflight.lock().await.is_empty());
+
+        cache.clear().await;
+        assert_eq!(cache.len().await, 0);
+        assert!(cache.inflight.lock().await.is_empty());
+
+        // Post-clear, a same-key fetch must reach the fetcher again.
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_ref = Arc::clone(&attempts);
+        let t = cache
+            .get_or_fetch("scope".to_string(), || async move {
+                attempts_ref.fetch_add(1, Ordering::SeqCst);
+                Ok(token("second"))
+            })
+            .await
+            .unwrap();
+        assert_eq!(t.value(), "second");
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -519,9 +519,23 @@ fn elect_leaders(pending: &mut VecDeque<TransferTask>) -> usize {
     // maximizes marginal shared-blob coverage: for each remaining
     // (non-leader) image, count blobs shared with the candidate that are
     // not already in a previous leader's blob set.
+    //
+    // Implementation uses an inverted index `blob_remaining_count` that
+    // maps each blob to the number of remaining groups containing it.
+    // A candidate i's marginal contribution from a blob d (where d is
+    // not in `leader_blob_union`) is `count[d] - 1` -- the count of
+    // other remaining groups that share d with i. Total cost per round
+    // is O(n * b_avg) instead of the O(n^2 * b) of a pairwise scan.
     let mut leader_set: Vec<usize> = Vec::new();
     let mut leader_blob_union: HashSet<Digest> = HashSet::new();
     let mut remaining: Vec<usize> = (0..num_groups).collect();
+
+    let mut blob_remaining_count: HashMap<Digest, usize> = HashMap::new();
+    for &i in &remaining {
+        for d in &group_blobs[i] {
+            *blob_remaining_count.entry(d.clone()).or_insert(0) += 1;
+        }
+    }
 
     loop {
         if remaining.len() <= 1 {
@@ -531,15 +545,10 @@ fn elect_leaders(pending: &mut VecDeque<TransferTask>) -> usize {
         let best = remaining
             .iter()
             .map(|&i| {
-                let marginal: usize = remaining
+                let marginal: usize = group_blobs[i]
                     .iter()
-                    .filter(|&&j| j != i)
-                    .map(|&j| {
-                        group_blobs[i]
-                            .intersection(&group_blobs[j])
-                            .filter(|b| !leader_blob_union.contains(*b))
-                            .count()
-                    })
+                    .filter(|d| !leader_blob_union.contains(*d))
+                    .map(|d| blob_remaining_count.get(d).copied().unwrap_or(0) - 1)
                     .sum();
                 (i, marginal)
             })
@@ -547,6 +556,11 @@ fn elect_leaders(pending: &mut VecDeque<TransferTask>) -> usize {
 
         match best {
             Some((idx, marginal)) if marginal > 0 => {
+                for d in &group_blobs[idx] {
+                    if let Some(c) = blob_remaining_count.get_mut(d) {
+                        *c -= 1;
+                    }
+                }
                 leader_blob_union.extend(group_blobs[idx].iter().cloned());
                 leader_set.push(idx);
                 remaining.retain(|&i| i != idx);
@@ -3651,6 +3665,51 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn elect_leaders_scales_subcubically() {
+        // Regression test for the cubic blow-up that caused production
+        // sync runs to hang silently at 100% CPU after the discovery
+        // phase. With 75 disjoint pairs (n=150 distinct source manifests)
+        // the greedy loop runs one round per pair; an O(n^3) version
+        // takes hundreds of milliseconds, while a sub-cubic version
+        // finishes in under 50ms.
+        let n_pairs: usize = 75;
+        let mut counter: usize = 0;
+        let mut next = || {
+            let s = format!("{counter:x}");
+            counter += 1;
+            s
+        };
+
+        let mut pending = VecDeque::new();
+        for pair_idx in 0..n_pairs {
+            let shared = next();
+            let cfg_a = next();
+            let lay_a1 = next();
+            let lay_a2 = next();
+            let data_a = Rc::new(test_pulled_manifest(&[&cfg_a, &shared, &lay_a1, &lay_a2]));
+            pending.push_back(test_task(data_a, &format!("a{pair_idx}")));
+
+            let cfg_b = next();
+            let lay_b1 = next();
+            let lay_b2 = next();
+            let data_b = Rc::new(test_pulled_manifest(&[&cfg_b, &shared, &lay_b1, &lay_b2]));
+            pending.push_back(test_task(data_b, &format!("b{pair_idx}")));
+        }
+
+        let start = Instant::now();
+        let leader_count = elect_leaders(&mut pending);
+        let elapsed = start.elapsed();
+
+        // One leader per pair: after the first member of a pair is
+        // elected, the other member's marginal coverage drops to 0.
+        assert_eq!(leader_count, n_pairs, "expected one leader per pair");
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "elect_leaders took {elapsed:?} for n=150 (75 pairs); expected sub-500ms on a non-cubic implementation",
+        );
     }
 
     // --- ResolvedArtifacts::type_matches tests ---


### PR DESCRIPTION
## Summary

- **Resolves #93.** `elect_leaders` reran a pairwise O(n²·b) scan per greedy round, giving O(n³·b) in the number of distinct source manifests. With ~hundreds of mappings the loop took minutes on a single-thread runtime, surfacing as a silent 100% CPU hang after discovery. Rewritten with an inverted index `blob_remaining_count` so each round costs O(n·b̄); total O(n²·b̄). A n=150 stress run drops from ~2.4s to <50ms in a debug build.
- **Per-scope token coalescing across all 6 Bearer auth providers.** The per-provider token cache mutex was held across `token_exchange::exchange()`, serializing distinct-scope fetches even when their cache entries were independent — a real throughput funnel under high-fanout Chainguard / Docker Hardened sync. A new `TokenCache` helper in `auth/token_cache.rs` owns the live token map plus a per-scope `Arc<Mutex<()>>` map; same-scope fetches coalesce via the per-scope mutex with a double-checked cache read, distinct scopes run in parallel. `basic`, `anonymous`, `docker-config`, `ecr-public`, `gcp`, and `acr` all route through it.
- **+6 tests, all gates green.** 1 regression test for the cubic scaling (timing-bounded), 5 helper unit tests covering same-scope coalescing / distinct-scope parallelism (deadlock-detected via `Barrier`) / failure-path retry / `clear()` behavior, and 1 wiremock integration test on `basic.rs` for end-to-end failure-path wiring.

## Test plan

- [ ] CI: `cargo test --workspace --locked`, `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo deny check`
- [ ] Review the `TokenCache` helper contract (`auth/token_cache.rs`) — it owns the parallelism guarantee; per-provider tests only verify wiring
- [ ] Spot-check provider migrations: `basic` is the canonical example, `anonymous` / `docker-config` mirror it 1:1, `ecr-public` / `gcp` thread their SDK credential refresh through the fetch closure, `acr` does the same with the AAD refresh+access two-step
- [ ] Behavioral verification on the issue #93 reproducer environment (Chainguard + DHI source, ECR FIPS target, 27 mappings) — the workaround `latest: 20` should no longer be required