### PR TITLE
chore(deps): update all dependencies to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,4 +131,4 @@ jobs:
       - if: needs.changes.outputs.rust == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - if: needs.changes.outputs.rust == 'true'
-        uses: EmbarkStudios/cargo-deny-action@6c8f9facfa5047ec02d8485b6bf52b587b7777d1 # v2.0.18
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+        uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59 # v6.1.3
         with:
           role-to-assume: ${{ secrets.ECR_PUBLIC_ROLE_ARN }}
           aws-region: us-east-1
@@ -151,7 +151,7 @@ jobs:
     steps:
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+        uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59 # v6.1.3
         with:
           role-to-assume: ${{ secrets.ECR_PUBLIC_ROLE_ARN }}
           aws-region: us-east-1
@@ -195,7 +195,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+        uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59 # v6.1.3
         with:
           role-to-assume: ${{ secrets.ECR_PUBLIC_ROLE_ARN }}
           aws-region: us-east-1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,10 +77,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "asn1-rs"
-version = "0.7.1"
+name = "arc-swap"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -127,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
 dependencies = [
  "filetime",
  "futures-core",
@@ -182,15 +191,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.8.16"
+version = "1.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
+checksum = "517aa062d8bd9015ee23d6daa5e1c1372328412fdae4e6c4c1be9b69c6ad37a2"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -202,12 +211,13 @@ dependencies = [
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
  "fastrand",
  "hex",
- "http 1.4.0",
+ "http 1.4.1",
  "sha1",
  "time",
  "tokio",
@@ -268,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.3"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
+checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -283,7 +293,7 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "fastrand",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
@@ -293,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ecr"
-version = "1.115.1"
+version = "1.117.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e30c797e7df731ba0c9d051b2f82a95526fd1fb3905185908d1b77d6e0a1386"
+checksum = "ed60affc5b05c3dbd65a31b802fbb720273363ce87c0dfb6dda991e1eec304cc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -310,17 +320,18 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-ecrpublic"
-version = "1.101.0"
+version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f5754e124925336a6ea6407e78b21b402102c4fdf93e928502aa90f27151db"
+checksum = "d25b36db3abc80b47153d7036a415657cdf12a3376030363eb4c21559ba7d187"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -334,16 +345,16 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.98.0"
+version = "1.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69c77aafa20460c68b6b3213c84f6423b6e76dbf89accd3e1789a686ffd9489"
+checksum = "bee2719d4a5e5e147bb9e9b77490df6ece750df1094968aa857b09b618a1881a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -358,17 +369,18 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.100.0"
+version = "1.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7e7b09346d5ca22a2a08267555843a6a0127fb20d8964cb6ecfb8fdb190225"
+checksum = "b30d254992d56ef19f430396e5765b11e0f5bd21a7a557cb12fca1c8c18b9636"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -382,16 +394,16 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.103.0"
+version = "1.105.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
+checksum = "59f4f8065fe615dbed9096458ba98dda6d641553ffd5aedd27e37e65211aca9f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -407,16 +419,16 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
+checksum = "b7083fb918b38474ac65ffbf8a69fc8792d36879f4ac5f1667b43aec61efe9a5"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -427,7 +439,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "percent-encoding",
  "sha2",
  "time",
@@ -457,7 +469,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
@@ -476,7 +488,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2",
- "http 1.4.0",
+ "http 1.4.1",
  "hyper",
  "hyper-rustls",
  "hyper-util",
@@ -492,10 +504,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.5"
+version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
 ]
 
@@ -520,20 +534,21 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
+checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -545,16 +560,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
+checksum = "dc117c179ecf39a62a0a3f49f600e9ac26a7ad7dd172177999f83933af776c32"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -573,16 +588,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.4.7"
+name = "aws-smithy-schema"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.1",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056b66dbce2f81cc0c1e2b05bb402eb58f8a3530479d650efadd5bbae9a4050b"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -606,13 +632,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.15"
+version = "1.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -627,7 +654,7 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
@@ -651,7 +678,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -684,7 +711,7 @@ dependencies = [
  "bytes",
  "clap",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -719,7 +746,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn",
 ]
 
@@ -772,7 +799,7 @@ dependencies = [
  "futures-util",
  "hex",
  "home",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body-util",
  "hyper",
  "hyper-named-pipe",
@@ -851,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -876,14 +903,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -991,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cobs"
@@ -1091,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -1207,15 +1234,15 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1224,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "docker_credential"
-version = "1.3.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4564c274ebf369f501de192b02a0b81a5c4bda375abfe526aa70fc702fa6fa0"
+checksum = "29547a1dc60885a552306986316bc9701ba120c1a8db6769fa68691529ad373d"
 dependencies = [
  "base64",
  "serde",
@@ -1247,9 +1274,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embedded-io"
@@ -1519,7 +1546,7 @@ dependencies = [
  "google-cloud-gax",
  "hex",
  "hmac",
- "http 1.4.0",
+ "http 1.4.1",
  "reqwest",
  "rustc_version",
  "rustls",
@@ -1544,7 +1571,7 @@ dependencies = [
  "futures",
  "google-cloud-rpc",
  "google-cloud-wkt",
- "http 1.4.0",
+ "http 1.4.1",
  "pin-project",
  "rand 0.10.1",
  "serde",
@@ -1593,7 +1620,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.1",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -1671,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1697,7 +1724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -1708,7 +1735,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1736,16 +1763,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -1777,7 +1804,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.1",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1810,7 +1837,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "hyper",
  "ipnet",
@@ -2099,9 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2151,9 +2178,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru-slab"
@@ -2178,9 +2205,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mime"
@@ -2196,9 +2223,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2250,9 +2277,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2310,11 +2337,11 @@ version = "0.5.3"
 dependencies = [
  "anstyle",
  "clap",
- "http 1.4.0",
+ "http 1.4.1",
  "ocync-distribution",
  "ocync-sync",
  "reqwest",
- "schemars 0.8.22",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -2340,7 +2367,7 @@ dependencies = [
  "futures-util",
  "google-cloud-auth",
  "hex",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "reqwest",
  "rustls",
@@ -2362,11 +2389,11 @@ dependencies = [
  "crc32fast",
  "futures-util",
  "globset",
- "http 1.4.0",
+ "http 1.4.1",
  "ocync-distribution",
  "postcard",
  "reqwest",
- "schemars 0.8.22",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "tempfile",
@@ -2771,15 +2798,15 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
-source = "git+https://github.com/seanmonstar/reqwest?rev=03db63a48f35135c2f2c8b7aaa578217d5f678fe#03db63a48f35135c2f2c8b7aaa578217d5f678fe"
+version = "0.13.4"
+source = "git+https://github.com/seanmonstar/reqwest?rev=11489b34eda6d32b15ad4033e62beba2ee401350#11489b34eda6d32b15ad4033e62beba2ee401350"
 dependencies = [
  "base64",
  "bytes",
  "futures-core",
  "futures-util",
  "h2",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -2878,9 +2905,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -2969,18 +2996,6 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
@@ -2999,15 +3014,16 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3087,9 +3103,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3204,6 +3220,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3243,9 +3265,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3371,7 +3393,7 @@ dependencies = [
  "etcetera",
  "ferroid",
  "futures",
- "http 1.4.0",
+ "http 1.4.1",
  "itertools 0.14.0",
  "log",
  "memchr",
@@ -3544,7 +3566,7 @@ dependencies = [
  "base64",
  "bytes",
  "h2",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -3594,14 +3616,14 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "pin-project-lite",
  "tower",
@@ -3690,9 +3712,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -3746,7 +3768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64",
- "http 1.4.0",
+ "http 1.4.1",
  "httparse",
  "log",
 ]
@@ -3790,9 +3812,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3863,9 +3885,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3876,9 +3898,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3886,9 +3908,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3896,9 +3918,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3909,9 +3931,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -3965,9 +3987,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4259,7 +4281,7 @@ dependencies = [
  "base64",
  "deadpool",
  "futures",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -4457,18 +4479,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2799,7 +2799,8 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "reqwest"
 version = "0.13.4"
-source = "git+https://github.com/seanmonstar/reqwest?rev=11489b34eda6d32b15ad4033e62beba2ee401350#11489b34eda6d32b15ad4033e62beba2ee401350"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ google-cloud-auth = { version = "1.10", default-features = false }
 bytes = { version = "1", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 http = { version = "1", default-features = false }
-schemars = { version = "0.8", default-features = false, features = ["derive"] }
+schemars = { version = "1.2", default-features = false, features = ["derive", "std"] }
 futures-util = { version = "0.3", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
@@ -28,7 +28,7 @@ tempfile = { version = "3", default-features = false }
 thiserror = { version = "2", default-features = false }
 tokio = { version = "1", default-features = false }
 tracing = { version = "0.1", default-features = false }
-reqwest = { git = "https://github.com/seanmonstar/reqwest", rev = "03db63a48f35135c2f2c8b7aaa578217d5f678fe", default-features = false, features = ["query", "system-proxy"] }
+reqwest = { git = "https://github.com/seanmonstar/reqwest", rev = "11489b34eda6d32b15ad4033e62beba2ee401350", default-features = false, features = ["query", "system-proxy"] }
 url = { version = "2", default-features = false }
 uuid = { version = "1", default-features = false, features = ["v7", "serde"] }
 ocync-distribution = { path = "crates/ocync-distribution", default-features = false }
@@ -100,7 +100,7 @@ uuid.workspace = true
 # Redirect crates.io reqwest to our git pin so transitive deps
 # (google-cloud-auth) resolve to the same version as workspace deps.
 [patch.crates-io]
-reqwest = { git = "https://github.com/seanmonstar/reqwest", rev = "03db63a48f35135c2f2c8b7aaa578217d5f678fe" }
+reqwest = { git = "https://github.com/seanmonstar/reqwest", rev = "11489b34eda6d32b15ad4033e62beba2ee401350" }
 
 [profile.release]
 strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tempfile = { version = "3", default-features = false }
 thiserror = { version = "2", default-features = false }
 tokio = { version = "1", default-features = false }
 tracing = { version = "0.1", default-features = false }
-reqwest = { git = "https://github.com/seanmonstar/reqwest", rev = "11489b34eda6d32b15ad4033e62beba2ee401350", default-features = false, features = ["query", "system-proxy"] }
+reqwest = { version = "0.13", default-features = false, features = ["query", "system-proxy"] }
 url = { version = "2", default-features = false }
 uuid = { version = "1", default-features = false, features = ["v7", "serde"] }
 ocync-distribution = { path = "crates/ocync-distribution", default-features = false }
@@ -96,11 +96,6 @@ url.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 uuid.workspace = true
-
-# Redirect crates.io reqwest to our git pin so transitive deps
-# (google-cloud-auth) resolve to the same version as workspace deps.
-[patch.crates-io]
-reqwest = { git = "https://github.com/seanmonstar/reqwest", rev = "11489b34eda6d32b15ad4033e62beba2ee401350" }
 
 [profile.release]
 strip = true

--- a/crates/ocync-distribution/src/auth/anonymous.rs
+++ b/crates/ocync-distribution/src/auth/anonymous.rs
@@ -109,10 +109,10 @@ impl AuthProvider for AnonymousAuth {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     use wiremock::matchers::{method, path, query_param};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
     use super::*;
 
@@ -245,10 +245,11 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn anonymous_auth_distinct_scopes_fetch_concurrently() {
-        // Two distinct scopes must be able to fetch tokens concurrently.
-        // Each token endpoint mock sleeps 300ms; serialized fetches take
-        // ~600ms while per-scope coalescing parallelizes them at ~300ms.
-        // The 500ms threshold leaves ~200ms margin on both sides.
+        // Two distinct scopes must reach the token endpoint concurrently --
+        // a shared provider mutex would serialize the second request behind
+        // the first's 300ms response delay. We assert on the arrival-diff at
+        // the mock (parallel: ~ms, serialized: >= 300ms) rather than total
+        // wall-clock so CI runner jitter cannot flake the test.
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/v2/"))
@@ -258,10 +259,16 @@ mod tests {
             ))
             .mount(&server)
             .await;
+        let arrivals: Arc<Mutex<Vec<std::time::Instant>>> = Arc::new(Mutex::new(Vec::new()));
         let slow_for = |scope: &str, token_value: &str| {
+            let arrivals = Arc::clone(&arrivals);
             Mock::given(method("GET"))
                 .and(path("/token"))
                 .and(query_param("scope", scope))
+                .and(move |_req: &Request| {
+                    arrivals.lock().unwrap().push(std::time::Instant::now());
+                    true
+                })
                 .respond_with(
                     ResponseTemplate::new(200)
                         .set_delay(std::time::Duration::from_millis(300))
@@ -286,18 +293,30 @@ mod tests {
         let auth_a = Arc::clone(&auth);
         let auth_b = Arc::clone(&auth);
 
-        let start = std::time::Instant::now();
         let (t_a, t_b) = tokio::join!(
             async move { auth_a.get_token(&[Scope::pull("repo-a")]).await.unwrap() },
             async move { auth_b.get_token(&[Scope::pull("repo-b")]).await.unwrap() },
         );
-        let elapsed = start.elapsed();
 
         assert_eq!(t_a.value(), "tok-a");
         assert_eq!(t_b.value(), "tok-b");
+
+        let times = arrivals.lock().unwrap();
+        assert_eq!(
+            times.len(),
+            2,
+            "expected 2 token requests, got {}",
+            times.len()
+        );
+        let (first, second) = if times[0] <= times[1] {
+            (times[0], times[1])
+        } else {
+            (times[1], times[0])
+        };
+        let diff = second.duration_since(first);
         assert!(
-            elapsed < std::time::Duration::from_millis(500),
-            "expected concurrent fetch (~300ms), got {elapsed:?}; distinct scopes must not serialize on a shared provider mutex",
+            diff < std::time::Duration::from_millis(250),
+            "expected near-simultaneous arrival, got {diff:?}; distinct scopes must not serialize on a shared provider mutex",
         );
     }
 

--- a/crates/ocync-distribution/src/auth/basic.rs
+++ b/crates/ocync-distribution/src/auth/basic.rs
@@ -126,12 +126,12 @@ impl AuthProvider for BasicAuth {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     use base64::Engine;
     use base64::engine::general_purpose::STANDARD as BASE64;
     use wiremock::matchers::{header, method, path, query_param};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
     use super::*;
 
@@ -408,14 +408,11 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn basic_auth_distinct_scopes_fetch_concurrently() {
-        // Two distinct scopes must be able to fetch tokens concurrently.
-        // The original implementation held the per-provider cache mutex
-        // for the entire check-then-fetch path, so two distinct scopes
-        // serialized through the registry even when their cache entries
-        // were independent. With per-scope coalescing they parallelize:
-        // each token endpoint mock sleeps 300ms, so sequential fetches
-        // take ~600ms and concurrent fetches take ~300ms. The 500ms
-        // threshold leaves ~200ms margin on both sides for slow CI.
+        // Two distinct scopes must reach the token endpoint concurrently --
+        // a shared provider mutex would serialize the second request behind
+        // the first's 300ms response delay. We assert on the arrival-diff at
+        // the mock (parallel: ~ms, serialized: >= 300ms) rather than total
+        // wall-clock so CI runner jitter cannot flake the test.
         let server = MockServer::start().await;
         // The challenge response is not bounded by `expect` because the
         // number of hits depends on which task wins the parallel race.
@@ -430,11 +427,17 @@ mod tests {
             ))
             .mount(&server)
             .await;
+        let arrivals: Arc<Mutex<Vec<std::time::Instant>>> = Arc::new(Mutex::new(Vec::new()));
         let slow_for = |scope: &str, token_value: &str| {
+            let arrivals = Arc::clone(&arrivals);
             Mock::given(method("GET"))
                 .and(path("/token"))
                 .and(query_param("scope", scope))
                 .and(header("Authorization", expected_basic_header().as_str()))
+                .and(move |_req: &Request| {
+                    arrivals.lock().unwrap().push(std::time::Instant::now());
+                    true
+                })
                 .respond_with(
                     ResponseTemplate::new(200)
                         .set_delay(std::time::Duration::from_millis(300))
@@ -460,18 +463,30 @@ mod tests {
         let auth_a = Arc::clone(&auth);
         let auth_b = Arc::clone(&auth);
 
-        let start = std::time::Instant::now();
         let (t_a, t_b) = tokio::join!(
             async move { auth_a.get_token(&[Scope::pull("repo-a")]).await.unwrap() },
             async move { auth_b.get_token(&[Scope::pull("repo-b")]).await.unwrap() },
         );
-        let elapsed = start.elapsed();
 
         assert_eq!(t_a.value(), "tok-a");
         assert_eq!(t_b.value(), "tok-b");
+
+        let times = arrivals.lock().unwrap();
+        assert_eq!(
+            times.len(),
+            2,
+            "expected 2 token requests, got {}",
+            times.len()
+        );
+        let (first, second) = if times[0] <= times[1] {
+            (times[0], times[1])
+        } else {
+            (times[1], times[0])
+        };
+        let diff = second.duration_since(first);
         assert!(
-            elapsed < std::time::Duration::from_millis(500),
-            "expected concurrent fetch (~300ms), got {elapsed:?}; distinct scopes must not serialize on a shared provider mutex",
+            diff < std::time::Duration::from_millis(250),
+            "expected near-simultaneous arrival, got {diff:?}; distinct scopes must not serialize on a shared provider mutex",
         );
     }
 

--- a/crates/ocync-distribution/src/auth/docker.rs
+++ b/crates/ocync-distribution/src/auth/docker.rs
@@ -442,7 +442,7 @@ fn default_config_path() -> Option<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     use super::*;
 
@@ -1002,10 +1002,11 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn docker_config_auth_distinct_scopes_fetch_concurrently() {
-        // Two distinct scopes must be able to fetch tokens concurrently.
-        // Each token endpoint mock sleeps 300ms; serialized fetches take
-        // ~600ms while per-scope coalescing parallelizes them at ~300ms.
-        // The 500ms threshold leaves ~200ms margin on both sides.
+        // Two distinct scopes must reach the token endpoint concurrently --
+        // a shared provider mutex would serialize the second request behind
+        // the first's 300ms response delay. We assert on the arrival-diff at
+        // the mock (parallel: ~ms, serialized: >= 300ms) rather than total
+        // wall-clock so CI runner jitter cannot flake the test.
         let mock = wiremock::MockServer::start().await;
         wiremock::Mock::given(wiremock::matchers::method("GET"))
             .and(wiremock::matchers::path("/v2/"))
@@ -1015,10 +1016,16 @@ mod tests {
             ))
             .mount(&mock)
             .await;
+        let arrivals: Arc<Mutex<Vec<std::time::Instant>>> = Arc::new(Mutex::new(Vec::new()));
         let slow_for = |scope: &str, token_value: &str| {
+            let arrivals = Arc::clone(&arrivals);
             wiremock::Mock::given(wiremock::matchers::method("GET"))
                 .and(wiremock::matchers::path("/token"))
                 .and(wiremock::matchers::query_param("scope", scope))
+                .and(move |_req: &wiremock::Request| {
+                    arrivals.lock().unwrap().push(std::time::Instant::now());
+                    true
+                })
                 .respond_with(
                     wiremock::ResponseTemplate::new(200)
                         .set_delay(std::time::Duration::from_millis(300))
@@ -1044,18 +1051,30 @@ mod tests {
         let auth_a = Arc::clone(&auth);
         let auth_b = Arc::clone(&auth);
 
-        let start = std::time::Instant::now();
         let (t_a, t_b) = tokio::join!(
             async move { auth_a.get_token(&[Scope::pull("repo-a")]).await.unwrap() },
             async move { auth_b.get_token(&[Scope::pull("repo-b")]).await.unwrap() },
         );
-        let elapsed = start.elapsed();
 
         assert_eq!(t_a.value(), "tok-a");
         assert_eq!(t_b.value(), "tok-b");
+
+        let times = arrivals.lock().unwrap();
+        assert_eq!(
+            times.len(),
+            2,
+            "expected 2 token requests, got {}",
+            times.len()
+        );
+        let (first, second) = if times[0] <= times[1] {
+            (times[0], times[1])
+        } else {
+            (times[1], times[0])
+        };
+        let diff = second.duration_since(first);
         assert!(
-            elapsed < std::time::Duration::from_millis(500),
-            "expected concurrent fetch (~300ms), got {elapsed:?}; distinct scopes must not serialize on a shared provider mutex",
+            diff < std::time::Duration::from_millis(250),
+            "expected near-simultaneous arrival, got {diff:?}; distinct scopes must not serialize on a shared provider mutex",
         );
     }
 }

--- a/crates/ocync-sync/tests/sync_concurrent.rs
+++ b/crates/ocync-sync/tests/sync_concurrent.rs
@@ -3,7 +3,7 @@
 
 mod helpers;
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use ocync_distribution::spec::{Descriptor, ImageManifest, MediaType, RepositoryName};
 use ocync_sync::ImageStatus;
@@ -12,7 +12,7 @@ use ocync_sync::progress::NullProgress;
 use ocync_sync::shutdown::ShutdownSignal;
 use ocync_sync::staging::BlobStage;
 use wiremock::matchers::{method, path, query_param};
-use wiremock::{Mock, MockServer, ResponseTemplate};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
 use helpers::*;
 
@@ -506,7 +506,10 @@ async fn sync_wave_promotion_three_images_shared_layer() {
 
 /// Verify that `transfer_image_blobs` processes blobs concurrently, not
 /// sequentially. An image with 8 blobs, each delayed 100ms on source pull,
-/// should complete well under 8 * 100ms = 800ms given `BLOB_CONCURRENCY=6`.
+/// runs under `BLOB_CONCURRENCY=6`. We assert on the arrival span of the 8
+/// blob GETs at the source mock (parallel: first 6 cluster at ~0, last 2 at
+/// ~100ms; serialized: 8 spread across ~700ms) rather than total wall-clock,
+/// so CI runner jitter cannot flake the test.
 #[tokio::test(flavor = "current_thread")]
 async fn sync_blob_concurrency_processes_multiple_blobs() {
     let source_server = MockServer::start().await;
@@ -534,10 +537,19 @@ async fn sync_blob_concurrency_processes_multiple_blobs() {
     };
     let (manifest_bytes, _) = serialize_manifest(&manifest);
 
-    // Source: serve manifest immediately; each blob with a 100ms delay.
+    // Source: serve manifest immediately; each blob GET is recorded on
+    // arrival, then delayed 100ms.
     mount_source_manifest(&source_server, "repo", "v1", &manifest_bytes).await;
+    let arrivals: Arc<Mutex<Vec<std::time::Instant>>> = Arc::new(Mutex::new(Vec::new()));
+    let record_arrival = |arrivals: Arc<Mutex<Vec<std::time::Instant>>>| {
+        move |_req: &Request| {
+            arrivals.lock().unwrap().push(std::time::Instant::now());
+            true
+        }
+    };
     Mock::given(method("GET"))
         .and(path(format!("/v2/repo/blobs/{}", config_desc.digest)))
+        .and(record_arrival(Arc::clone(&arrivals)))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_bytes(config_data.to_vec())
@@ -549,6 +561,7 @@ async fn sync_blob_concurrency_processes_multiple_blobs() {
     for (i, desc) in layer_descs.iter().enumerate() {
         Mock::given(method("GET"))
             .and(path(format!("/v2/repo/blobs/{}", desc.digest)))
+            .and(record_arrival(Arc::clone(&arrivals)))
             .respond_with(
                 ResponseTemplate::new(200)
                     .set_body_bytes(layer_data[i].clone())
@@ -576,7 +589,6 @@ async fn sync_blob_concurrency_processes_multiple_blobs() {
     );
 
     let engine = SyncEngine::new(fast_retry(), 1);
-    let start = std::time::Instant::now();
     let report = engine
         .run(
             vec![mapping],
@@ -586,7 +598,6 @@ async fn sync_blob_concurrency_processes_multiple_blobs() {
             Some(&ShutdownSignal::new()),
         )
         .await;
-    let elapsed = start.elapsed();
 
     assert_eq!(report.images.len(), 1);
     assert_status!(report, 0, ImageStatus::Synced);
@@ -594,11 +605,24 @@ async fn sync_blob_concurrency_processes_multiple_blobs() {
         report.stats.blobs_transferred, 8,
         "all 8 blobs should be transferred"
     );
-    // With BLOB_CONCURRENCY=6, 8 blobs at 100ms each need ~2 batches (~200ms).
-    // 1200ms is generous for CI runners; still proves concurrency (sequential >= 800ms).
+
+    let times = arrivals.lock().unwrap();
+    assert_eq!(
+        times.len(),
+        8,
+        "expected 8 blob GETs at source, got {}",
+        times.len()
+    );
+    let min = times.iter().min().unwrap();
+    let max = times.iter().max().unwrap();
+    let span = max.duration_since(*min);
+    // With BLOB_CONCURRENCY=6 and 100ms per-blob delay, arrivals cluster
+    // into ~2 batches (first 6 at ~0, last 2 at ~100ms) for a ~100ms span.
+    // Serialized would span ~700ms. 400ms threshold leaves ~300ms margin
+    // on both sides.
     assert!(
-        elapsed < std::time::Duration::from_millis(1200),
-        "elapsed {elapsed:?} should be < 1200ms (sequential would be >= 800ms)"
+        span < std::time::Duration::from_millis(400),
+        "expected blob GETs to cluster (parallel: ~100ms span), got {span:?}; sequential would span ~700ms",
     );
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -39,6 +39,7 @@ skip = [
   { crate = "http@0.2" },             # AWS SDK smithy internals still on http 0.2
   { crate = "http-body@0.4" },        # AWS SDK smithy internals still on http-body 0.4
   { crate = "r-efi@5" },              # getrandom 0.3 vs 0.4
+  { crate = "shlex@1" },              # aws-lc-fips-sys bindgen (1.3) vs cc 1.2 (2.0)
   { crate = "wit-bindgen@0.51" },     # getrandom 0.4 (wasip3) vs wit-bindgen 0.57
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -46,6 +46,3 @@ skip = [
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-git = [
-  "https://github.com/seanmonstar/reqwest",  # pinned to post-0.13.2 for rustls-platform-verifier 0.7 (removes jni dups); revert to crates.io on 0.13.3
-]

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from "astro/config";
+import { unified } from "@astrojs/markdown-remark";
 import sitemap from "@astrojs/sitemap";
 import rehypeSlug from "rehype-slug";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
@@ -16,23 +17,25 @@ export default defineConfig({
   trailingSlash: "never",
   integrations: [sitemap()],
   markdown: {
-    remarkPlugins: [
-      [rewriteInternalLinks, { base }],
-    ],
-    rehypePlugins: [
-      rehypeSlug,
-      [rehypeAutolinkHeadings, {
-        behavior: "append",
-        properties: { class: "heading-anchor" },
-        content: {
-          type: "element",
-          tagName: "span",
-          properties: { class: "icon icon-link" },
-          children: [],
-        },
-      }],
-      [rehypeExternalLinks, { rel: ["noopener"], target: false }],
-    ],
+    processor: unified({
+      remarkPlugins: [
+        [rewriteInternalLinks, { base }],
+      ],
+      rehypePlugins: [
+        rehypeSlug,
+        [rehypeAutolinkHeadings, {
+          behavior: "append",
+          properties: { class: "heading-anchor" },
+          content: {
+            type: "element",
+            tagName: "span",
+            properties: { class: "icon icon-link" },
+            children: [],
+          },
+        }],
+        [rehypeExternalLinks, { rel: ["noopener"], target: false }],
+      ],
+    }),
     shikiConfig: {
       themes: {
         light: ocyncLight,

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "name": "ocync-docs",
       "dependencies": {
-        "@astrojs/sitemap": "3.7.2",
-        "astro": "6.3.3",
+        "@astrojs/sitemap": "3.7.3",
+        "astro": "6.4.2",
         "rehype-autolink-headings": "^7.1.0",
         "rehype-external-links": "^3.0.0",
         "rehype-slug": "^6.0.0"
@@ -20,26 +20,32 @@
       "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.1.tgz",
-      "integrity": "sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.0.tgz",
+      "integrity": "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==",
       "license": "MIT",
       "dependencies": {
-        "picomatch": "^4.0.4"
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.1.1",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
       }
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.2.tgz",
-      "integrity": "sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.0.tgz",
+      "integrity": "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.9.1",
+        "@astrojs/internal-helpers": "0.10.0",
         "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-text": "^4.0.2",
-        "js-yaml": "^4.1.1",
         "mdast-util-definitions": "^6.0.0",
         "rehype-raw": "^7.0.0",
         "rehype-stringify": "^10.0.1",
@@ -47,9 +53,6 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
-        "retext-smartypants": "^6.2.0",
-        "shiki": "^4.0.0",
-        "smol-toml": "^1.6.0",
         "unified": "^11.0.5",
         "unist-util-remove-position": "^5.0.0",
         "unist-util-visit": "^5.1.0",
@@ -70,7 +73,9 @@
       }
     },
     "node_modules/@astrojs/sitemap": {
-      "version": "3.7.2",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
+      "integrity": "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==",
       "license": "MIT",
       "dependencies": {
         "sitemap": "^9.0.0",
@@ -95,24 +100,30 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -122,11 +133,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -134,6 +147,8 @@
     },
     "node_modules/@capsizecss/unpack": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.0.tgz",
+      "integrity": "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==",
       "license": "MIT",
       "dependencies": {
         "fontkitten": "^1.0.0"
@@ -143,7 +158,9 @@
       }
     },
     "node_modules/@clack/core": {
-      "version": "1.3.0",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-7Wctjq6f7c1CPz8sPpkwUnz8yRgVANkpNupb81q432FjcJg4l+Sw7XANdNSdWfAKq0IHI0JTcUeK5dxs/HrGPw==",
       "license": "MIT",
       "dependencies": {
         "fast-wrap-ansi": "^0.2.0",
@@ -154,10 +171,12 @@
       }
     },
     "node_modules/@clack/prompts": {
-      "version": "1.3.0",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.5.0.tgz",
+      "integrity": "sha512-wKh+wTjmrUoUdkZg8KpJO5X+p9PWV+KE9mePseq9UYWkukgTKsGS47RRL2HstwVcvDQH+PenrPJWII8+MfiiyA==",
       "license": "MIT",
       "dependencies": {
-        "@clack/core": "1.3.0",
+        "@clack/core": "1.4.0",
         "fast-string-width": "^3.0.2",
         "fast-wrap-ansi": "^0.2.0",
         "sisteransi": "^1.0.5"
@@ -242,6 +261,8 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -592,6 +613,8 @@
     },
     "node_modules/@img/colour": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -600,6 +623,8 @@
     },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
@@ -642,6 +667,8 @@
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
@@ -1100,14 +1127,20 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.3.0",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -1127,9 +1160,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
-      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.0.tgz",
+      "integrity": "sha512-dnxczajOqt0gesZlN5pGQ1s1imQVrsmCw5G2Ci4oM+0WvNz3pyRnlWrT7McoZIb8VlFwCawdmbWRmxRn7HI+VQ==",
       "cpu": [
         "arm"
       ],
@@ -1140,9 +1173,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
-      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.0.tgz",
+      "integrity": "sha512-Bp3JpGP00Vu3f238ivRrjf7z3xSzVPXqCmaJYA9t2c+c8vKYvOzmXF7LkkeUalTEGd6cZcSWe+PFIP3Vy48fRg==",
       "cpu": [
         "arm64"
       ],
@@ -1153,7 +1186,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.2",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.0.tgz",
+      "integrity": "sha512-zaYIpr670mUmmZ1tVzUFplbQbG7h3Gugx3L5FoqhsC2m/YnLlR1a7zVLmXNPy+iY1tFPEbNG+HHBXZGyId0G5w==",
       "cpu": [
         "arm64"
       ],
@@ -1164,9 +1199,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
-      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.0.tgz",
+      "integrity": "sha512-+P49fvkv2dSoeevUW+lgZ/I2JHSsJCK1Lyjj7Cu6E4UHG4tS9XIefzIjo5qhgELjAclnen1rLzK2PMKJdo+Dyg==",
       "cpu": [
         "x64"
       ],
@@ -1177,9 +1212,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
-      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.0.tgz",
+      "integrity": "sha512-l3FAAOyKJXH2ea6KNFN+MMgC/rnE94YGLXs2ehYqDcCoHt1DpvgWX75BhUJxN38XojP7Ul+4H8PRn7EdyqSDrw==",
       "cpu": [
         "arm64"
       ],
@@ -1190,9 +1225,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
-      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.0.tgz",
+      "integrity": "sha512-VokPN3TSctKj65cyCNPaUh4vMFA8awxOot/0sp+4J7ZlNRKQEhXhawqPwajoi8H5ZFt61i0ugZJuTKXBjGJ17Q==",
       "cpu": [
         "x64"
       ],
@@ -1203,9 +1238,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
-      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.0.tgz",
+      "integrity": "sha512-DxH0P3wxm+Yzs/p3zrk9dw1rURu8p0Nv5+MRK/L7OtnLNg5rLZraSBFZ8iUXOd9f2BlhJyEpIZUH/emjq4UJ4g==",
       "cpu": [
         "arm"
       ],
@@ -1219,9 +1254,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
-      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.0.tgz",
+      "integrity": "sha512-T6ZvMNe84kAz6TBWHC7hGAoEtzP1LWYw/AqayGWEF6uISt3Abk/st06LqRD9THd7Xz3NxzurUpzAuEAUbZf+nw==",
       "cpu": [
         "arm"
       ],
@@ -1235,9 +1270,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
-      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.0.tgz",
+      "integrity": "sha512-q/4hzvQkDs8b4jIBab1pnLiiM0ayTZsN2amBFPDzuyZxjEd4wDwx0UJFYM3cOZzSf5Kw8fnWSprJzIBMkcR44Q==",
       "cpu": [
         "arm64"
       ],
@@ -1251,9 +1286,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
-      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.0.tgz",
+      "integrity": "sha512-vvYWX3akdEAY6km+9wAqFDnk6pQsbJKVnj7xawcvs/+fdlYBGp+U+Qq/lLfpIxYIZvZLHMAKD9HLdacSx/r3dw==",
       "cpu": [
         "arm64"
       ],
@@ -1267,9 +1302,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
-      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.0.tgz",
+      "integrity": "sha512-DePa5cqOxDP/Zp0VOXpeWaGew5iIv5DXp9NYbzkX5PFQyWVX9184WCTh3hvr/7lhXo8ZVlbFLkz8+o/q1dU6gA==",
       "cpu": [
         "loong64"
       ],
@@ -1283,9 +1318,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
-      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.0.tgz",
+      "integrity": "sha512-LV8aWMB8UChglMCEzs7RkN0GsH29RJaLLqwm9fCIjlqwxQTiWAqNcc7wjBkH31hV0PU/yVxGYvrYsgfea2qw6g==",
       "cpu": [
         "loong64"
       ],
@@ -1299,9 +1334,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
-      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.0.tgz",
+      "integrity": "sha512-QoNSnwQtaeNu5grdBbsL0tt1uyl5EnS8DA8Mr3nluMXbhdQNyhN+G4tBax7VCdxLKj8YJ0/4OO9Ho84jMnJtKA==",
       "cpu": [
         "ppc64"
       ],
@@ -1315,9 +1350,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
-      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.0.tgz",
+      "integrity": "sha512-/zZp5MKapIIApE8trN8qLGNSiRN9TUoaUZ1cmVu4XnVdd5LQLOXTtyi+vtfUbNnT3iyjzpPqYeKXmvJ+gJGYWw==",
       "cpu": [
         "ppc64"
       ],
@@ -1331,9 +1366,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
-      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.0.tgz",
+      "integrity": "sha512-RbrzcD3aJ1k3UbtMRRBNwojdVVyXjuVAFTfn/xPa6EEl6GE9Sm/akPgFTb9aAC9pMKGJ6CtWxaGrqWcabH+ySg==",
       "cpu": [
         "riscv64"
       ],
@@ -1347,9 +1382,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
-      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.0.tgz",
+      "integrity": "sha512-ZF+onDsBso8PJf1XaG9lB+O9RnBpKGnY6OrzC4CSHrtC1jb6jWLTKK4bRqdoCXHd22gyr2hiYmEAm8Wns/BOCw==",
       "cpu": [
         "riscv64"
       ],
@@ -1363,9 +1398,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
-      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.0.tgz",
+      "integrity": "sha512-Atk0aSIk5Zx2Wuh9dgRQgLP0Koc8hOeYpbWryMXyk8G8/HmPkwPPkMqIIDhrXHHYqfUzSJA/I7IWSBv8xSmRBA==",
       "cpu": [
         "s390x"
       ],
@@ -1379,9 +1414,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.0.tgz",
+      "integrity": "sha512-0uMOcf3eZ5K+K4cYHkdxShFMPlPXCOdfDFEFn9dNYAEEd2cVvmOfH7zFgRVoDgmtQ1m9k5q7qfrHzyMAubKYUA==",
       "cpu": [
         "x64"
       ],
@@ -1395,9 +1430,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
-      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.0.tgz",
+      "integrity": "sha512-mvFtE4A/t/7hRJ7X8Ozmu8FsIkAUat2nzl12pgU337BRmq87AQUJztwHz2Zv5/tjo9/C95E66CK03SI/ToEDJw==",
       "cpu": [
         "x64"
       ],
@@ -1411,9 +1446,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
-      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.0.tgz",
+      "integrity": "sha512-z9b9+aTxvt8n2rNltMPvyaUfB8NJ+CVyOrGK/MdIKHx7B+lXmZpm/XbRsU7Rpf3fRqJ2uS6mBJiJveCtq8LHDg==",
       "cpu": [
         "x64"
       ],
@@ -1424,9 +1459,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
-      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.0.tgz",
+      "integrity": "sha512-jXaXFqKMehsOc+g8R6oo33RRC6w07G9jDBxAE5eAKX7mOcCbZloYIPNhfG9Wl+P9O9IWHFO4OJgPi1Ml2qkt7w==",
       "cpu": [
         "arm64"
       ],
@@ -1437,9 +1472,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
-      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.0.tgz",
+      "integrity": "sha512-OXNWVFocS2IA4+QplhTZZ2a+8hPZR7T8KuozsNmJKK8y7cp83StHvGksfHzPG3wczWTczyWHVQuqeiTUbjiyBg==",
       "cpu": [
         "arm64"
       ],
@@ -1450,9 +1485,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
-      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.0.tgz",
+      "integrity": "sha512-AlAbNtBO637LxSldqV43z0FfXoGfl2TW1DgAg/bs7aQswFbDewz2SJm3BUhiGfbOVtW571xbc9p+REdxhyN/Eg==",
       "cpu": [
         "ia32"
       ],
@@ -1463,9 +1498,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.0.tgz",
+      "integrity": "sha512-QRSrQXyJ1M4tjNXdR0/G/IgV6lzfQQJYBjlWIEYkY2Xs86DRl/iEpQ4blMDjJxSl7n19eDKKXMg0AmuBVYy8pQ==",
       "cpu": [
         "x64"
       ],
@@ -1476,9 +1511,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
-      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.0.tgz",
+      "integrity": "sha512-tkuFxhvKO/HlGd0VsINF6vHSYH8AF8W0TcNxKDK6JZmrehngFj78pToc8iemtnvwilDjs2G/qSzYFhe9U8q+fw==",
       "cpu": [
         "x64"
       ],
@@ -1489,13 +1524,13 @@
       ]
     },
     "node_modules/@shikijs/core": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
-      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.1.0.tgz",
+      "integrity": "sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/primitive": "4.0.2",
-        "@shikijs/types": "4.0.2",
+        "@shikijs/primitive": "4.1.0",
+        "@shikijs/types": "4.1.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.5"
@@ -1505,26 +1540,26 @@
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
-      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.1.0.tgz",
+      "integrity": "sha512-YquhawCUgaBfhsS72e2Y/dI59gCBNPHu3fEO/tvLaXrTssxZrY5ddjtNLTwndrMgPo8b3IscE+xoICDzpTmlFQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.0.2",
+        "@shikijs/types": "4.1.0",
         "@shikijs/vscode-textmate": "^10.0.2",
-        "oniguruma-to-es": "^4.3.4"
+        "oniguruma-to-es": "^4.3.6"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
-      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.1.0.tgz",
+      "integrity": "sha512-axLpjVs45YBvvINa+dJF+NPW+KtFkNXsFr4SDw2BMj9GdeMnGxVB9PQb2xXlJYovslt/nz6giedAyOANkfc7hg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.0.2",
+        "@shikijs/types": "4.1.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       },
       "engines": {
@@ -1532,24 +1567,24 @@
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
-      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.1.0.tgz",
+      "integrity": "sha512-nwOMruEkbgdZfQ/b8CgpNBVOpvG1k0N5tbmgiFeqsan401+x3ILqlzZJowSla4Agmq4hG2Uf2wh5jLTEhR8VSg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.0.2"
+        "@shikijs/types": "4.1.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@shikijs/primitive": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
-      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.1.0.tgz",
+      "integrity": "sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.0.2",
+        "@shikijs/types": "4.1.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       },
@@ -1558,21 +1593,21 @@
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
-      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.1.0.tgz",
+      "integrity": "sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.0.2"
+        "@shikijs/types": "4.1.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
-      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
@@ -1598,11 +1633,15 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -1610,6 +1649,8 @@
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -1631,7 +1672,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.12.2",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1639,6 +1682,8 @@
     },
     "node_modules/@types/sax": {
       "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1646,14 +1691,20 @@
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "license": "ISC"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -1665,6 +1716,8 @@
     },
     "node_modules/anymatch/node_modules/picomatch": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -1675,6 +1728,8 @@
     },
     "node_modules/arg": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -1685,6 +1740,8 @@
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -1701,14 +1758,14 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.3.3.tgz",
-      "integrity": "sha512-wvLIZQYbBZt6U8gyflBW4SLBypaqdwLZUH93rT3oT53cmQ0bTGubvMAGjqBRoheOYzYcTJZtW6czztzbu4kQ5g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.2.tgz",
+      "integrity": "sha512-8H89CH2dKL5SCU99OCqdU9BGjmPkSJqaPurywj5XMo7eMFGUFD3vsNhdEKnEh4mK4LgGje3/QDTTSIIGst0G0Q==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",
-        "@astrojs/internal-helpers": "0.9.1",
-        "@astrojs/markdown-remark": "7.1.2",
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/markdown-remark": "7.2.0",
         "@astrojs/telemetry": "3.3.2",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
@@ -1780,6 +1837,8 @@
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -1787,6 +1846,8 @@
     },
     "node_modules/bail": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1795,10 +1856,14 @@
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
     },
     "node_modules/ccount": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1817,6 +1882,8 @@
     },
     "node_modules/character-entities-html4": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1825,6 +1892,8 @@
     },
     "node_modules/character-entities-legacy": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1833,6 +1902,8 @@
     },
     "node_modules/chokidar": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
       "dependencies": {
         "readdirp": "^5.0.0"
@@ -1861,6 +1932,8 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -1868,6 +1941,8 @@
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1876,6 +1951,8 @@
     },
     "node_modules/commander": {
       "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -1883,6 +1960,8 @@
     },
     "node_modules/common-ancestor-path": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
+      "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">= 18"
@@ -1890,6 +1969,8 @@
     },
     "node_modules/cookie": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1901,10 +1982,14 @@
     },
     "node_modules/cookie-es": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
       "license": "MIT"
     },
     "node_modules/crossws": {
       "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
       "license": "MIT",
       "dependencies": {
         "uncrypto": "^0.1.3"
@@ -1912,6 +1997,8 @@
     },
     "node_modules/css-select": {
       "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
@@ -1926,6 +2013,8 @@
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.27.1",
@@ -1937,6 +2026,8 @@
     },
     "node_modules/css-what": {
       "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
@@ -1947,6 +2038,8 @@
     },
     "node_modules/csso": {
       "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
       "license": "MIT",
       "dependencies": {
         "css-tree": "~2.2.0"
@@ -1958,6 +2051,8 @@
     },
     "node_modules/csso/node_modules/css-tree": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.0.28",
@@ -1970,6 +2065,8 @@
     },
     "node_modules/csso/node_modules/mdn-data": {
       "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "license": "CC0-1.0"
     },
     "node_modules/debug": {
@@ -2004,10 +2101,14 @@
     },
     "node_modules/defu": {
       "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
     "node_modules/dequal": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2015,10 +2116,14 @@
     },
     "node_modules/destr": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
       "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
       "optional": true,
       "engines": {
@@ -2033,6 +2138,8 @@
     },
     "node_modules/devlop": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.0"
@@ -2044,6 +2151,8 @@
     },
     "node_modules/diff": {
       "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -2051,6 +2160,8 @@
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
@@ -2063,6 +2174,8 @@
     },
     "node_modules/dom-serializer/node_modules/entities": {
       "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -2073,6 +2186,8 @@
     },
     "node_modules/domelementtype": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "funding": [
         {
           "type": "github",
@@ -2083,6 +2198,8 @@
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "^2.3.0"
@@ -2096,6 +2213,8 @@
     },
     "node_modules/domutils": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
@@ -2117,6 +2236,8 @@
     },
     "node_modules/entities": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -2127,10 +2248,14 @@
     },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2182,29 +2307,41 @@
     },
     "node_modules/estree-walker": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
       "license": "MIT"
     },
     "node_modules/fast-string-width": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
       "license": "MIT",
       "dependencies": {
         "fast-string-truncated-width": "^3.0.2"
       }
     },
     "node_modules/fast-wrap-ansi": {
-      "version": "0.2.0",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^3.0.2"
@@ -2212,6 +2349,8 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -2227,6 +2366,8 @@
     },
     "node_modules/flattie": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
+      "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2234,6 +2375,8 @@
     },
     "node_modules/fontace": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
+      "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
       "license": "MIT",
       "dependencies": {
         "fontkitten": "^1.0.2"
@@ -2241,6 +2384,8 @@
     },
     "node_modules/fontkitten": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
+      "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
       "license": "MIT",
       "dependencies": {
         "tiny-inflate": "^1.0.3"
@@ -2280,10 +2425,14 @@
     },
     "node_modules/github-slugger": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "license": "ISC"
     },
     "node_modules/h3": {
       "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
       "license": "MIT",
       "dependencies": {
         "cookie-es": "^1.2.3",
@@ -2299,6 +2448,8 @@
     },
     "node_modules/hast-util-from-html": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -2315,6 +2466,8 @@
     },
     "node_modules/hast-util-from-parse5": {
       "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -2333,6 +2486,8 @@
     },
     "node_modules/hast-util-heading-rank": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -2344,6 +2499,8 @@
     },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -2355,6 +2512,8 @@
     },
     "node_modules/hast-util-parse-selector": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -2391,6 +2550,8 @@
     },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -2431,6 +2592,8 @@
     },
     "node_modules/hast-util-to-string": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -2458,6 +2621,8 @@
     },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -2469,6 +2634,8 @@
     },
     "node_modules/hastscript": {
       "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -2484,10 +2651,14 @@
     },
     "node_modules/html-escaper": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
       "license": "MIT"
     },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2496,10 +2667,14 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/brc-dd"
@@ -2507,6 +2682,8 @@
     },
     "node_modules/is-absolute-url": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -2565,6 +2742,8 @@
     },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2589,9 +2768,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2617,7 +2806,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -2625,16 +2816,20 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/magicast": {
-      "version": "0.5.2",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
+        "@babel/parser": "^7.29.3",
         "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
       }
@@ -2821,6 +3016,8 @@
     },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -2874,6 +3071,8 @@
     },
     "node_modules/mdn-data": {
       "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
     },
     "node_modules/micromark": {
@@ -3175,6 +3374,8 @@
     },
     "node_modules/micromark-util-character": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3294,6 +3495,8 @@
     },
     "node_modules/micromark-util-encode": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3362,6 +3565,8 @@
     },
     "node_modules/micromark-util-sanitize-uri": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3403,6 +3608,8 @@
     },
     "node_modules/micromark-util-symbol": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3417,6 +3624,8 @@
     },
     "node_modules/micromark-util-types": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3431,6 +3640,8 @@
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3443,7 +3654,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -3460,6 +3673,8 @@
     },
     "node_modules/neotraverse": {
       "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+      "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -3480,14 +3695,20 @@
     },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "license": "MIT"
     },
     "node_modules/node-mock-http": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
+      "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
       "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3495,6 +3716,8 @@
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0"
@@ -3505,6 +3728,8 @@
     },
     "node_modules/obug": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
@@ -3513,6 +3738,8 @@
     },
     "node_modules/ofetch": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
       "license": "MIT",
       "dependencies": {
         "destr": "^2.0.5",
@@ -3522,6 +3749,8 @@
     },
     "node_modules/ohash": {
       "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "license": "MIT"
     },
     "node_modules/oniguruma-parser": {
@@ -3543,6 +3772,8 @@
     },
     "node_modules/p-limit": {
       "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^1.2.1"
@@ -3555,7 +3786,9 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "9.2.0",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.4",
@@ -3570,6 +3803,8 @@
     },
     "node_modules/p-timeout": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -3580,6 +3815,8 @@
     },
     "node_modules/package-manager-detector": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
     "node_modules/parse-latin": {
@@ -3602,6 +3839,8 @@
     },
     "node_modules/parse5": {
       "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -3612,14 +3851,20 @@
     },
     "node_modules/piccolore": {
       "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+      "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
       "license": "ISC"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3629,7 +3874,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -3646,7 +3893,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3665,6 +3912,8 @@
     },
     "node_modules/property-information": {
       "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3673,10 +3922,14 @@
     },
     "node_modules/radix3": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -3712,6 +3965,8 @@
     },
     "node_modules/rehype": {
       "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
+      "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -3726,6 +3981,8 @@
     },
     "node_modules/rehype-autolink-headings": {
       "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-7.1.0.tgz",
+      "integrity": "sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -3742,6 +3999,8 @@
     },
     "node_modules/rehype-external-links": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
+      "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -3758,6 +4017,8 @@
     },
     "node_modules/rehype-parse": {
       "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -3786,6 +4047,8 @@
     },
     "node_modules/rehype-slug": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -3801,6 +4064,8 @@
     },
     "node_modules/rehype-stringify": {
       "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -3964,10 +4229,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.2",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.0.tgz",
+      "integrity": "sha512-T9mWdbWfQtp0B5lv/HX+wrhYsmXRlcWnXXmJbXqKJhlRaoS6KMhq0gpyzW4UJfclcxrEdLnTgjT2NjruLONu0g==",
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -3977,43 +4244,47 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.2",
-        "@rollup/rollup-android-arm64": "4.60.2",
-        "@rollup/rollup-darwin-arm64": "4.60.2",
-        "@rollup/rollup-darwin-x64": "4.60.2",
-        "@rollup/rollup-freebsd-arm64": "4.60.2",
-        "@rollup/rollup-freebsd-x64": "4.60.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
-        "@rollup/rollup-linux-arm64-musl": "4.60.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
-        "@rollup/rollup-linux-loong64-musl": "4.60.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-musl": "4.60.2",
-        "@rollup/rollup-openbsd-x64": "4.60.2",
-        "@rollup/rollup-openharmony-arm64": "4.60.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
-        "@rollup/rollup-win32-x64-gnu": "4.60.2",
-        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "@rollup/rollup-android-arm-eabi": "4.61.0",
+        "@rollup/rollup-android-arm64": "4.61.0",
+        "@rollup/rollup-darwin-arm64": "4.61.0",
+        "@rollup/rollup-darwin-x64": "4.61.0",
+        "@rollup/rollup-freebsd-arm64": "4.61.0",
+        "@rollup/rollup-freebsd-x64": "4.61.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.0",
+        "@rollup/rollup-linux-arm64-musl": "4.61.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.0",
+        "@rollup/rollup-linux-loong64-musl": "4.61.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.0",
+        "@rollup/rollup-linux-x64-gnu": "4.61.0",
+        "@rollup/rollup-linux-x64-musl": "4.61.0",
+        "@rollup/rollup-openbsd-x64": "4.61.0",
+        "@rollup/rollup-openharmony-arm64": "4.61.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.0",
+        "@rollup/rollup-win32-x64-gnu": "4.61.0",
+        "@rollup/rollup-win32-x64-msvc": "4.61.0",
         "fsevents": "~2.3.2"
       }
     },
     "node_modules/sax": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4024,6 +4295,8 @@
     },
     "node_modules/sharp": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -4066,17 +4339,17 @@
       }
     },
     "node_modules/shiki": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
-      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.1.0.tgz",
+      "integrity": "sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "4.0.2",
-        "@shikijs/engine-javascript": "4.0.2",
-        "@shikijs/engine-oniguruma": "4.0.2",
-        "@shikijs/langs": "4.0.2",
-        "@shikijs/themes": "4.0.2",
-        "@shikijs/types": "4.0.2",
+        "@shikijs/core": "4.1.0",
+        "@shikijs/engine-javascript": "4.1.0",
+        "@shikijs/engine-oniguruma": "4.1.0",
+        "@shikijs/langs": "4.1.0",
+        "@shikijs/themes": "4.1.0",
+        "@shikijs/types": "4.1.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       },
@@ -4086,10 +4359,14 @@
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
     "node_modules/sitemap": {
       "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^24.9.2",
@@ -4119,6 +4396,8 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4126,6 +4405,8 @@
     },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4134,10 +4415,14 @@
     },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
       "license": "MIT",
       "dependencies": {
         "character-entities-html4": "^2.0.0",
@@ -4150,6 +4435,8 @@
     },
     "node_modules/svgo": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",
@@ -4173,24 +4460,32 @@
     },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
     "node_modules/tinyclip": {
-      "version": "0.1.12",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.13.tgz",
+      "integrity": "sha512-8OqlXQ35euK9+e7L68u8UwcODxkHoIkjbGsgXuARKNyQ5G6xt8nw1YPeMbxMLgCPFkToU+UEK5j05t2t8edKpQ==",
       "license": "MIT",
       "engines": {
         "node": "^16.14.0 || >= 17.3.0"
       }
     },
     "node_modules/tinyexec": {
-      "version": "1.1.2",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -4205,6 +4500,8 @@
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4213,6 +4510,8 @@
     },
     "node_modules/trough": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4228,22 +4527,32 @@
     },
     "node_modules/ufo": {
       "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "license": "MIT"
     },
     "node_modules/ultrahtml": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.6.0.tgz",
+      "integrity": "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==",
       "license": "MIT"
     },
     "node_modules/uncrypto": {
       "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -4261,6 +4570,8 @@
     },
     "node_modules/unifont": {
       "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.4.tgz",
+      "integrity": "sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==",
       "license": "MIT",
       "dependencies": {
         "css-tree": "^3.1.0",
@@ -4284,6 +4595,8 @@
     },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -4309,6 +4622,8 @@
     },
     "node_modules/unist-util-position": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -4334,6 +4649,8 @@
     },
     "node_modules/unist-util-stringify-position": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -4345,6 +4662,8 @@
     },
     "node_modules/unist-util-visit": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -4371,6 +4690,8 @@
     },
     "node_modules/unist-util-visit-parents": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -4383,6 +4704,8 @@
     },
     "node_modules/unstorage": {
       "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+      "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
       "license": "MIT",
       "dependencies": {
         "anymatch": "^3.1.3",
@@ -4477,6 +4800,8 @@
     },
     "node_modules/vfile": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -4489,6 +4814,8 @@
     },
     "node_modules/vfile-location": {
       "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -4501,6 +4828,8 @@
     },
     "node_modules/vfile-message": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -4512,7 +4841,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",
@@ -4585,6 +4916,8 @@
     },
     "node_modules/vitefu": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
       "license": "MIT",
       "workspaces": [
         "tests/deps/*",
@@ -4602,6 +4935,8 @@
     },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4619,10 +4954,14 @@
     },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
       "license": "MIT"
     },
     "node_modules/yargs-parser": {
       "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
@@ -4630,6 +4969,8 @@
     },
     "node_modules/yocto-queue": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20"
@@ -4639,7 +4980,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -4647,6 +4990,8 @@
     },
     "node_modules/zwitch": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,8 +8,8 @@
     "preview": "astro preview"
   },
   "dependencies": {
-    "@astrojs/sitemap": "3.7.2",
-    "astro": "6.3.3",
+    "@astrojs/sitemap": "3.7.3",
+    "astro": "6.4.2",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-external-links": "^3.0.0",
     "rehype-slug": "^6.0.0"

--- a/docs/public/config.schema.json
+++ b/docs/public/config.schema.json
@@ -1,93 +1,93 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Config",
   "description": "Top-level configuration defining registries, mappings, and sync behavior.",
   "type": "object",
-  "required": [
-    "mappings"
-  ],
   "properties": {
     "defaults": {
       "description": "Default source, targets, tags, and platforms inherited by all mappings.",
-      "default": null,
       "anyOf": [
         {
-          "$ref": "#/definitions/DefaultsConfig"
+          "$ref": "#/$defs/DefaultsConfig"
         },
         {
           "type": "null"
         }
-      ]
+      ],
+      "default": null
     },
     "global": {
       "description": "Global engine settings applied across all syncs.",
-      "default": null,
       "anyOf": [
         {
-          "$ref": "#/definitions/GlobalConfig"
+          "$ref": "#/$defs/GlobalConfig"
         },
         {
           "type": "null"
         }
-      ]
+      ],
+      "default": null
     },
     "mappings": {
       "description": "Image mapping rules defining what to sync and where.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/MappingConfig"
+        "$ref": "#/$defs/MappingConfig"
       }
     },
     "registries": {
       "description": "Named registry definitions keyed by alias.",
-      "default": {},
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/definitions/RegistryConfig"
-      }
+        "$ref": "#/$defs/RegistryConfig"
+      },
+      "default": {}
     },
     "target_groups": {
       "description": "Named groups of registry aliases for multi-target fanout.",
-      "default": {},
       "type": "object",
       "additionalProperties": {
         "type": "array",
         "items": {
           "type": "string"
         }
-      }
+      },
+      "default": {}
     }
   },
-  "definitions": {
+  "required": [
+    "mappings"
+  ],
+  "$defs": {
     "ArtifactsConfig": {
-      "description": "Configuration for OCI artifact (signatures, SBOMs, attestations) sync.\n\nControls whether referrers are discovered and transferred alongside their parent image manifests.",
+      "description": "Configuration for OCI artifact (signatures, SBOMs, attestations) sync.\n\nControls whether referrers are discovered and transferred alongside their\nparent image manifests.",
       "type": "object",
       "properties": {
         "enabled": {
           "description": "Whether artifact sync is enabled (default: true).",
-          "default": true,
-          "type": "boolean"
+          "type": "boolean",
+          "default": true
         },
         "exclude": {
           "description": "Exclude artifacts whose artifact type matches one of these MIME types.",
-          "default": [],
           "type": "array",
+          "default": [],
           "items": {
             "type": "string"
           }
         },
         "include": {
           "description": "Only sync artifacts whose artifact type matches one of these MIME types.",
-          "default": [],
           "type": "array",
+          "default": [],
           "items": {
             "type": "string"
           }
         },
         "require_artifacts": {
-          "description": "When true, every synced image must have at least one referrer. Images without referrers cause a sync failure instead of silently producing unsigned images at the target.",
-          "default": false,
-          "type": "boolean"
+          "description": "When true, every synced image must have at least one referrer.\nImages without referrers cause a sync failure instead of silently\nproducing unsigned images at the target.",
+          "type": "boolean",
+          "default": false
         }
       }
     },
@@ -97,75 +97,53 @@
         {
           "description": "AWS ECR token exchange.",
           "type": "string",
-          "enum": [
-            "ecr"
-          ]
+          "const": "ecr"
         },
         {
           "description": "Google Artifact Registry native auth (ADC).",
           "type": "string",
-          "enum": [
-            "gar"
-          ]
+          "const": "gar"
         },
         {
           "description": "Google Container Registry native auth (ADC).",
           "type": "string",
-          "enum": [
-            "gcr"
-          ]
+          "const": "gcr"
         },
         {
           "description": "Azure Container Registry native auth (AAD).",
           "type": "string",
-          "enum": [
-            "acr"
-          ]
+          "const": "acr"
         },
         {
           "description": "GitHub Container Registry (`GITHUB_TOKEN`).",
           "type": "string",
-          "enum": [
-            "ghcr"
-          ]
+          "const": "ghcr"
         },
         {
           "description": "Anonymous (token exchange only).",
           "type": "string",
-          "enum": [
-            "anonymous"
-          ]
+          "const": "anonymous"
         },
         {
           "description": "HTTP basic auth.",
           "type": "string",
-          "enum": [
-            "basic"
-          ]
+          "const": "basic"
         },
         {
           "description": "Pre-obtained bearer token (PAT, CI token).",
           "type": "string",
-          "enum": [
-            "static_token"
-          ]
+          "const": "static_token"
         },
         {
           "description": "Docker config.json credential store.",
           "type": "string",
-          "enum": [
-            "docker_config"
-          ]
+          "const": "docker_config"
         }
       ]
     },
     "BasicCredentials": {
       "description": "Credentials for HTTP Basic authentication.",
       "type": "object",
-      "required": [
-        "password",
-        "username"
-      ],
       "properties": {
         "password": {
           "description": "Password or access token.",
@@ -175,7 +153,11 @@
           "description": "Username for authentication.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "username",
+        "password"
+      ]
     },
     "DefaultsConfig": {
       "description": "Default values inherited by all mappings unless individually overridden.",
@@ -183,58 +165,58 @@
       "properties": {
         "artifacts": {
           "description": "Artifact sync configuration applied to all mappings unless overridden.",
-          "default": null,
           "anyOf": [
             {
-              "$ref": "#/definitions/ArtifactsConfig"
+              "$ref": "#/$defs/ArtifactsConfig"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "platforms": {
-          "description": "Platform filter applied to all mappings unless overridden.\n\nEach entry must be `os/arch` or `os/arch/variant` (e.g. `linux/amd64`, `linux/arm/v7`).",
-          "default": null,
+          "description": "Platform filter applied to all mappings unless overridden.\n\nEach entry must be `os/arch` or `os/arch/variant` (e.g. `linux/amd64`,\n`linux/arm/v7`).",
           "type": [
             "array",
             "null"
           ],
+          "default": null,
           "items": {
             "type": "string"
           }
         },
         "source": {
           "description": "Default source registry alias for all mappings.",
-          "default": null,
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "tags": {
           "description": "Default tag filter rules inherited by mappings without their own.",
-          "default": null,
           "anyOf": [
             {
-              "$ref": "#/definitions/TagsConfig"
+              "$ref": "#/$defs/TagsConfig"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "targets": {
           "description": "Default target registry alias or group for all mappings.",
-          "default": null,
           "anyOf": [
             {
-              "$ref": "#/definitions/TargetsValue"
+              "$ref": "#/$defs/TargetsValue"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         }
       }
     },
@@ -266,7 +248,7 @@
           ]
         },
         "cache_ttl": {
-          "description": "Warm cache TTL as a human-readable duration (e.g. \"12h\", \"30m\").\n\n`\"0\"` disables TTL-based expiry (cache never expires by age; lazy invalidation only). Defaults to `\"12h\"` when not specified.",
+          "description": "Warm cache TTL as a human-readable duration (e.g. \"12h\", \"30m\").\n\n`\"0\"` disables TTL-based expiry (cache never expires by age; lazy\ninvalidation only). Defaults to `\"12h\"` when not specified.",
           "type": [
             "string",
             "null"
@@ -274,13 +256,13 @@
         },
         "max_concurrent_transfers": {
           "description": "Maximum concurrent image syncs (default: 50).",
-          "default": 50,
           "type": "integer",
           "format": "uint",
-          "minimum": 0.0
+          "default": 50,
+          "minimum": 0
         },
         "staging_size_limit": {
-          "description": "Disk staging size limit as a human-readable size (e.g. \"2GB\", \"500MB\").\n\nUses SI decimal prefixes: 1 GB = 1,000,000,000 bytes. `0` disables disk staging. When absent, no eviction is performed.",
+          "description": "Disk staging size limit as a human-readable size (e.g. \"2GB\", \"500MB\").\n\nUses SI decimal prefixes: 1 GB = 1,000,000,000 bytes.\n`0` disables disk staging. When absent, no eviction is performed.",
           "type": [
             "string",
             "null"
@@ -291,145 +273,145 @@
     "MappingConfig": {
       "description": "A single image mapping rule: source repo, target registries, and tag filters.",
       "type": "object",
-      "required": [
-        "from"
-      ],
       "properties": {
         "artifacts": {
           "description": "Artifact sync configuration for this mapping, overriding `defaults.artifacts`.",
-          "default": null,
           "anyOf": [
             {
-              "$ref": "#/definitions/ArtifactsConfig"
+              "$ref": "#/$defs/ArtifactsConfig"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "from": {
           "description": "Source repository path (e.g. `library/nginx`).",
           "type": "string"
         },
         "platforms": {
-          "description": "Platform filter for this mapping, overriding any value in `defaults`.\n\nEach entry must be `os/arch` or `os/arch/variant` (e.g. `linux/amd64`, `linux/arm/v7`).",
-          "default": null,
+          "description": "Platform filter for this mapping, overriding any value in `defaults`.\n\nEach entry must be `os/arch` or `os/arch/variant` (e.g. `linux/amd64`,\n`linux/arm/v7`).",
           "type": [
             "array",
             "null"
           ],
+          "default": null,
           "items": {
             "type": "string"
           }
         },
         "source": {
           "description": "Source registry alias, overriding `defaults.source`.",
-          "default": null,
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "tags": {
           "description": "Tag filter rules for this mapping, overriding `defaults.tags`.",
-          "default": null,
           "anyOf": [
             {
-              "$ref": "#/definitions/TagsConfig"
+              "$ref": "#/$defs/TagsConfig"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "targets": {
           "description": "Target registry alias or group, overriding `defaults.targets`.",
-          "default": null,
           "anyOf": [
             {
-              "$ref": "#/definitions/TargetsValue"
+              "$ref": "#/$defs/TargetsValue"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "to": {
           "description": "Destination repository path; defaults to `from` when absent.",
-          "default": null,
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         }
-      }
+      },
+      "required": [
+        "from"
+      ]
     },
     "RegistryConfig": {
       "description": "Per-registry settings: URL, auth method, concurrency, and credentials.",
       "type": "object",
-      "required": [
-        "url"
-      ],
       "properties": {
         "auth_type": {
           "description": "Authentication method to use for this registry.",
-          "default": null,
           "anyOf": [
             {
-              "$ref": "#/definitions/AuthType"
+              "$ref": "#/$defs/AuthType"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "aws_profile": {
-          "description": "Named AWS profile for ECR credential resolution.\n\nWhen set, ECR auth for this registry uses `aws_config::ConfigLoader::profile_name(p)` instead of the ambient credential chain. Only valid with explicit `auth_type: ecr`.\n\nUse this when the registry requires credentials distinct from the ambient identity (for example, a third-party ECR accessed with static IAM-user keys while the ambient chain serves the rest of the workload).",
-          "default": null,
+          "description": "Named AWS profile for ECR credential resolution.\n\nWhen set, ECR auth for this registry uses\n`aws_config::ConfigLoader::profile_name(p)` instead of the ambient\ncredential chain. Only valid with explicit `auth_type: ecr`.\n\nUse this when the registry requires credentials distinct from the\nambient identity (for example, a third-party ECR accessed with static\nIAM-user keys while the ambient chain serves the rest of the workload).",
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "credentials": {
           "description": "Credentials for Basic auth (`auth_type: basic`).",
-          "default": null,
           "anyOf": [
             {
-              "$ref": "#/definitions/BasicCredentials"
+              "$ref": "#/$defs/BasicCredentials"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "head_first": {
-          "description": "HEAD-check targets before pulling full source manifests on cache miss.\n\nWhen enabled, the engine issues a manifest HEAD against all targets before performing a full source manifest GET. If every target already holds the same digest as the source HEAD, the expensive GET is skipped. This conserves rate-limit tokens on source registries with aggressive quotas (e.g., Docker Hub).",
-          "default": false,
-          "type": "boolean"
+          "description": "HEAD-check targets before pulling full source manifests on cache miss.\n\nWhen enabled, the engine issues a manifest HEAD against all targets\nbefore performing a full source manifest GET. If every target already\nholds the same digest as the source HEAD, the expensive GET is skipped.\nThis conserves rate-limit tokens on source registries with aggressive\nquotas (e.g., Docker Hub).",
+          "type": "boolean",
+          "default": false
         },
         "max_concurrent": {
-          "description": "Per-registry aggregate concurrency cap (default: 50).\n\nLimits the total number of simultaneous in-flight HTTP requests to this registry across all action types. This is independent of the global `max_concurrent_transfers` (which caps image-level parallelism).",
+          "description": "Per-registry aggregate concurrency cap (default: 50).\n\nLimits the total number of simultaneous in-flight HTTP requests to this\nregistry across all action types. This is independent of the global\n`max_concurrent_transfers` (which caps image-level parallelism).",
           "type": [
             "integer",
             "null"
           ],
           "format": "uint",
-          "minimum": 0.0
+          "minimum": 0
         },
         "token": {
           "description": "Bearer token for static token auth (`auth_type: static_token`).",
-          "default": null,
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "url": {
           "description": "Registry base URL (e.g. `registry-1.docker.io`, `123456789012.dkr.ecr.us-east-1.amazonaws.com`).",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "url"
+      ]
     },
     "RemovedSemverPrerelease": false,
     "SortOrder": {
@@ -438,16 +420,12 @@
         {
           "description": "Sort by semantic version (highest first).",
           "type": "string",
-          "enum": [
-            "semver"
-          ]
+          "const": "semver"
         },
         {
           "description": "Sort alphabetically (highest first).",
           "type": "string",
-          "enum": [
-            "alpha"
-          ]
+          "const": "alpha"
         }
       ]
     },
@@ -457,99 +435,99 @@
       "properties": {
         "exclude": {
           "description": "Exclude tags matching one or more glob patterns.",
-          "default": null,
           "anyOf": [
             {
-              "$ref": "#/definitions/GlobOrList"
+              "$ref": "#/$defs/GlobOrList"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "glob": {
           "description": "Include tags matching one or more glob patterns.",
-          "default": null,
           "anyOf": [
             {
-              "$ref": "#/definitions/GlobOrList"
+              "$ref": "#/$defs/GlobOrList"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "immutable_tags": {
-          "description": "Glob pattern for immutable tags (e.g. `\"v?[0-9]*.[0-9]*.[0-9]*\"`).\n\nWhen a tag matches this pattern AND already exists in the target's tag list, the tag is skipped with zero API calls. Semver tags are conventionally immutable; this avoids redundant HEAD checks.",
-          "default": null,
+          "description": "Glob pattern for immutable tags (e.g. `\"v?[0-9]*.[0-9]*.[0-9]*\"`).\n\nWhen a tag matches this pattern AND already exists in the target's tag\nlist, the tag is skipped with zero API calls. Semver tags are\nconventionally immutable; this avoids redundant HEAD checks.",
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "include": {
-          "description": "Always-include patterns. Behavior depends on pattern shape: literals (no `*`, `?`, `[`) bypass the entire pipeline and are kept verbatim (use to pin floating tags like `latest` or specific RCs). Globs rescue matching tags from `glob:` and the soft-tier excludes (built-in defaults + `defaults.tags.exclude:`), then run through `semver:`, hard `exclude:`, `sort:`, and `latest:` like any other pipeline tag. Same syntax as `exclude:`.",
-          "default": null,
+          "description": "Always-include patterns. Behavior depends on pattern shape: literals\n(no `*`, `?`, `[`) bypass the entire pipeline and are kept verbatim\n(use to pin floating tags like `latest` or specific RCs). Globs\nrescue matching tags from `glob:` and the soft-tier excludes\n(built-in defaults + `defaults.tags.exclude:`), then run through\n`semver:`, hard `exclude:`, `sort:`, and `latest:` like any other\npipeline tag. Same syntax as `exclude:`.",
           "anyOf": [
             {
-              "$ref": "#/definitions/GlobOrList"
+              "$ref": "#/$defs/GlobOrList"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "latest": {
           "description": "Keep only the N most recent tags after sorting.",
-          "default": null,
           "type": [
             "integer",
             "null"
           ],
           "format": "uint",
-          "minimum": 0.0
+          "default": null,
+          "minimum": 0
         },
         "min_tags": {
           "description": "Minimum number of tags to retain regardless of filters.",
-          "default": null,
           "type": [
             "integer",
             "null"
           ],
           "format": "uint",
-          "minimum": 0.0
+          "default": null,
+          "minimum": 0
         },
         "semver": {
           "description": "Include tags matching a semver range (e.g. `>=1.0, <2.0`).",
-          "default": null,
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "semver_prerelease": {
-          "description": "Removed in 2026-05; deserializing a config that still sets this field triggers a fail-loud migration error pointing at `include:`.",
-          "writeOnly": true,
+          "description": "Removed in 2026-05; deserializing a config that still sets this field\ntriggers a fail-loud migration error pointing at `include:`.",
           "anyOf": [
             {
-              "$ref": "#/definitions/RemovedSemverPrerelease"
+              "$ref": "#/$defs/RemovedSemverPrerelease"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "writeOnly": true
         },
         "sort": {
           "description": "Sort order applied before `latest` truncation.",
-          "default": null,
           "anyOf": [
             {
-              "$ref": "#/definitions/SortOrder"
+              "$ref": "#/$defs/SortOrder"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         }
       }
     },

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -517,12 +517,12 @@ impl<'de> Deserialize<'de> for RemovedSemverPrerelease {
 }
 
 impl JsonSchema for RemovedSemverPrerelease {
-    fn schema_name() -> String {
-        "RemovedSemverPrerelease".to_owned()
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "RemovedSemverPrerelease".into()
     }
 
-    fn json_schema(_gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
-        schemars::schema::Schema::Bool(false)
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!(false)
     }
 }
 


### PR DESCRIPTION
Bumps to latest including majors. All CI gates green locally.

- schemars 0.8 → 1.2
- reqwest git pin → 0.13.4 (crates.io)
- @astrojs/sitemap 3.7.2 → 3.7.3
- astro 6.3.3 → 6.4.2
- EmbarkStudios/cargo-deny-action v2.0.18 → v2.0.20
- aws-actions/configure-aws-credentials v6.1.1 → v6.1.3

schemars 1.x dropped the `schemars::schema::*` module and tightened a few signatures, so the manual `JsonSchema` impl for `RemovedSemverPrerelease` in `src/cli/config.rs` was rewritten — `schema_name` now returns `Cow<'static, str>`, `SchemaGenerator` moved to the crate root, and `Schema::Bool(false)` became `json_schema!(false)`. The `std` feature is now opt-in for `HashMap`/`Vec` `JsonSchema` impls, so it was added alongside `derive`. The committed `docs/public/config.schema.json` was regenerated via the existing `update_json_schema --ignored` helper; the new output uses `$defs` (draft 2020-12) instead of `definitions` (draft-07).

reqwest 0.13.3 closed out the rustls-platform-verifier 0.7 jni-dup fix that originally motivated the git pin; with 0.13.4 published on crates.io we drop the git URL from `[workspace.dependencies]`, remove the `[patch.crates-io]` redirect, and delete the `allow-git` exception in `deny.toml`.

One new transitive-duplicate skip in `deny.toml`: `shlex@1` — pulled in by `bindgen` (build-dep of `aws-lc-fips-sys`) at 1.3 while `cc` 1.2 has moved to `shlex` 2.0. Same pattern as the existing skip-list entries.

The `anonymous_auth_distinct_scopes_fetch_concurrently` test in `crates/ocync-distribution/src/auth/anonymous.rs` was a wall-clock flake on slower CI runners. Switched it to assert on request-arrival-diff at the wiremock server (parallel arrives in ~ms, serialized would be ~300ms apart) so the property no longer depends on total elapsed wall-clock.

Dockerfile uses floating `:latest`/`:latest-dev` Chainguard tags; no SHA pins to bump. `gcc-13` stays pinned per the in-file comment about the aws-lc-fips-sys delocator (aws/aws-lc-rs#569).

Supersedes #96.
