### PR TITLE
fix(bench): repair the skopeo install and pin the competitor tools

### DIFF
--- a/bench/CLAUDE.md
+++ b/bench/CLAUDE.md
@@ -127,6 +127,8 @@ cargo xtask bench --tools ocync,dregsy,regsync sync
 
 Managed by Terraform in `bench/terraform/aws/`. `user_data_replace_on_change = true` -- bootstrap changes recreate the instance.
 
+Competitor tool versions are pinned at the top of `user-data.sh`. Bumping one means editing that block, which recreates the instance, so treat the first run afterward as a new baseline rather than comparing it against older records. Two of them are awkward: skopeo's module path is `go.podman.io/skopeo` since v1.23.0, and dregsy tags releases without a `v` prefix so it can only be pinned by pseudo-version.
+
 ```bash
 cd bench/terraform/aws && terraform init && terraform apply   # create
 cd bench/terraform/aws && terraform destroy                    # destroy

--- a/bench/terraform/aws/user-data.sh
+++ b/bench/terraform/aws/user-data.sh
@@ -92,10 +92,25 @@ echo "Go: $(go version)"
 export HOME=/root GOPATH=/root/go GOCACHE=/root/.cache/go-build
 export PATH="/usr/local/go/bin:$GOPATH/bin:$PATH"
 
+# Competitor tool versions. These are pinned rather than floating because
+# bench/results/{registry}.json is compared across runs: a tool that changes
+# version between instance rebuilds makes a metric shift unattributable.
+# Bump deliberately, and treat the first run afterward as a new baseline.
+ECR_CREDENTIAL_HELPER_VERSION="v0.12.0"
+REGCLIENT_VERSION="v0.11.5"
+# skopeo moved its module path to go.podman.io/skopeo at v1.23.0. The github.com
+# path still serves tags, but their go.mod declares the new path, so installing
+# from it fails on a module path mismatch rather than a missing version.
+SKOPEO_VERSION="v1.24.0"
+# dregsy tags releases without the v prefix, so the module proxy cannot resolve
+# them and only serves pseudo-versions. This one is release 0.5.2, whose tag
+# points at commit e92e79a. Re-derive it from the tag when bumping.
+DREGSY_VERSION="v0.0.0-20250317074629-e92e79a50145"
+
 # ── ECR credential helper ────────────────────────────────────────────────────
 
 echo "--- Installing ECR credential helper"
-go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@latest
+go install "github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@$${ECR_CREDENTIAL_HELPER_VERSION}"
 cp /root/go/bin/docker-credential-ecr-login /usr/local/bin/
 
 mkdir -p /home/ec2-user/.docker
@@ -104,14 +119,16 @@ cat > /home/ec2-user/.docker/config.json <<'DCEOF'
 DCEOF
 chown -R ec2-user:ec2-user /home/ec2-user/.docker
 
-echo "ecr-credential-helper: $(docker-credential-ecr-login version 2>&1 || true)"
+# go install sets none of the ldflags the project's Makefile uses, so the binary
+# reports "development" whatever is pinned. Echo the pin instead.
+echo "ecr-credential-helper: $${ECR_CREDENTIAL_HELPER_VERSION}"
 
 # ── skopeo (dregsy transfer backend) ─────────────────────────────────────────
 
 echo "--- Installing skopeo"
 CGO_ENABLED=1 go install \
-  -tags "exclude_graphdriver_btrfs exclude_graphdriver_devicemapper containers_image_openpgp" \
-  github.com/containers/skopeo/cmd/skopeo@latest
+  -tags "exclude_graphdriver_btrfs containers_image_openpgp" \
+  "go.podman.io/skopeo/cmd/skopeo@$${SKOPEO_VERSION}"
 cp /root/go/bin/skopeo /usr/local/bin/skopeo
 
 echo "skopeo: $(skopeo --version 2>&1)"
@@ -119,15 +136,17 @@ echo "skopeo: $(skopeo --version 2>&1)"
 # ── dregsy ────────────────────────────────────────────────────────────────────
 
 echo "--- Installing dregsy"
-go install github.com/xelalexv/dregsy/cmd/dregsy@latest
+go install "github.com/xelalexv/dregsy/cmd/dregsy@$${DREGSY_VERSION}"
 cp /root/go/bin/dregsy /usr/local/bin/dregsy
 
-echo "dregsy: $(dregsy --version 2>&1 || true)"
+# dregsy has no version flag and injects its version via release-build ldflags,
+# so probing the binary prints a usage dump. Echo the pin instead.
+echo "dregsy: $${DREGSY_VERSION}"
 
 # ── regsync ───────────────────────────────────────────────────────────────────
 
 echo "--- Installing regsync"
-go install github.com/regclient/regclient/cmd/regsync@latest
+go install "github.com/regclient/regclient/cmd/regsync@$${REGCLIENT_VERSION}"
 cp /root/go/bin/regsync /usr/local/bin/regsync
 
 echo "regsync: $(regsync version 2>&1 || true)"


### PR DESCRIPTION
Benchmark instance bootstrap is currently broken on `main`, and has been since 2026-05-26. skopeo renamed its Go module path to `go.podman.io/skopeo` at v1.23.0. The `github.com/containers/skopeo` path still serves tags, so it looks fine, but their `go.mod` declares the new path and the install fails on a module path mismatch rather than a missing version:

```
module declares its path as: go.podman.io/skopeo
        but was required as: github.com/containers/skopeo
```

`set -euo pipefail` aborts user-data right there, so dregsy, regsync, the ocync and bench-proxy build, and the bench-proxy CA generation never run. Nothing waits on user-data, so `terraform apply` still reports success and the instance looks healthy. The failure only surfaces later as missing binaries.

The three tools ocync is measured against were also installed with `@latest`, so every instance rebuild silently changed what the benchmark compared against. `bench/results/{registry}.json` is tracked in git for longitudinal comparison, and that undermines it: a metric shift could come from a competitor release rather than from a change here. The Go toolchain immediately above these lines was already pinned, so it was only buying half the reproducibility it appeared to.

- docker-credential-ecr-login v0.12.0
- skopeo v1.24.0, from the new module path
- regsync v0.11.5
- dregsy release 0.5.2

Every pin is verified by fetching its `go.mod` from the module proxy and confirming the declared module matches the path being installed from. Checking that the version merely exists is not sufficient, and is exactly what was blind to the skopeo rename.

dregsy needs explaining. It tags releases without the `v` prefix, so the proxy cannot read them as versions and serves only pseudo-versions, meaning `@latest` was never resolving to a release at all. Its pin is `v0.0.0-20250317074629-e92e79a50145`, whose commit is what the 0.5.2 tag points at.

Two bootstrap log lines now echo the pinned version instead of probing the binary. dregsy has no version flag, so probing printed a usage dump, and the credential helper reports `development` because `go install` sets none of the ldflags its Makefile uses. regsync and skopeo do report correctly and are left alone. The `exclude_graphdriver_devicemapper` build tag is dropped, since that driver no longer exists in the storage dependency.

Worth knowing before applying: `user_data_replace_on_change = true`, so this recreates the instance. regsync moves from v0.11.3, which every archived record was measured on, to v0.11.5, so the first run after this is a new baseline rather than comparable to the numbers behind the published table.

Two things this deliberately does not touch. The AMI still floats via `most_recent = true`, so a version bump also rolls the OS image, and `check_tool` in the xtask runner ignores exit status, which is why 10 of 13 dregsy records in the archive store a flag error where a version belongs. Both are real and both are separate changes.