### PR TITLE
fix(bench): pin the AMI and record the binary that moves dregsy's bytes

### DIFF
--- a/bench/CLAUDE.md
+++ b/bench/CLAUDE.md
@@ -127,7 +127,9 @@ cargo xtask bench --tools ocync,dregsy,regsync sync
 
 Managed by Terraform in `bench/terraform/aws/`. `user_data_replace_on_change = true` -- bootstrap changes recreate the instance.
 
-Competitor tool versions are pinned at the top of `user-data.sh`. Bumping one means editing that block, which recreates the instance, so treat the first run afterward as a new baseline rather than comparing it against older records. Two of them are awkward: skopeo's module path is `go.podman.io/skopeo` since v1.23.0, and dregsy tags releases without a `v` prefix so it can only be pinned by pseudo-version.
+Competitor tool versions are pinned at the top of `user-data.sh`, and the AMI is pinned to an exact name in `locals`. Bumping either means editing that value, which recreates the instance, so treat the first run afterward as a new baseline rather than comparing it against older records. Three of these are awkward: skopeo's module path is `go.podman.io/skopeo` since v1.23.0, dregsy tags releases without a `v` prefix so it can only be pinned by pseudo-version, and AL2023 publishes several kernel variants under one release with near-identical timestamps, so matching a release prefix picks between them arbitrarily rather than tracking the newest release.
+
+dregsy transfers nothing itself. Its config sets `relay: skopeo`, so skopeo moves every byte dregsy is credited with, and the run record captures skopeo's version alongside dregsy's for that reason.
 
 ```bash
 cd bench/terraform/aws && terraform init && terraform apply   # create

--- a/bench/terraform/aws/main.tf
+++ b/bench/terraform/aws/main.tf
@@ -35,6 +35,24 @@ locals {
   ebs_iops        = 6000
   ebs_throughput  = 400 # MB/s
   my_ip           = "${trimspace(data.http.my_ip.response_body)}/32"
+
+  # Pinned to an exact image so the kernel and OS packages cannot move between
+  # rebuilds, which would make a benchmark shift unattributable. AL2023
+  # publishes several kernel variants under one release with near-identical
+  # creation timestamps, so matching a release prefix selects between them
+  # arbitrarily rather than merely tracking the newest release.
+  #
+  # kernel-6.1 is the variant AWS ships as the AL2023 default, which the SSM
+  # parameter al2023-ami-kernel-default-x86_64 resolves to. The 6.12 and 6.18
+  # builds are opt-in. Moving to one is a deliberate change to what is measured
+  # on a network-bound benchmark, not a routine refresh.
+  #
+  # AWS deprecates AL2023 images after roughly three months and hides them from
+  # describe-images, so this eventually stops resolving and apply fails. That
+  # failure is the prompt to move to a current image rather than keep launching
+  # one with unpatched kernel and glibc updates. Treat the run after a bump as
+  # a new baseline.
+  ami_name = "al2023-ami-2023.12.20260803.3-kernel-6.1-x86_64"
 }
 
 ################################################################################
@@ -54,12 +72,11 @@ data "aws_availability_zones" "available" {
 }
 
 data "aws_ami" "al2023" {
-  most_recent = true
-  owners      = ["amazon"]
+  owners = ["amazon"]
 
   filter {
     name   = "name"
-    values = ["al2023-ami-2023.*-x86_64"]
+    values = [local.ami_name]
   }
 
   filter {

--- a/xtask/src/bench/mod.rs
+++ b/xtask/src/bench/mod.rs
@@ -299,12 +299,19 @@ pub(crate) async fn run(args: BenchArgs) -> Result<(), Box<dyn std::error::Error
     let ecr_client = ecr::client().await;
     ecr::validate_credentials(&ecr_client).await?;
 
-    // Check each tool binary and collect versions.
+    // Check each tool binary and collect versions, along with any binary a tool
+    // relays its transfers through, whose version moves that tool's numbers.
     let mut tool_versions: BTreeMap<String, String> = BTreeMap::new();
+    let mut relay_versions: BTreeMap<String, String> = BTreeMap::new();
     for &tool in &tools {
         let version = runner::check_tool(tool).await?;
         eprintln!("  {}: {version}", tool);
         tool_versions.insert(tool.to_string(), version);
+
+        for (binary, version) in runner::check_relays(tool).await? {
+            eprintln!("  {binary}: {version} (relay)");
+            relay_versions.insert(binary, version);
+        }
     }
 
     // Build ocync from workspace if it is one of the tools.
@@ -338,6 +345,7 @@ pub(crate) async fn run(args: BenchArgs) -> Result<(), Box<dyn std::error::Error
         corpus_size: corpus.images.len(),
         total_tags: corpus.total_tags(),
         tool_versions,
+        relay_versions,
         scenarios: Vec::new(),
         scale: Vec::new(),
     };

--- a/xtask/src/bench/report.rs
+++ b/xtask/src/bench/report.rs
@@ -305,6 +305,13 @@ pub(crate) struct BenchReport {
     pub(crate) total_tags: usize,
     /// Tool version strings keyed by tool name.
     pub(crate) tool_versions: BTreeMap<String, String>,
+    /// Versions of binaries a tool relays its transfers through, keyed by
+    /// binary name.
+    ///
+    /// Kept apart from [`Self::tool_versions`] because these are not
+    /// benchmarked tools and must not become columns in the metric tables.
+    #[serde(default)]
+    pub(crate) relay_versions: BTreeMap<String, String>,
     /// Per-scenario results.
     pub(crate) scenarios: Vec<ScenarioResult>,
     /// Scaling curve data points (empty when the scale scenario was not run).
@@ -420,6 +427,9 @@ fn summary_markdown(report: &BenchReport) -> String {
     out.push_str("## Tool Versions\n\n");
     for (tool, version) in &report.tool_versions {
         out.push_str(&format!("- **{tool}**: {version}\n"));
+    }
+    for (binary, version) in &report.relay_versions {
+        out.push_str(&format!("- **{binary}**: {version} (relay)\n"));
     }
     out.push('\n');
 
@@ -862,6 +872,7 @@ mod tests {
             instance: test_instance(),
             corpus_size: 28,
             total_tags: 40,
+            relay_versions: BTreeMap::new(),
             tool_versions: BTreeMap::from([
                 ("ocync".to_string(), "0.1.0".to_string()),
                 ("dregsy".to_string(), "0.5.0".to_string()),
@@ -992,12 +1003,35 @@ mod tests {
     }
 
     #[test]
+    fn relay_versions_are_reported_but_never_become_columns() {
+        let mut report = sample_report();
+        report
+            .relay_versions
+            .insert("skopeo".to_string(), "skopeo version 1.24.0".to_string());
+
+        // A relay is not benchmarked, so it has no run data. Letting it reach
+        // the column list renders an empty column in every metric table.
+        assert!(
+            !tool_columns(&report).contains(&"skopeo".to_string()),
+            "relay binary leaked into metric table columns: {:?}",
+            tool_columns(&report)
+        );
+
+        let md = summary_markdown(&report);
+        assert!(
+            md.contains("**skopeo**: skopeo version 1.24.0 (relay)"),
+            "relay version missing from the versions section"
+        );
+    }
+
+    #[test]
     fn summary_markdown_empty_scenarios_omits_table() {
         let report = BenchReport {
             timestamp: "2026-04-15-100000".to_string(),
             instance: test_instance(),
             corpus_size: 28,
             total_tags: 40,
+            relay_versions: BTreeMap::new(),
             tool_versions: BTreeMap::from([("ocync".to_string(), "0.1.0".to_string())]),
             scenarios: vec![],
             scale: vec![],
@@ -1013,6 +1047,7 @@ mod tests {
             instance: test_instance(),
             corpus_size: 28,
             total_tags: 40,
+            relay_versions: BTreeMap::new(),
             tool_versions: BTreeMap::from([
                 ("ocync".to_string(), "0.1.0".to_string()),
                 ("dregsy".to_string(), "0.5.0".to_string()),
@@ -1180,6 +1215,7 @@ mod tests {
             instance: test_instance(),
             corpus_size: 28,
             total_tags: 40,
+            relay_versions: BTreeMap::new(),
             tool_versions: BTreeMap::from([("ocync".to_string(), "0.1.0".to_string())]),
             scenarios: vec![ScenarioResult {
                 scenario: "Cold sync".to_string(),
@@ -1225,6 +1261,7 @@ mod tests {
             instance: test_instance(),
             corpus_size: 28,
             total_tags: 40,
+            relay_versions: BTreeMap::new(),
             tool_versions: BTreeMap::from([("ocync".to_string(), "0.1.0".to_string())]),
             scenarios: vec![ScenarioResult {
                 scenario: "Warm sync (no-op)".to_string(),
@@ -1298,6 +1335,7 @@ mod tests {
             instance: test_instance(),
             corpus_size: 42,
             total_tags: 55,
+            relay_versions: BTreeMap::new(),
             tool_versions: BTreeMap::from([
                 ("ocync".to_string(), "0.1.0".to_string()),
                 ("dregsy".to_string(), "0.5.0".to_string()),
@@ -1393,6 +1431,7 @@ mod tests {
             instance: test_instance(),
             corpus_size: 42,
             total_tags: 55,
+            relay_versions: BTreeMap::new(),
             tool_versions: BTreeMap::from([
                 ("ocync".to_string(), "0.1.0".to_string()),
                 ("dregsy".to_string(), "0.5.0".to_string()),
@@ -1452,6 +1491,7 @@ mod tests {
             instance: test_instance(),
             corpus_size: 42,
             total_tags: 55,
+            relay_versions: BTreeMap::new(),
             tool_versions: BTreeMap::from([
                 ("ocync".to_string(), "0.1.0".to_string()),
                 ("dregsy".to_string(), "0.5.0".to_string()),
@@ -1534,6 +1574,7 @@ mod tests {
             instance: test_instance(),
             corpus_size: 39,
             total_tags: 51,
+            relay_versions: BTreeMap::new(),
             tool_versions: BTreeMap::from([("ocync".to_string(), "0.1.0".to_string())]),
             scenarios: vec![
                 ScenarioResult {
@@ -1593,6 +1634,7 @@ mod tests {
             instance: test_instance(),
             corpus_size: 39,
             total_tags: 51,
+            relay_versions: BTreeMap::new(),
             tool_versions: BTreeMap::from([("ocync".to_string(), "0.1.0".to_string())]),
             scenarios: vec![ScenarioResult {
                 scenario: "Warm sync (no-op)".to_string(),
@@ -1626,6 +1668,7 @@ mod tests {
             instance: test_instance(),
             corpus_size: 28,
             total_tags: 40,
+            relay_versions: BTreeMap::new(),
             tool_versions: BTreeMap::from([
                 ("ocync".into(), "0.1.0".into()),
                 ("dregsy".into(), "0.5.0".into()),
@@ -1684,6 +1727,7 @@ mod tests {
             instance: test_instance(),
             corpus_size: 28,
             total_tags: 40,
+            relay_versions: BTreeMap::new(),
             tool_versions: BTreeMap::from([("dregsy".into(), "0.5.0".into())]),
             scenarios: vec![ScenarioResult {
                 scenario: "Cold sync".into(),
@@ -1717,6 +1761,7 @@ mod tests {
             instance: test_instance(),
             corpus_size: 28,
             total_tags: 40,
+            relay_versions: BTreeMap::new(),
             tool_versions: BTreeMap::from([("ocync".into(), "0.1.0".into())]),
             scenarios: vec![ScenarioResult {
                 scenario: "Cold sync".into(),

--- a/xtask/src/bench/runner.rs
+++ b/xtask/src/bench/runner.rs
@@ -87,28 +87,42 @@ fn reports_version(tool: Tool) -> bool {
     }
 }
 
+/// Binaries a tool delegates its transfers to, whose versions move its numbers.
+///
+/// `dregsy` transfers nothing itself. Its generated config sets `relay: skopeo`,
+/// so skopeo moves every byte dregsy is credited with, and a skopeo change
+/// shifts dregsy's measurements with nothing in dregsy's own version to explain
+/// it. Recorded alongside the benchmarked tools for that reason.
+fn relay_binaries(tool: Tool) -> &'static [&'static str] {
+    match tool {
+        Tool::Dregsy => &["skopeo"],
+        Tool::Regsync | Tool::Ocync => &[],
+    }
+}
+
 /// Extracts a single-line version string from a completed version probe.
 ///
 /// A non-zero exit yields diagnostic text rather than a version, so it is
-/// never recorded as one. For a tool that reports a version this is an error,
-/// since `check_tool` is the only gate run before the benchmark starts. For a
-/// tool that reports none it is expected, and the probe served only to confirm
-/// the binary runs.
+/// never recorded as one. Where the binary reports a version this is an error,
+/// since these probes are the only gate run before the benchmark starts. Where
+/// it reports none it is expected, and the probe served only to confirm the
+/// binary runs.
 fn version_from_probe(
-    tool: Tool,
+    name: &str,
+    reports_version: bool,
     success: bool,
     stdout: &str,
     stderr: &str,
 ) -> Result<String, String> {
     if !success {
-        if reports_version(tool) {
+        if reports_version {
             let detail = stderr
                 .lines()
                 .chain(stdout.lines())
                 .find(|l| !l.trim().is_empty())
                 .unwrap_or("no output")
                 .trim();
-            return Err(format!("{tool} version probe failed: {detail}"));
+            return Err(format!("{name} version probe failed: {detail}"));
         }
         return Ok(UNKNOWN_VERSION.to_string());
     }
@@ -129,24 +143,50 @@ fn version_from_probe(
         .to_string())
 }
 
-/// Runs a tool's version probe and returns a single-line version string.
+/// Runs a version probe and returns a single-line version string.
 ///
 /// Errors when the binary cannot be executed, which means it is missing, and
-/// when a tool that reports a version fails to. [`UNKNOWN_VERSION`] is returned
-/// only for a tool that has no version to report, whose pinned version is
-/// recorded in the benchmark instance bootstrap instead.
-pub(crate) async fn check_tool(tool: Tool) -> Result<String, String> {
-    let args = version_args(tool);
-    let output = tokio::process::Command::new(tool.binary())
+/// when a binary that reports a version fails to. [`UNKNOWN_VERSION`] is
+/// returned only where there is no version to report, in which case the pinned
+/// version is recorded in the benchmark instance bootstrap instead.
+async fn probe_version(
+    binary: &str,
+    args: &[&str],
+    reports_version: bool,
+) -> Result<String, String> {
+    let output = tokio::process::Command::new(binary)
         .args(args)
         .output()
         .await
-        .map_err(|e| format!("failed to run {} {:?}: {}", tool.binary(), args, e))?;
+        .map_err(|e| format!("failed to run {binary} {args:?}: {e}"))?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
 
-    version_from_probe(tool, output.status.success(), &stdout, &stderr)
+    version_from_probe(
+        binary,
+        reports_version,
+        output.status.success(),
+        &stdout,
+        &stderr,
+    )
+}
+
+/// Runs a benchmarked tool's version probe.
+pub(crate) async fn check_tool(tool: Tool) -> Result<String, String> {
+    probe_version(tool.binary(), version_args(tool), reports_version(tool)).await
+}
+
+/// Returns the version of every binary `tool` relays its transfers through.
+///
+/// Keyed by binary name so the run record names what actually moved the bytes.
+pub(crate) async fn check_relays(tool: Tool) -> Result<Vec<(String, String)>, String> {
+    let mut versions = Vec::new();
+    for &binary in relay_binaries(tool) {
+        let version = probe_version(binary, &["--version"], true).await?;
+        versions.push((binary.to_string(), version));
+    }
+    Ok(versions)
 }
 
 /// Builds ocync and bench-proxy in release mode from the given workspace root.
@@ -436,7 +476,14 @@ mod tests {
 
     #[test]
     fn failed_probe_is_not_recorded_as_a_version() {
-        let version = version_from_probe(Tool::Dregsy, false, "", DREGSY_PROBE_STDERR).unwrap();
+        let version = version_from_probe(
+            "dregsy",
+            reports_version(Tool::Dregsy),
+            false,
+            "",
+            DREGSY_PROBE_STDERR,
+        )
+        .unwrap();
 
         assert_eq!(version, "unknown");
         assert!(
@@ -447,11 +494,17 @@ mod tests {
 
     #[test]
     fn failed_probe_errors_for_a_tool_that_reports_a_version() {
-        // check_tool is the only gate before the benchmark runs, so a broken
-        // ocync or regsync must not pass it as an absent version.
+        // These probes are the only gate before the benchmark runs, so a broken
+        // ocync or regsync must not pass as an absent version.
         for tool in [Tool::Ocync, Tool::Regsync] {
-            let err = version_from_probe(tool, false, "", "error: linker not found")
-                .expect_err("a tool that reports a version must fail loudly");
+            let err = version_from_probe(
+                tool.binary(),
+                reports_version(tool),
+                false,
+                "",
+                "error: linker not found",
+            )
+            .expect_err("a tool that reports a version must fail loudly");
             assert!(
                 err.contains("version probe failed") && err.contains("linker not found"),
                 "unhelpful error for {tool}: {err}"
@@ -460,22 +513,43 @@ mod tests {
     }
 
     #[test]
+    fn relay_probe_failure_is_an_error() {
+        // skopeo moves every byte dregsy is credited with, so a broken skopeo
+        // must not be recorded as an absent version either.
+        let err = version_from_probe("skopeo", true, false, "", "skopeo: command failed")
+            .expect_err("a relay binary must fail loudly");
+        assert!(err.contains("skopeo version probe failed"), "{err}");
+    }
+
+    #[test]
+    fn dregsy_relays_through_skopeo() {
+        assert_eq!(relay_binaries(Tool::Dregsy), &["skopeo"]);
+        assert!(relay_binaries(Tool::Ocync).is_empty());
+        assert!(relay_binaries(Tool::Regsync).is_empty());
+    }
+
+    #[test]
     fn successful_probe_reads_the_version() {
         assert_eq!(
-            version_from_probe(Tool::Ocync, true, "ocync 0.6.0\n", "").unwrap(),
+            version_from_probe("ocync", true, true, "ocync 0.6.0\n", "").unwrap(),
             "ocync 0.6.0"
         );
         // regsync pads its output and precedes the tag with a blank line.
         assert_eq!(
-            version_from_probe(Tool::Regsync, true, "\nVCSTag:     v0.11.5\n", "").unwrap(),
+            version_from_probe("regsync", true, true, "\nVCSTag:     v0.11.5\n", "").unwrap(),
             "VCSTag:     v0.11.5"
+        );
+        // skopeo reports cleanly on stdout with a zero exit.
+        assert_eq!(
+            version_from_probe("skopeo", true, true, "skopeo version 1.24.0\n", "").unwrap(),
+            "skopeo version 1.24.0"
         );
     }
 
     #[test]
     fn successful_probe_falls_back_to_stderr() {
         assert_eq!(
-            version_from_probe(Tool::Ocync, true, "   ", "ocync 0.6.0").unwrap(),
+            version_from_probe("ocync", true, true, "   ", "ocync 0.6.0").unwrap(),
             "ocync 0.6.0"
         );
     }
@@ -483,7 +557,7 @@ mod tests {
     #[test]
     fn successful_probe_with_no_output_is_unknown() {
         assert_eq!(
-            version_from_probe(Tool::Ocync, true, "", "").unwrap(),
+            version_from_probe("ocync", true, true, "", "").unwrap(),
             "unknown"
         );
     }


### PR DESCRIPTION
Two inputs still moved between otherwise identical instance rebuilds, so a benchmark shift could not be attributed to a change here.

The AMI was resolved with `most_recent` over the release prefix `al2023-ami-2023.*-x86_64`. AL2023 publishes several kernel variants under one release with near-identical creation timestamps, so that was not merely tracking the newest release, it was selecting between kernel 6.1, 6.12 and 6.18 arbitrarily. Kernel, glibc and NIC driver were all outside operator control on a network-bound benchmark. It now pins an exact image name, verified to match exactly one image in the region.

AWS deprecates AL2023 images after roughly three months and hides them from `describe-images`, so this pin eventually stops resolving and apply fails. That is intended. The failure is the prompt to move to a current image, rather than keep launching one with unpatched kernel and glibc updates, and the comment says so.

dregsy transfers nothing itself. Its generated config sets `relay: skopeo`, so skopeo moves every byte dregsy is credited with, and a skopeo bump shifted dregsy's numbers with nothing in the record to explain it. Relay binaries are now probed and recorded alongside the tool that delegates to them, and a relay failing its probe is an error, since it is as load-bearing as the tool itself.

Relay versions are kept in their own field rather than added to `tool_versions`. That map's keys drive the metric table columns, and a relay is never benchmarked, so reusing it would have rendered an empty skopeo column in every table. A test asserts the separation, kill-tested by feeding relay keys into the column list and confirming it fails.

CI is the gate for this one. Locally `cargo fmt`, `clippy -D warnings`, `terraform fmt` and `terraform validate` pass, and all 144 xtask tests pass. The eight testcontainers-backed integration tests in `ocync-distribution` currently fail on my machine with `WaitContainer(StartupTimeout)`, which is container startup rather than an assertion, and this diff touches only `bench/` and `xtask/` so it cannot reach that crate. I have not proven the failure is environmental, so it wants a clean CI runner to confirm rather than my say-so.