### PR TITLE
fix(bench): float the tool and image versions, record what each run used

### DIFF
--- a/bench/CLAUDE.md
+++ b/bench/CLAUDE.md
@@ -127,9 +127,17 @@ cargo xtask bench --tools ocync,dregsy,regsync sync
 
 Managed by Terraform in `bench/terraform/aws/`. `user_data_replace_on_change = true` -- bootstrap changes recreate the instance.
 
-Competitor tool versions are pinned at the top of `user-data.sh`, and the AMI is pinned to an exact name in `locals`. Bumping either means editing that value, which recreates the instance, so treat the first run afterward as a new baseline rather than comparing it against older records. Three of these are awkward: skopeo's module path is `go.podman.io/skopeo` since v1.23.0, dregsy tags releases without a `v` prefix so it can only be pinned by pseudo-version, and AL2023 publishes several kernel variants under one release with near-identical timestamps, so matching a release prefix picks between them arbitrarily rather than tracking the newest release.
+A benchmark run is a point in time, not a fixed rig. Nothing is pinned: competitor tools install at `@latest` and the image is the current AL2023 default release. What makes two runs comparable is the record of what each used, so the run record carries the tool versions, the relay versions and the image id.
+
+**Versions are fixed at instance creation, not per run.** The `go install` calls live in user-data, and `bench-remote` only rebuilds ocync. An instance built in March still runs March's dregsy in September. To benchmark against current competitor releases, replace the instance. Read the versions out of the run record rather than assuming they match what is current today.
+
+Three resolution details are easy to get wrong. skopeo's module path is `go.podman.io/skopeo` since v1.23.0, and the old `github.com/containers/skopeo` path still serves tags whose `go.mod` declares the new path, so installing from it fails on a path mismatch rather than a missing version. `@latest` never crosses a major version boundary under semantic import versioning, so when one of these tags v2 the install silently sticks on the highest v1 until the path gains a `/v2` suffix. And dregsy tags releases without a `v` prefix, so the proxy reads no valid semver and `@latest` resolves to a pseudo-version off the default branch rather than to a release.
+
+Versions are read from the binaries rather than assumed. `go install` sets none of the ldflags a release build uses, so the ECR credential helper reports `development` and dregsy has no version flag at all. Both are recovered with `go version -m`, which reads the module version stamped into the binary.
 
 dregsy transfers nothing itself. Its config sets `relay: skopeo`, so skopeo moves every byte dregsy is credited with, and the run record captures skopeo's version alongside dregsy's for that reason.
+
+The image floats but `ignore_ami_changes` is set, because `ami` is ForceNew: without it, AWS advancing the AL2023 parameter means the next apply for any unrelated reason destroys a running instance and its results. New images arrive when the instance is next replaced deliberately.
 
 ```bash
 cd bench/terraform/aws && terraform init && terraform apply   # create

--- a/bench/terraform/aws/main.tf
+++ b/bench/terraform/aws/main.tf
@@ -35,24 +35,6 @@ locals {
   ebs_iops        = 6000
   ebs_throughput  = 400 # MB/s
   my_ip           = "${trimspace(data.http.my_ip.response_body)}/32"
-
-  # Pinned to an exact image so the kernel and OS packages cannot move between
-  # rebuilds, which would make a benchmark shift unattributable. AL2023
-  # publishes several kernel variants under one release with near-identical
-  # creation timestamps, so matching a release prefix selects between them
-  # arbitrarily rather than merely tracking the newest release.
-  #
-  # kernel-6.1 is the variant AWS ships as the AL2023 default, which the SSM
-  # parameter al2023-ami-kernel-default-x86_64 resolves to. The 6.12 and 6.18
-  # builds are opt-in. Moving to one is a deliberate change to what is measured
-  # on a network-bound benchmark, not a routine refresh.
-  #
-  # AWS deprecates AL2023 images after roughly three months and hides them from
-  # describe-images, so this eventually stops resolving and apply fails. That
-  # failure is the prompt to move to a current image rather than keep launching
-  # one with unpatched kernel and glibc updates. Treat the run after a bump as
-  # a new baseline.
-  ami_name = "al2023-ami-2023.12.20260803.3-kernel-6.1-x86_64"
 }
 
 ################################################################################
@@ -69,20 +51,6 @@ data "http" "my_ip" {
 
 data "aws_availability_zones" "available" {
   state = "available"
-}
-
-data "aws_ami" "al2023" {
-  owners = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = [local.ami_name]
-  }
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
 }
 
 data "aws_caller_identity" "current" {}
@@ -245,7 +213,18 @@ module "ec2" {
 
   name = "ocync-bench"
 
-  ami           = data.aws_ami.al2023.id
+  # The module resolves the current AL2023 default-kernel release from its own
+  # ami_ssm_parameter default. A name glob is not equivalent: AL2023 ships
+  # several kernel variants under one release with near-identical creation
+  # timestamps, so most_recent over a prefix selects between kernels arbitrarily.
+  #
+  # ami is ForceNew, and AWS advances that parameter as it publishes. Without
+  # this the next apply for any unrelated reason, an operator IP change is
+  # enough, destroys a running instance and its results. New images are picked
+  # up when the instance is next replaced deliberately, and the run record
+  # names the image each run used.
+  ignore_ami_changes = true
+
   instance_type = local.instance_type
   subnet_id     = module.vpc.public_subnets[0]
   key_name      = module.key_pair.key_pair_name

--- a/bench/terraform/aws/user-data.sh
+++ b/bench/terraform/aws/user-data.sh
@@ -92,25 +92,16 @@ echo "Go: $(go version)"
 export HOME=/root GOPATH=/root/go GOCACHE=/root/.cache/go-build
 export PATH="/usr/local/go/bin:$GOPATH/bin:$PATH"
 
-# Competitor tool versions. These are pinned rather than floating because
-# bench/results/{registry}.json is compared across runs: a tool that changes
-# version between instance rebuilds makes a metric shift unattributable.
-# Bump deliberately, and treat the first run afterward as a new baseline.
-ECR_CREDENTIAL_HELPER_VERSION="v0.12.0"
-REGCLIENT_VERSION="v0.11.5"
-# skopeo moved its module path to go.podman.io/skopeo at v1.23.0. The github.com
-# path still serves tags, but their go.mod declares the new path, so installing
-# from it fails on a module path mismatch rather than a missing version.
-SKOPEO_VERSION="v1.24.0"
-# dregsy tags releases without the v prefix, so the module proxy cannot resolve
-# them and only serves pseudo-versions. This one is release 0.5.2, whose tag
-# points at commit e92e79a. Re-derive it from the tag when bumping.
-DREGSY_VERSION="v0.0.0-20250317074629-e92e79a50145"
+# Competitor tools install at @latest, so a run compares ocync against what
+# was current when this instance was built. These resolve once, here, not per
+# run: to measure against newer releases, replace the instance. What makes two
+# runs comparable is the record of what each used, which the harness writes
+# into bench/results/{registry}.json.
 
 # ── ECR credential helper ────────────────────────────────────────────────────
 
 echo "--- Installing ECR credential helper"
-go install "github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@$${ECR_CREDENTIAL_HELPER_VERSION}"
+go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@latest
 cp /root/go/bin/docker-credential-ecr-login /usr/local/bin/
 
 mkdir -p /home/ec2-user/.docker
@@ -119,16 +110,21 @@ cat > /home/ec2-user/.docker/config.json <<'DCEOF'
 DCEOF
 chown -R ec2-user:ec2-user /home/ec2-user/.docker
 
-# go install sets none of the ldflags the project's Makefile uses, so the binary
-# reports "development" whatever is pinned. Echo the pin instead.
-echo "ecr-credential-helper: $${ECR_CREDENTIAL_HELPER_VERSION}"
+# `go version -m` reads the module version stamped into the binary, which is
+# the only version several of these report. The credential helper leaves its
+# own version at "development" because go install sets none of the ldflags its
+# Makefile uses, and dregsy has no version flag at all.
+echo "ecr-credential-helper: $(go version -m /usr/local/bin/docker-credential-ecr-login | awk '$1 == "mod" { print $3; exit }')"
 
 # ── skopeo (dregsy transfer backend) ─────────────────────────────────────────
 
 echo "--- Installing skopeo"
+# skopeo moved its module path to go.podman.io/skopeo at v1.23.0. The github.com
+# path still serves tags, but their go.mod declares the new path, so installing
+# from it fails on a module path mismatch rather than a missing version.
 CGO_ENABLED=1 go install \
   -tags "exclude_graphdriver_btrfs containers_image_openpgp" \
-  "go.podman.io/skopeo/cmd/skopeo@$${SKOPEO_VERSION}"
+  go.podman.io/skopeo/cmd/skopeo@latest
 cp /root/go/bin/skopeo /usr/local/bin/skopeo
 
 echo "skopeo: $(skopeo --version 2>&1)"
@@ -136,17 +132,18 @@ echo "skopeo: $(skopeo --version 2>&1)"
 # ── dregsy ────────────────────────────────────────────────────────────────────
 
 echo "--- Installing dregsy"
-go install "github.com/xelalexv/dregsy/cmd/dregsy@$${DREGSY_VERSION}"
+# dregsy tags releases without the v prefix, so the module proxy cannot read
+# them as versions and @latest resolves to a pseudo-version off the default
+# branch rather than to a release.
+go install github.com/xelalexv/dregsy/cmd/dregsy@latest
 cp /root/go/bin/dregsy /usr/local/bin/dregsy
 
-# dregsy has no version flag and injects its version via release-build ldflags,
-# so probing the binary prints a usage dump. Echo the pin instead.
-echo "dregsy: $${DREGSY_VERSION}"
+echo "dregsy: $(go version -m /usr/local/bin/dregsy | awk '$1 == "mod" { print $3; exit }')"
 
 # ── regsync ───────────────────────────────────────────────────────────────────
 
 echo "--- Installing regsync"
-go install "github.com/regclient/regclient/cmd/regsync@$${REGCLIENT_VERSION}"
+go install github.com/regclient/regclient/cmd/regsync@latest
 cp /root/go/bin/regsync /usr/local/bin/regsync
 
 echo "regsync: $(regsync version 2>&1 || true)"

--- a/xtask/src/bench/mod.rs
+++ b/xtask/src/bench/mod.rs
@@ -443,7 +443,9 @@ pub(crate) async fn run(args: BenchArgs) -> Result<(), Box<dyn std::error::Error
             memory_gib: report.instance.memory_mib as f64 / 1024.0,
             network: report.instance.network_performance.clone(),
             region: report.instance.region.clone(),
+            image_id: report.instance.image_id.clone(),
         },
+        relays: report.relay_versions.clone(),
         corpus: report::CorpusInfo {
             images: report.corpus_size,
             tags: report.total_tags,

--- a/xtask/src/bench/report.rs
+++ b/xtask/src/bench/report.rs
@@ -28,6 +28,14 @@ pub(crate) struct RunRecord {
     pub(crate) git_ref: String,
     /// Machine and cloud provider metadata.
     pub(crate) machine: MachineInfo,
+    /// Versions of binaries the benchmarked tools relay their transfers
+    /// through, keyed by binary name.
+    ///
+    /// dregsy transfers nothing itself, so skopeo's version moves dregsy's
+    /// numbers. Recorded here rather than only in the per-run summary, which
+    /// is not tracked in git and dies with the instance.
+    #[serde(default)]
+    pub(crate) relays: BTreeMap<String, String>,
     /// Corpus size context.
     pub(crate) corpus: CorpusInfo,
     /// Per-scenario results.
@@ -51,6 +59,19 @@ pub(crate) struct MachineInfo {
     pub(crate) network: String,
     /// Cloud region (e.g. `us-east-1`).
     pub(crate) region: String,
+    /// Machine image the instance booted (e.g. `ami-0742fcde83639b335`), or
+    /// `"unknown"` outside a cloud instance.
+    ///
+    /// The image carries the kernel, glibc and NIC driver, so two runs on
+    /// different images are not directly comparable however identical the rest
+    /// of the metadata looks.
+    #[serde(default = "unknown_string")]
+    pub(crate) image_id: String,
+}
+
+/// Default for record fields added after runs were already archived.
+fn unknown_string() -> String {
+    "unknown".to_string()
 }
 
 /// Corpus size metadata.
@@ -160,6 +181,8 @@ pub(crate) struct InstanceInfo {
     pub(crate) network_performance: String,
     /// AWS region (e.g. `us-east-1`), or `"unknown"` outside EC2.
     pub(crate) region: String,
+    /// AMI the instance booted, or `"unknown"` outside EC2.
+    pub(crate) image_id: String,
 }
 
 impl InstanceInfo {
@@ -171,6 +194,7 @@ impl InstanceInfo {
     pub(crate) fn collect() -> Self {
         let instance_type = read_imds("instance-type").unwrap_or_else(|| "unknown".into());
         let region = read_imds("placement/region").unwrap_or_else(|| "unknown".into());
+        let image_id = read_imds("ami-id").unwrap_or_else(|| "unknown".into());
 
         // Query DescribeInstanceTypes for authoritative hardware specs.
         let (arch, cpu_manufacturer, vcpus, memory_mib, network_performance) =
@@ -210,6 +234,7 @@ impl InstanceInfo {
                 network_performance
             },
             region,
+            image_id,
         }
     }
 }
@@ -863,6 +888,7 @@ mod tests {
             memory_mib: 8192,
             network_performance: "Up to 12.5 Gigabit".into(),
             region: "us-east-1".into(),
+            image_id: "unknown".into(),
         }
     }
 
@@ -1087,7 +1113,9 @@ mod tests {
                 memory_gib: 32.0,
                 network: "Up to 50 Gigabit".into(),
                 region: "us-east-1".into(),
+                image_id: "unknown".into(),
             },
+            relays: BTreeMap::new(),
             corpus: CorpusInfo {
                 images: 42,
                 tags: 55,
@@ -1138,7 +1166,9 @@ mod tests {
                 memory_gib: 32.0,
                 network: "Up to 50 Gigabit".into(),
                 region: "us-east-1".into(),
+                image_id: "unknown".into(),
             },
+            relays: BTreeMap::new(),
             corpus: CorpusInfo {
                 images: 10,
                 tags: 15,
@@ -1172,7 +1202,9 @@ mod tests {
                 memory_gib: 8.0,
                 network: "Up to 12.5 Gigabit".into(),
                 region: "us-east-1".into(),
+                image_id: "unknown".into(),
             },
+            relays: BTreeMap::new(),
             corpus: CorpusInfo { images: 5, tags: 8 },
             scenarios: vec![],
         };
@@ -1201,7 +1233,9 @@ mod tests {
                 memory_gib: 0.0,
                 network: "unknown".into(),
                 region: "unknown".into(),
+                image_id: "unknown".into(),
             },
+            relays: BTreeMap::new(),
             corpus: CorpusInfo { images: 0, tags: 0 },
             scenarios: vec![],
         };

--- a/xtask/src/bench/runner.rs
+++ b/xtask/src/bench/runner.rs
@@ -77,9 +77,10 @@ fn version_args(tool: Tool) -> &'static [&'static str] {
 /// Whether a tool reports its own version.
 ///
 /// `dregsy` has none to report: it takes no version flag, and its release
-/// version is injected by ldflags that `go install` does not set. Every other
-/// tool exits zero from its version subcommand, so a failure there means the
-/// binary is broken rather than merely quiet.
+/// version is injected by ldflags that `go install` does not set. Its version
+/// comes from the module stamped into the binary instead. Every other tool
+/// exits zero from its version subcommand, so a failure there means the binary
+/// is broken rather than merely quiet.
 fn reports_version(tool: Tool) -> bool {
     match tool {
         Tool::Dregsy => false,
@@ -87,20 +88,29 @@ fn reports_version(tool: Tool) -> bool {
     }
 }
 
-/// Binaries a tool delegates its transfers to, whose versions move its numbers.
+/// Binaries a tool delegates to, whose versions move its numbers.
 ///
 /// `dregsy` transfers nothing itself. Its generated config sets `relay: skopeo`,
 /// so skopeo moves every byte dregsy is credited with, and a skopeo change
 /// shifts dregsy's measurements with nothing in dregsy's own version to explain
-/// it. Recorded alongside the benchmarked tools for that reason.
+/// it.
+///
+/// Both Go tools authenticate to ECR through the credential helper, so a
+/// release of it that changes token caching moves their request counts. ocync
+/// calls the AWS SDK directly and does not use it.
 fn relay_binaries(tool: Tool) -> &'static [&'static str] {
     match tool {
-        Tool::Dregsy => &["skopeo"],
-        Tool::Regsync | Tool::Ocync => &[],
+        Tool::Dregsy => &["skopeo", "docker-credential-ecr-login"],
+        Tool::Regsync => &["docker-credential-ecr-login"],
+        Tool::Ocync => &[],
     }
 }
 
 /// Extracts a single-line version string from a completed version probe.
+///
+/// `Ok(None)` means the binary ran but reported no version, which callers
+/// resolve from the module version stamped into it. That is distinct from the
+/// literal string `unknown`, which a tool could legitimately print.
 ///
 /// A non-zero exit yields diagnostic text rather than a version, so it is
 /// never recorded as one. Where the binary reports a version this is an error,
@@ -113,7 +123,7 @@ fn version_from_probe(
     success: bool,
     stdout: &str,
     stderr: &str,
-) -> Result<String, String> {
+) -> Result<Option<String>, String> {
     if !success {
         if reports_version {
             let detail = stderr
@@ -124,7 +134,7 @@ fn version_from_probe(
                 .trim();
             return Err(format!("{name} version probe failed: {detail}"));
         }
-        return Ok(UNKNOWN_VERSION.to_string());
+        return Ok(None);
     }
 
     // Some tools write the version to stderr, so fall back to it.
@@ -138,22 +148,19 @@ fn version_from_probe(
     Ok(raw
         .lines()
         .find(|l| !l.trim().is_empty())
-        .unwrap_or(UNKNOWN_VERSION)
-        .trim()
-        .to_string())
+        .map(|l| l.trim().to_string()))
 }
 
 /// Runs a version probe and returns a single-line version string.
 ///
 /// Errors when the binary cannot be executed, which means it is missing, and
-/// when a binary that reports a version fails to. [`UNKNOWN_VERSION`] is
-/// returned only where there is no version to report, in which case the pinned
-/// version is recorded in the benchmark instance bootstrap instead.
+/// when a binary that reports a version fails to. `Ok(None)` means the binary
+/// ran but reported no version of its own.
 async fn probe_version(
     binary: &str,
     args: &[&str],
     reports_version: bool,
-) -> Result<String, String> {
+) -> Result<Option<String>, String> {
     let output = tokio::process::Command::new(binary)
         .args(args)
         .output()
@@ -172,9 +179,60 @@ async fn probe_version(
     )
 }
 
+/// Extracts the module version from `go version -m` output.
+///
+/// The build info lists one `mod` line holding the main module's path and
+/// version, followed by a `dep` line per dependency.
+fn module_version_from_build_info(output: &str) -> Option<&str> {
+    output.lines().find_map(|line| {
+        let mut fields = line.split_whitespace();
+        if fields.next()? != "mod" {
+            return None;
+        }
+        fields.next()?; // module path
+        fields.next()
+    })
+}
+
+/// Reads the module version stamped into a Go binary on `PATH`.
+///
+/// This is the only version several of these tools carry. `go install` sets
+/// none of the ldflags a project's release build uses, so a tool that reports
+/// its version from a linker-injected variable reports a placeholder, and
+/// dregsy has no version flag at all.
+async fn go_module_version(binary: &str) -> Option<String> {
+    let output = tokio::process::Command::new("sh")
+        .arg("-c")
+        .arg(format!("go version -m \"$(command -v {binary})\""))
+        .output()
+        .await
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    module_version_from_build_info(&stdout).map(str::to_string)
+}
+
 /// Runs a benchmarked tool's version probe.
+///
+/// Falls back to the binary's stamped module version where the tool reports
+/// none, so a run record names the version that produced its numbers. The
+/// fallback keys off the probe reporting nothing rather than off a sentinel
+/// string, so a tool that prints the word `unknown` is still recorded as
+/// having reported it.
 pub(crate) async fn check_tool(tool: Tool) -> Result<String, String> {
-    probe_version(tool.binary(), version_args(tool), reports_version(tool)).await
+    if let Some(version) =
+        probe_version(tool.binary(), version_args(tool), reports_version(tool)).await?
+    {
+        return Ok(version);
+    }
+
+    Ok(go_module_version(tool.binary())
+        .await
+        .unwrap_or_else(|| UNKNOWN_VERSION.to_string()))
 }
 
 /// Returns the version of every binary `tool` relays its transfers through.
@@ -183,7 +241,19 @@ pub(crate) async fn check_tool(tool: Tool) -> Result<String, String> {
 pub(crate) async fn check_relays(tool: Tool) -> Result<Vec<(String, String)>, String> {
     let mut versions = Vec::new();
     for &binary in relay_binaries(tool) {
-        let version = probe_version(binary, &["--version"], true).await?;
+        // These are all Go binaries, and the stamped module version names the
+        // artifact exactly. Asking the binary is the weaker source: the
+        // credential helper prints "development" whatever it was built from,
+        // because `go install` sets none of its Makefile's ldflags.
+        let version = match go_module_version(binary).await {
+            Some(version) => version,
+            // Still probe, so a missing binary fails here rather than midway
+            // through a run. A relay need not accept `--version`, so a
+            // non-zero exit is not itself an error.
+            None => probe_version(binary, &["--version"], false)
+                .await?
+                .unwrap_or_else(|| UNKNOWN_VERSION.to_string()),
+        };
         versions.push((binary.to_string(), version));
     }
     Ok(versions)
@@ -485,11 +555,22 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(version, "unknown");
-        assert!(
-            !version.contains("flag provided but not defined"),
-            "diagnostic output leaked into the recorded version: {version}"
+        assert_eq!(
+            version, None,
+            "a failed probe must report no version, not diagnostic text"
         );
+    }
+
+    #[test]
+    fn zero_exit_probe_output_is_taken_verbatim() {
+        // dregsy builds from an unpinned commit, so nothing fixes its exit
+        // code. Were it to start exiting zero, its log line must not be
+        // rescued by a sentinel comparison and recorded as a version.
+        let logged = "time=\"2026-04-26T13:17:46Z\" level=info msg=\"dregsy \"";
+        let version =
+            version_from_probe("dregsy", reports_version(Tool::Dregsy), true, logged, "").unwrap();
+
+        assert_eq!(version, Some(logged.to_string()));
     }
 
     #[test]
@@ -513,36 +594,84 @@ mod tests {
     }
 
     #[test]
-    fn relay_probe_failure_is_an_error() {
-        // skopeo moves every byte dregsy is credited with, so a broken skopeo
-        // must not be recorded as an absent version either.
-        let err = version_from_probe("skopeo", true, false, "", "skopeo: command failed")
-            .expect_err("a relay binary must fail loudly");
-        assert!(err.contains("skopeo version probe failed"), "{err}");
+    fn module_version_is_read_from_build_info() {
+        // Real `go version -m` output. The mod line carries the main module,
+        // and every dep line after it must be ignored.
+        let output = "/usr/local/bin/dregsy: go1.26.2\n\
+             \tpath\tgithub.com/xelalexv/dregsy/cmd/dregsy\n\
+             \tmod\tgithub.com/xelalexv/dregsy\tv0.0.0-20250317074629-e92e79a50145\th1:abc=\n\
+             \tdep\tgithub.com/sirupsen/logrus\tv1.9.3\th1:def=\n";
+
+        assert_eq!(
+            module_version_from_build_info(output),
+            Some("v0.0.0-20250317074629-e92e79a50145")
+        );
     }
 
     #[test]
-    fn dregsy_relays_through_skopeo() {
-        assert_eq!(relay_binaries(Tool::Dregsy), &["skopeo"]);
+    fn module_version_absent_without_a_mod_line() {
+        // `go version -m` writes nothing to stdout for a non-Go binary, and
+        // go_module_version discards stderr, so an empty input is the only
+        // shape the parser sees in that case.
+        assert_eq!(module_version_from_build_info(""), None);
+
+        // A Go binary whose build info carries no main module still lists its
+        // dependencies, which must not be mistaken for the module version.
+        let deps_only = "/usr/local/bin/x: go1.26.2\n\
+             \tdep\tgithub.com/sirupsen/logrus\tv1.9.3\th1:def=\n";
+        assert_eq!(module_version_from_build_info(deps_only), None);
+    }
+
+    #[test]
+    fn relays_cover_every_binary_that_moves_a_tools_numbers() {
+        // dregsy delegates every transfer to skopeo, and both Go tools reach
+        // ECR through the credential helper. ocync calls the AWS SDK directly.
+        assert_eq!(
+            relay_binaries(Tool::Dregsy),
+            &["skopeo", "docker-credential-ecr-login"]
+        );
+        assert_eq!(
+            relay_binaries(Tool::Regsync),
+            &["docker-credential-ecr-login"]
+        );
         assert!(relay_binaries(Tool::Ocync).is_empty());
-        assert!(relay_binaries(Tool::Regsync).is_empty());
+    }
+
+    #[test]
+    fn a_placeholder_reporting_relay_still_needs_its_module_version() {
+        // The credential helper exits zero and prints "development" whatever
+        // it was built from, so the probe alone would record that as a version
+        // and the module lookup must take precedence.
+        let probed = version_from_probe(
+            "docker-credential-ecr-login",
+            false,
+            true,
+            "docker-credential-ecr-login (github.com/awslabs/amazon-ecr-credential-helper/ecr-login) development\n",
+            "",
+        )
+        .unwrap();
+
+        assert!(
+            probed.is_some_and(|v| v.contains("development")),
+            "probe is expected to yield a placeholder, which is why relays prefer the module version"
+        );
     }
 
     #[test]
     fn successful_probe_reads_the_version() {
         assert_eq!(
             version_from_probe("ocync", true, true, "ocync 0.6.0\n", "").unwrap(),
-            "ocync 0.6.0"
+            Some("ocync 0.6.0".to_string())
         );
         // regsync pads its output and precedes the tag with a blank line.
         assert_eq!(
             version_from_probe("regsync", true, true, "\nVCSTag:     v0.11.5\n", "").unwrap(),
-            "VCSTag:     v0.11.5"
+            Some("VCSTag:     v0.11.5".to_string())
         );
         // skopeo reports cleanly on stdout with a zero exit.
         assert_eq!(
             version_from_probe("skopeo", true, true, "skopeo version 1.24.0\n", "").unwrap(),
-            "skopeo version 1.24.0"
+            Some("skopeo version 1.24.0".to_string())
         );
     }
 
@@ -550,15 +679,15 @@ mod tests {
     fn successful_probe_falls_back_to_stderr() {
         assert_eq!(
             version_from_probe("ocync", true, true, "   ", "ocync 0.6.0").unwrap(),
-            "ocync 0.6.0"
+            Some("ocync 0.6.0".to_string())
         );
     }
 
     #[test]
-    fn successful_probe_with_no_output_is_unknown() {
+    fn successful_probe_with_no_output_reports_nothing() {
         assert_eq!(
             version_from_probe("ocync", true, true, "", "").unwrap(),
-            "unknown"
+            None
         );
     }
 


### PR DESCRIPTION
A benchmark run is a point in time, not a fixed rig. Pinning the competitor tools measured ocync against versions nobody runs, and pinning the AMI did the same for the OS. Both float again.

The record was the missing half, and it predates the pinning. `bench/results/{registry}.json` named neither the image, nor skopeo, which moves every byte dregsy is credited with, nor the credential helper both Go tools authenticate to ECR through. It now carries all three: the image id from instance metadata, and relay versions read from the module stamped into each binary. That is the only version several of these carry, since `go install` sets none of a release build's ldflags, so the credential helper reports `development` and dregsy has no version flag at all.

`ami` is ForceNew and AWS advances the AL2023 parameter as it publishes, so `ignore_ami_changes` is set. Without it the next apply for any unrelated reason destroys a running instance and its results, and re-reading `data.http.my_ip` every plan means an operator IP change alone is such a reason. New images arrive on deliberate replacement. The ec2 module resolves the same SSM parameter from its own default, so the data sources doing it by hand are gone, which also drops two API calls per plan.

Two things survive from the pinning work because they were bugs rather than pins. skopeo installs from `go.podman.io/skopeo`, since the `github.com` path serves tags whose `go.mod` declares the new path and fails on a mismatch. And the version probe now distinguishes "reported nothing" from the literal string `unknown`, so a tool that logs a line on a zero exit cannot have that line recorded as its version, which is the bug #116 fixed and a sentinel comparison would have re-opened.

Worth knowing rather than assuming, and now written down in `bench/CLAUDE.md`: `@latest` resolves once, at instance creation, because the `go install` calls live in user-data and `bench-remote` only rebuilds ocync. An instance built in March runs March's dregsy in September. Benchmarking against newer competitor releases means replacing the instance, and the run record is what says which versions a given result came from. Two related traps are documented there too: `@latest` never crosses a major version boundary under semantic import versioning, and dregsy tags without a `v` prefix so it resolves to a pseudo-version off the default branch rather than a release.

CI is the gate. Locally `cargo fmt`, `clippy -D warnings`, `check --no-default-features --features non-fips`, `cargo deny`, `terraform fmt`, `terraform validate` and 147 xtask tests pass. The testcontainers-backed integration tests in `ocync-distribution` fail on my machine with `WaitContainer(StartupTimeout)`, which is container startup rather than an assertion, and this diff cannot reach that crate.