### PR TITLE
fix(bench): record why a version is unknown

### DIFF
--- a/bench/CLAUDE.md
+++ b/bench/CLAUDE.md
@@ -133,9 +133,18 @@ A benchmark run is a point in time, not a fixed rig. Nothing is pinned: competit
 
 Three resolution details are easy to get wrong. skopeo's module path is `go.podman.io/skopeo` since v1.23.0, and the old `github.com/containers/skopeo` path still serves tags whose `go.mod` declares the new path, so installing from it fails on a path mismatch rather than a missing version. `@latest` never crosses a major version boundary under semantic import versioning, so when one of these tags v2 the install silently sticks on the highest v1 until the path gains a `/v2` suffix. And dregsy tags releases without a `v` prefix, so the proxy reads no valid semver and `@latest` resolves to a pseudo-version off the default branch rather than to a release.
 
-Versions are read from the binaries rather than assumed. `go install` sets none of the ldflags a release build uses, so the ECR credential helper reports `development` and dregsy has no version flag at all. Both are recovered with `go version -m`, which reads the module version stamped into the binary. That can still come up empty, for a binary built from a working tree (Go stamps `(devel)`, which names no release) or where Go is absent, and the record then reads `unknown` with the reason on stderr. Treat an `unknown` as a run whose provenance was lost rather than as a harness bug.
+Versions are read from the binaries rather than assumed. `go install` sets none of the ldflags a release build uses, so the ECR credential helper reports `development` and dregsy has no version flag at all. Both are recovered with `go version -m`, which reads the module version stamped into the binary.
 
-The bootstrap log is `/var/log/user-data.log` on the instance, not `cloud-init-output.log`: `user-data.sh` redirects its own output there.
+That lookup can still come up empty, for a binary built from a working tree (Go stamps `(devel)`, which names no release) or where Go is absent. What the record then holds depends on which path asked:
+
+- A benchmarked tool records `unknown (<reason>)`.
+- A relay falls back to asking the binary, so it records either that answer plus `(module version unavailable: <reason>)`, or, if the binary reported nothing either, `unknown (<reason>, and --version reported nothing)`.
+
+So a relay never reads as a plain version when its lookup failed, which matters most for the credential helper: its `development` placeholder is otherwise indistinguishable from a healthy release build. Grep the archive for `unavailable` as well as `unknown (` to find runs whose provenance is incomplete, and treat either as a lost record rather than a harness bug.
+
+Reasons carry no absolute paths and are length-capped, because they are committed to `bench/results/{registry}.json`.
+
+The bootstrap log is `/var/log/user-data.log` on the instance, not `cloud-init-output.log`: `user-data.sh` redirects its own output there. The benchmark run log is streamed to the operator's terminal live and never persisted, and under `--fetch` not even streamed, so a warning it emits is seen once or not at all. That is why anything affecting a run's provenance is written into the record rather than only logged.
 
 dregsy transfers nothing itself. Its config sets `relay: skopeo`, so skopeo moves every byte dregsy is credited with, and the run record captures skopeo's version alongside dregsy's for that reason.
 

--- a/xtask/src/bench/mod.rs
+++ b/xtask/src/bench/mod.rs
@@ -218,15 +218,27 @@ fn registry_key(target_registry: &str) -> &'static str {
 }
 
 /// Returns the short git commit hash of HEAD.
+///
+/// This is the record's only anchor from numbers back to the code that
+/// produced them, so a failure is announced rather than silently recorded as
+/// `unknown`. The run log is streamed to the operator and never persisted, so
+/// this warning is the only chance to notice.
 fn git_ref() -> String {
-    std::process::Command::new("git")
+    let resolved = std::process::Command::new("git")
         .args(["rev-parse", "--short", "HEAD"])
         .output()
         .ok()
         .filter(|o| o.status.success())
         .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| "unknown".into())
+        .map(|s| s.trim().to_string());
+
+    resolved.unwrap_or_else(|| {
+        eprintln!(
+            "WARNING: could not resolve HEAD, so this run cannot be tied to a commit. \
+             Recording the git ref as \"unknown\"."
+        );
+        "unknown".into()
+    })
 }
 
 /// Derives the cloud provider name from a registry key.
@@ -315,11 +327,13 @@ pub(crate) async fn run(args: BenchArgs) -> Result<(), Box<dyn std::error::Error
         let version = runner::check_tool(tool, workspace_root).await?;
         eprintln!("  {}: {version}", tool);
         tool_versions.insert(tool.to_string(), version);
+    }
 
-        for (binary, version) in runner::check_relays(tool).await? {
-            eprintln!("  {binary}: {version} (relay)");
-            relay_versions.insert(binary, version);
-        }
+    // Relays are shared between tools, so they are resolved once over the whole
+    // set rather than per tool.
+    for (binary, version) in runner::check_relays(&tools).await? {
+        eprintln!("  {binary} (relay): {version}");
+        relay_versions.insert(binary, version);
     }
 
     // 4. Determine output directory.

--- a/xtask/src/bench/report.rs
+++ b/xtask/src/bench/report.rs
@@ -74,6 +74,22 @@ fn unknown_string() -> String {
     "unknown".to_string()
 }
 
+/// Reads an instance metadata field, warning when it cannot be resolved.
+///
+/// `read_imds` returns `None` for an absent curl, an unreachable metadata
+/// service and a non-UTF-8 body alike, and the run log is never persisted, so
+/// the warning is the operator's only signal that a comparability anchor is
+/// missing from the record.
+fn imds_or_unknown(path: &str) -> String {
+    read_imds(path).unwrap_or_else(|| {
+        eprintln!(
+            "WARNING: instance metadata {path} unavailable, recording \"unknown\". \
+             Runs cannot be compared on it."
+        );
+        unknown_string()
+    })
+}
+
 /// Corpus size metadata.
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct CorpusInfo {
@@ -192,9 +208,13 @@ impl InstanceInfo {
     /// `describe-instance-types` provides authoritative CPU, memory,
     /// and network specs. Falls back to `"unknown"` / 0 outside EC2.
     pub(crate) fn collect() -> Self {
-        let instance_type = read_imds("instance-type").unwrap_or_else(|| "unknown".into());
-        let region = read_imds("placement/region").unwrap_or_else(|| "unknown".into());
-        let image_id = read_imds("ami-id").unwrap_or_else(|| "unknown".into());
+        // Announced rather than silently recorded: the image and instance type
+        // are what decide whether two runs are comparable, and a bare
+        // "unknown" in the archive is indistinguishable from an older record
+        // that predates the field.
+        let instance_type = imds_or_unknown("instance-type");
+        let region = imds_or_unknown("placement/region");
+        let image_id = imds_or_unknown("ami-id");
 
         // Query DescribeInstanceTypes for authoritative hardware specs.
         let (arch, cpu_manufacturer, vcpus, memory_mib, network_performance) =
@@ -453,8 +473,10 @@ fn summary_markdown(report: &BenchReport) -> String {
     for (tool, version) in &report.tool_versions {
         out.push_str(&format!("- **{tool}**: {version}\n"));
     }
+    // The marker leads, since a version can now carry a parenthesised reason
+    // and a trailing "(relay)" would read as part of it.
     for (binary, version) in &report.relay_versions {
-        out.push_str(&format!("- **{binary}**: {version} (relay)\n"));
+        out.push_str(&format!("- **{binary}** (relay): {version}\n"));
     }
     out.push('\n');
 
@@ -1043,9 +1065,11 @@ mod tests {
             tool_columns(&report)
         );
 
+        // The marker leads, so a version carrying a parenthesised reason does
+        // not read as though "(relay)" were part of that reason.
         let md = summary_markdown(&report);
         assert!(
-            md.contains("**skopeo**: skopeo version 1.24.0 (relay)"),
+            md.contains("**skopeo** (relay): skopeo version 1.24.0"),
             "relay version missing from the versions section"
         );
     }

--- a/xtask/src/bench/runner.rs
+++ b/xtask/src/bench/runner.rs
@@ -1,5 +1,6 @@
 //! Tool execution: spawn benchmark tool processes with timing and output capture.
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, Instant};
@@ -59,8 +60,70 @@ pub(crate) struct RunResult {
     pub(crate) timing_path: Option<PathBuf>,
 }
 
-/// Version string recorded when a tool cannot report its own version.
+/// Prefix of a recorded version where none could be determined.
+///
+/// Never recorded bare: [`unknown_version`] always appends why, so a check for
+/// a lost-provenance run tests this as a prefix rather than for equality.
 const UNKNOWN_VERSION: &str = "unknown";
+
+/// Longest subprocess diagnostic carried into a recorded version.
+const MAX_REASON_LEN: usize = 160;
+
+/// Trims a subprocess diagnostic to something safe to commit.
+///
+/// These reasons come from local tooling and land in a git-tracked file, so an
+/// absolute path would commit one machine's directory layout to the repository
+/// and an unbounded line would fight the archive's stated aim of staying small
+/// enough to accumulate. Paths are reduced to their final component.
+fn sanitize_reason(reason: &str) -> String {
+    let cleaned: Vec<String> = reason
+        .split_whitespace()
+        .map(|token| match token.rsplit_once('/') {
+            Some((_, name)) if token.starts_with('/') && !name.is_empty() => name.to_string(),
+            _ => token.to_string(),
+        })
+        .collect();
+
+    let mut out = cleaned.join(" ");
+    if out.chars().count() > MAX_REASON_LEN {
+        out = out.chars().take(MAX_REASON_LEN).collect::<String>() + "...";
+    }
+    out
+}
+
+/// Records that no version could be determined, and why.
+///
+/// The reason belongs in the record rather than only on stderr. The archive
+/// outlives the instance, the run log is streamed to the operator's terminal
+/// and never persisted, and a bare `unknown` reads the same for a binary with
+/// no build info, an absent Go toolchain and a working-tree build. A run whose
+/// provenance was lost should say so where the numbers are.
+fn unknown_version(reason: &str) -> String {
+    format!("{UNKNOWN_VERSION} ({})", sanitize_reason(reason))
+}
+
+/// Records a version the binary reported while the authoritative lookup failed.
+///
+/// Several of these print a placeholder when built without their release
+/// ldflags, and a placeholder is indistinguishable from a healthy release build
+/// once it reaches the archive. Carrying the reason keeps that distinguishable.
+fn reported_version(reported: &str, reason: &str) -> String {
+    format!(
+        "{reported} (module version unavailable: {})",
+        sanitize_reason(reason)
+    )
+}
+
+/// Chooses what to record for a relay whose module lookup failed.
+///
+/// Both outcomes carry the lookup failure. Neither may read as a plain
+/// version, since that is what makes a lost record look like a healthy one.
+fn relay_version_after_failed_lookup(reported: Option<String>, reason: &str) -> String {
+    match reported {
+        Some(reported) => reported_version(&reported, reason),
+        None => unknown_version(&format!("{reason}, and --version reported nothing")),
+    }
+}
 
 /// Returns the version argument(s) for a given tool.
 ///
@@ -106,6 +169,18 @@ fn relay_binaries(tool: Tool) -> &'static [&'static str] {
     }
 }
 
+/// First non-blank line of a process's output, trimmed.
+///
+/// Tools pad their output and split it across streams, and only the first
+/// meaningful line is wanted whether it is a version or a diagnostic.
+fn first_line<'a>(primary: &'a str, fallback: &'a str) -> Option<&'a str> {
+    primary
+        .lines()
+        .chain(fallback.lines())
+        .find(|l| !l.trim().is_empty())
+        .map(str::trim)
+}
+
 /// Extracts a single-line version string from a completed version probe.
 ///
 /// `Ok(None)` means the binary ran but reported no version, which callers
@@ -126,29 +201,14 @@ fn version_from_probe(
 ) -> Result<Option<String>, String> {
     if !success {
         if reports_version {
-            let detail = stderr
-                .lines()
-                .chain(stdout.lines())
-                .find(|l| !l.trim().is_empty())
-                .unwrap_or("no output")
-                .trim();
+            let detail = first_line(stderr, stdout).unwrap_or("no output");
             return Err(format!("{name} version probe failed: {detail}"));
         }
         return Ok(None);
     }
 
     // Some tools write the version to stderr, so fall back to it.
-    let raw = if stdout.trim().is_empty() {
-        stderr
-    } else {
-        stdout
-    };
-
-    // Take only the first non-empty line to keep the summary clean.
-    Ok(raw
-        .lines()
-        .find(|l| !l.trim().is_empty())
-        .map(|l| l.trim().to_string()))
+    Ok(first_line(stdout, stderr).map(str::to_string))
 }
 
 /// Runs a version probe and returns a single-line version string.
@@ -210,12 +270,7 @@ fn no_module_version_reason(success: bool, stdout: &str, stderr: &str) -> String
         return "build info carries no released module version".to_string();
     }
 
-    let detail = stderr
-        .lines()
-        .chain(stdout.lines())
-        .find(|l| !l.trim().is_empty())
-        .unwrap_or("no output")
-        .trim();
+    let detail = first_line(stderr, stdout).unwrap_or("no output");
     format!("go version -m failed: {detail}")
 }
 
@@ -281,20 +336,25 @@ pub(crate) async fn check_tool(tool: Tool, workspace_root: &Path) -> Result<Stri
     match go_module_version(&binary).await {
         Ok(version) => Ok(version),
         Err(reason) => {
-            eprintln!(
-                "WARNING: no version for {binary}: {reason}. Recording \"{UNKNOWN_VERSION}\"."
-            );
-            Ok(UNKNOWN_VERSION.to_string())
+            eprintln!("WARNING: no version for {binary}: {reason}");
+            Ok(unknown_version(&reason))
         }
     }
 }
 
-/// Returns the version of every binary `tool` relays its transfers through.
+/// Returns the version of every binary the given tools relay through.
 ///
 /// Keyed by binary name so the run record names what actually moved the bytes.
-pub(crate) async fn check_relays(tool: Tool) -> Result<Vec<(String, String)>, String> {
+/// Takes the whole tool set because relays are shared: probing per tool would
+/// read the credential helper's build info twice and warn twice about it.
+pub(crate) async fn check_relays(tools: &[Tool]) -> Result<Vec<(String, String)>, String> {
+    let binaries: BTreeSet<&'static str> = tools
+        .iter()
+        .flat_map(|&tool| relay_binaries(tool).iter().copied())
+        .collect();
+
     let mut versions = Vec::new();
-    for &binary in relay_binaries(tool) {
+    for binary in binaries {
         // These are all Go binaries, and the stamped module version names the
         // artifact exactly. Asking the binary is the weaker source: the
         // credential helper prints "development" whatever it was built from,
@@ -302,17 +362,15 @@ pub(crate) async fn check_relays(tool: Tool) -> Result<Vec<(String, String)>, St
         let version = match go_module_version(binary).await {
             Ok(version) => version,
             Err(reason) => {
+                eprintln!("WARNING: no module version for {binary}: {reason}");
+
                 // Still probe, so a missing binary fails here rather than
                 // midway through a run. A relay need not accept `--version`,
-                // so a non-zero exit is not itself an error. Announced,
-                // because this is the weaker source and may be a placeholder.
-                eprintln!(
-                    "WARNING: no module version for {binary}: {reason}. \
-                     Falling back to asking the binary."
-                );
-                probe_version(binary, &["--version"], false)
-                    .await?
-                    .unwrap_or_else(|| UNKNOWN_VERSION.to_string())
+                // so a non-zero exit is not itself an error. Either way the
+                // reason is carried, since what the binary reports may be a
+                // placeholder that reads like a healthy release build.
+                let reported = probe_version(binary, &["--version"], false).await?;
+                relay_version_after_failed_lookup(reported, &reason)
             }
         };
         versions.push((binary.to_string(), version));
@@ -658,6 +716,96 @@ mod tests {
             module_version_from_build_info(output),
             Some("v0.0.0-20250317074629-e92e79a50145")
         );
+    }
+
+    #[test]
+    fn an_unknown_version_records_why() {
+        // The archive outlives the instance and the run log is never
+        // persisted, so a bare "unknown" would leave a lost-provenance run
+        // indistinguishable from an absent Go toolchain months later. The
+        // exact shape is asserted because bench/CLAUDE.md documents it.
+        assert_eq!(
+            unknown_version("sh: go: command not found"),
+            "unknown (sh: go: command not found)"
+        );
+    }
+
+    #[test]
+    fn neither_relay_outcome_reads_as_a_plain_version() {
+        // Whichever way the fallback goes, the record must show that the
+        // authoritative lookup failed. A bare "development" is what makes a
+        // lost record indistinguishable from a healthy release build.
+        let reason = "sh: go: command not found";
+
+        let answered = relay_version_after_failed_lookup(
+            Some("docker-credential-ecr-login (...) development".to_string()),
+            reason,
+        );
+        assert!(
+            answered.contains("module version unavailable"),
+            "{answered}"
+        );
+        assert!(answered.contains("command not found"), "{answered}");
+
+        let silent = relay_version_after_failed_lookup(None, reason);
+        assert!(silent.starts_with(UNKNOWN_VERSION), "{silent}");
+        assert!(silent.contains("command not found"), "{silent}");
+        assert!(
+            silent.contains("--version reported nothing"),
+            "the second failure is also part of why: {silent}"
+        );
+    }
+
+    #[test]
+    fn a_reported_version_carries_a_failed_module_lookup() {
+        // The credential helper prints this placeholder whatever it was built
+        // from, so without the reason the record reads like a healthy release.
+        let recorded = reported_version(
+            "docker-credential-ecr-login (github.com/awslabs/...) development",
+            "sh: go: command not found",
+        );
+
+        assert!(
+            recorded.starts_with("docker-credential-ecr-login"),
+            "{recorded}"
+        );
+        assert!(
+            recorded.contains("module version unavailable"),
+            "{recorded}"
+        );
+        assert!(recorded.contains("command not found"), "{recorded}");
+    }
+
+    #[test]
+    fn a_recorded_reason_carries_no_local_paths_and_is_bounded() {
+        // These land in a git-tracked file, so an absolute path would commit
+        // one machine's directory layout to the repository.
+        let recorded =
+            unknown_version("could not read Go build info from /Users/someone/go/bin/skopeo");
+        assert!(!recorded.contains("/Users/"), "{recorded}");
+        assert!(recorded.contains("skopeo"), "{recorded}");
+
+        let long = unknown_version(&"x".repeat(500));
+        assert!(
+            long.chars().count() < 200,
+            "unbounded reason: {}",
+            long.len()
+        );
+    }
+
+    #[test]
+    fn first_line_prefers_the_primary_stream() {
+        // The two-argument shape exists only to encode this precedence, so a
+        // swap must fail here rather than silently archive a warning as a
+        // version.
+        assert_eq!(
+            first_line("from stdout", "from stderr"),
+            Some("from stdout")
+        );
+        assert_eq!(first_line("\n  \nreal line\n", ""), Some("real line"));
+        // Some tools report only on stderr, which is why a fallback exists.
+        assert_eq!(first_line("   ", "from stderr"), Some("from stderr"));
+        assert_eq!(first_line("", ""), None);
     }
 
     #[test]


### PR DESCRIPTION
A run record stored a bare `unknown` for several distinct causes: a binary with no build info, a working-tree build, an absent Go toolchain, and a probe that exited non-zero. The archive outlives the instance and the run log is streamed to the operator rather than persisted, so by the time anyone reads the numbers the reason is gone. It is recorded alongside now.

The relay path needed both of its exits covered, not just the one I fixed first. Where the module lookup fails and the binary does answer — the common case — the answer is recorded with the lookup failure attached. The credential helper prints `development` whatever it was built from, so without that the archive shows a placeholder indistinguishable from a healthy release build, and the warning naming the real cause dies with the instance. Where neither source answers, both failures are named rather than just the first.

Reasons are stripped of absolute paths and length-capped before being recorded. They come from local tooling and land in a git-tracked file, so an unsanitised one commits a developer's home directory layout into the repository: `go version -m` on a non-Go binary prints the absolute path twice.

`git_ref` and the instance metadata fields recorded a bare `unknown` with no warning at all. They are the record's other provenance anchors — `image_id`'s own doc says two runs on different images are not comparable — and the same argument applies, so both now say something.

Relays resolve once over the whole tool set rather than per tool. The credential helper is a relay for both Go tools, so it was probed twice and warned about twice.

Three copies of the same first-non-blank-line scan collapse into one helper. Two of them already differed in whether they crossed from stdout to stderr, and its stream precedence is now pinned by a test — swapping the arguments previously left the suite green while archiving a warning as a version.

The relay decision is factored into a pure function so it is actually covered: reverting it fails one test rather than none. `check_relays` itself still reaches a real process spawn and has no unit test, which is why the decision had to come out of it.

CI is the gate. Locally fmt, clippy, non-fips, deny and 156 xtask tests pass.