### PR TITLE
feat(sync): isolate failures per mapping and report progress while running

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,8 @@ ocync syncs content bit-for-bit from source to target(s). We do NOT convert, tra
 A run covers many images across many mappings. One denial, one unreachable registry, one bad repository name must never cancel the rest.
 
 - `SyncReport` is the contract: the engine never fails as a whole, and the CLI driver must not either. No `?` on a per-mapping or per-image path in `synchronize::run`, `resolve_all`, or `analyze::run`. Record the failure, log it, continue.
-- Anything constructed per-registry (clients, ECR batch checkers) fails only the mappings that reference it. Store the error against the alias instead of aborting construction.
+- Anything constructed per-registry (clients, ECR batch checkers) fails only the mappings that reference it. Store the error against the alias instead of aborting construction, and keep the classification with it: a stringified error cannot be told apart from a denial later.
+- Isolation applies at every level it can. One dead target does not cancel a mapping's other targets; one unreadable image does not cancel the rest of an analysis; one bad config file does not cancel the others.
 - Isolated failures must stay visible. Fold them into the exit code, the cycle tail, and the `--json` document, and preserve the specific exit code the abort used to produce. Silent tolerance is worse than the abort it replaces.
 - Optional optimizations (batch checkers, target tag listings for immutable skip) degrade with a WARN. Required work does not.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,15 @@ ocync syncs content bit-for-bit from source to target(s). We do NOT convert, tra
 - Blob bytes are streamed directly from source to target without modification.
 - All registries in production accept both Docker v2 and OCI manifests. There is no real-world use case for format conversion, and it would break every digest-based optimization (skip detection, transfer state cache, immutable tag handling, head-first).
 
+## Failure isolation
+
+A run covers many images across many mappings. One denial, one unreachable registry, one bad repository name must never cancel the rest.
+
+- `SyncReport` is the contract: the engine never fails as a whole, and the CLI driver must not either. No `?` on a per-mapping or per-image path in `synchronize::run`, `resolve_all`, or `analyze::run`. Record the failure, log it, continue.
+- Anything constructed per-registry (clients, ECR batch checkers) fails only the mappings that reference it. Store the error against the alias instead of aborting construction.
+- Isolated failures must stay visible. Fold them into the exit code, the cycle tail, and the `--json` document, and preserve the specific exit code the abort used to produce. Silent tolerance is worse than the abort it replaces.
+- Optional optimizations (batch checkers, target tag listings for immutable skip) degrade with a WARN. Required work does not.
+
 ## Scope discipline
 
 Every PR ships the smallest correct change + one test that catches regression. Defer scaffolding to a follow-up PR justified by a second observation.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,8 @@ url.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+# `test-util` supplies the paused clock the prepare-ticker tests drive.
+tokio = { workspace = true, features = ["test-util"] }
 uuid.workspace = true
 
 [profile.release]

--- a/crates/ocync-sync/CLAUDE.md
+++ b/crates/ocync-sync/CLAUDE.md
@@ -18,7 +18,7 @@ Sync orchestration engine - pipelined discovery/execution, leader-follower blob 
 - `select!` uses `biased;` (prefer execution completions to free permits).
 - Emptiness guards (`if !pool.is_empty()`) on every branch prevent busy-looping.
 - Shutdown branch must check work-remaining or it blocks the else exit.
-- Same rule for the `run_progress` heartbeat branch: its guard is the disjunction of the execution and discovery branches' own preconditions (`!execution_futures.is_empty() || (!shutting_down && !discovery_paused && !discovery_futures.is_empty())`). Guarding it on "futures remain" alone leaves it armed after shutdown freezes discovery, starving `else => break` and hanging the engine for a full interval. `sync_progress.rs` pins this.
+- Same rule for the `run_heartbeat` branch: its guard is the disjunction of the execution and discovery branches' own preconditions (`!execution_futures.is_empty() || (!shutting_down && !discovery_paused && !discovery_futures.is_empty())`). Guarding it on "futures remain" alone leaves it armed after shutdown freezes discovery, starving `else => break` and hanging the engine for a full interval. `sync_progress.rs` pins this.
 
 ## Leader-follower blob mounting
 

--- a/crates/ocync-sync/CLAUDE.md
+++ b/crates/ocync-sync/CLAUDE.md
@@ -18,6 +18,7 @@ Sync orchestration engine - pipelined discovery/execution, leader-follower blob 
 - `select!` uses `biased;` (prefer execution completions to free permits).
 - Emptiness guards (`if !pool.is_empty()`) on every branch prevent busy-looping.
 - Shutdown branch must check work-remaining or it blocks the else exit.
+- Same rule for the `run_progress` heartbeat branch: its guard is the disjunction of the execution and discovery branches' own preconditions (`!execution_futures.is_empty() || (!shutting_down && !discovery_paused && !discovery_futures.is_empty())`). Guarding it on "futures remain" alone leaves it armed after shutdown freezes discovery, starving `else => break` and hanging the engine for a full interval. `sync_progress.rs` pins this.
 
 ## Leader-follower blob mounting
 

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -932,6 +932,10 @@ impl SyncEngine {
         let mut heartbeat = tokio::time::interval(self.heartbeat_interval);
         heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         heartbeat.reset();
+        // The `select!` branch only fires on a poll where no work was ready,
+        // so a steady completion stream would starve it. This deadline is
+        // checked from the work arms too, which is what guarantees a cadence.
+        let mut next_heartbeat = tokio::time::Instant::now() + self.heartbeat_interval;
 
         // Seed discovery with all (mapping, tag) pairs.
         for mapping in &mappings {
@@ -1087,6 +1091,17 @@ impl SyncEngine {
                 Some(result) = execution_futures.next(), if !execution_futures.is_empty() => {
                     progress.image_completed(&result);
                     results.push(result);
+                    if tokio::time::Instant::now() >= next_heartbeat {
+                        progress.run_heartbeat(RunProgress {
+                            in_discovery: discovery_futures.len(),
+                            pending: pending.len(),
+                            in_flight: execution_futures.len(),
+                            completed: results.len(),
+                            elapsed: run_start.elapsed(),
+                        });
+                        next_heartbeat = tokio::time::Instant::now() + self.heartbeat_interval;
+                        heartbeat.reset();
+                    }
                 }
                 _ = async {
                     // Guard above ensures shutdown.is_some(); unwrap cannot panic.
@@ -1194,6 +1209,7 @@ impl SyncEngine {
                         completed: results.len(),
                         elapsed: run_start.elapsed(),
                     });
+                    next_heartbeat = tokio::time::Instant::now() + self.heartbeat_interval;
                 }
                 else => break,
             }

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -746,7 +746,7 @@ const BLOB_CONCURRENCY: usize = 6;
 /// Default shutdown drain deadline in seconds.
 const DEFAULT_DRAIN_DEADLINE_SECS: u64 = 25;
 
-/// Default cadence for [`crate::progress::ProgressReporter::run_progress`] callbacks.
+/// Default cadence for [`crate::progress::ProgressReporter::run_heartbeat`] callbacks.
 ///
 /// Discovery and execution can each run for minutes without an image reaching
 /// a terminal state. Without a periodic callback the caller has no way to tell
@@ -816,7 +816,7 @@ impl SyncEngine {
         self
     }
 
-    /// Configure how often [`crate::progress::ProgressReporter::run_progress`] fires while the
+    /// Configure how often [`crate::progress::ProgressReporter::run_heartbeat`] fires while the
     /// run still has work in flight. Default 30 seconds.
     ///
     /// # Panics
@@ -1171,8 +1171,8 @@ impl SyncEngine {
                 _ = heartbeat.tick(), if !execution_futures.is_empty()
                     || (!shutting_down && !discovery_paused && !discovery_futures.is_empty()) =>
                 {
-                    progress.run_progress(crate::progress::RunProgress {
-                        discovering: discovery_futures.len(),
+                    progress.run_heartbeat(crate::progress::RunProgress {
+                        in_discovery: discovery_futures.len(),
                         pending: pending.len(),
                         in_flight: execution_futures.len(),
                         completed: results.len(),

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -44,6 +44,7 @@ use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::cache::{PlatformFilterKey, SnapshotKey, SourceSnapshot, TransferStateCache};
+use crate::progress::RunProgress;
 use crate::retry::{self, RetryConfig};
 use crate::shutdown::ShutdownSignal;
 use crate::staging::BlobStage;
@@ -772,6 +773,8 @@ pub struct SyncEngine {
     mount_source_wait_deadline: Duration,
     /// Cadence for in-flight progress callbacks. Default: 30 seconds.
     heartbeat_interval: Duration,
+    /// Whether the end-of-run prune may treat absent entries as deleted.
+    prune_cache: bool,
 }
 
 impl SyncEngine {
@@ -787,6 +790,7 @@ impl SyncEngine {
             source_head_timeout: Duration::from_secs(5),
             mount_source_wait_deadline: Duration::from_secs(60),
             heartbeat_interval: Duration::from_secs(DEFAULT_HEARTBEAT_SECS),
+            prune_cache: true,
         }
     }
 
@@ -829,6 +833,18 @@ impl SyncEngine {
             "heartbeat interval must be greater than zero"
         );
         self.heartbeat_interval = interval;
+        self
+    }
+
+    /// Whether the end-of-run cache prune may run. Default `true`.
+    ///
+    /// The prune derives "still live" from the mappings it was handed, so it
+    /// cannot tell a mapping deleted from config from one that failed to
+    /// resolve this run. Callers that dropped work before the engine started
+    /// must pass `false`, or a single transient denial discards the cached
+    /// state for everything it could not reach and the next run re-fetches it.
+    pub fn with_cache_pruning(mut self, prune: bool) -> Self {
+        self.prune_cache = prune;
         self
     }
 
@@ -1171,7 +1187,7 @@ impl SyncEngine {
                 _ = heartbeat.tick(), if !execution_futures.is_empty()
                     || (!shutting_down && !discovery_paused && !discovery_futures.is_empty()) =>
                 {
-                    progress.run_heartbeat(crate::progress::RunProgress {
+                    progress.run_heartbeat(RunProgress {
                         in_discovery: discovery_futures.len(),
                         pending: pending.len(),
                         in_flight: execution_futures.len(),
@@ -1187,7 +1203,11 @@ impl SyncEngine {
 
         // Prune stale cache entries for tags/targets no longer in the mapping set.
         // Prevents unbounded cache growth when source tags or targets are deleted.
-        {
+        //
+        // Skipped when the caller could not resolve everything: absence would
+        // then mean "failed this run", not "deleted from config", and pruning
+        // on it throws away cache state the next run has to re-earn.
+        if self.prune_cache {
             let live_keys: HashSet<SnapshotKey> = mappings
                 .iter()
                 .flat_map(|m| {

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -746,6 +746,14 @@ const BLOB_CONCURRENCY: usize = 6;
 /// Default shutdown drain deadline in seconds.
 const DEFAULT_DRAIN_DEADLINE_SECS: u64 = 25;
 
+/// Default cadence for [`crate::progress::ProgressReporter::run_progress`] callbacks.
+///
+/// Discovery and execution can each run for minutes without an image reaching
+/// a terminal state. Without a periodic callback the caller has no way to tell
+/// a slow run from a wedged one. 30 seconds is short enough to notice a stall
+/// and long enough that the callback is not itself the noise.
+const DEFAULT_HEARTBEAT_SECS: u64 = 30;
+
 /// Sync engine - orchestrates concurrent image transfers across registries.
 ///
 /// Discovery futures drain first via `tokio::select!`, then leader-follower
@@ -762,6 +770,8 @@ pub struct SyncEngine {
     source_head_timeout: Duration,
     /// Deadline for the per-blob mount-source wait. Default: 60 seconds.
     mount_source_wait_deadline: Duration,
+    /// Cadence for in-flight progress callbacks. Default: 30 seconds.
+    heartbeat_interval: Duration,
 }
 
 impl SyncEngine {
@@ -776,6 +786,7 @@ impl SyncEngine {
             drain_deadline: Duration::from_secs(DEFAULT_DRAIN_DEADLINE_SECS),
             source_head_timeout: Duration::from_secs(5),
             mount_source_wait_deadline: Duration::from_secs(60),
+            heartbeat_interval: Duration::from_secs(DEFAULT_HEARTBEAT_SECS),
         }
     }
 
@@ -802,6 +813,22 @@ impl SyncEngine {
     /// falls back to push instead of hanging. Default 60 seconds.
     pub fn with_mount_source_wait_deadline(mut self, deadline: Duration) -> Self {
         self.mount_source_wait_deadline = deadline;
+        self
+    }
+
+    /// Configure how often [`crate::progress::ProgressReporter::run_progress`] fires while the
+    /// run still has work in flight. Default 30 seconds.
+    ///
+    /// # Panics
+    ///
+    /// Panics on [`Duration::ZERO`] - a zero-period interval would spin the
+    /// engine's `select!` loop.
+    pub fn with_heartbeat_interval(mut self, interval: Duration) -> Self {
+        assert!(
+            !interval.is_zero(),
+            "heartbeat interval must be greater than zero"
+        );
+        self.heartbeat_interval = interval;
         self
     }
 
@@ -882,6 +909,13 @@ impl SyncEngine {
         };
 
         let mut immutable_tag_skips: u64 = 0;
+
+        // Liveness heartbeat. `interval` yields its first tick immediately;
+        // `reset` pushes it out a full period so the first callback lands
+        // after the run has actually been quiet for that long.
+        let mut heartbeat = tokio::time::interval(self.heartbeat_interval);
+        heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        heartbeat.reset();
 
         // Seed discovery with all (mapping, tag) pairs.
         for mapping in &mappings {
@@ -1125,6 +1159,25 @@ impl SyncEngine {
                             }
                         }
                     }
+                }
+                // Last in `biased` order: real work always pre-empts the
+                // heartbeat.
+                //
+                // The guard is the disjunction of the two work branches' own
+                // preconditions, and must stay that way. A looser guard (say,
+                // "discovery futures remain") leaves this branch enabled after
+                // shutdown has frozen discovery, which starves the `else` exit
+                // and hangs the engine for a whole interval.
+                _ = heartbeat.tick(), if !execution_futures.is_empty()
+                    || (!shutting_down && !discovery_paused && !discovery_futures.is_empty()) =>
+                {
+                    progress.run_progress(crate::progress::RunProgress {
+                        discovering: discovery_futures.len(),
+                        pending: pending.len(),
+                        in_flight: execution_futures.len(),
+                        completed: results.len(),
+                        elapsed: run_start.elapsed(),
+                    });
                 }
                 else => break,
             }

--- a/crates/ocync-sync/src/lib.rs
+++ b/crates/ocync-sync/src/lib.rs
@@ -50,12 +50,20 @@ pub struct SyncReport {
 }
 
 impl SyncReport {
+    /// Whether any image synced or was skipped.
+    ///
+    /// Exposed because a caller that also tracks failures the report cannot
+    /// see, such as a mapping dropped before the engine ran, has to fold them
+    /// into the exit code itself and would otherwise re-derive this predicate.
+    pub fn has_success(&self) -> bool {
+        self.images
+            .iter()
+            .any(|i| matches!(i.status, ImageStatus::Synced | ImageStatus::Skipped { .. }))
+    }
+
     /// Derive process exit code from results.
     pub fn exit_code(&self) -> i32 {
-        let has_success = self
-            .images
-            .iter()
-            .any(|i| matches!(i.status, ImageStatus::Synced | ImageStatus::Skipped { .. }));
+        let has_success = self.has_success();
         let has_failure = self
             .images
             .iter()

--- a/crates/ocync-sync/src/progress.rs
+++ b/crates/ocync-sync/src/progress.rs
@@ -6,13 +6,13 @@ use crate::{ImageResult, SyncReport};
 
 /// Snapshot of a run that is still in flight.
 ///
-/// Passed to [`ProgressReporter::run_progress`] on a fixed cadence so a long
+/// Passed to [`ProgressReporter::run_heartbeat`] on a fixed cadence so a long
 /// sync emits a liveness signal instead of going silent between the first
 /// image starting and the last one finishing.
 #[derive(Debug, Clone, Copy)]
 pub struct RunProgress {
     /// Tags still in discovery (source HEAD or manifest pull).
-    pub discovering: usize,
+    pub in_discovery: usize,
     /// Discovered transfers waiting for a concurrency permit.
     pub pending: usize,
     /// Transfers currently executing.
@@ -38,7 +38,7 @@ pub trait ProgressReporter {
     /// Discovery and execution can both run for minutes without an image
     /// reaching a terminal state, so this is the only signal a caller has
     /// that the run is progressing rather than wedged.
-    fn run_progress(&self, progress: RunProgress);
+    fn run_heartbeat(&self, snapshot: RunProgress);
     /// Called when the entire sync run completes.
     fn run_completed(&self, report: &SyncReport);
 }
@@ -50,7 +50,7 @@ pub struct NullProgress;
 impl ProgressReporter for NullProgress {
     fn image_started(&self, _: &str, _: &str) {}
     fn image_completed(&self, _: &ImageResult) {}
-    fn run_progress(&self, _: RunProgress) {}
+    fn run_heartbeat(&self, _: RunProgress) {}
     fn run_completed(&self, _: &SyncReport) {}
 }
 
@@ -80,8 +80,8 @@ mod tests {
         };
         p.image_completed(&result);
 
-        p.run_progress(RunProgress {
-            discovering: 3,
+        p.run_heartbeat(RunProgress {
+            in_discovery: 3,
             pending: 2,
             in_flight: 1,
             completed: 4,

--- a/crates/ocync-sync/src/progress.rs
+++ b/crates/ocync-sync/src/progress.rs
@@ -1,6 +1,27 @@
 //! Progress reporting trait and no-op implementation.
 
+use std::time::Duration;
+
 use crate::{ImageResult, SyncReport};
+
+/// Snapshot of a run that is still in flight.
+///
+/// Passed to [`ProgressReporter::run_progress`] on a fixed cadence so a long
+/// sync emits a liveness signal instead of going silent between the first
+/// image starting and the last one finishing.
+#[derive(Debug, Clone, Copy)]
+pub struct RunProgress {
+    /// Tags still in discovery (source HEAD or manifest pull).
+    pub discovering: usize,
+    /// Discovered transfers waiting for a concurrency permit.
+    pub pending: usize,
+    /// Transfers currently executing.
+    pub in_flight: usize,
+    /// Images that have reached a terminal state.
+    pub completed: usize,
+    /// Wall-clock time since the run started.
+    pub elapsed: Duration,
+}
 
 /// Reports progress during a sync run.
 ///
@@ -12,6 +33,12 @@ pub trait ProgressReporter {
     fn image_started(&self, source: &str, target: &str);
     /// Called when an individual image transfer completes.
     fn image_completed(&self, result: &ImageResult);
+    /// Called on a fixed cadence while the run still has work in flight.
+    ///
+    /// Discovery and execution can both run for minutes without an image
+    /// reaching a terminal state, so this is the only signal a caller has
+    /// that the run is progressing rather than wedged.
+    fn run_progress(&self, progress: RunProgress);
     /// Called when the entire sync run completes.
     fn run_completed(&self, report: &SyncReport);
 }
@@ -23,6 +50,7 @@ pub struct NullProgress;
 impl ProgressReporter for NullProgress {
     fn image_started(&self, _: &str, _: &str) {}
     fn image_completed(&self, _: &ImageResult) {}
+    fn run_progress(&self, _: RunProgress) {}
     fn run_completed(&self, _: &SyncReport) {}
 }
 
@@ -51,6 +79,14 @@ mod tests {
             artifacts_skipped: false,
         };
         p.image_completed(&result);
+
+        p.run_progress(RunProgress {
+            discovering: 3,
+            pending: 2,
+            in_flight: 1,
+            completed: 4,
+            elapsed: Duration::from_secs(30),
+        });
 
         let report = SyncReport {
             run_id: Uuid::now_v7(),

--- a/crates/ocync-sync/tests/sync_progress.rs
+++ b/crates/ocync-sync/tests/sync_progress.rs
@@ -32,9 +32,10 @@ impl ProgressReporter for RecordingProgress {
 
 /// Run a two-image sync with the given heartbeat cadence.
 ///
-/// `source_delay` is applied to the source manifest GET. Under `start_paused`
-/// wiremock's delay is a `tokio::time::sleep`, so it advances with virtual
-/// time and gives the run a known duration to measure the cadence against.
+/// `source_delay` is applied to the source manifest GET, giving discovery a
+/// known duration for the cadence assertion to measure against. Real time, not
+/// a paused clock: virtual time auto-advances to any pending deadline, which
+/// would make a heartbeat fire for any interval at all.
 async fn run_with_heartbeat(
     interval: Duration,
     source_delay: Duration,
@@ -125,9 +126,9 @@ async fn heartbeat_fires_while_work_is_in_flight() {
 /// The heartbeat is timer-gated, not emitted unconditionally: a run that
 /// finishes well inside one interval reports nothing.
 ///
-/// Deliberately NOT `start_paused`: virtual time auto-advances to any pending
-/// deadline, which would fire even a ten-minute interval and make this pass
-/// for the wrong reason.
+/// Real time for the same reason as the test above: a paused clock advances to
+/// any pending deadline, so even a ten-minute interval would fire and this
+/// would pass for the wrong reason.
 #[tokio::test]
 async fn heartbeat_stays_silent_for_a_short_run() {
     let (report, snapshots) = run_with_heartbeat(Duration::from_secs(600), Duration::ZERO).await;

--- a/crates/ocync-sync/tests/sync_progress.rs
+++ b/crates/ocync-sync/tests/sync_progress.rs
@@ -1,0 +1,170 @@
+//! Progress reporting integration tests: the in-flight heartbeat contract.
+
+mod helpers;
+
+use std::cell::RefCell;
+use std::time::Duration;
+
+use ocync_sync::engine::{SyncEngine, TagPair};
+use ocync_sync::progress::{ProgressReporter, RunProgress};
+use ocync_sync::staging::BlobStage;
+use ocync_sync::{ImageResult, ImageStatus, ShutdownSignal, SyncReport};
+use wiremock::MockServer;
+
+use helpers::*;
+
+/// Records every [`RunProgress`] snapshot the engine emits.
+#[derive(Default)]
+struct RecordingProgress {
+    snapshots: RefCell<Vec<RunProgress>>,
+}
+
+impl ProgressReporter for RecordingProgress {
+    fn image_started(&self, _source: &str, _target: &str) {}
+    fn image_completed(&self, _result: &ImageResult) {}
+    fn run_progress(&self, progress: RunProgress) {
+        self.snapshots.borrow_mut().push(progress);
+    }
+    fn run_completed(&self, _report: &SyncReport) {}
+}
+
+/// Run a two-image sync with the given heartbeat cadence.
+async fn run_with_heartbeat(interval: Duration) -> (SyncReport, Vec<RunProgress>) {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    for tag in ["v1", "v2"] {
+        let parts = ManifestBuilder::new(format!("config-{tag}").as_bytes())
+            .layer(format!("layer-{tag}").as_bytes())
+            .build();
+        parts.mount_source(&source_server, "library/app", tag).await;
+        parts.mount_target(&target_server, "mirror/app", tag).await;
+    }
+
+    let mapping = mapping_with_distinct_repos(
+        &source_server,
+        &target_server,
+        "library/app",
+        "mirror/app",
+        vec![TagPair::same("v1"), TagPair::same("v2")],
+    );
+
+    let progress = RecordingProgress::default();
+    let report = SyncEngine::new(fast_retry(), 50)
+        .with_heartbeat_interval(interval)
+        .run(
+            vec![mapping],
+            empty_cache(),
+            BlobStage::disabled(),
+            &progress,
+            None,
+        )
+        .await;
+
+    let snapshots = progress.snapshots.take();
+    (report, snapshots)
+}
+
+/// A run that outlives the heartbeat cadence reports itself as in progress.
+///
+/// Without this the engine is silent between the first image starting and the
+/// last one finishing, which is indistinguishable from a wedged run.
+#[tokio::test]
+async fn heartbeat_fires_while_work_is_in_flight() {
+    let (report, snapshots) = run_with_heartbeat(Duration::from_millis(1)).await;
+
+    assert_eq!(report.stats.images_synced, 2);
+    assert!(
+        !snapshots.is_empty(),
+        "a run longer than the heartbeat interval must report progress"
+    );
+
+    // The branch is guarded on work remaining, so every snapshot must show at
+    // least one tag discovering or one transfer executing. A snapshot with
+    // both at zero would mean the heartbeat outlived the work it describes.
+    for s in &snapshots {
+        assert!(
+            s.discovering + s.in_flight > 0,
+            "heartbeat fired with nothing in flight: {s:?}"
+        );
+        assert!(
+            s.completed <= 2,
+            "completed count exceeds the images in the run: {s:?}"
+        );
+    }
+}
+
+/// The heartbeat is timer-gated, not emitted unconditionally: a run that
+/// finishes well inside one interval reports nothing.
+#[tokio::test]
+async fn heartbeat_stays_silent_for_a_short_run() {
+    let (report, snapshots) = run_with_heartbeat(Duration::from_secs(600)).await;
+
+    assert_eq!(report.stats.images_synced, 2);
+    assert!(
+        snapshots.is_empty(),
+        "short run must not emit progress, got {} snapshot(s)",
+        snapshots.len()
+    );
+}
+
+/// The heartbeat must not keep the engine alive past its work. A completed run
+/// returns rather than looping on the timer.
+#[tokio::test]
+async fn heartbeat_does_not_block_run_completion() {
+    let (report, _) = run_with_heartbeat(Duration::from_millis(1)).await;
+
+    assert_eq!(report.images.len(), 2);
+    for image in &report.images {
+        assert!(
+            matches!(image.status, ImageStatus::Synced),
+            "expected all images synced, got {:?}",
+            image.status
+        );
+    }
+}
+
+/// Shutdown freezes discovery, so undiscovered tags stop being work the engine
+/// can do. The heartbeat branch must go with them: if it stays enabled it
+/// starves the loop's exit and the engine hangs for a full interval.
+#[tokio::test]
+async fn heartbeat_does_not_stall_shutdown_with_discovery_outstanding() {
+    let source_server = MockServer::start().await;
+    let target_server = MockServer::start().await;
+
+    let parts = ManifestBuilder::new(b"config").layer(b"layer").build();
+    parts
+        .mount_source(&source_server, "library/app", "v1")
+        .await;
+    parts.mount_target(&target_server, "mirror/app", "v1").await;
+
+    let mapping = mapping_with_distinct_repos(
+        &source_server,
+        &target_server,
+        "library/app",
+        "mirror/app",
+        vec![TagPair::same("v1")],
+    );
+
+    // Triggered up front so the engine shuts down with discovery still queued.
+    let shutdown = ShutdownSignal::new();
+    shutdown.trigger();
+
+    // An interval far longer than the test's patience: if the guard regresses,
+    // the engine waits this out instead of exiting and the timeout fires.
+    let engine =
+        SyncEngine::new(fast_retry(), 10).with_heartbeat_interval(Duration::from_secs(600));
+
+    let progress = RecordingProgress::default();
+    let run = engine.run(
+        vec![mapping],
+        empty_cache(),
+        BlobStage::disabled(),
+        &progress,
+        Some(&shutdown),
+    );
+
+    tokio::time::timeout(Duration::from_secs(5), run)
+        .await
+        .expect("engine must exit on shutdown, not wait out the heartbeat interval");
+}

--- a/crates/ocync-sync/tests/sync_progress.rs
+++ b/crates/ocync-sync/tests/sync_progress.rs
@@ -5,11 +5,13 @@ mod helpers;
 use std::cell::RefCell;
 use std::time::Duration;
 
+use ocync_distribution::spec::MediaType;
 use ocync_sync::engine::{SyncEngine, TagPair};
 use ocync_sync::progress::{ProgressReporter, RunProgress};
 use ocync_sync::staging::BlobStage;
 use ocync_sync::{ImageResult, ShutdownSignal, SyncReport};
-use wiremock::MockServer;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use helpers::*;
 
@@ -29,7 +31,14 @@ impl ProgressReporter for RecordingProgress {
 }
 
 /// Run a two-image sync with the given heartbeat cadence.
-async fn run_with_heartbeat(interval: Duration) -> (SyncReport, Vec<RunProgress>) {
+///
+/// `source_delay` is applied to the source manifest GET. Under `start_paused`
+/// wiremock's delay is a `tokio::time::sleep`, so it advances with virtual
+/// time and gives the run a known duration to measure the cadence against.
+async fn run_with_heartbeat(
+    interval: Duration,
+    source_delay: Duration,
+) -> (SyncReport, Vec<RunProgress>) {
     let source_server = MockServer::start().await;
     let target_server = MockServer::start().await;
 
@@ -37,6 +46,18 @@ async fn run_with_heartbeat(interval: Duration) -> (SyncReport, Vec<RunProgress>
         let parts = ManifestBuilder::new(format!("config-{tag}").as_bytes())
             .layer(format!("layer-{tag}").as_bytes())
             .build();
+        // Registered before `mount_source` so this delayed responder is the
+        // one that answers the manifest GET.
+        Mock::given(method("GET"))
+            .and(path(format!("/v2/library/app/manifests/{tag}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(parts.bytes.clone())
+                    .insert_header("content-type", MediaType::OciManifest.as_str())
+                    .set_delay(source_delay),
+            )
+            .mount(&source_server)
+            .await;
         parts.mount_source(&source_server, "library/app", tag).await;
         parts.mount_target(&target_server, "mirror/app", tag).await;
     }
@@ -70,17 +91,20 @@ async fn run_with_heartbeat(interval: Duration) -> (SyncReport, Vec<RunProgress>
 /// Without this the engine is silent between the first image starting and the
 /// last one finishing, which is indistinguishable from a wedged run.
 ///
-/// `start_paused` makes this deterministic rather than a race against a short
-/// wall-clock interval: registry I/O is not a timer, so tokio auto-advances to
-/// the heartbeat deadline whenever the run is blocked on the network.
-#[tokio::test(start_paused = true)]
+/// The source responds after a known delay, so the cadence is measurable
+/// rather than assumed. Asserting only "at least one" would pass for any
+/// interval at all; the lower bound below is what ties the count to the
+/// period, and it fails if the interval is widened past the delay.
+#[tokio::test]
 async fn heartbeat_fires_while_work_is_in_flight() {
-    let (report, snapshots) = run_with_heartbeat(Duration::from_secs(1)).await;
+    let (report, snapshots) =
+        run_with_heartbeat(Duration::from_millis(100), Duration::from_millis(800)).await;
 
     assert_eq!(report.stats.images_synced, 2);
     assert!(
-        !snapshots.is_empty(),
-        "a run longer than the heartbeat interval must report progress"
+        snapshots.len() >= 4,
+        "800ms of blocked discovery at a 100ms cadence must report repeatedly, got {}",
+        snapshots.len()
     );
 
     // The branch is guarded on work remaining, so every snapshot must show at
@@ -106,7 +130,7 @@ async fn heartbeat_fires_while_work_is_in_flight() {
 /// for the wrong reason.
 #[tokio::test]
 async fn heartbeat_stays_silent_for_a_short_run() {
-    let (report, snapshots) = run_with_heartbeat(Duration::from_secs(600)).await;
+    let (report, snapshots) = run_with_heartbeat(Duration::from_secs(600), Duration::ZERO).await;
 
     assert_eq!(report.stats.images_synced, 2);
     assert!(

--- a/crates/ocync-sync/tests/sync_progress.rs
+++ b/crates/ocync-sync/tests/sync_progress.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use ocync_sync::engine::{SyncEngine, TagPair};
 use ocync_sync::progress::{ProgressReporter, RunProgress};
 use ocync_sync::staging::BlobStage;
-use ocync_sync::{ImageResult, ImageStatus, ShutdownSignal, SyncReport};
+use ocync_sync::{ImageResult, ShutdownSignal, SyncReport};
 use wiremock::MockServer;
 
 use helpers::*;
@@ -22,8 +22,8 @@ struct RecordingProgress {
 impl ProgressReporter for RecordingProgress {
     fn image_started(&self, _source: &str, _target: &str) {}
     fn image_completed(&self, _result: &ImageResult) {}
-    fn run_progress(&self, progress: RunProgress) {
-        self.snapshots.borrow_mut().push(progress);
+    fn run_heartbeat(&self, snapshot: RunProgress) {
+        self.snapshots.borrow_mut().push(snapshot);
     }
     fn run_completed(&self, _report: &SyncReport) {}
 }
@@ -69,9 +69,13 @@ async fn run_with_heartbeat(interval: Duration) -> (SyncReport, Vec<RunProgress>
 ///
 /// Without this the engine is silent between the first image starting and the
 /// last one finishing, which is indistinguishable from a wedged run.
-#[tokio::test]
+///
+/// `start_paused` makes this deterministic rather than a race against a short
+/// wall-clock interval: registry I/O is not a timer, so tokio auto-advances to
+/// the heartbeat deadline whenever the run is blocked on the network.
+#[tokio::test(start_paused = true)]
 async fn heartbeat_fires_while_work_is_in_flight() {
-    let (report, snapshots) = run_with_heartbeat(Duration::from_millis(1)).await;
+    let (report, snapshots) = run_with_heartbeat(Duration::from_secs(1)).await;
 
     assert_eq!(report.stats.images_synced, 2);
     assert!(
@@ -84,7 +88,7 @@ async fn heartbeat_fires_while_work_is_in_flight() {
     // both at zero would mean the heartbeat outlived the work it describes.
     for s in &snapshots {
         assert!(
-            s.discovering + s.in_flight > 0,
+            s.in_discovery + s.in_flight > 0,
             "heartbeat fired with nothing in flight: {s:?}"
         );
         assert!(
@@ -96,6 +100,10 @@ async fn heartbeat_fires_while_work_is_in_flight() {
 
 /// The heartbeat is timer-gated, not emitted unconditionally: a run that
 /// finishes well inside one interval reports nothing.
+///
+/// Deliberately NOT `start_paused`: virtual time auto-advances to any pending
+/// deadline, which would fire even a ten-minute interval and make this pass
+/// for the wrong reason.
 #[tokio::test]
 async fn heartbeat_stays_silent_for_a_short_run() {
     let (report, snapshots) = run_with_heartbeat(Duration::from_secs(600)).await;
@@ -106,22 +114,6 @@ async fn heartbeat_stays_silent_for_a_short_run() {
         "short run must not emit progress, got {} snapshot(s)",
         snapshots.len()
     );
-}
-
-/// The heartbeat must not keep the engine alive past its work. A completed run
-/// returns rather than looping on the timer.
-#[tokio::test]
-async fn heartbeat_does_not_block_run_completion() {
-    let (report, _) = run_with_heartbeat(Duration::from_millis(1)).await;
-
-    assert_eq!(report.images.len(), 2);
-    for image in &report.images {
-        assert!(
-            matches!(image.status, ImageStatus::Synced),
-            "expected all images synced, got {:?}",
-            image.status
-        );
-    }
 }
 
 /// Shutdown freezes discovery, so undiscovered tags stop being work the engine

--- a/docs/src/content/cli-reference.md
+++ b/docs/src/content/cli-reference.md
@@ -179,6 +179,8 @@ A mapping that resolved but could not use one of its targets also exits `1`: the
 
 `analyze` follows the same shape. It exits `1` when it read some images but not all (or could not reach a target it was asked to estimate for), and `2` when it could read none.
 
+`--dry-run` resolves mappings for real, which lists tags against the source registry unless the config names only exact tag literals. It therefore reports the same unresolved mappings, dropped targets, and exit codes as a real run: a CI stage using it as a config lint will fail on a registry outage, where previously it always exited `0`.
+
 `auth check` exits `3` when any config file could not be read, `4` when credentials were rejected, and `1` when a registry failed for another reason. Files after an unreadable one are still checked.
 
 ## Structured output

--- a/docs/src/content/cli-reference.md
+++ b/docs/src/content/cli-reference.md
@@ -175,6 +175,12 @@ ocync auth check -c config.yaml -c config2.yaml
 
 A mapping that fails to resolve is skipped rather than aborting the run, and counts as a failure for the exit code: `1` when other mappings still synced or skipped images, `2` when none did, and `4` when nothing ran and every mapping was denied.
 
+A mapping that resolved but could not use one of its targets also exits `1`: the images did not reach a registry the config named.
+
+`analyze` follows the same shape. It exits `1` when it read some images but not all (or could not reach a target it was asked to estimate for), and `2` when it could read none.
+
+`auth check` exits `3` when any config file could not be read, `4` when credentials were rejected, and `1` when a registry failed for another reason. Files after an unreadable one are still checked.
+
 ## Structured output
 
 Use `--json` to get machine-readable sync reports for CI/CD pipelines:

--- a/docs/src/content/cli-reference.md
+++ b/docs/src/content/cli-reference.md
@@ -173,6 +173,8 @@ ocync auth check -c config.yaml -c config2.yaml
 | `3` | Invalid configuration |
 | `4` | Authentication or authorization failure |
 
+A mapping that fails to resolve is skipped rather than aborting the run, and counts as a failure for the exit code: `1` when other mappings still synced or skipped images, `2` when none did, and `4` when nothing ran and every mapping was denied.
+
 ## Structured output
 
 Use `--json` to get machine-readable sync reports for CI/CD pipelines:

--- a/docs/src/content/observability.md
+++ b/docs/src/content/observability.md
@@ -16,6 +16,8 @@ Reports include per-image results and aggregate statistics: blobs transferred, b
 
 A mapping that could not be resolved at all -- unreachable registry, denied tag listing, bad repository name -- never reaches the engine and so produces no per-image entry. Those mappings are listed separately under `unresolved_mappings`, which is omitted entirely when every mapping resolved. The rest of the run still proceeds; one failing mapping does not cancel the others.
 
+A mapping that resolved but lost one of several targets is not unresolved: it synced to the targets that worked. The ones it could not use appear under `dropped_targets`, also omitted when empty, and each is summarised in the cycle tail as `| N targets dropped`. A dropped target moves the exit code off success, because images did not reach a registry the config named.
+
 Abbreviated example:
 
 ```json
@@ -51,9 +53,20 @@ Abbreviated example:
       "from": "cgr.dev/chainguard/private",
       "error": "mapping 'cgr.dev/chainguard/private': registry error: 403 Forbidden"
     }
+  ],
+  "dropped_targets": [
+    {
+      "from": "cgr.dev/chainguard/nginx",
+      "registry": "backup-ecr",
+      "error": "mapping 'cgr.dev/chainguard/nginx': target registry 'backup-ecr' is unavailable: ECR auth setup for '...': 403 Forbidden"
+    }
   ]
 }
 ```
+
+### analyze
+
+`ocync analyze --json` reports `images_analyzed`, `images_partial` (recorded, but missing at least one platform of a multi-arch image), `images_failed` (could not be read at all), and `dropped_targets` (excluded from the mount-savings estimate). An analysis that could not read everything exits non-zero, because the totals are short by whatever it missed.
 
 ## Progress indicators
 

--- a/docs/src/content/observability.md
+++ b/docs/src/content/observability.md
@@ -66,7 +66,7 @@ Abbreviated example:
 
 ### analyze
 
-`ocync analyze --json` reports `images_analyzed`, `images_partial` (recorded, but missing at least one platform of a multi-arch image), `images_failed` (could not be read at all), and `dropped_targets` (excluded from the mount-savings estimate). An analysis that could not read everything exits non-zero, because the totals are short by whatever it missed.
+`ocync analyze --json` reports `images_analyzed`, `images_partial` (recorded, but missing at least one platform of a multi-arch image), `images_failed` (could not be read at all), plus `unresolved_mappings` and `dropped_targets` in the same shape `sync` uses, so one consumer reads both. An analysis that could not read everything exits non-zero, because the totals are short by whatever it missed.
 
 ## Progress indicators
 

--- a/docs/src/content/observability.md
+++ b/docs/src/content/observability.md
@@ -64,10 +64,10 @@ Abbreviated example:
 
 At the default verbosity, per-image lines are suppressed, so a long run would otherwise be silent from start to finish. Two periodic lines fill that gap:
 
-- `resolving mappings` during mapping resolution, once the phase has run for more than five seconds
-- `sync in progress` every 30 seconds while discovery or transfers are still in flight, carrying `discovering`, `pending`, `in_flight`, `completed`, and `elapsed_secs`
+- `preparing sync` every five seconds before the engine starts, carrying `phase` (`registries`, `batch checkers`, or `mappings`), `done`, `total`, and `elapsed_secs`. This window is sequential network work: a token mint per registry, then a tag listing per mapping.
+- `sync in progress` every 30 seconds while discovery or transfers are still in flight, carrying `in_discovery`, `pending`, `in_flight`, `completed`, and `elapsed_secs`
 
-Both are timer-gated, so a run that finishes quickly emits neither.
+Both fire on wall-clock rather than on item boundaries, so a single slow mapping still reports, and a run that finishes inside one interval emits neither.
 
 Disable all progress output with `--quiet`.
 

--- a/docs/src/content/observability.md
+++ b/docs/src/content/observability.md
@@ -14,6 +14,8 @@ ocync sync -c config.yaml --json
 
 Reports include per-image results and aggregate statistics: blobs transferred, bytes moved, mounts performed, cache hits, and errors.
 
+A mapping that could not be resolved at all -- unreachable registry, denied tag listing, bad repository name -- never reaches the engine and so produces no per-image entry. Those mappings are listed separately under `unresolved_mappings`, which is omitted entirely when every mapping resolved. The rest of the run still proceeds; one failing mapping does not cancel the others.
+
 Abbreviated example:
 
 ```json
@@ -43,7 +45,13 @@ Abbreviated example:
     "discovery_head_failures": 0,
     "discovery_target_stale": 0
   },
-  "duration": { "secs": 4, "nanos": 210000000 }
+  "duration": { "secs": 4, "nanos": 210000000 },
+  "unresolved_mappings": [
+    {
+      "from": "cgr.dev/chainguard/private",
+      "error": "mapping 'cgr.dev/chainguard/private': registry error: 403 Forbidden"
+    }
+  ]
 }
 ```
 
@@ -53,6 +61,13 @@ Abbreviated example:
 
 - **TTY**: real-time progress bars with per-image and aggregate stats
 - **Non-TTY / CI**: periodic heartbeat lines with summary counts
+
+At the default verbosity, per-image lines are suppressed, so a long run would otherwise be silent from start to finish. Two periodic lines fill that gap:
+
+- `resolving mappings` during mapping resolution, once the phase has run for more than five seconds
+- `sync in progress` every 30 seconds while discovery or transfers are still in flight, carrying `discovering`, `pending`, `in_flight`, `completed`, and `elapsed_secs`
+
+Both are timer-gated, so a run that finishes quickly emits neither.
 
 Disable all progress output with `--quiet`.
 

--- a/src/cli/commands/analyze.rs
+++ b/src/cli/commands/analyze.rs
@@ -20,8 +20,8 @@ use ocync_sync::ShutdownSignal;
 
 use crate::cli::commands::synchronize::{
     ClientMap, DroppedTarget, MappingResolution, PreparePhase, PrepareTracker, UnresolvedMapping,
-    build_clients, log_unresolved_mapping, resolve_mapping, shared_failure_code,
-    with_prepare_progress,
+    build_clients, log_unresolved_mapping, referenced_registries, resolve_mapping,
+    shared_failure_code, with_prepare_progress,
 };
 use crate::cli::config::{Config, load_config};
 use crate::cli::output::format_bytes;
@@ -91,8 +91,8 @@ pub(crate) async fn run(
     // to span the whole loop, not just the client build, or the tag-listing
     // stretch it exists for stays silent.
     let tracker = PrepareTracker::default();
-    let analysis = with_prepare_progress(&tracker, async {
-        let clients = build_clients(&config, &tracker).await;
+    let analysis = with_prepare_progress(&tracker, "analysis", async {
+        let clients = build_clients(&config, &referenced_registries(&config), &tracker).await;
         tracker.begin(PreparePhase::Mappings, config.mappings.len());
         collect_analysis(&config, &clients, &no_checkers, shutdown, &tracker).await
     })
@@ -175,7 +175,7 @@ async fn collect_analysis(
 
         for tag_pair in &resolved.tags {
             if shutdown.is_triggered() {
-                tracing::info!("shutdown signal received, stopping analysis early");
+                // The outer loop logs it; saying so once is enough.
                 analysis.interrupted = true;
                 break;
             }

--- a/src/cli/commands/analyze.rs
+++ b/src/cli/commands/analyze.rs
@@ -18,7 +18,10 @@ use ocync_distribution::{Digest, RepositoryName};
 
 use ocync_sync::ShutdownSignal;
 
-use crate::cli::commands::synchronize::{MappingResolution, build_clients, resolve_mapping};
+use crate::cli::commands::synchronize::{
+    MappingResolution, PrepareTracker, build_clients, log_unresolved_mapping, resolve_mapping,
+    with_prepare_progress,
+};
 use crate::cli::config::load_config;
 use crate::cli::output::format_bytes;
 use crate::cli::{CliError, ExitCode};
@@ -53,12 +56,16 @@ pub(crate) async fn run(
     shutdown: &ShutdownSignal,
 ) -> Result<ExitCode, CliError> {
     let config = load_config(&args.config)?;
-    let clients = build_clients(&config).await;
+    // Client construction mints a token per registry with nothing else in the
+    // log; the ticker keeps that window visible.
+    let tracker = PrepareTracker::default();
+    let clients = with_prepare_progress(&tracker, build_clients(&config, &tracker)).await;
     // Analyze doesn't push anything, so no batch checkers needed.
     let no_checkers: HashMap<String, Rc<dyn BatchBlobChecker>> = HashMap::new();
 
     let mut blobs: HashMap<Digest, BlobAggregate> = HashMap::new();
     let mut image_count = 0usize;
+    let mut failed_images = 0usize;
 
     for mapping in &config.mappings {
         if shutdown.is_triggered() {
@@ -73,11 +80,7 @@ pub(crate) async fn run(
             Ok(MappingResolution::Resolved(r)) => r,
             Ok(MappingResolution::NoMatchingTags(_)) => continue,
             Err(err) => {
-                tracing::error!(
-                    from = %mapping.from,
-                    error = %err,
-                    "mapping could not be resolved; skipping"
-                );
+                log_unresolved_mapping(&mapping.from, &err);
                 continue;
             }
         };
@@ -91,7 +94,11 @@ pub(crate) async fn run(
             image_count += 1;
             let image_ref = format!("{}:{}", resolved.source_repo, tag_pair.source);
             tracing::info!(image = %image_ref, "analyzing");
-            collect_blobs(
+            // One unreadable image must not end the analysis: the remaining
+            // tags and mappings are independent of it. The count above already
+            // includes this image, so the totals stay honest about what was
+            // attempted.
+            if let Err(err) = collect_blobs(
                 &resolved.source_client,
                 &resolved.source_repo,
                 &tag_pair.source,
@@ -100,8 +107,19 @@ pub(crate) async fn run(
                 &resolved.target_repo,
                 &mut blobs,
             )
-            .await?;
+            .await
+            {
+                tracing::error!(image = %image_ref, error = %err, "image could not be analyzed; skipping");
+                failed_images += 1;
+            }
         }
+    }
+
+    if failed_images > 0 {
+        tracing::warn!(
+            failed_images,
+            "some images could not be analyzed; blob totals below exclude them"
+        );
     }
 
     if args.json {
@@ -144,15 +162,23 @@ async fn collect_blobs(
     // Recurse into index children to collect per-platform manifest blobs.
     if let ManifestKind::Index(index) = &pulled.manifest {
         for child in &index.manifests {
-            let child_pulled = source_client
+            // Platforms are independent: a missing arm64 manifest should not
+            // discard the amd64 blobs already recorded for this image.
+            let child_pulled = match source_client
                 .manifest_pull(source_repo, &child.digest.to_string())
                 .await
-                .map_err(|e| {
-                    CliError::Input(format!(
-                        "manifest_pull {image_ref} child {}: {e}",
-                        child.digest
-                    ))
-                })?;
+            {
+                Ok(pulled) => pulled,
+                Err(e) => {
+                    tracing::warn!(
+                        image = %image_ref,
+                        child = %child.digest,
+                        error = %e,
+                        "index child could not be pulled; skipping this platform"
+                    );
+                    continue;
+                }
+            };
             for descriptor in descriptors_of(&child_pulled.manifest) {
                 record_blob(
                     descriptor.digest,

--- a/src/cli/commands/analyze.rs
+++ b/src/cli/commands/analyze.rs
@@ -53,7 +53,7 @@ pub(crate) async fn run(
     shutdown: &ShutdownSignal,
 ) -> Result<ExitCode, CliError> {
     let config = load_config(&args.config)?;
-    let clients = build_clients(&config).await?;
+    let clients = build_clients(&config).await;
     // Analyze doesn't push anything, so no batch checkers needed.
     let no_checkers: HashMap<String, Rc<dyn BatchBlobChecker>> = HashMap::new();
 
@@ -66,11 +66,21 @@ pub(crate) async fn run(
             break;
         }
 
-        let resolved =
-            match resolve_mapping(mapping, &config, &clients, &no_checkers, false).await? {
-                MappingResolution::Resolved(r) => r,
-                MappingResolution::NoMatchingTags(_) => continue,
-            };
+        // One unresolvable mapping must not cost the analysis every mapping
+        // behind it, same as `sync`.
+        let resolved = match resolve_mapping(mapping, &config, &clients, &no_checkers, false).await
+        {
+            Ok(MappingResolution::Resolved(r)) => r,
+            Ok(MappingResolution::NoMatchingTags(_)) => continue,
+            Err(err) => {
+                tracing::error!(
+                    from = %mapping.from,
+                    error = %err,
+                    "mapping could not be resolved; skipping"
+                );
+                continue;
+            }
+        };
 
         for tag_pair in &resolved.tags {
             if shutdown.is_triggered() {

--- a/src/cli/commands/analyze.rs
+++ b/src/cli/commands/analyze.rs
@@ -19,10 +19,10 @@ use ocync_distribution::{Digest, RepositoryName};
 use ocync_sync::ShutdownSignal;
 
 use crate::cli::commands::synchronize::{
-    MappingResolution, PreparePhase, PrepareTracker, build_clients, log_unresolved_mapping,
-    resolve_mapping, with_prepare_progress,
+    ClientMap, DroppedTarget, MappingResolution, PreparePhase, PrepareTracker, build_clients,
+    log_unresolved_mapping, resolve_mapping, with_prepare_progress,
 };
-use crate::cli::config::load_config;
+use crate::cli::config::{Config, load_config};
 use crate::cli::output::format_bytes;
 use crate::cli::{CliError, ExitCode};
 
@@ -50,6 +50,26 @@ struct BlobAggregate {
     target_repos: BTreeMap<String, BTreeSet<RepositoryName>>,
 }
 
+/// What an analysis produced, including what it could not read.
+///
+/// The three image counts are disjoint views of the same attempts: `analyzed`
+/// is every image that contributed blobs, `partial` is the subset of those
+/// missing at least one platform, and `failed` contributed nothing at all.
+#[derive(Debug, Default)]
+struct Analysis {
+    blobs: HashMap<Digest, BlobAggregate>,
+    /// Images that contributed blobs, complete or not.
+    analyzed: usize,
+    /// Images recorded with at least one platform missing.
+    partial: usize,
+    /// Images that could not be read at all.
+    failed: usize,
+    /// Mappings that never produced any images to read.
+    unresolved: usize,
+    /// Targets excluded from the mount-savings estimate.
+    dropped: Vec<DroppedTarget>,
+}
+
 /// Run the analyze command.
 pub(crate) async fn run(
     args: &AnalyzeArgs,
@@ -59,20 +79,45 @@ pub(crate) async fn run(
     // Analyze doesn't push anything, so no batch checkers needed.
     let no_checkers: HashMap<String, Rc<dyn BatchBlobChecker>> = HashMap::new();
 
-    let mut blobs: HashMap<Digest, BlobAggregate> = HashMap::new();
-    let mut image_count = 0usize;
-    let mut failed_images = 0usize;
-
-    // Client construction mints a token per registry and each mapping lists a
-    // repository's tags, all before the first `analyzing` line. The ticker
-    // spans both, as it does in `sync`.
+    // Client construction mints a token per registry and every mapping lists a
+    // repository's tags, all before the first `analyzing` line. The ticker has
+    // to span the whole loop, not just the client build, or the tag-listing
+    // stretch it exists for stays silent.
     let tracker = PrepareTracker::default();
-    let clients = with_prepare_progress(&tracker, async {
+    let analysis = with_prepare_progress(&tracker, async {
         let clients = build_clients(&config, &tracker).await;
         tracker.begin(PreparePhase::Mappings, config.mappings.len());
-        clients
+        collect_analysis(&config, &clients, &no_checkers, shutdown, &tracker).await
     })
     .await;
+
+    if analysis.failed > 0 || analysis.partial > 0 || analysis.unresolved > 0 {
+        tracing::warn!(
+            failed_images = analysis.failed,
+            partial_images = analysis.partial,
+            unresolved_mappings = analysis.unresolved,
+            "the analysis is incomplete; the reported totals are short by whatever it could not read"
+        );
+    }
+
+    if args.json {
+        print_json(&analysis)?;
+    } else {
+        print_text(&analysis);
+    }
+
+    Ok(analyze_exit_code(&analysis))
+}
+
+/// Walk every mapping and tag, recording blobs and what could not be read.
+async fn collect_analysis(
+    config: &Config,
+    clients: &ClientMap,
+    no_checkers: &HashMap<String, Rc<dyn BatchBlobChecker>>,
+    shutdown: &ShutdownSignal,
+    tracker: &PrepareTracker,
+) -> Analysis {
+    let mut analysis = Analysis::default();
 
     for mapping in &config.mappings {
         if shutdown.is_triggered() {
@@ -80,14 +125,18 @@ pub(crate) async fn run(
             break;
         }
 
+        // Advanced up front so every exit from the match below still counts
+        // the mapping: a `continue` that skips it strands the progress line
+        // short of its total.
+        tracker.advance();
+
         // One unresolvable mapping must not cost the analysis every mapping
         // behind it, same as `sync`.
-        let resolved = match resolve_mapping(mapping, &config, &clients, &no_checkers, false).await
-        {
+        let resolved = match resolve_mapping(mapping, config, clients, no_checkers, false).await {
             Ok(MappingResolution::Resolved(r, dropped)) => {
-                // Analyze reports what a sync would move; a target it cannot
-                // reach changes that answer, so say so rather than quietly
-                // costing it out of the totals.
+                // Analyze reports what a sync would move, so a target it
+                // cannot reach changes the answer and has to be reported
+                // rather than quietly costed out of the estimate.
                 for target in &dropped {
                     tracing::warn!(
                         from = %target.from,
@@ -96,11 +145,18 @@ pub(crate) async fn run(
                         "target registry unavailable; excluded from the mount-savings estimate"
                     );
                 }
+                analysis.dropped.extend(dropped);
                 r
             }
-            Ok(MappingResolution::NoMatchingTags(_)) => continue,
+            Ok(MappingResolution::NoMatchingTags(_, dropped)) => {
+                analysis.dropped.extend(dropped);
+                continue;
+            }
             Err(err) => {
                 log_unresolved_mapping(&mapping.from, &err);
+                // A mapping the analysis could not resolve is a hole in the
+                // estimate exactly like an image it could not read.
+                analysis.unresolved += 1;
                 continue;
             }
         };
@@ -111,13 +167,10 @@ pub(crate) async fn run(
                 break;
             }
 
-            image_count += 1;
             let image_ref = format!("{}:{}", resolved.source_repo, tag_pair.source);
             tracing::info!(image = %image_ref, "analyzing");
             // One unreadable image must not end the analysis: the remaining
-            // tags and mappings are independent of it. The count above already
-            // includes this image, so the totals stay honest about what was
-            // attempted.
+            // tags and mappings are independent of it.
             match collect_blobs(
                 &resolved.source_client,
                 &resolved.source_repo,
@@ -125,58 +178,54 @@ pub(crate) async fn run(
                 &image_ref,
                 &resolved.targets,
                 &resolved.target_repo,
-                &mut blobs,
+                &mut analysis.blobs,
             )
             .await
             {
-                Ok(Completeness::Full) => {}
-                // A skipped index child leaves this image's blob set short,
-                // which is the same kind of hole as a skipped image and has
-                // to reach the same counter, exit code, and report.
-                Ok(Completeness::Partial) => failed_images += 1,
+                Ok(Completeness::Full) => analysis.analyzed += 1,
+                // A skipped index child still leaves this image's other
+                // platforms recorded, so it counts as analyzed. Conflating it
+                // with a total failure reported a mostly-complete run as zero
+                // images and exited 2.
+                Ok(Completeness::Partial) => {
+                    analysis.analyzed += 1;
+                    analysis.partial += 1;
+                }
                 Err(err) => {
                     tracing::error!(
                         image = %image_ref,
                         error = %err,
                         "image could not be analyzed; skipping"
                     );
-                    failed_images += 1;
+                    analysis.failed += 1;
                 }
             }
         }
-        tracker.advance();
     }
 
-    if failed_images > 0 {
-        tracing::warn!(
-            failed_images,
-            "some images could not be analyzed; they are excluded from the reported blob totals"
-        );
-    }
-
-    if args.json {
-        print_json(&blobs, image_count, failed_images)?;
-    } else {
-        print_text(&blobs, image_count, failed_images);
-    }
-
-    Ok(analyze_exit_code(image_count, failed_images))
+    analysis
 }
 
-/// Exit code for an analysis that could not read every image.
+/// Exit code for an analysis that could not read everything it was asked to.
 ///
-/// An incomplete report must not look like a clean one: the totals are
-/// missing whatever those images contributed.
-fn analyze_exit_code(image_count: usize, failed_images: usize) -> ExitCode {
-    match (image_count.saturating_sub(failed_images), failed_images) {
-        (_, 0) => ExitCode::Success,
-        (0, _) => ExitCode::Failure,
-        _ => ExitCode::PartialFailure,
+/// An incomplete estimate must not look like a clean one: the totals are short
+/// by whatever the unread images and unreachable targets hold.
+fn analyze_exit_code(analysis: &Analysis) -> ExitCode {
+    if analysis.failed == 0
+        && analysis.partial == 0
+        && analysis.unresolved == 0
+        && analysis.dropped.is_empty()
+    {
+        return ExitCode::Success;
     }
+    if analysis.analyzed == 0 {
+        return ExitCode::Failure;
+    }
+    ExitCode::PartialFailure
 }
 
 /// Whether every blob referenced by an image was recorded.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
 enum Completeness {
     /// Every referenced manifest was pulled.
     Full,
@@ -327,7 +376,8 @@ fn compute_mount_savings(blobs: &HashMap<Digest, BlobAggregate>) -> BTreeMap<Str
     savings
 }
 
-fn print_text(blobs: &HashMap<Digest, BlobAggregate>, image_count: usize, failed_images: usize) {
+fn print_text(analysis: &Analysis) {
+    let blobs = &analysis.blobs;
     let total_blobs = blobs.len();
     let total_bytes: u64 = blobs.values().map(|b| b.size).sum();
 
@@ -336,11 +386,20 @@ fn print_text(blobs: &HashMap<Digest, BlobAggregate>, image_count: usize, failed
 
     let mount_savings_by_target = compute_mount_savings(blobs);
 
-    let analyzed = image_count.saturating_sub(failed_images);
-    if failed_images > 0 {
-        println!("Analyzed {analyzed} of {image_count} image mappings ({failed_images} failed)");
+    let attempted = analysis.analyzed + analysis.failed;
+    if analysis.failed > 0 || analysis.partial > 0 {
+        println!(
+            "Analyzed {} of {attempted} image mappings ({} incomplete, {} failed)",
+            analysis.analyzed, analysis.partial, analysis.failed,
+        );
     } else {
-        println!("Analyzed {analyzed} image mappings");
+        println!("Analyzed {} image mappings", analysis.analyzed);
+    }
+    for target in &analysis.dropped {
+        println!(
+            "  WARNING: target {} unreachable; excluded from the estimate",
+            target.registry
+        );
     }
     println!();
     println!(
@@ -364,16 +423,26 @@ fn print_text(blobs: &HashMap<Digest, BlobAggregate>, image_count: usize, failed
     }
 }
 
-fn print_json(
-    blobs: &HashMap<Digest, BlobAggregate>,
-    image_count: usize,
-    failed_images: usize,
-) -> Result<(), CliError> {
+fn print_json(analysis: &Analysis) -> Result<(), CliError> {
+    let blobs = &analysis.blobs;
     let mount_savings_by_target = compute_mount_savings(blobs);
 
     let report = serde_json::json!({
-        "images_analyzed": image_count.saturating_sub(failed_images),
-        "images_failed": failed_images,
+        "images_analyzed": analysis.analyzed,
+        "images_partial": analysis.partial,
+        "images_failed": analysis.failed,
+        "unresolved_mappings": analysis.unresolved,
+        // A target the estimate could not reach changes the answer, so it is
+        // part of the document rather than a log line only.
+        "dropped_targets": analysis
+            .dropped
+            .iter()
+            .map(|d| serde_json::json!({
+                "from": d.from,
+                "registry": d.registry,
+                "error": d.error,
+            }))
+            .collect::<Vec<_>>(),
         "total_blobs": blobs.len(),
         "total_bytes": blobs.values().map(|b| b.size).sum::<u64>(),
         "shared_blobs": blobs.values().filter(|b| b.images.len() > 1).count(),
@@ -390,4 +459,75 @@ fn print_json(
             .map_err(|e| CliError::Input(format!("serialize report: {e}")))?
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn analysis(analyzed: usize, partial: usize, failed: usize, dropped: usize) -> Analysis {
+        Analysis {
+            blobs: HashMap::new(),
+            analyzed,
+            partial,
+            failed,
+            unresolved: 0,
+            dropped: (0..dropped)
+                .map(|i| DroppedTarget {
+                    from: "repo/one".into(),
+                    registry: format!("mirror-{i}"),
+                    error: "403 Forbidden".into(),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn a_complete_analysis_is_a_clean_exit() {
+        assert_eq!(analyze_exit_code(&analysis(3, 0, 0, 0)), ExitCode::Success);
+        assert_eq!(analyze_exit_code(&analysis(0, 0, 0, 0)), ExitCode::Success);
+    }
+
+    /// An image missing one platform still contributed the others, so the
+    /// report is partial, not empty. Counting it as a total failure reported a
+    /// mostly-complete run as zero images analyzed and exited 2.
+    #[test]
+    fn a_partial_image_is_partial_not_failed() {
+        assert_eq!(
+            analyze_exit_code(&analysis(1, 1, 0, 0)),
+            ExitCode::PartialFailure
+        );
+    }
+
+    #[test]
+    fn nothing_readable_is_a_failure() {
+        assert_eq!(analyze_exit_code(&analysis(0, 0, 3, 0)), ExitCode::Failure);
+    }
+
+    #[test]
+    fn some_readable_is_partial() {
+        assert_eq!(
+            analyze_exit_code(&analysis(2, 0, 1, 0)),
+            ExitCode::PartialFailure
+        );
+    }
+
+    /// A mapping the analysis could not resolve is as much a hole in the
+    /// estimate as an image it could not read.
+    #[test]
+    fn an_unresolved_mapping_alone_is_partial() {
+        let mut a = analysis(3, 0, 0, 0);
+        a.unresolved = 1;
+        assert_eq!(analyze_exit_code(&a), ExitCode::PartialFailure);
+    }
+
+    /// An unreachable target changes the mount-savings answer even when every
+    /// image read cleanly, so it cannot report as a clean run.
+    #[test]
+    fn an_unreachable_target_alone_is_partial() {
+        assert_eq!(
+            analyze_exit_code(&analysis(3, 0, 0, 1)),
+            ExitCode::PartialFailure
+        );
+    }
 }

--- a/src/cli/commands/analyze.rs
+++ b/src/cli/commands/analyze.rs
@@ -19,8 +19,9 @@ use ocync_distribution::{Digest, RepositoryName};
 use ocync_sync::ShutdownSignal;
 
 use crate::cli::commands::synchronize::{
-    ClientMap, DroppedTarget, MappingResolution, PreparePhase, PrepareTracker, build_clients,
-    log_unresolved_mapping, resolve_mapping, with_prepare_progress,
+    ClientMap, DroppedTarget, MappingResolution, PreparePhase, PrepareTracker, UnresolvedMapping,
+    build_clients, log_unresolved_mapping, resolve_mapping, shared_failure_code,
+    with_prepare_progress,
 };
 use crate::cli::config::{Config, load_config};
 use crate::cli::output::format_bytes;
@@ -64,10 +65,16 @@ struct Analysis {
     partial: usize,
     /// Images that could not be read at all.
     failed: usize,
-    /// Mappings that never produced any images to read.
-    unresolved: usize,
+    /// Mappings that produced no images to read.
+    ///
+    /// The same shape `sync` reports, so one consumer can read both. Each
+    /// carries its classification, so a wholly denied analysis exits 4 the way
+    /// `sync` does rather than collapsing to the generic failure.
+    unresolved: Vec<UnresolvedMapping>,
     /// Targets excluded from the mount-savings estimate.
     dropped: Vec<DroppedTarget>,
+    /// Whether shutdown cut the walk short.
+    interrupted: bool,
 }
 
 /// Run the analyze command.
@@ -91,11 +98,11 @@ pub(crate) async fn run(
     })
     .await;
 
-    if analysis.failed > 0 || analysis.partial > 0 || analysis.unresolved > 0 {
+    if analysis.failed > 0 || analysis.partial > 0 || !analysis.unresolved.is_empty() {
         tracing::warn!(
             failed_images = analysis.failed,
             partial_images = analysis.partial,
-            unresolved_mappings = analysis.unresolved,
+            unresolved_mappings = analysis.unresolved.len(),
             "the analysis is incomplete; the reported totals are short by whatever it could not read"
         );
     }
@@ -122,6 +129,7 @@ async fn collect_analysis(
     for mapping in &config.mappings {
         if shutdown.is_triggered() {
             tracing::info!("shutdown signal received, stopping analysis early");
+            analysis.interrupted = true;
             break;
         }
 
@@ -132,31 +140,35 @@ async fn collect_analysis(
 
         // One unresolvable mapping must not cost the analysis every mapping
         // behind it, same as `sync`.
-        let resolved = match resolve_mapping(mapping, config, clients, no_checkers, false).await {
-            Ok(MappingResolution::Resolved(r, dropped)) => {
-                // Analyze reports what a sync would move, so a target it
-                // cannot reach changes the answer and has to be reported
-                // rather than quietly costed out of the estimate.
-                for target in &dropped {
-                    tracing::warn!(
-                        from = %target.from,
-                        registry = %target.registry,
-                        error = %target.error,
-                        "target registry unavailable; excluded from the mount-savings estimate"
-                    );
-                }
-                analysis.dropped.extend(dropped);
-                r
-            }
-            Ok(MappingResolution::NoMatchingTags(_, dropped)) => {
-                analysis.dropped.extend(dropped);
-                continue;
-            }
+        // Dropped targets arrive whatever the outcome: analyze reports what a
+        // sync would move, so a target it cannot reach changes the answer even
+        // when the mapping itself then fails.
+        let (outcome, dropped) =
+            resolve_mapping(mapping, config, clients, no_checkers, false).await;
+        for target in &dropped {
+            tracing::warn!(
+                from = %target.from,
+                registry = %target.registry,
+                error = %target.error,
+                "target registry unavailable; excluded from the mount-savings estimate"
+            );
+        }
+        analysis.dropped.extend(dropped);
+
+        let resolved = match outcome {
+            Ok(MappingResolution::Resolved(r)) => r,
+            Ok(MappingResolution::NoMatchingTags(_)) => continue,
             Err(err) => {
                 log_unresolved_mapping(&mapping.from, &err);
                 // A mapping the analysis could not resolve is a hole in the
-                // estimate exactly like an image it could not read.
-                analysis.unresolved += 1;
+                // estimate exactly like an image it could not read. Its
+                // classification is kept so a wholly denied analysis reports
+                // as a denial rather than a generic failure.
+                analysis.unresolved.push(UnresolvedMapping {
+                    from: mapping.from.clone(),
+                    code: err.exit_code(),
+                    error: err.to_string(),
+                });
                 continue;
             }
         };
@@ -164,6 +176,7 @@ async fn collect_analysis(
         for tag_pair in &resolved.tags {
             if shutdown.is_triggered() {
                 tracing::info!("shutdown signal received, stopping analysis early");
+                analysis.interrupted = true;
                 break;
             }
 
@@ -211,17 +224,32 @@ async fn collect_analysis(
 /// An incomplete estimate must not look like a clean one: the totals are short
 /// by whatever the unread images and unreachable targets hold.
 fn analyze_exit_code(analysis: &Analysis) -> ExitCode {
+    // An interrupted walk is a truncated report, which is the same kind of
+    // incompleteness as an unreadable image and must not read as clean.
     if analysis.failed == 0
         && analysis.partial == 0
-        && analysis.unresolved == 0
+        && analysis.unresolved.is_empty()
         && analysis.dropped.is_empty()
+        && !analysis.interrupted
     {
         return ExitCode::Success;
     }
-    if analysis.analyzed == 0 {
-        return ExitCode::Failure;
+    if analysis.interrupted && analysis.analyzed > 0 {
+        return ExitCode::PartialFailure;
     }
-    ExitCode::PartialFailure
+    // Something was read, or the only defect was an unreachable target: the
+    // report exists, it is just short. `sync` reports the same case as partial.
+    if analysis.analyzed > 0 || (analysis.failed == 0 && analysis.unresolved.is_empty()) {
+        return ExitCode::PartialFailure;
+    }
+    // Nothing readable at all. Keep the specific cause when every failure
+    // agrees on one, so a wholly denied analysis exits 4 like `sync`.
+    let codes = analysis
+        .unresolved
+        .iter()
+        .map(|u| u.code)
+        .chain((analysis.failed > 0).then_some(ExitCode::Failure));
+    shared_failure_code(codes)
 }
 
 /// Whether every blob referenced by an image was recorded.
@@ -387,6 +415,12 @@ fn print_text(analysis: &Analysis) {
     let mount_savings_by_target = compute_mount_savings(blobs);
 
     let attempted = analysis.analyzed + analysis.failed;
+    if !analysis.unresolved.is_empty() {
+        println!(
+            "  WARNING: {} mapping(s) could not be resolved; excluded entirely",
+            analysis.unresolved.len()
+        );
+    }
     if analysis.failed > 0 || analysis.partial > 0 {
         println!(
             "Analyzed {} of {attempted} image mappings ({} incomplete, {} failed)",
@@ -434,15 +468,7 @@ fn print_json(analysis: &Analysis) -> Result<(), CliError> {
         "unresolved_mappings": analysis.unresolved,
         // A target the estimate could not reach changes the answer, so it is
         // part of the document rather than a log line only.
-        "dropped_targets": analysis
-            .dropped
-            .iter()
-            .map(|d| serde_json::json!({
-                "from": d.from,
-                "registry": d.registry,
-                "error": d.error,
-            }))
-            .collect::<Vec<_>>(),
+        "dropped_targets": analysis.dropped,
         "total_blobs": blobs.len(),
         "total_bytes": blobs.values().map(|b| b.size).sum::<u64>(),
         "shared_blobs": blobs.values().filter(|b| b.images.len() > 1).count(),
@@ -471,7 +497,8 @@ mod tests {
             analyzed,
             partial,
             failed,
-            unresolved: 0,
+            unresolved: Vec::new(),
+            interrupted: false,
             dropped: (0..dropped)
                 .map(|i| DroppedTarget {
                     from: "repo/one".into(),
@@ -512,12 +539,24 @@ mod tests {
         );
     }
 
+    /// A run cut short by SIGINT is a truncated report, not a clean one.
+    #[test]
+    fn an_interrupted_analysis_is_partial() {
+        let mut a = analysis(3, 0, 0, 0);
+        a.interrupted = true;
+        assert_eq!(analyze_exit_code(&a), ExitCode::PartialFailure);
+    }
+
     /// A mapping the analysis could not resolve is as much a hole in the
     /// estimate as an image it could not read.
     #[test]
     fn an_unresolved_mapping_alone_is_partial() {
         let mut a = analysis(3, 0, 0, 0);
-        a.unresolved = 1;
+        a.unresolved = vec![UnresolvedMapping {
+            from: "repo/one".into(),
+            error: "403 Forbidden".into(),
+            code: ExitCode::AuthError,
+        }];
         assert_eq!(analyze_exit_code(&a), ExitCode::PartialFailure);
     }
 

--- a/src/cli/commands/analyze.rs
+++ b/src/cli/commands/analyze.rs
@@ -19,8 +19,8 @@ use ocync_distribution::{Digest, RepositoryName};
 use ocync_sync::ShutdownSignal;
 
 use crate::cli::commands::synchronize::{
-    MappingResolution, PrepareTracker, build_clients, log_unresolved_mapping, resolve_mapping,
-    with_prepare_progress,
+    MappingResolution, PreparePhase, PrepareTracker, build_clients, log_unresolved_mapping,
+    resolve_mapping, with_prepare_progress,
 };
 use crate::cli::config::load_config;
 use crate::cli::output::format_bytes;
@@ -56,16 +56,23 @@ pub(crate) async fn run(
     shutdown: &ShutdownSignal,
 ) -> Result<ExitCode, CliError> {
     let config = load_config(&args.config)?;
-    // Client construction mints a token per registry with nothing else in the
-    // log; the ticker keeps that window visible.
-    let tracker = PrepareTracker::default();
-    let clients = with_prepare_progress(&tracker, build_clients(&config, &tracker)).await;
     // Analyze doesn't push anything, so no batch checkers needed.
     let no_checkers: HashMap<String, Rc<dyn BatchBlobChecker>> = HashMap::new();
 
     let mut blobs: HashMap<Digest, BlobAggregate> = HashMap::new();
     let mut image_count = 0usize;
     let mut failed_images = 0usize;
+
+    // Client construction mints a token per registry and each mapping lists a
+    // repository's tags, all before the first `analyzing` line. The ticker
+    // spans both, as it does in `sync`.
+    let tracker = PrepareTracker::default();
+    let clients = with_prepare_progress(&tracker, async {
+        let clients = build_clients(&config, &tracker).await;
+        tracker.begin(PreparePhase::Mappings, config.mappings.len());
+        clients
+    })
+    .await;
 
     for mapping in &config.mappings {
         if shutdown.is_triggered() {
@@ -77,7 +84,20 @@ pub(crate) async fn run(
         // behind it, same as `sync`.
         let resolved = match resolve_mapping(mapping, &config, &clients, &no_checkers, false).await
         {
-            Ok(MappingResolution::Resolved(r)) => r,
+            Ok(MappingResolution::Resolved(r, dropped)) => {
+                // Analyze reports what a sync would move; a target it cannot
+                // reach changes that answer, so say so rather than quietly
+                // costing it out of the totals.
+                for target in &dropped {
+                    tracing::warn!(
+                        from = %target.from,
+                        registry = %target.registry,
+                        error = %target.error,
+                        "target registry unavailable; excluded from the mount-savings estimate"
+                    );
+                }
+                r
+            }
             Ok(MappingResolution::NoMatchingTags(_)) => continue,
             Err(err) => {
                 log_unresolved_mapping(&mapping.from, &err);
@@ -98,7 +118,7 @@ pub(crate) async fn run(
             // tags and mappings are independent of it. The count above already
             // includes this image, so the totals stay honest about what was
             // attempted.
-            if let Err(err) = collect_blobs(
+            match collect_blobs(
                 &resolved.source_client,
                 &resolved.source_repo,
                 &tag_pair.source,
@@ -109,26 +129,59 @@ pub(crate) async fn run(
             )
             .await
             {
-                tracing::error!(image = %image_ref, error = %err, "image could not be analyzed; skipping");
-                failed_images += 1;
+                Ok(Completeness::Full) => {}
+                // A skipped index child leaves this image's blob set short,
+                // which is the same kind of hole as a skipped image and has
+                // to reach the same counter, exit code, and report.
+                Ok(Completeness::Partial) => failed_images += 1,
+                Err(err) => {
+                    tracing::error!(
+                        image = %image_ref,
+                        error = %err,
+                        "image could not be analyzed; skipping"
+                    );
+                    failed_images += 1;
+                }
             }
         }
+        tracker.advance();
     }
 
     if failed_images > 0 {
         tracing::warn!(
             failed_images,
-            "some images could not be analyzed; blob totals below exclude them"
+            "some images could not be analyzed; they are excluded from the reported blob totals"
         );
     }
 
     if args.json {
-        print_json(&blobs, image_count)?;
+        print_json(&blobs, image_count, failed_images)?;
     } else {
-        print_text(&blobs, image_count);
+        print_text(&blobs, image_count, failed_images);
     }
 
-    Ok(ExitCode::Success)
+    Ok(analyze_exit_code(image_count, failed_images))
+}
+
+/// Exit code for an analysis that could not read every image.
+///
+/// An incomplete report must not look like a clean one: the totals are
+/// missing whatever those images contributed.
+fn analyze_exit_code(image_count: usize, failed_images: usize) -> ExitCode {
+    match (image_count.saturating_sub(failed_images), failed_images) {
+        (_, 0) => ExitCode::Success,
+        (0, _) => ExitCode::Failure,
+        _ => ExitCode::PartialFailure,
+    }
+}
+
+/// Whether every blob referenced by an image was recorded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Completeness {
+    /// Every referenced manifest was pulled.
+    Full,
+    /// At least one index child could not be pulled, so blobs are missing.
+    Partial,
 }
 
 /// Pull a manifest (recursively for indexes) and record every blob's
@@ -141,7 +194,7 @@ async fn collect_blobs(
     targets: &[ocync_sync::engine::TargetEntry],
     target_repo: &RepositoryName,
     blobs: &mut HashMap<Digest, BlobAggregate>,
-) -> Result<(), CliError> {
+) -> Result<Completeness, CliError> {
     let pulled = source_client
         .manifest_pull(source_repo, tag)
         .await
@@ -158,6 +211,8 @@ async fn collect_blobs(
             blobs,
         );
     }
+
+    let mut completeness = Completeness::Full;
 
     // Recurse into index children to collect per-platform manifest blobs.
     if let ManifestKind::Index(index) = &pulled.manifest {
@@ -176,6 +231,7 @@ async fn collect_blobs(
                         error = %e,
                         "index child could not be pulled; skipping this platform"
                     );
+                    completeness = Completeness::Partial;
                     continue;
                 }
             };
@@ -192,7 +248,7 @@ async fn collect_blobs(
         }
     }
 
-    Ok(())
+    Ok(completeness)
 }
 
 /// Descriptor data extracted from a manifest.
@@ -271,7 +327,7 @@ fn compute_mount_savings(blobs: &HashMap<Digest, BlobAggregate>) -> BTreeMap<Str
     savings
 }
 
-fn print_text(blobs: &HashMap<Digest, BlobAggregate>, image_count: usize) {
+fn print_text(blobs: &HashMap<Digest, BlobAggregate>, image_count: usize, failed_images: usize) {
     let total_blobs = blobs.len();
     let total_bytes: u64 = blobs.values().map(|b| b.size).sum();
 
@@ -280,7 +336,12 @@ fn print_text(blobs: &HashMap<Digest, BlobAggregate>, image_count: usize) {
 
     let mount_savings_by_target = compute_mount_savings(blobs);
 
-    println!("Analyzed {image_count} image mappings");
+    let analyzed = image_count.saturating_sub(failed_images);
+    if failed_images > 0 {
+        println!("Analyzed {analyzed} of {image_count} image mappings ({failed_images} failed)");
+    } else {
+        println!("Analyzed {analyzed} image mappings");
+    }
     println!();
     println!(
         "Unique blobs: {total_blobs} ({})",
@@ -303,11 +364,16 @@ fn print_text(blobs: &HashMap<Digest, BlobAggregate>, image_count: usize) {
     }
 }
 
-fn print_json(blobs: &HashMap<Digest, BlobAggregate>, image_count: usize) -> Result<(), CliError> {
+fn print_json(
+    blobs: &HashMap<Digest, BlobAggregate>,
+    image_count: usize,
+    failed_images: usize,
+) -> Result<(), CliError> {
     let mount_savings_by_target = compute_mount_savings(blobs);
 
     let report = serde_json::json!({
-        "images_analyzed": image_count,
+        "images_analyzed": image_count.saturating_sub(failed_images),
+        "images_failed": failed_images,
         "total_blobs": blobs.len(),
         "total_bytes": blobs.values().map(|b| b.size).sum::<u64>(),
         "shared_blobs": blobs.values().filter(|b| b.images.len() > 1).count(),

--- a/src/cli/commands/auth.rs
+++ b/src/cli/commands/auth.rs
@@ -46,6 +46,11 @@ async fn run_check_to<W: Write>(configs: &[PathBuf], out: &mut W) -> Result<Exit
                     }
                     Err(err) => {
                         let _ = writeln!(out, "  FAIL  {name} ({safe_url}) -- {err}");
+                        // `ping` accepts 401 as reachable but returns Err on
+                        // 403, which is a denial and keeps the auth code.
+                        if err.is_auth_error() {
+                            auth_error = true;
+                        }
                         all_ok = false;
                     }
                 },
@@ -103,7 +108,10 @@ mod tests {
         std::fs::File::create(&good)
             .and_then(|mut f| {
                 f.write_all(
-                    b"registries:\n  r:\n    url: unreachable.invalid\n    auth_type: static_token\n    token: t\nmappings: []\n",
+                    // A URL that fails to parse, so the check reports the
+                    // registry without issuing a request: the test must not
+                    // depend on name resolution or a network timeout.
+                    b"registries:\n  r:\n    url: \"exa mple\"\n    auth_type: static_token\n    token: t\nmappings: []\n",
                 )
             })
             .expect("write good config");

--- a/src/cli/commands/auth.rs
+++ b/src/cli/commands/auth.rs
@@ -11,7 +11,16 @@ pub(crate) async fn run_check(configs: &[PathBuf]) -> Result<ExitCode, CliError>
     let mut all_ok = true;
 
     for path in configs {
-        let config = load_config(path)?;
+        // `-c` is repeatable and the files are independent, so one unreadable
+        // config must not skip the registries defined in the others.
+        let config = match load_config(path) {
+            Ok(config) => config,
+            Err(err) => {
+                eprintln!("  FAIL  {} -- {err}", path.display());
+                all_ok = false;
+                continue;
+            }
+        };
 
         for (name, reg) in &config.registries {
             let safe_url = redact_url(&reg.url);

--- a/src/cli/commands/auth.rs
+++ b/src/cli/commands/auth.rs
@@ -9,6 +9,9 @@ use crate::cli::{CliError, ExitCode, build_registry_client};
 /// Run credential checks against all registries in config files.
 pub(crate) async fn run_check(configs: &[PathBuf]) -> Result<ExitCode, CliError> {
     let mut all_ok = true;
+    // Tracked apart from `all_ok`: a broken config file is a different problem
+    // from a rejected credential, and keeps its own exit code.
+    let mut config_error = false;
 
     for path in configs {
         // `-c` is repeatable and the files are independent, so one unreadable
@@ -17,6 +20,7 @@ pub(crate) async fn run_check(configs: &[PathBuf]) -> Result<ExitCode, CliError>
             Ok(config) => config,
             Err(err) => {
                 eprintln!("  FAIL  {} -- {err}", path.display());
+                config_error = true;
                 all_ok = false;
                 continue;
             }
@@ -42,9 +46,51 @@ pub(crate) async fn run_check(configs: &[PathBuf]) -> Result<ExitCode, CliError>
         }
     }
 
-    if all_ok {
+    if config_error {
+        // Reported ahead of a credential failure: an unreadable config is the
+        // cause the operator has to fix first.
+        Ok(ExitCode::ConfigError)
+    } else if all_ok {
         Ok(ExitCode::Success)
     } else {
         Ok(ExitCode::PartialFailure)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+
+    /// `-c` is repeatable and the files are independent, so a broken one must
+    /// not skip the rest, and must keep the config exit code rather than
+    /// being flattened into a credential failure.
+    #[tokio::test]
+    async fn unreadable_config_is_reported_without_skipping_the_others() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bad = dir.path().join("bad.yaml");
+        let good = dir.path().join("good.yaml");
+        // Not valid config, so `load_config` fails.
+        std::fs::File::create(&bad)
+            .and_then(|mut f| f.write_all(b"mappings: [[[["))
+            .expect("write bad config");
+        // Valid, and defines no registries, so the check does no network I/O.
+        std::fs::File::create(&good)
+            .and_then(|mut f| f.write_all(b"registries: {}\nmappings: []\n"))
+            .expect("write good config");
+
+        let code = run_check(&[bad, good.clone()]).await.expect("runs");
+
+        assert_eq!(
+            code,
+            ExitCode::ConfigError,
+            "a broken config keeps the config exit code"
+        );
+
+        // The negative half: on its own the good config is clean, proving the
+        // run above actually reached it rather than stopping at the bad one.
+        let code = run_check(&[good]).await.expect("runs");
+        assert_eq!(code, ExitCode::Success);
     }
 }

--- a/src/cli/commands/auth.rs
+++ b/src/cli/commands/auth.rs
@@ -1,5 +1,6 @@
 //! The `auth check` subcommand - credential validation.
 
+use std::io::{self, Write};
 use std::path::PathBuf;
 
 use crate::cli::config::load_config;
@@ -8,10 +9,20 @@ use crate::cli::{CliError, ExitCode, build_registry_client};
 
 /// Run credential checks against all registries in config files.
 pub(crate) async fn run_check(configs: &[PathBuf]) -> Result<ExitCode, CliError> {
+    run_check_to(configs, &mut io::stderr()).await
+}
+
+/// [`run_check`] with the status sink injected, so a test can assert which
+/// files and registries were actually reached.
+async fn run_check_to<W: Write>(configs: &[PathBuf], out: &mut W) -> Result<ExitCode, CliError> {
     let mut all_ok = true;
     // Tracked apart from `all_ok`: a broken config file is a different problem
     // from a rejected credential, and keeps its own exit code.
     let mut config_error = false;
+    // `ping` treats 401 as reachable, so a denial almost always arrives from
+    // client construction. Keeping its classification is what lets a wholly
+    // denied check exit 4 instead of a generic partial failure.
+    let mut auth_error = false;
 
     for path in configs {
         // `-c` is repeatable and the files are independent, so one unreadable
@@ -19,7 +30,7 @@ pub(crate) async fn run_check(configs: &[PathBuf]) -> Result<ExitCode, CliError>
         let config = match load_config(path) {
             Ok(config) => config,
             Err(err) => {
-                eprintln!("  FAIL  {} -- {err}", path.display());
+                let _ = writeln!(out, "  FAIL  {} -- {err}", path.display());
                 config_error = true;
                 all_ok = false;
                 continue;
@@ -31,41 +42,54 @@ pub(crate) async fn run_check(configs: &[PathBuf]) -> Result<ExitCode, CliError>
             match build_registry_client(&reg.url, Some(reg)).await {
                 Ok(client) => match client.ping().await {
                     Ok(()) => {
-                        eprintln!("  OK    {name} ({safe_url})");
+                        let _ = writeln!(out, "  OK    {name} ({safe_url})");
                     }
                     Err(err) => {
-                        eprintln!("  FAIL  {name} ({safe_url}) -- {err}");
+                        let _ = writeln!(out, "  FAIL  {name} ({safe_url}) -- {err}");
                         all_ok = false;
                     }
                 },
                 Err(err) => {
-                    eprintln!("  FAIL  {name} -- {err}");
+                    let _ = writeln!(out, "  FAIL  {name} -- {err}");
+                    if matches!(err.exit_code(), ExitCode::AuthError) {
+                        auth_error = true;
+                    }
                     all_ok = false;
                 }
             }
         }
     }
 
+    Ok(classify(config_error, all_ok, auth_error))
+}
+
+/// Pick the exit code for a completed check.
+///
+/// Ordered by which cause the operator has to fix first: an unreadable config
+/// outranks a denial, which outranks a generic failure.
+fn classify(config_error: bool, all_ok: bool, auth_error: bool) -> ExitCode {
     if config_error {
-        // Reported ahead of a credential failure: an unreadable config is the
-        // cause the operator has to fix first.
-        Ok(ExitCode::ConfigError)
+        ExitCode::ConfigError
     } else if all_ok {
-        Ok(ExitCode::Success)
+        ExitCode::Success
+    } else if auth_error {
+        ExitCode::AuthError
     } else {
-        Ok(ExitCode::PartialFailure)
+        ExitCode::PartialFailure
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
-
     use super::*;
 
     /// `-c` is repeatable and the files are independent, so a broken one must
     /// not skip the rest, and must keep the config exit code rather than
     /// being flattened into a credential failure.
+    ///
+    /// Both files are named in the output, which is what distinguishes
+    /// continuing from returning early: an early return would report only the
+    /// first and still produce the same exit code.
     #[tokio::test]
     async fn unreadable_config_is_reported_without_skipping_the_others() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -75,22 +99,53 @@ mod tests {
         std::fs::File::create(&bad)
             .and_then(|mut f| f.write_all(b"mappings: [[[["))
             .expect("write bad config");
-        // Valid, and defines no registries, so the check does no network I/O.
+        // Valid, and names one registry that resolves offline.
         std::fs::File::create(&good)
-            .and_then(|mut f| f.write_all(b"registries: {}\nmappings: []\n"))
+            .and_then(|mut f| {
+                f.write_all(
+                    b"registries:\n  r:\n    url: unreachable.invalid\n    auth_type: static_token\n    token: t\nmappings: []\n",
+                )
+            })
             .expect("write good config");
 
-        let code = run_check(&[bad, good.clone()]).await.expect("runs");
+        let mut out = Vec::new();
+        let code = run_check_to(&[bad.clone(), good], &mut out)
+            .await
+            .expect("runs");
+        let out = String::from_utf8(out).expect("utf8");
 
         assert_eq!(
             code,
             ExitCode::ConfigError,
             "a broken config keeps the config exit code"
         );
+        assert!(
+            out.contains("bad.yaml"),
+            "the broken file is reported: {out}"
+        );
+        // The half an early return would fail: the file *after* the broken one
+        // was still checked.
+        assert!(
+            out.contains("  r "),
+            "the registry from the later config was still checked: {out}"
+        );
+    }
 
-        // The negative half: on its own the good config is clean, proving the
-        // run above actually reached it rather than stopping at the bad one.
-        let code = run_check(&[good]).await.expect("runs");
-        assert_eq!(code, ExitCode::Success);
+    /// A denied credential keeps the auth exit code rather than collapsing
+    /// into the generic partial failure.
+    #[test]
+    fn auth_failures_outrank_a_generic_partial_failure() {
+        assert_eq!(
+            classify(false, false, true),
+            ExitCode::AuthError,
+            "a denial reports as one"
+        );
+        assert_eq!(
+            classify(true, false, true),
+            ExitCode::ConfigError,
+            "a broken config is the cause to fix first"
+        );
+        assert_eq!(classify(false, false, false), ExitCode::PartialFailure);
+        assert_eq!(classify(false, true, false), ExitCode::Success);
     }
 }

--- a/src/cli/commands/auth.rs
+++ b/src/cli/commands/auth.rs
@@ -15,14 +15,10 @@ pub(crate) async fn run_check(configs: &[PathBuf]) -> Result<ExitCode, CliError>
 /// [`run_check`] with the status sink injected, so a test can assert which
 /// files and registries were actually reached.
 async fn run_check_to<W: Write>(configs: &[PathBuf], out: &mut W) -> Result<ExitCode, CliError> {
-    let mut all_ok = true;
-    // Tracked apart from `all_ok`: a broken config file is a different problem
-    // from a rejected credential, and keeps its own exit code.
-    let mut config_error = false;
     // `ping` treats 401 as reachable, so a denial almost always arrives from
-    // client construction. Keeping its classification is what lets a wholly
+    // client construction. Keeping the classification is what lets a wholly
     // denied check exit 4 instead of a generic partial failure.
-    let mut auth_error = false;
+    let mut worst = Worst::Clean;
 
     for path in configs {
         // `-c` is repeatable and the files are independent, so one unreadable
@@ -31,8 +27,7 @@ async fn run_check_to<W: Write>(configs: &[PathBuf], out: &mut W) -> Result<Exit
             Ok(config) => config,
             Err(err) => {
                 let _ = writeln!(out, "  FAIL  {} -- {err}", path.display());
-                config_error = true;
-                all_ok = false;
+                worst = worst.max(Worst::Unreadable);
                 continue;
             }
         };
@@ -48,39 +43,57 @@ async fn run_check_to<W: Write>(configs: &[PathBuf], out: &mut W) -> Result<Exit
                         let _ = writeln!(out, "  FAIL  {name} ({safe_url}) -- {err}");
                         // `ping` accepts 401 as reachable but returns Err on
                         // 403, which is a denial and keeps the auth code.
-                        if err.is_auth_error() {
-                            auth_error = true;
-                        }
-                        all_ok = false;
+                        worst = worst.max(if err.is_auth_error() {
+                            Worst::Denied
+                        } else {
+                            Worst::Failed
+                        });
                     }
                 },
                 Err(err) => {
                     let _ = writeln!(out, "  FAIL  {name} -- {err}");
-                    if matches!(err.exit_code(), ExitCode::AuthError) {
-                        auth_error = true;
-                    }
-                    all_ok = false;
+                    worst = worst.max(if matches!(err.exit_code(), ExitCode::AuthError) {
+                        Worst::Denied
+                    } else {
+                        Worst::Failed
+                    });
                 }
             }
         }
     }
 
-    Ok(classify(config_error, all_ok, auth_error))
+    Ok(worst.exit_code())
 }
 
 /// Pick the exit code for a completed check.
 ///
 /// Ordered by which cause the operator has to fix first: an unreadable config
 /// outranks a denial, which outranks a generic failure.
-fn classify(config_error: bool, all_ok: bool, auth_error: bool) -> ExitCode {
-    if config_error {
-        ExitCode::ConfigError
-    } else if all_ok {
-        ExitCode::Success
-    } else if auth_error {
-        ExitCode::AuthError
-    } else {
-        ExitCode::PartialFailure
+/// The worst thing a credential check ran into.
+///
+/// Ordered by which cause the operator has to fix first, so folding is
+/// `max` and the precedence lives in the type rather than an if-chain.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Worst {
+    /// Every registry answered.
+    #[default]
+    Clean,
+    /// A registry failed for a reason that is not a denial.
+    Failed,
+    /// Credentials were rejected.
+    Denied,
+    /// A config file could not be read at all.
+    Unreadable,
+}
+
+impl Worst {
+    fn exit_code(self) -> ExitCode {
+        match self {
+            Self::Clean => ExitCode::Success,
+            Self::Failed => ExitCode::PartialFailure,
+            Self::Denied => ExitCode::AuthError,
+            Self::Unreadable => ExitCode::ConfigError,
+        }
     }
 }
 
@@ -143,17 +156,15 @@ mod tests {
     /// into the generic partial failure.
     #[test]
     fn auth_failures_outrank_a_generic_partial_failure() {
-        assert_eq!(
-            classify(false, false, true),
-            ExitCode::AuthError,
-            "a denial reports as one"
-        );
-        assert_eq!(
-            classify(true, false, true),
-            ExitCode::ConfigError,
-            "a broken config is the cause to fix first"
-        );
-        assert_eq!(classify(false, false, false), ExitCode::PartialFailure);
-        assert_eq!(classify(false, true, false), ExitCode::Success);
+        assert_eq!(Worst::Denied.exit_code(), ExitCode::AuthError);
+        assert_eq!(Worst::Unreadable.exit_code(), ExitCode::ConfigError);
+        assert_eq!(Worst::Failed.exit_code(), ExitCode::PartialFailure);
+        assert_eq!(Worst::Clean.exit_code(), ExitCode::Success);
+
+        // The ordering is the precedence: a broken config is the cause to fix
+        // before a denial, and a denial before a generic failure.
+        assert!(Worst::Unreadable > Worst::Denied);
+        assert!(Worst::Denied > Worst::Failed);
+        assert!(Worst::Failed > Worst::Clean);
     }
 }

--- a/src/cli/commands/dry_run.rs
+++ b/src/cli/commands/dry_run.rs
@@ -6,6 +6,8 @@ use std::collections::HashSet;
 use std::io::{self, Write};
 
 use ocync_sync::engine::{ResolvedMapping, TagPair};
+
+use crate::cli::commands::synchronize::{DroppedTarget, UnresolvedMapping};
 use ocync_sync::filter::{DropKind, FilterReport};
 
 /// Default sample cap per drop reason and per include-rescue list. Removed
@@ -17,20 +19,45 @@ const SAMPLE_CAP: usize = 5;
 ///
 /// `verbose` is the global `cli.verbose >= 1` toggle; when true, all
 /// rejected tags per drop reason are printed (no sample cap).
-pub(crate) fn print(mappings: &[ResolvedMapping], verbose: bool) {
+pub(crate) fn print(
+    mappings: &[ResolvedMapping],
+    unresolved: &[UnresolvedMapping],
+    dropped: &[DroppedTarget],
+    verbose: bool,
+) {
     let stdout = io::stdout();
     let mut handle = stdout.lock();
     // Stdout write errors during dry-run are almost always SIGPIPE (e.g.
     // `ocync sync --dry-run | head`). Swallow them: the user explicitly
     // asked us to stop writing.
-    let _ = write_to(&mut handle, mappings, verbose);
+    let _ = write_to(&mut handle, mappings, unresolved, dropped, verbose);
 }
 
 pub(crate) fn write_to<W: Write>(
     w: &mut W,
     mappings: &[ResolvedMapping],
+    unresolved: &[UnresolvedMapping],
+    dropped: &[DroppedTarget],
     verbose: bool,
 ) -> io::Result<()> {
+    // Written before the plan: the plan describes what a sync would do, and
+    // these are the parts of the config it could not describe at all. Without
+    // them a wholly denied dry run prints "no mappings to sync", which reads
+    // as a filter problem while the exit code reports a credential failure.
+    for u in unresolved {
+        writeln!(w, "dry-run: {} -- UNRESOLVED: {}", u.from, u.error)?;
+    }
+    for d in dropped {
+        writeln!(
+            w,
+            "dry-run: {} -- target {} unreachable: {}",
+            d.from, d.registry, d.error
+        )?;
+    }
+    if !unresolved.is_empty() || !dropped.is_empty() {
+        writeln!(w)?;
+    }
+
     if mappings.is_empty() {
         writeln!(w, "dry-run: no mappings to sync")?;
         return Ok(());
@@ -311,8 +338,31 @@ mod tests {
 
     #[test]
     fn empty_mappings_emits_no_mappings_message() {
-        let out = capture(|w| write_to(w, &[], false));
+        let out = capture(|w| write_to(w, &[], &[], &[], false));
         assert_eq!(out, "dry-run: no mappings to sync\n");
+    }
+
+    /// A wholly denied dry run must say so. Printing only "no mappings to
+    /// sync" reads as a filter problem while the exit code reports a
+    /// credential failure.
+    #[test]
+    fn unresolved_mappings_are_named_before_the_plan() {
+        let unresolved = [UnresolvedMapping {
+            from: "library/nginx".into(),
+            error: "registry error: 403 Forbidden".into(),
+            code: crate::cli::ExitCode::AuthError,
+        }];
+        let dropped = [DroppedTarget {
+            from: "library/alpine".into(),
+            registry: "backup".into(),
+            error: "unavailable".into(),
+        }];
+
+        let out = capture(|w| write_to(w, &[], &unresolved, &dropped, false));
+
+        assert!(out.contains("library/nginx"), "{out}");
+        assert!(out.contains("403 Forbidden"), "{out}");
+        assert!(out.contains("target backup unreachable"), "{out}");
     }
 
     #[test]

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use ocync_distribution::auth::detect::{ProviderKind, detect_provider_kind};
 use ocync_distribution::ecr::{BatchBlobChecker, BatchChecker};
@@ -20,6 +20,7 @@ use ocync_sync::filter::{FilterConfig, build_glob_set, is_referrers_fallback_tag
 use ocync_sync::retry::RetryConfig;
 use ocync_sync::shutdown::ShutdownSignal;
 use ocync_sync::staging::BlobStage;
+use serde::Serialize;
 
 use crate::SyncArgs;
 use crate::cli::config::{
@@ -39,6 +40,21 @@ const CACHE_FILE_NAME: &str = "transfer_state.bin";
 /// example data without overwhelming the log line.
 const NO_TAGS_SAMPLE_CAP: usize = 5;
 
+/// Minimum gap between progress lines while mappings are being resolved.
+///
+/// Resolution is sequential and network-bound - one tag listing per mapping -
+/// so a large config can spend minutes here before the engine starts and the
+/// first per-image line appears. Emitting on a timer rather than per mapping
+/// keeps fast configs silent and slow ones legible.
+const RESOLVE_PROGRESS_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Registry clients keyed by config alias.
+///
+/// A registry whose auth provider could not be built is stored as its error
+/// text rather than dropped, so the failure surfaces only on the mappings
+/// that actually reference it.
+pub(crate) type ClientMap = HashMap<String, Result<Arc<RegistryClient>, String>>;
+
 /// Outcome of resolving a single mapping. Either the mapping is ready for the
 /// engine, or no source tag survived filtering and the caller decides whether
 /// to log a WARN (sync mode: always; watch mode: only on transition).
@@ -51,6 +67,25 @@ const NO_TAGS_SAMPLE_CAP: usize = 5;
 pub(crate) enum MappingResolution {
     Resolved(ResolvedMapping),
     NoMatchingTags(NoTagsInfo),
+}
+
+/// A mapping that never became transferable work.
+///
+/// Resolution failures are per-mapping: an unreachable registry or a 403 on
+/// one repository's tag listing must not stop the mappings behind it.
+#[derive(Debug, Serialize)]
+pub(crate) struct MappingFailure {
+    /// Source repository path from the mapping config.
+    pub from: String,
+    /// Why the mapping could not be resolved.
+    pub error: String,
+    /// Whether the cause was an authentication or authorization failure.
+    ///
+    /// Kept out of the JSON document -- it exists only so a run where every
+    /// mapping was denied still exits with the dedicated auth code that a
+    /// run-wide abort used to produce.
+    #[serde(skip)]
+    pub auth: bool,
 }
 
 /// Diagnostic context for a mapping whose filter rejected every source tag.
@@ -251,24 +286,17 @@ pub(crate) async fn run(
 ) -> Result<ExitCode, CliError> {
     let config = load_config(&args.config)?;
 
-    let clients = build_clients(&config).await?;
-    let batch_checkers = build_batch_checkers(&config).await?;
+    let clients = build_clients(&config).await;
+    let batch_checkers = build_batch_checkers(&config).await;
 
-    let mut mappings = Vec::new();
-    for mapping in &config.mappings {
-        match resolve_mapping(mapping, &config, &clients, &batch_checkers, args.dry_run).await? {
-            MappingResolution::Resolved(resolved) => mappings.push(resolved),
-            MappingResolution::NoMatchingTags(info) => {
-                let should_warn = match watch_log.as_mut() {
-                    Some(state) => state.observe_no_match(&info.from),
-                    None => true,
-                };
-                if should_warn {
-                    emit_no_tags_warn(&info);
-                }
-            }
-        }
-    }
+    let (mappings, unresolved) = resolve_all(
+        &config,
+        &clients,
+        &batch_checkers,
+        args.dry_run,
+        watch_log.as_deref_mut(),
+    )
+    .await;
 
     if let Some(state) = watch_log.as_mut() {
         for resolved in &mappings {
@@ -285,7 +313,7 @@ pub(crate) async fn run(
 
     if args.dry_run {
         crate::cli::commands::dry_run::print(&mappings, verbose);
-        return Ok(ExitCode::Success);
+        return Ok(dry_run_exit_code(mappings.len(), unresolved.len()));
     }
 
     let (cache_dir, cache_path) = resolve_cache_path(&config, &args.config);
@@ -372,16 +400,55 @@ pub(crate) async fn run(
     emit_mapping_outcomes(&descriptors, &report, watch_log.as_deref_mut());
     // Watch mode: suppress the cycle tail when no per-mapping line emitted
     // (steady-state idle); sync mode: always emit as the final marker.
-    let cycle_had_activity = watch_log
-        .as_deref()
-        .is_none_or(|s| s.cycle_emit_count() > 0);
+    // Unresolved mappings always force the tail -- they produce no per-mapping
+    // line, so without this a cycle where every mapping 403'd would go quiet.
+    let cycle_had_activity = !unresolved.is_empty()
+        || watch_log
+            .as_deref()
+            .is_none_or(|s| s.cycle_emit_count() > 0);
     if cycle_had_activity {
-        emit_cycle_tail(&descriptors, &report);
+        emit_cycle_tail(&descriptors, unresolved.len(), &report);
     }
 
-    write_output(&report, args.json)?;
+    write_output(&report, &unresolved, args.json)?;
 
-    Ok(ExitCode::from_report(report.exit_code()))
+    Ok(combined_exit_code(&report, &unresolved))
+}
+
+/// Exit code for a dry run, which produces no [`SyncReport`] to fold into.
+fn dry_run_exit_code(resolved: usize, unresolved: usize) -> ExitCode {
+    match (resolved, unresolved) {
+        (_, 0) => ExitCode::Success,
+        (0, _) => ExitCode::Failure,
+        _ => ExitCode::PartialFailure,
+    }
+}
+
+/// Fold mapping-level resolution failures into the run's exit code.
+///
+/// A mapping that never reached the engine produces no [`ocync_sync::ImageResult`],
+/// so [`SyncReport::exit_code`] cannot see it. Counting each as a failure is
+/// what keeps a run whose mappings all 403'd from exiting 0.
+fn combined_exit_code(report: &SyncReport, unresolved: &[MappingFailure]) -> ExitCode {
+    if unresolved.is_empty() {
+        return ExitCode::from_report(report.exit_code());
+    }
+    let has_success = report.images.iter().any(|i| {
+        matches!(
+            i.status,
+            ocync_sync::ImageStatus::Synced | ocync_sync::ImageStatus::Skipped { .. }
+        )
+    });
+    if has_success {
+        return ExitCode::PartialFailure;
+    }
+    // Nothing ran and every mapping was denied. Before failures were isolated
+    // the first 403 aborted the run with the dedicated auth code; keep that
+    // code here so pipelines alerting on it still fire.
+    if report.images.is_empty() && unresolved.iter().all(|f| f.auth) {
+        return ExitCode::AuthError;
+    }
+    ExitCode::Failure
 }
 
 /// Per-mapping metadata captured before the engine consumes `mappings`,
@@ -522,25 +589,37 @@ fn format_mapping_outcome(d: &MappingDescriptor, o: &MappingOutcome, recovered: 
 
 /// One-line cycle tail rolling up totals across all mappings. The caller
 /// is responsible for gating this in watch mode (skip on idle cycles).
-fn emit_cycle_tail(descriptors: &[MappingDescriptor], report: &SyncReport) {
+fn emit_cycle_tail(descriptors: &[MappingDescriptor], unresolved: usize, report: &SyncReport) {
+    let line = format_cycle_tail(descriptors.len(), unresolved, report);
+    // Counts are already in the message; structured fields would be a
+    // verbatim restatement in text output. JSON aggregators parse the
+    // message (or use the SyncReport via `--json`).
+    if report.stats.images_failed > 0 || unresolved > 0 {
+        tracing::warn!("{line}");
+    } else {
+        tracing::info!("{line}");
+    }
+}
+
+/// Render the cycle tail. Split from [`emit_cycle_tail`] so the wording is
+/// testable without a tracing subscriber.
+fn format_cycle_tail(mapping_count: usize, unresolved: usize, report: &SyncReport) -> String {
     let s = &report.stats;
-    let line = format!(
-        "summary: {} mappings | {} synced, {} skipped, {} failed | {} in {}",
-        descriptors.len(),
+    // Unresolved mappings never reached the engine, so they are absent from
+    // every count above and need their own clause.
+    let unresolved_clause = if unresolved > 0 {
+        format!(" | {unresolved} unresolved")
+    } else {
+        String::new()
+    };
+    format!(
+        "summary: {mapping_count} mappings | {} synced, {} skipped, {} failed{unresolved_clause} | {} in {}",
         s.images_synced,
         s.images_skipped,
         s.images_failed,
         format_bytes(s.bytes_transferred),
         format_duration(report.duration),
-    );
-    // Counts are already in the message; structured fields would be a
-    // verbatim restatement in text output. JSON aggregators parse the
-    // message (or use the SyncReport via `--json`).
-    if s.images_failed > 0 {
-        tracing::warn!("{line}");
-    } else {
-        tracing::info!("{line}");
-    }
+    )
 }
 
 /// Parse a human-readable duration string into a [`Duration`].
@@ -602,16 +681,48 @@ fn parse_size(s: &str) -> Option<u64> {
 }
 
 /// Build a `RegistryClient` for each named registry in config, keyed by name.
-pub(crate) async fn build_clients(
-    config: &Config,
-) -> Result<HashMap<String, Arc<RegistryClient>>, CliError> {
-    let mut clients = HashMap::with_capacity(config.registries.len());
+///
+/// Auth setup reaches the network (ECR, GAR, ACR all mint a token), so any one
+/// registry can fail. Record the failure against that alias instead of
+/// aborting: registries the failing one shares no mapping with still sync, and
+/// the mappings that do reference it fail with the original error text.
+pub(crate) async fn build_clients(config: &Config) -> ClientMap {
+    let mut clients = ClientMap::with_capacity(config.registries.len());
     for (name, reg) in &config.registries {
         let hostname = bare_hostname(&reg.url);
-        let client = build_registry_client(hostname, Some(reg)).await?;
-        clients.insert(name.clone(), Arc::new(client));
+        let entry = match build_registry_client(hostname, Some(reg)).await {
+            Ok(client) => Ok(Arc::new(client)),
+            Err(err) => {
+                tracing::error!(
+                    registry = %name,
+                    error = %err,
+                    "registry client setup failed; mappings using this registry will be skipped"
+                );
+                Err(err.to_string())
+            }
+        };
+        clients.insert(name.clone(), entry);
     }
-    Ok(clients)
+    clients
+}
+
+/// Look up a usable client for `name`, turning a missing or failed registry
+/// into a mapping-scoped error rather than a run-wide one.
+fn client_for(
+    clients: &ClientMap,
+    name: &str,
+    mapping_from: &str,
+    role: &str,
+) -> Result<Arc<RegistryClient>, CliError> {
+    match clients.get(name) {
+        Some(Ok(client)) => Ok(Arc::clone(client)),
+        Some(Err(err)) => Err(CliError::Input(format!(
+            "mapping '{mapping_from}': {role} registry '{name}' is unavailable: {err}"
+        ))),
+        None => Err(CliError::Input(format!(
+            "mapping '{mapping_from}': {role} registry '{name}' not found in clients"
+        ))),
+    }
 }
 
 /// Build batch blob checkers for ECR registries.
@@ -619,9 +730,7 @@ pub(crate) async fn build_clients(
 /// Automatically creates a [`BatchChecker`] for every registry detected
 /// as ECR (via explicit `auth_type: ecr` or hostname auto-detection). No
 /// user configuration is needed - if we know it's ECR, we use the batch API.
-async fn build_batch_checkers(
-    config: &Config,
-) -> Result<HashMap<String, Rc<dyn BatchBlobChecker>>, CliError> {
+async fn build_batch_checkers(config: &Config) -> HashMap<String, Rc<dyn BatchBlobChecker>> {
     let mut checkers: HashMap<String, Rc<dyn BatchBlobChecker>> = HashMap::new();
 
     for (name, reg) in &config.registries {
@@ -640,13 +749,84 @@ async fn build_batch_checkers(
             continue;
         }
 
-        let checker = BatchChecker::from_hostname(hostname, reg.aws_profile.as_deref())
-            .await
-            .map_err(|e| CliError::Input(format!("ECR batch checker for '{name}': {e}")))?;
-        checkers.insert(name.clone(), Rc::new(checker));
+        // The checker only gates the manifest commit on ECR's blob-visibility
+        // API. Losing it costs an optimization, not correctness -- `with_retry`
+        // still catches the `BLOB_UPLOAD_UNKNOWN` this would have avoided -- so
+        // a failure here degrades rather than aborting the run.
+        match BatchChecker::from_hostname(hostname, reg.aws_profile.as_deref()).await {
+            Ok(checker) => {
+                checkers.insert(name.clone(), Rc::new(checker));
+            }
+            Err(e) => tracing::warn!(
+                registry = %name,
+                error = %e,
+                "ECR batch checker unavailable; manifest commits fall back to retry-on-conflict"
+            ),
+        }
     }
 
-    Ok(checkers)
+    checkers
+}
+
+/// Resolve every configured mapping, isolating per-mapping failures.
+///
+/// One unreachable registry, one 403 on a tag listing, or one bad repository
+/// name must not cost the run every other mapping. Each failure is logged and
+/// recorded; resolution continues. Returns the mappings that are ready for the
+/// engine plus one [`MappingFailure`] per mapping that is not.
+async fn resolve_all(
+    config: &Config,
+    clients: &ClientMap,
+    batch_checkers: &HashMap<String, Rc<dyn BatchBlobChecker>>,
+    with_report: bool,
+    mut watch_log: Option<&mut WatchLogState>,
+) -> (Vec<ResolvedMapping>, Vec<MappingFailure>) {
+    let total = config.mappings.len();
+    let started = Instant::now();
+    let mut last_progress = started;
+    let mut resolved = Vec::new();
+    let mut failures = Vec::new();
+
+    for (index, mapping) in config.mappings.iter().enumerate() {
+        match resolve_mapping(mapping, config, clients, batch_checkers, with_report).await {
+            Ok(MappingResolution::Resolved(m)) => resolved.push(m),
+            Ok(MappingResolution::NoMatchingTags(info)) => {
+                let should_warn = match watch_log.as_deref_mut() {
+                    Some(state) => state.observe_no_match(&info.from),
+                    None => true,
+                };
+                if should_warn {
+                    emit_no_tags_warn(&info);
+                }
+            }
+            Err(err) => {
+                tracing::error!(
+                    from = %mapping.from,
+                    error = %err,
+                    "mapping could not be resolved; continuing with the remaining mappings"
+                );
+                failures.push(MappingFailure {
+                    from: mapping.from.clone(),
+                    auth: matches!(err.exit_code(), ExitCode::AuthError),
+                    error: err.to_string(),
+                });
+            }
+        }
+
+        // Timer-gated so a config that resolves in a second stays silent while
+        // one that takes minutes reports where it is.
+        if index + 1 < total && last_progress.elapsed() >= RESOLVE_PROGRESS_INTERVAL {
+            tracing::info!(
+                resolved = index + 1,
+                total,
+                elapsed_secs = started.elapsed().as_secs(),
+                "resolving mappings"
+            );
+            last_progress = Instant::now();
+        }
+    }
+
+    (resolved, failures)
 }
 
 /// Resolve a single mapping config into a [`MappingResolution`].
@@ -658,7 +838,7 @@ async fn build_batch_checkers(
 pub(crate) async fn resolve_mapping(
     mapping: &MappingConfig,
     config: &Config,
-    clients: &HashMap<String, Arc<RegistryClient>>,
+    clients: &ClientMap,
     batch_checkers: &HashMap<String, Rc<dyn BatchBlobChecker>>,
     with_report: bool,
 ) -> Result<MappingResolution, CliError> {
@@ -674,12 +854,7 @@ pub(crate) async fn resolve_mapping(
             ))
         })?;
 
-    let source_client = clients.get(source_name).cloned().ok_or_else(|| {
-        CliError::Input(format!(
-            "mapping '{}': source registry '{}' not found in clients",
-            mapping.from, source_name,
-        ))
-    })?;
+    let source_client = client_for(clients, source_name, &mapping.from, "source")?;
 
     // --- Target registries ---
     let targets_value = mapping
@@ -701,12 +876,7 @@ pub(crate) async fn resolve_mapping(
     let mut targets: Vec<TargetEntry> = target_names
         .into_iter()
         .map(|name| {
-            let client = clients.get(&name).cloned().ok_or_else(|| {
-                CliError::Input(format!(
-                    "mapping '{}': target registry '{}' not found in clients",
-                    mapping.from, name,
-                ))
-            })?;
+            let client = client_for(clients, &name, &mapping.from, "target")?;
             let batch_checker = batch_checkers.get(&name).cloned();
             Ok(TargetEntry {
                 name: RegistryAlias::new(name),
@@ -987,10 +1157,38 @@ fn describe_filter(
     build_filter(mapping_tags, defaults_tags).describe()
 }
 
+/// The `--json` document: the engine's report plus the mappings that never
+/// reached it.
+///
+/// Without the extra key a consumer that only reads the report would see a
+/// clean run when mappings were dropped before the engine started.
+#[derive(Serialize)]
+struct SyncOutput<'a> {
+    #[serde(flatten)]
+    report: &'a SyncReport,
+    /// Mappings dropped during resolution. Absent when every mapping resolved,
+    /// so the document shape is unchanged on a clean run.
+    #[serde(skip_serializing_if = "slice_is_empty")]
+    unresolved_mappings: &'a [MappingFailure],
+}
+
+/// Serde predicate for a borrowed slice field.
+fn slice_is_empty<T>(s: &&[T]) -> bool {
+    s.is_empty()
+}
+
 /// Write sync output as JSON when `--json` is passed.
-fn write_output(report: &SyncReport, json: bool) -> Result<(), CliError> {
+fn write_output(
+    report: &SyncReport,
+    unresolved: &[MappingFailure],
+    json: bool,
+) -> Result<(), CliError> {
     if json {
-        let json = serde_json::to_string_pretty(report)
+        let output = SyncOutput {
+            report,
+            unresolved_mappings: unresolved,
+        };
+        let json = serde_json::to_string_pretty(&output)
             .map_err(|e| CliError::Input(format!("failed to serialize report: {e}")))?;
         println!("{json}");
     }
@@ -2088,6 +2286,288 @@ include: ["1.25.0-rc1"]
         assert_eq!(candidate_count, Some(2));
         let report = report.expect("dry-run path returns report even when min_tags would error");
         assert_eq!(report.min_tags, Some(10));
+    }
+
+    // -----------------------------------------------------------------
+    // Failure isolation
+    // -----------------------------------------------------------------
+
+    /// Config with three mappings; the middle one names a registry that does
+    /// not exist. Tag selection uses literal globs so resolution never touches
+    /// the network.
+    fn three_mapping_config() -> Config {
+        serde_yaml::from_str(
+            r#"
+registries:
+  src:
+    url: source.test
+  dst:
+    url: target.test
+defaults:
+  source: src
+  targets: [dst]
+mappings:
+  - from: repo/one
+    tags:
+      glob: ["v1"]
+  - from: repo/two
+    source: nonexistent
+    tags:
+      glob: ["v1"]
+  - from: repo/three
+    tags:
+      glob: ["v1"]
+"#,
+        )
+        .expect("config yaml parses")
+    }
+
+    fn test_client(url: &str) -> Arc<RegistryClient> {
+        Arc::new(
+            ocync_distribution::RegistryClientBuilder::new(url::Url::parse(url).unwrap())
+                .build()
+                .unwrap(),
+        )
+    }
+
+    fn working_clients() -> ClientMap {
+        ClientMap::from([
+            ("src".to_string(), Ok(test_client("https://source.test"))),
+            ("dst".to_string(), Ok(test_client("https://target.test"))),
+        ])
+    }
+
+    /// A mapping that cannot be resolved must not cost the run the mappings
+    /// behind it. Before this, the first failure `?`-returned out of `run` and
+    /// every later mapping was silently dropped.
+    #[tokio::test]
+    async fn resolve_all_isolates_a_failing_mapping() {
+        let config = three_mapping_config();
+        let (resolved, failures) =
+            resolve_all(&config, &working_clients(), &HashMap::new(), false, None).await;
+
+        assert_eq!(failures.len(), 1, "only the bad mapping should fail");
+        assert_eq!(failures[0].from, "repo/two");
+
+        // The negative half: the mapping *after* the failure still resolved.
+        let names: Vec<&str> = resolved.iter().map(|m| m.source_repo.as_str()).collect();
+        assert_eq!(names, vec!["repo/one", "repo/three"]);
+    }
+
+    /// A registry whose client could not be built fails only the mappings that
+    /// reference it, and the original setup error reaches the caller.
+    #[tokio::test]
+    async fn resolve_all_scopes_a_failed_registry_to_its_mappings() {
+        let config: Config = serde_yaml::from_str(
+            r#"
+registries:
+  src:
+    url: source.test
+  broken:
+    url: broken.test
+  dst:
+    url: target.test
+defaults:
+  source: src
+  targets: [dst]
+mappings:
+  - from: repo/one
+    tags:
+      glob: ["v1"]
+  - from: repo/two
+    source: broken
+    tags:
+      glob: ["v1"]
+"#,
+        )
+        .expect("config yaml parses");
+
+        let clients = ClientMap::from([
+            ("src".to_string(), Ok(test_client("https://source.test"))),
+            (
+                "broken".to_string(),
+                Err("ECR auth setup for 'broken.test': 403 Forbidden".to_string()),
+            ),
+            ("dst".to_string(), Ok(test_client("https://target.test"))),
+        ]);
+
+        let (resolved, failures) =
+            resolve_all(&config, &clients, &HashMap::new(), false, None).await;
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].source_repo.as_str(), "repo/one");
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].from, "repo/two");
+        assert!(
+            failures[0].error.contains("403 Forbidden"),
+            "the setup error must survive to the mapping failure: {}",
+            failures[0].error
+        );
+    }
+
+    /// Every mapping resolving means no failures recorded -- the isolation
+    /// path must not manufacture failures on a clean config.
+    #[tokio::test]
+    async fn resolve_all_reports_no_failures_when_all_mappings_resolve() {
+        let config: Config = serde_yaml::from_str(
+            r#"
+registries:
+  src:
+    url: source.test
+  dst:
+    url: target.test
+defaults:
+  source: src
+  targets: [dst]
+mappings:
+  - from: repo/one
+    tags:
+      glob: ["v1"]
+"#,
+        )
+        .expect("config yaml parses");
+
+        let (resolved, failures) =
+            resolve_all(&config, &working_clients(), &HashMap::new(), false, None).await;
+
+        assert_eq!(resolved.len(), 1);
+        assert!(failures.is_empty());
+    }
+
+    // -----------------------------------------------------------------
+    // Exit codes
+    // -----------------------------------------------------------------
+
+    fn report_from(statuses: Vec<ocync_sync::ImageStatus>) -> SyncReport {
+        report_with(
+            statuses
+                .into_iter()
+                .map(|status| img("src/repo:v1", "dst/repo:v1", status, 0))
+                .collect(),
+        )
+    }
+
+    fn failure(from: &str, auth: bool) -> MappingFailure {
+        MappingFailure {
+            from: from.into(),
+            error: "boom".into(),
+            auth,
+        }
+    }
+
+    /// An unresolved mapping produces no `ImageResult`, so the report alone
+    /// would score the run a clean success. It must not.
+    #[test]
+    fn combined_exit_code_downgrades_a_clean_report_with_unresolved_mappings() {
+        let report = report_from(vec![ocync_sync::ImageStatus::Synced]);
+        assert_eq!(combined_exit_code(&report, &[]), ExitCode::Success);
+        assert_eq!(
+            combined_exit_code(&report, &[failure("repo/two", false)]),
+            ExitCode::PartialFailure
+        );
+    }
+
+    /// Nothing synced and mappings unresolved is a total failure, not partial.
+    #[test]
+    fn combined_exit_code_is_failure_when_nothing_succeeded() {
+        let empty = report_with(Vec::new());
+        let failures = [failure("repo/one", false), failure("repo/two", true)];
+        assert_eq!(combined_exit_code(&empty, &failures), ExitCode::Failure);
+    }
+
+    /// A skipped image still counts as the run having done its job, so an
+    /// unresolved mapping alongside it is a partial failure.
+    #[test]
+    fn combined_exit_code_treats_skipped_images_as_success() {
+        let report = report_from(vec![ocync_sync::ImageStatus::Skipped {
+            reason: ocync_sync::SkipReason::DigestMatch,
+        }]);
+        assert_eq!(
+            combined_exit_code(&report, &[failure("repo/two", false)]),
+            ExitCode::PartialFailure
+        );
+    }
+
+    /// Isolating failures must not silently retire the auth exit code: a run
+    /// denied everywhere still reports 4, not the generic 2.
+    #[test]
+    fn combined_exit_code_keeps_the_auth_code_when_every_mapping_was_denied() {
+        let empty = report_with(Vec::new());
+        let denied = [failure("repo/one", true), failure("repo/two", true)];
+        assert_eq!(combined_exit_code(&empty, &denied), ExitCode::AuthError);
+    }
+
+    /// One non-auth failure in the set is enough to make it a generic failure.
+    #[test]
+    fn combined_exit_code_does_not_claim_auth_for_a_mixed_failure_set() {
+        let empty = report_with(Vec::new());
+        let mixed = [failure("repo/one", true), failure("repo/two", false)];
+        assert_eq!(combined_exit_code(&empty, &mixed), ExitCode::Failure);
+    }
+
+    #[test]
+    fn dry_run_exit_code_maps_resolution_counts() {
+        assert_eq!(dry_run_exit_code(3, 0), ExitCode::Success);
+        assert_eq!(dry_run_exit_code(2, 1), ExitCode::PartialFailure);
+        assert_eq!(dry_run_exit_code(0, 1), ExitCode::Failure);
+    }
+
+    // -----------------------------------------------------------------
+    // Reporting surfaces
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn cycle_tail_names_unresolved_mappings() {
+        let report = report_with(Vec::new());
+        let line = format_cycle_tail(4, 2, &report);
+        assert!(line.contains("2 unresolved"), "{line}");
+    }
+
+    #[test]
+    fn cycle_tail_omits_the_clause_when_everything_resolved() {
+        let report = report_with(Vec::new());
+        let line = format_cycle_tail(4, 0, &report);
+        assert!(!line.contains("unresolved"), "{line}");
+    }
+
+    /// `--json` consumers must be able to see mappings that never reached the
+    /// engine; otherwise the isolation change hides failures from automation.
+    #[test]
+    fn json_output_carries_unresolved_mappings() {
+        let report = report_with(Vec::new());
+        let failures = vec![MappingFailure {
+            from: "repo/two".into(),
+            error: "403 Forbidden".into(),
+            auth: true,
+        }];
+        let value = serde_json::to_value(SyncOutput {
+            report: &report,
+            unresolved_mappings: &failures,
+        })
+        .expect("serializes");
+
+        assert_eq!(value["unresolved_mappings"][0]["from"], "repo/two");
+        assert_eq!(value["unresolved_mappings"][0]["error"], "403 Forbidden");
+        // The auth flag drives the exit code only; it is not part of the document.
+        assert!(
+            value["unresolved_mappings"][0].get("auth").is_none(),
+            "{value}"
+        );
+        // Flattened, not nested: the report's own keys stay at the top level.
+        assert!(value.get("stats").is_some(), "{value}");
+    }
+
+    /// The key is absent on a clean run so the document shape is unchanged.
+    #[test]
+    fn json_output_omits_unresolved_mappings_when_empty() {
+        let report = report_with(Vec::new());
+        let value = serde_json::to_value(SyncOutput {
+            report: &report,
+            unresolved_mappings: &[],
+        })
+        .expect("serializes");
+
+        assert!(value.get("unresolved_mappings").is_none(), "{value}");
     }
 
     /// Full wire-up: `select_filtered_tags` + `ResolvedMapping` construction +

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -54,9 +54,12 @@ const PREPARE_PROGRESS_INTERVAL: Duration = Duration::from_secs(5);
 /// A step of the pre-engine phase.
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) enum PreparePhase {
+    /// Building a client per referenced registry.
     #[default]
     Registries,
+    /// Building an ECR blob-visibility checker per target registry.
     BatchCheckers,
+    /// Listing and filtering tags, one mapping at a time.
     Mappings,
 }
 
@@ -205,9 +208,8 @@ impl fmt::Display for RegistryRole {
 /// the disparity instead of the allocation traffic.
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum MappingResolution {
-    /// Ready for the engine, plus any target dropped along the way.
-    Resolved(ResolvedMapping, Vec<DroppedTarget>),
-    NoMatchingTags(NoTagsInfo, Vec<DroppedTarget>),
+    Resolved(ResolvedMapping),
+    NoMatchingTags(NoTagsInfo),
 }
 
 /// A target a mapping could not use.
@@ -235,13 +237,29 @@ pub(crate) struct UnresolvedMapping {
     pub from: String,
     /// Why the mapping could not be resolved.
     pub error: String,
-    /// Whether the cause was an authentication or authorization failure.
+    /// What the failure would have exited with had it aborted the run.
     ///
-    /// Kept out of the JSON document -- it exists only so a run where every
-    /// mapping was denied still exits with the dedicated auth code that a
-    /// run-wide abort used to produce.
+    /// Kept out of the JSON document. A bool would collapse every non-auth
+    /// classification into the generic failure code, retiring exit 3 and with
+    /// it the `min_tags` tripwire, whose whole job is to stop a run.
     #[serde(skip)]
-    pub auth: bool,
+    pub code: ExitCode,
+}
+
+/// Fold a run's failure classifications into one exit code.
+///
+/// A specific code survives only when every failure agrees on it: mixed causes
+/// report the generic failure, because no single one names what to fix.
+pub(crate) fn shared_failure_code(codes: impl IntoIterator<Item = ExitCode>) -> ExitCode {
+    let mut codes = codes.into_iter();
+    let Some(first) = codes.next() else {
+        return ExitCode::Failure;
+    };
+    if matches!(first, ExitCode::AuthError | ExitCode::ConfigError) && codes.all(|c| c == first) {
+        first
+    } else {
+        ExitCode::Failure
+    }
 }
 
 /// Diagnostic context for a mapping whose filter rejected every source tag.
@@ -322,8 +340,10 @@ impl fmt::Display for NoTagsInfo {
 #[derive(Debug, Default)]
 pub(crate) struct WatchLogState {
     warned_no_tags: HashSet<String>,
-    /// `"{mapping}\0{registry}"` for every target currently reported down.
+    /// [`target_key`] for every target currently reported down.
     dropped_targets: HashSet<String>,
+    /// Mappings currently reported as unresolvable.
+    unresolved: HashSet<String>,
     last_outcomes: HashMap<String, MappingOutcome>,
     cycle_emit_count: u32,
 }
@@ -353,20 +373,46 @@ impl WatchLogState {
     /// Keyed on mapping plus registry so two mappings losing the same mirror
     /// each report once, and a second mirror going down still reports.
     fn observe_dropped_target(&mut self, from: &str, registry: &str) -> bool {
-        let changed = self
-            .dropped_targets
-            .insert(format!("{from}\u{0}{registry}"));
+        let changed = self.dropped_targets.insert(target_key(from, registry));
         if changed {
             self.cycle_emit_count = self.cycle_emit_count.saturating_add(1);
         }
         changed
     }
 
-    /// Forget every dropped target for `from`, so a mirror coming back
-    /// re-arms the WARN if it goes down again.
-    fn clear_dropped_targets(&mut self, from: &str) {
-        let prefix = format!("{from}\u{0}");
-        self.dropped_targets.retain(|k| !k.starts_with(&prefix));
+    /// Forget any target of `from` absent from `still_down`, so a mirror that
+    /// recovered warns again if it fails later.
+    ///
+    /// Reconciling rather than clearing wholesale is what makes a partial
+    /// recovery work: clearing only when nothing is down leaves a recovered
+    /// mirror suppressed for as long as any sibling stays down.
+    fn forget_recovered_targets(&mut self, from: &str, still_down: &HashSet<&str>) {
+        let prefix = target_key(from, "");
+        self.dropped_targets
+            .retain(|key| match key.strip_prefix(&prefix) {
+                // Another mapping's key.
+                None => true,
+                Some(registry) => still_down.contains(registry),
+            });
+    }
+
+    /// Record a mapping that could not be resolved. Returns `true` on
+    /// transition into the failure state (caller emits the ERROR).
+    fn observe_mapping_unresolved(&mut self, from: &str) -> bool {
+        // A mapping that stops resolving reports no outcome this cycle, so a
+        // stale entry here would suppress the recovery line when it returns
+        // with identical counts.
+        self.last_outcomes.remove(from);
+        let changed = self.unresolved.insert(from.to_string());
+        if changed {
+            self.cycle_emit_count = self.cycle_emit_count.saturating_add(1);
+        }
+        changed
+    }
+
+    /// Record a mapping that resolved, re-arming its unresolved ERROR.
+    fn observe_mapping_resolved(&mut self, from: &str) {
+        self.unresolved.remove(from);
     }
 
     /// Record a successful resolution. Returns `true` when the mapping was
@@ -414,7 +460,23 @@ impl WatchLogState {
             .retain(|k| active_set.contains(k.as_str()));
         self.last_outcomes
             .retain(|k, _| active_set.contains(k.as_str()));
+        self.unresolved.retain(|k| active_set.contains(k.as_str()));
+        // Composite keys need a prefix split, which is why this cannot join
+        // the retains above. A mapping removed and later re-added would
+        // otherwise keep a stale key and never warn about its dead mirror.
+        self.dropped_targets.retain(|key| {
+            key.split_once('\u{0}')
+                .is_some_and(|(from, _)| active_set.contains(from))
+        });
     }
+}
+
+/// Key a dropped target by mapping and registry.
+///
+/// NUL-separated because neither a repository path nor a registry alias can
+/// contain it, so the split back is unambiguous.
+fn target_key(from: &str, registry: &str) -> String {
+    format!("{from}\u{0}{registry}")
 }
 
 /// Resolve the cache directory and file path from config.
@@ -470,10 +532,10 @@ pub(crate) async fn run(
     // sequential network work with no output of their own. One ticker spans
     // the lot so the run is never silent for longer than the interval.
     let tracker = PrepareTracker::default();
-    let (mappings, unresolved, dropped_targets) = with_prepare_progress(&tracker, async {
+    let resolution = with_prepare_progress(&tracker, async {
         let clients = build_clients(&config, &tracker).await;
         let batch_checkers = build_batch_checkers(&config, &clients, &tracker).await;
-        let (mappings, unresolved, dropped_targets) = resolve_all(
+        resolve_all(
             &config,
             &clients,
             &batch_checkers,
@@ -481,10 +543,15 @@ pub(crate) async fn run(
             watch_log.as_deref_mut(),
             &tracker,
         )
-        .await;
-        (mappings, unresolved, dropped_targets)
+        .await
     })
     .await;
+    let Resolution {
+        resolved: mappings,
+        unresolved,
+        dropped_targets,
+        no_match,
+    } = resolution;
 
     if let Some(state) = watch_log.as_mut() {
         for resolved in &mappings {
@@ -500,9 +567,9 @@ pub(crate) async fn run(
     }
 
     if args.dry_run {
-        crate::cli::commands::dry_run::print(&mappings, verbose);
+        crate::cli::commands::dry_run::print(&mappings, &unresolved, &dropped_targets, verbose);
         return Ok(dry_run_exit_code(
-            mappings.len(),
+            mappings.len() + no_match,
             &unresolved,
             &dropped_targets,
         ));
@@ -570,14 +637,29 @@ pub(crate) async fn run(
     // grouped from the report's per-image outcomes.
     let descriptors: Vec<MappingDescriptor> = mappings
         .iter()
-        .map(|m| MappingDescriptor {
-            from: m.source_repo.as_str().to_string(),
-            target_repo: m.target_repo.as_str().to_string(),
-            target_names: m.targets.iter().map(|t| (*t.name).to_string()).collect(),
+        .map(|m| {
+            let from = m.source_repo.as_str().to_string();
+            MappingDescriptor {
+                target_repo: m.target_repo.as_str().to_string(),
+                target_names: m.targets.iter().map(|t| (*t.name).to_string()).collect(),
+                // Taken from the dropped list rather than `m.targets`, which
+                // is already filtered: without it the bracket disappears at
+                // exactly the moment a registry is missing from it.
+                dropped_names: dropped_targets
+                    .iter()
+                    .filter(|d| d.from == from)
+                    .map(|d| d.registry.clone())
+                    .collect(),
+                from,
+            }
         })
         .collect();
 
-    let engine = SyncEngine::new(RetryConfig::default(), max_concurrent);
+    // Anything dropped before the engine started is absent from the mappings
+    // it sees, and the prune cannot tell that from a deletion.
+    let complete = unresolved.is_empty() && dropped_targets.is_empty();
+    let engine =
+        SyncEngine::new(RetryConfig::default(), max_concurrent).with_cache_pruning(complete);
     let report = engine
         .run(mappings, cache.clone(), staging, progress, shutdown)
         .await;
@@ -610,7 +692,12 @@ pub(crate) async fn run(
 
     write_output(&report, &unresolved, &dropped_targets, args.json)?;
 
-    Ok(combined_exit_code(&report, &unresolved, &dropped_targets))
+    Ok(combined_exit_code(
+        &report,
+        &unresolved,
+        &dropped_targets,
+        no_match,
+    ))
 }
 
 /// Exit code for a dry run, which produces no [`SyncReport`] to fold into.
@@ -644,11 +731,7 @@ fn dry_run_exit_code(
 /// failure code, so an operator can tell "fix the credentials" from "fix
 /// something else" without reading the log.
 fn total_failure_code(unresolved: &[UnresolvedMapping]) -> ExitCode {
-    if !unresolved.is_empty() && unresolved.iter().all(|f| f.auth) {
-        ExitCode::AuthError
-    } else {
-        ExitCode::Failure
-    }
+    shared_failure_code(unresolved.iter().map(|u| u.code))
 }
 
 /// Fold mapping-level resolution failures into the run's exit code.
@@ -660,6 +743,7 @@ fn combined_exit_code(
     report: &SyncReport,
     unresolved: &[UnresolvedMapping],
     dropped: &[DroppedTarget],
+    no_match: usize,
 ) -> ExitCode {
     if unresolved.is_empty() {
         // A dropped target means images never reached a registry the config
@@ -669,7 +753,9 @@ fn combined_exit_code(
             other => other,
         };
     }
-    if report.has_success() {
+    // A mapping whose filter matched nothing is healthy with nothing to do, so
+    // it counts as the run working, even though it contributes no image.
+    if report.has_success() || no_match > 0 {
         return ExitCode::PartialFailure;
     }
     // Images that ran and failed for non-auth reasons make this a generic
@@ -687,6 +773,8 @@ struct MappingDescriptor {
     from: String,
     target_repo: String,
     target_names: Vec<String>,
+    /// Registries the config named that this mapping could not use.
+    dropped_names: Vec<String>,
 }
 
 /// Per-mapping aggregated outcome derived from [`SyncReport.images`].
@@ -805,8 +893,15 @@ fn format_mapping_outcome(d: &MappingDescriptor, o: &MappingOutcome, recovered: 
     // Multi-target mappings need the bracket to disambiguate which targets
     // the line refers to. Single-target mappings: omit -- the destination
     // is already in the `from -> to` arrow.
-    let targets_clause = if d.target_names.len() > 1 {
-        format!(" [{}]", d.target_names.join(", "))
+    // Shown whenever more than one registry was configured, which includes the
+    // case where only one survived: that is precisely when the operator needs
+    // to see which.
+    let targets_clause = if d.target_names.len() + d.dropped_names.len() > 1 {
+        let mut names = d.target_names.join(", ");
+        if !d.dropped_names.is_empty() {
+            names.push_str(&format!(", {} unreachable", d.dropped_names.join(", ")));
+        }
+        format!(" [{names}]")
     } else {
         String::new()
     };
@@ -852,7 +947,12 @@ fn format_cycle_tail(
         String::new()
     };
     let dropped_clause = if dropped_count > 0 {
-        format!(" | {dropped_count} targets dropped")
+        let plural = if dropped_count == 1 {
+            "target"
+        } else {
+            "targets"
+        };
+        format!(" | {dropped_count} {plural} dropped")
     } else {
         String::new()
     };
@@ -975,6 +1075,10 @@ fn referenced_registries(config: &Config) -> HashSet<String> {
             .source
             .as_deref()
             .or(defaults.and_then(|d| d.source.as_deref()))
+            // Only aliases that exist: an unknown one is reported per mapping
+            // during resolution, and counting it here inflates the progress
+            // total past the number of clients actually built.
+            .filter(|name| known.contains(name))
         {
             used.insert(source.to_owned());
         }
@@ -983,6 +1087,17 @@ fn referenced_registries(config: &Config) -> HashSet<String> {
         }
     }
     used
+}
+
+/// Registry aliases named as a target by at least one mapping.
+fn referenced_targets(config: &Config) -> HashSet<String> {
+    let known: HashSet<&str> = config.registries.keys().map(String::as_str).collect();
+    config
+        .mappings
+        .iter()
+        .filter_map(|m| mapping_target_names(m, config, &known).ok())
+        .flatten()
+        .collect()
 }
 
 /// Target registry aliases a mapping names, with groups expanded.
@@ -1040,10 +1155,14 @@ fn client_for(
 
 /// Build batch blob checkers for ECR registries.
 ///
-/// Creates a [`BatchChecker`] for every registry that a mapping references,
-/// whose client built successfully, and that is detected as ECR (via explicit
-/// `auth_type: ecr` or hostname auto-detection). No user configuration is
-/// needed - if we know it's ECR, we use the batch API.
+/// Creates a [`BatchChecker`] for every registry that a mapping names as a
+/// *target*, whose client built successfully, and that is detected as ECR (via
+/// explicit `auth_type: ecr` or hostname auto-detection). No user
+/// configuration is needed - if we know it's ECR, we use the batch API.
+///
+/// Targets only: the map is read in exactly one place, keyed by target alias,
+/// so a checker for a source-only registry is an AWS round trip per cycle that
+/// nothing can consume.
 async fn build_batch_checkers(
     config: &Config,
     clients: &ClientMap,
@@ -1055,10 +1174,13 @@ async fn build_batch_checkers(
     // avoids re-resolving every mapping's target groups a second time. Only
     // registries whose client actually built are worth a checker: the rest
     // have already failed and would just repeat the round trip.
+    let targets = referenced_targets(config);
     let usable: Vec<(&String, &RegistryConfig)> = config
         .registries
         .iter()
-        .filter(|(name, _)| matches!(clients.get(*name), Some(Ok(_))))
+        .filter(|(name, _)| {
+            targets.contains(name.as_str()) && matches!(clients.get(*name), Some(Ok(_)))
+        })
         .collect();
     tracker.begin(PreparePhase::BatchCheckers, usable.len());
     for (name, reg) in usable {
@@ -1098,6 +1220,21 @@ async fn build_batch_checkers(
     checkers
 }
 
+/// What resolving a whole config produced.
+pub(crate) struct Resolution {
+    /// Mappings ready for the engine.
+    pub resolved: Vec<ResolvedMapping>,
+    /// Mappings that produced no work at all.
+    pub unresolved: Vec<UnresolvedMapping>,
+    /// Targets dropped from otherwise usable mappings.
+    pub dropped_targets: Vec<DroppedTarget>,
+    /// Mappings whose filter legitimately matched nothing.
+    ///
+    /// Healthy, but they contribute no images, so without counting them a run
+    /// that was half fine and half denied looks wholly denied.
+    pub no_match: usize,
+}
+
 /// Resolve every configured mapping, isolating per-mapping failures.
 ///
 /// One unreachable registry, one 403 on a tag listing, or one bad repository
@@ -1111,30 +1248,34 @@ async fn resolve_all(
     with_report: bool,
     mut watch_log: Option<&mut WatchLogState>,
     tracker: &PrepareTracker,
-) -> (
-    Vec<ResolvedMapping>,
-    Vec<UnresolvedMapping>,
-    Vec<DroppedTarget>,
-) {
+) -> Resolution {
     tracker.begin(PreparePhase::Mappings, config.mappings.len());
     let mut resolved = Vec::new();
     let mut unresolved = Vec::new();
     let mut dropped_targets = Vec::new();
+    let mut no_match = 0usize;
 
     for mapping in &config.mappings {
-        match resolve_mapping(mapping, config, clients, batch_checkers, with_report).await {
-            Ok(MappingResolution::Resolved(m, dropped)) => {
-                if dropped.is_empty()
-                    && let Some(state) = watch_log.as_deref_mut()
-                {
-                    // Every target back: re-arm so a future outage warns again.
-                    state.clear_dropped_targets(&mapping.from);
+        // Dropped targets come back whatever the outcome, so a mapping that
+        // loses a mirror and then fails on its tag listing still reports the
+        // outage. Reconciled against the previous cycle before anything else,
+        // so a mirror that recovered re-arms even if the mapping then failed.
+        let (outcome, dropped) =
+            resolve_mapping(mapping, config, clients, batch_checkers, with_report).await;
+        reconcile_dropped_targets(&mapping.from, &dropped, watch_log.as_deref_mut());
+        dropped_targets.extend(dropped);
+
+        match outcome {
+            Ok(MappingResolution::Resolved(m)) => {
+                if let Some(state) = watch_log.as_deref_mut() {
+                    state.observe_mapping_resolved(&mapping.from);
                 }
-                report_dropped_targets(&dropped, watch_log.as_deref_mut());
                 resolved.push(m);
-                dropped_targets.extend(dropped);
             }
-            Ok(MappingResolution::NoMatchingTags(info, dropped)) => {
+            Ok(MappingResolution::NoMatchingTags(info)) => {
+                if let Some(state) = watch_log.as_deref_mut() {
+                    state.observe_mapping_resolved(&mapping.from);
+                }
                 let should_warn = match watch_log.as_deref_mut() {
                     Some(state) => state.observe_no_match(&info.from),
                     None => true,
@@ -1142,17 +1283,25 @@ async fn resolve_all(
                 if should_warn {
                     emit_no_tags_warn(&info);
                 }
-                // A mapping whose filter matched nothing can still have lost a
-                // real target. Without this, the same outage reports
-                // differently depending on whether any tag happened to match.
-                report_dropped_targets(&dropped, watch_log.as_deref_mut());
-                dropped_targets.extend(dropped);
+                // A filter that legitimately matches nothing is a healthy
+                // mapping with nothing to do, not a failure.
+                no_match += 1;
             }
             Err(err) => {
-                log_unresolved_mapping(&mapping.from, &err);
+                // Gated like every other watch surface: without it a
+                // permanently broken mapping logs an ERROR every cycle while
+                // `cycle_emit_count` stays at zero, so watch prints "no state
+                // changes" beside the error stream it just produced.
+                let should_log = match watch_log.as_deref_mut() {
+                    Some(state) => state.observe_mapping_unresolved(&mapping.from),
+                    None => true,
+                };
+                if should_log {
+                    log_unresolved_mapping(&mapping.from, &err);
+                }
                 unresolved.push(UnresolvedMapping {
                     from: mapping.from.clone(),
-                    auth: matches!(err.exit_code(), ExitCode::AuthError),
+                    code: err.exit_code(),
                     error: err.to_string(),
                 });
             }
@@ -1160,29 +1309,47 @@ async fn resolve_all(
         tracker.advance();
     }
 
-    (resolved, unresolved, dropped_targets)
+    Resolution {
+        resolved,
+        unresolved,
+        dropped_targets,
+        no_match,
+    }
 }
 
-/// WARN once per target that went down, not once per watch cycle.
+/// WARN once per target that goes down, not once per watch cycle.
 ///
-/// Without the transition gate a permanently dead mirror warns on every cycle
-/// while `cycle_emit_count` stays at zero, so watch prints "no state changes"
-/// beside the warning it just emitted.
-fn report_dropped_targets(dropped: &[DroppedTarget], mut watch_log: Option<&mut WatchLogState>) {
+/// Reconciles rather than accumulates: a mirror that came back is forgotten
+/// even while a sibling stays down, so when it fails again it warns again.
+/// Accumulating suppressed the second outage until every target of the mapping
+/// was simultaneously healthy, which a flapping fleet may never reach.
+fn reconcile_dropped_targets(
+    from: &str,
+    dropped: &[DroppedTarget],
+    watch_log: Option<&mut WatchLogState>,
+) {
+    let Some(state) = watch_log else {
+        for target in dropped {
+            warn_dropped_target(target);
+        }
+        return;
+    };
+    let now: HashSet<&str> = dropped.iter().map(|t| t.registry.as_str()).collect();
+    state.forget_recovered_targets(from, &now);
     for target in dropped {
-        let should_warn = match watch_log.as_deref_mut() {
-            Some(state) => state.observe_dropped_target(&target.from, &target.registry),
-            None => true,
-        };
-        if should_warn {
-            tracing::warn!(
-                from = %target.from,
-                registry = %target.registry,
-                error = %target.error,
-                "target registry unavailable; syncing the mapping's remaining targets"
-            );
+        if state.observe_dropped_target(from, &target.registry) {
+            warn_dropped_target(target);
         }
     }
+}
+
+fn warn_dropped_target(target: &DroppedTarget) {
+    tracing::warn!(
+        from = %target.from,
+        registry = %target.registry,
+        error = %target.error,
+        "target registry unavailable; syncing the mapping's remaining targets"
+    );
 }
 
 /// Report a mapping that could not be turned into work.
@@ -1212,10 +1379,10 @@ fn build_targets(
     clients: &ClientMap,
     batch_checkers: &HashMap<String, Rc<dyn BatchBlobChecker>>,
     from: &str,
-) -> (Vec<TargetEntry>, Vec<DroppedTarget>, Option<CliError>) {
+    dropped: &mut Vec<DroppedTarget>,
+) -> (Vec<TargetEntry>, Option<CliError>) {
     let mut targets = Vec::with_capacity(target_names.len());
-    let mut dropped = Vec::new();
-    let mut last_err = None;
+    let mut worst_err: Option<CliError> = None;
     for name in target_names {
         match client_for(clients, &name, from, RegistryRole::Target) {
             Ok(client) => targets.push(TargetEntry {
@@ -1230,11 +1397,24 @@ fn build_targets(
                     registry: name,
                     error: err.to_string(),
                 });
-                last_err = Some(err);
+                // Keep a denial over anything else rather than the last one
+                // seen: target order comes straight from the config file, and
+                // the same outage should not exit 2 or 4 depending on how the
+                // list happens to be written.
+                let replace = match &worst_err {
+                    None => true,
+                    Some(existing) => {
+                        !matches!(existing.exit_code(), ExitCode::AuthError)
+                            && matches!(err.exit_code(), ExitCode::AuthError)
+                    }
+                };
+                if replace {
+                    worst_err = Some(err);
+                }
             }
         }
     }
-    (targets, dropped, last_err)
+    (targets, worst_err)
 }
 
 /// Resolve a single mapping config into a [`MappingResolution`].
@@ -1249,6 +1429,31 @@ pub(crate) async fn resolve_mapping(
     clients: &ClientMap,
     batch_checkers: &HashMap<String, Rc<dyn BatchBlobChecker>>,
     with_report: bool,
+) -> (Result<MappingResolution, CliError>, Vec<DroppedTarget>) {
+    // Targets are resolved first and returned unconditionally: every `?` in
+    // the rest of resolution would otherwise discard them, and a mapping that
+    // loses a mirror and then hits a rate limit on its tag listing would
+    // report the outage nowhere.
+    let mut dropped = Vec::new();
+    let result = resolve_mapping_inner(
+        mapping,
+        config,
+        clients,
+        batch_checkers,
+        with_report,
+        &mut dropped,
+    )
+    .await;
+    (result, dropped)
+}
+
+async fn resolve_mapping_inner(
+    mapping: &MappingConfig,
+    config: &Config,
+    clients: &ClientMap,
+    batch_checkers: &HashMap<String, Rc<dyn BatchBlobChecker>>,
+    with_report: bool,
+    dropped: &mut Vec<DroppedTarget>,
 ) -> Result<MappingResolution, CliError> {
     // --- Source registry ---
     let source_name = mapping
@@ -1268,8 +1473,13 @@ pub(crate) async fn resolve_mapping(
     let known: HashSet<&str> = config.registries.keys().map(String::as_str).collect();
     let target_names = mapping_target_names(mapping, config, &known)?;
 
-    let (mut targets, dropped, last_target_err) =
-        build_targets(target_names, clients, batch_checkers, &mapping.from);
+    let (mut targets, last_target_err) = build_targets(
+        target_names,
+        clients,
+        batch_checkers,
+        &mapping.from,
+        dropped,
+    );
     // Every named target failed, so the mapping has nowhere to sync. Surface
     // the underlying cause rather than a generic "no targets". A config that
     // names no targets at all is left alone: that produced a zero-target
@@ -1347,7 +1557,7 @@ pub(crate) async fn resolve_mapping(
             filter_desc: describe_filter(mapping_tags, defaults_tags),
             samples: Vec::new(),
         });
-        return Ok(MappingResolution::NoMatchingTags(info, dropped));
+        return Ok(MappingResolution::NoMatchingTags(info));
     }
 
     // --- Target repo ---
@@ -1414,23 +1624,20 @@ pub(crate) async fn resolve_mapping(
         None => ResolvedArtifacts::default(),
     };
 
-    Ok(MappingResolution::Resolved(
-        ResolvedMapping {
-            source_authority,
-            source_client,
-            source_repo: RepositoryName::new(mapping.from.clone())?,
-            target_repo: RepositoryName::new(target_repo)?,
-            targets,
-            tags: filtered.into_iter().map(TagPair::same).collect(),
-            platforms,
-            head_first,
-            immutable_glob,
-            artifacts_config: Rc::new(artifacts),
-            candidate_count,
-            filter_report,
-        },
-        dropped,
-    ))
+    Ok(MappingResolution::Resolved(ResolvedMapping {
+        source_authority,
+        source_client,
+        source_repo: RepositoryName::new(mapping.from.clone())?,
+        target_repo: RepositoryName::new(target_repo)?,
+        targets,
+        tags: filtered.into_iter().map(TagPair::same).collect(),
+        platforms,
+        head_first,
+        immutable_glob,
+        artifacts_config: Rc::new(artifacts),
+        candidate_count,
+        filter_report,
+    }))
 }
 
 /// Emit a tracing WARN for a [`NoTagsInfo`] with both a human-readable
@@ -2547,6 +2754,7 @@ include: ["1.25.0-rc1"]
             from: "library/alpine".into(),
             target_repo: "mirror/alpine".into(),
             target_names: vec!["ttl".into()],
+            dropped_names: Vec::new(),
         };
         let synced_only = MappingOutcome {
             synced: 3,
@@ -2582,6 +2790,27 @@ include: ["1.25.0-rc1"]
     }
 
     /// Multi-target mappings keep the `[targets]` bracket so the operator
+    /// A mapping that lost a target still names its registries: the one line
+    /// whose job is saying where the images went must not go quiet at the
+    /// moment one of them is missing.
+    #[test]
+    fn format_mapping_outcome_names_an_unreachable_target() {
+        let d = MappingDescriptor {
+            from: "library/alpine".into(),
+            target_repo: "mirror/alpine".into(),
+            target_names: vec!["good".into()],
+            dropped_names: vec!["broken".into()],
+        };
+        let outcome = MappingOutcome {
+            synced: 4,
+            ..Default::default()
+        };
+
+        let line = format_mapping_outcome(&d, &outcome, false);
+
+        assert!(line.contains("[good, broken unreachable]"), "{line}");
+    }
+
     /// can see which destinations the outcome covers.
     #[test]
     fn format_mapping_outcome_multi_target_keeps_bracket() {
@@ -2589,6 +2818,7 @@ include: ["1.25.0-rc1"]
             from: "library/alpine".into(),
             target_repo: "mirror/alpine".into(),
             target_names: vec!["ecr-prod".into(), "ghcr-mirror".into()],
+            dropped_names: Vec::new(),
         };
         let synced = MappingOutcome {
             synced: 1,
@@ -2751,12 +2981,6 @@ mappings:
         })
     }
 
-    type Resolution = (
-        Vec<ResolvedMapping>,
-        Vec<UnresolvedMapping>,
-        Vec<DroppedTarget>,
-    );
-
     async fn resolve(config: &Config, clients: &ClientMap) -> Resolution {
         resolve_all(
             config,
@@ -2774,7 +2998,11 @@ mappings:
     #[tokio::test]
     async fn resolve_all_isolates_a_failing_mapping() {
         let config = three_mapping_config();
-        let (resolved, unresolved, _dropped) = resolve(&config, &working_clients()).await;
+        let Resolution {
+            resolved,
+            unresolved,
+            ..
+        } = resolve(&config, &working_clients()).await;
 
         assert_eq!(unresolved.len(), 1, "only the bad mapping should fail");
         assert_eq!(unresolved[0].from, "repo/two");
@@ -2821,7 +3049,12 @@ mappings:
             ("dst".to_string(), Ok(test_client("https://target.test"))),
         ]);
 
-        let (resolved, unresolved, _dropped) = resolve(&config, &clients).await;
+        let Resolution {
+            resolved,
+            unresolved,
+            dropped_targets: _dropped,
+            ..
+        } = resolve(&config, &clients).await;
 
         assert_eq!(resolved.len(), 1);
         assert_eq!(resolved[0].source_repo.as_str(), "repo/one");
@@ -2835,7 +3068,7 @@ mappings:
         // The classification has to survive too, or a wholly denied run
         // silently drops from the auth exit code to the generic one.
         assert!(
-            unresolved[0].auth,
+            matches!(unresolved[0].code, ExitCode::AuthError),
             "a denied registry must stay classified as a denial"
         );
     }
@@ -2862,7 +3095,11 @@ mappings:
         )
         .expect("config yaml parses");
 
-        let (resolved, unresolved, _dropped) = resolve(&config, &working_clients()).await;
+        let Resolution {
+            resolved,
+            unresolved,
+            ..
+        } = resolve(&config, &working_clients()).await;
 
         assert_eq!(resolved.len(), 1);
         assert!(unresolved.is_empty());
@@ -2903,7 +3140,12 @@ mappings:
             ),
         ]);
 
-        let (resolved, unresolved, dropped) = resolve(&config, &clients).await;
+        let Resolution {
+            resolved,
+            unresolved,
+            dropped_targets: dropped,
+            ..
+        } = resolve(&config, &clients).await;
 
         assert!(
             unresolved.is_empty(),
@@ -2933,12 +3175,12 @@ mappings:
         }];
 
         assert_eq!(
-            combined_exit_code(&report, &[], &dropped),
+            combined_exit_code(&report, &[], &dropped, 0),
             ExitCode::PartialFailure,
             "an unreached target must not report as a clean run"
         );
         assert_eq!(
-            combined_exit_code(&report, &[], &[]),
+            combined_exit_code(&report, &[], &[], 0),
             ExitCode::Success,
             "and must not fire when nothing was dropped"
         );
@@ -2948,7 +3190,7 @@ mappings:
         );
 
         let line = format_cycle_tail(1, 0, dropped.len(), &report);
-        assert!(line.contains("1 targets dropped"), "{line}");
+        assert!(line.contains("1 target dropped"), "{line}");
 
         let value = serde_json::to_value(SyncOutput {
             report: &report,
@@ -2989,7 +3231,12 @@ mappings:
             ),
         ]);
 
-        let (resolved, unresolved, _dropped) = resolve(&config, &clients).await;
+        let Resolution {
+            resolved,
+            unresolved,
+            dropped_targets: _dropped,
+            ..
+        } = resolve(&config, &clients).await;
 
         assert!(resolved.is_empty());
         assert_eq!(unresolved.len(), 1);
@@ -2998,7 +3245,7 @@ mappings:
             "the cause must survive, not a generic 'no targets': {}",
             unresolved[0].error
         );
-        assert!(unresolved[0].auth);
+        assert!(matches!(unresolved[0].code, ExitCode::AuthError));
     }
 
     /// The guard, not just the helper: `build_clients` must not construct a
@@ -3180,7 +3427,10 @@ mappings:
 
         assert!(checkers.is_empty(), "neither registry is ECR");
         let p = tracker.state.get();
-        assert_eq!(p.total, 2);
+        assert_eq!(
+            p.total, 1,
+            "only the target registry is a checker candidate; the map is read by target alias"
+        );
         assert_eq!(p.done, p.total, "every registry considered must be counted");
     }
 
@@ -3204,10 +3454,81 @@ mappings:
             "the same mirror under another mapping is its own transition"
         );
 
-        // Recovery re-arms only the mapping that recovered.
-        state.clear_dropped_targets("repo/one");
-        assert!(state.observe_dropped_target("repo/one", "mirror-a"));
-        assert!(!state.observe_dropped_target("repo/two", "mirror-a"));
+        // Partial recovery: mirror-a is back, mirror-b is still down. The
+        // all-or-nothing clear this replaced left mirror-a suppressed for as
+        // long as any sibling stayed down.
+        let still_down: HashSet<&str> = ["mirror-b"].into_iter().collect();
+        state.forget_recovered_targets("repo/one", &still_down);
+        assert!(
+            state.observe_dropped_target("repo/one", "mirror-a"),
+            "a recovered mirror must warn again when it fails again"
+        );
+        assert!(
+            !state.observe_dropped_target("repo/one", "mirror-b"),
+            "the mirror that never recovered must stay quiet"
+        );
+        assert!(
+            !state.observe_dropped_target("repo/two", "mirror-a"),
+            "another mapping's state is untouched"
+        );
+    }
+
+    /// A mapping dropped from config must not leave state behind, or
+    /// re-adding it later silently suppresses its next outage.
+    #[test]
+    fn retain_active_prunes_dropped_targets_and_unresolved() {
+        let mut state = WatchLogState::default();
+        state.observe_dropped_target("repo/gone", "mirror-a");
+        state.observe_dropped_target("repo/stays", "mirror-a");
+        state.observe_mapping_unresolved("repo/gone");
+        state.observe_mapping_unresolved("repo/stays");
+
+        state.retain_active(["repo/stays"]);
+
+        assert!(
+            state.observe_dropped_target("repo/gone", "mirror-a"),
+            "the removed mapping's target key must be gone"
+        );
+        assert!(
+            !state.observe_dropped_target("repo/stays", "mirror-a"),
+            "the surviving mapping keeps its state"
+        );
+        assert!(state.observe_mapping_unresolved("repo/gone"));
+        assert!(!state.observe_mapping_unresolved("repo/stays"));
+    }
+
+    /// A mapping that stops resolving must not keep its last outcome, or the
+    /// recovery cycle reports nothing when the counts come back identical.
+    #[test]
+    fn becoming_unresolved_clears_the_last_outcome() {
+        let mut state = WatchLogState::default();
+        let outcome = MappingOutcome {
+            synced: 0,
+            skipped: 5,
+            failed: 0,
+            bytes: 0,
+        };
+        assert!(
+            state
+                .observe_mapping_outcome("repo/one", &outcome)
+                .is_some()
+        );
+        // Same counts again: suppressed, as designed.
+        assert!(
+            state
+                .observe_mapping_outcome("repo/one", &outcome)
+                .is_none()
+        );
+
+        state.observe_mapping_unresolved("repo/one");
+        state.observe_mapping_resolved("repo/one");
+
+        assert!(
+            state
+                .observe_mapping_outcome("repo/one", &outcome)
+                .is_some(),
+            "recovery must report even when the counts are unchanged"
+        );
     }
 
     /// A mapping naming no targets at all keeps its old zero-target shape
@@ -3233,7 +3554,12 @@ mappings:
 
         let clients =
             ClientMap::from([("src".to_string(), Ok(test_client("https://source.test")))]);
-        let (resolved, unresolved, dropped) = resolve(&config, &clients).await;
+        let Resolution {
+            resolved,
+            unresolved,
+            dropped_targets: dropped,
+            ..
+        } = resolve(&config, &clients).await;
 
         assert_eq!(resolved.len(), 1, "no targets is not a resolution failure");
         assert!(resolved[0].targets.is_empty());
@@ -3261,7 +3587,11 @@ mappings:
         UnresolvedMapping {
             from: from.into(),
             error: "boom".into(),
-            auth,
+            code: if auth {
+                ExitCode::AuthError
+            } else {
+                ExitCode::Failure
+            },
         }
     }
 
@@ -3270,9 +3600,9 @@ mappings:
     #[test]
     fn combined_exit_code_downgrades_a_clean_report_with_unresolved_mappings() {
         let report = report_from(vec![ocync_sync::ImageStatus::Synced]);
-        assert_eq!(combined_exit_code(&report, &[], &[]), ExitCode::Success);
+        assert_eq!(combined_exit_code(&report, &[], &[], 0), ExitCode::Success);
         assert_eq!(
-            combined_exit_code(&report, &[unresolved_mapping("repo/two", false)], &[]),
+            combined_exit_code(&report, &[unresolved_mapping("repo/two", false)], &[], 0),
             ExitCode::PartialFailure
         );
     }
@@ -3286,7 +3616,7 @@ mappings:
             unresolved_mapping("repo/two", true),
         ];
         assert_eq!(
-            combined_exit_code(&empty, &failures, &[]),
+            combined_exit_code(&empty, &failures, &[], 0),
             ExitCode::Failure
         );
     }
@@ -3299,7 +3629,7 @@ mappings:
             reason: ocync_sync::SkipReason::DigestMatch,
         }]);
         assert_eq!(
-            combined_exit_code(&report, &[unresolved_mapping("repo/two", false)], &[]),
+            combined_exit_code(&report, &[unresolved_mapping("repo/two", false)], &[], 0),
             ExitCode::PartialFailure
         );
     }
@@ -3314,7 +3644,7 @@ mappings:
             unresolved_mapping("repo/two", true),
         ];
         assert_eq!(
-            combined_exit_code(&empty, &denied, &[]),
+            combined_exit_code(&empty, &denied, &[], 0),
             ExitCode::AuthError
         );
     }
@@ -3327,7 +3657,10 @@ mappings:
             unresolved_mapping("repo/one", true),
             unresolved_mapping("repo/two", false),
         ];
-        assert_eq!(combined_exit_code(&empty, &mixed, &[]), ExitCode::Failure);
+        assert_eq!(
+            combined_exit_code(&empty, &mixed, &[], 0),
+            ExitCode::Failure
+        );
     }
 
     #[test]
@@ -3383,7 +3716,7 @@ mappings:
         let failures = vec![UnresolvedMapping {
             from: "repo/two".into(),
             error: "403 Forbidden".into(),
-            auth: true,
+            code: ExitCode::AuthError,
         }];
         let value = serde_json::to_value(SyncOutput {
             report: &report,
@@ -3394,7 +3727,7 @@ mappings:
 
         assert_eq!(value["unresolved_mappings"][0]["from"], "repo/two");
         assert_eq!(value["unresolved_mappings"][0]["error"], "403 Forbidden");
-        // The auth flag drives the exit code only; it is not part of the document.
+        // The classification drives the exit code only; not part of the document.
         assert!(
             value["unresolved_mappings"][0].get("auth").is_none(),
             "{value}"
@@ -3466,7 +3799,7 @@ mappings:
         };
 
         let mut buf: Vec<u8> = Vec::new();
-        crate::cli::commands::dry_run::write_to(&mut buf, &[mapping], false).unwrap();
+        crate::cli::commands::dry_run::write_to(&mut buf, &[mapping], &[], &[], false).unwrap();
         let out = String::from_utf8(buf).unwrap();
 
         // The end-to-end output surfaces the BelowMinTags warning.

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -313,7 +313,7 @@ pub(crate) async fn run(
 
     if args.dry_run {
         crate::cli::commands::dry_run::print(&mappings, verbose);
-        return Ok(dry_run_exit_code(mappings.len(), unresolved.len()));
+        return Ok(dry_run_exit_code(mappings.len(), &unresolved));
     }
 
     let (cache_dir, cache_path) = resolve_cache_path(&config, &args.config);
@@ -416,11 +416,26 @@ pub(crate) async fn run(
 }
 
 /// Exit code for a dry run, which produces no [`SyncReport`] to fold into.
-fn dry_run_exit_code(resolved: usize, unresolved: usize) -> ExitCode {
-    match (resolved, unresolved) {
-        (_, 0) => ExitCode::Success,
-        (0, _) => ExitCode::Failure,
-        _ => ExitCode::PartialFailure,
+fn dry_run_exit_code(resolved: usize, unresolved: &[MappingFailure]) -> ExitCode {
+    if unresolved.is_empty() {
+        return ExitCode::Success;
+    }
+    if resolved > 0 {
+        return ExitCode::PartialFailure;
+    }
+    total_failure_code(unresolved)
+}
+
+/// Exit code for a run where nothing succeeded.
+///
+/// Keeps the dedicated auth code when every mapping was denied. Before
+/// failures were isolated the first 403 aborted with that code, and dropping
+/// to the generic failure code would silently retire it.
+fn total_failure_code(unresolved: &[MappingFailure]) -> ExitCode {
+    if !unresolved.is_empty() && unresolved.iter().all(|f| f.auth) {
+        ExitCode::AuthError
+    } else {
+        ExitCode::Failure
     }
 }
 
@@ -442,13 +457,12 @@ fn combined_exit_code(report: &SyncReport, unresolved: &[MappingFailure]) -> Exi
     if has_success {
         return ExitCode::PartialFailure;
     }
-    // Nothing ran and every mapping was denied. Before failures were isolated
-    // the first 403 aborted the run with the dedicated auth code; keep that
-    // code here so pipelines alerting on it still fire.
-    if report.images.is_empty() && unresolved.iter().all(|f| f.auth) {
-        return ExitCode::AuthError;
+    // Images that ran and failed for non-auth reasons make this a generic
+    // failure regardless of why the unresolved mappings were dropped.
+    if !report.images.is_empty() {
+        return ExitCode::Failure;
     }
-    ExitCode::Failure
+    total_failure_code(unresolved)
 }
 
 /// Per-mapping metadata captured before the engine consumes `mappings`,
@@ -2507,9 +2521,26 @@ mappings:
 
     #[test]
     fn dry_run_exit_code_maps_resolution_counts() {
-        assert_eq!(dry_run_exit_code(3, 0), ExitCode::Success);
-        assert_eq!(dry_run_exit_code(2, 1), ExitCode::PartialFailure);
-        assert_eq!(dry_run_exit_code(0, 1), ExitCode::Failure);
+        assert_eq!(dry_run_exit_code(3, &[]), ExitCode::Success);
+        assert_eq!(
+            dry_run_exit_code(2, &[failure("repo/two", false)]),
+            ExitCode::PartialFailure
+        );
+        assert_eq!(
+            dry_run_exit_code(0, &[failure("repo/two", false)]),
+            ExitCode::Failure
+        );
+    }
+
+    /// `--dry-run` returns before the engine, so it never sees a `SyncReport`
+    /// and has to apply the auth rule itself. Missing that here silently
+    /// downgraded a denied dry run from 4 to 2.
+    #[test]
+    fn dry_run_exit_code_keeps_the_auth_code_when_every_mapping_was_denied() {
+        let denied = [failure("repo/one", true), failure("repo/two", true)];
+        assert_eq!(dry_run_exit_code(0, &denied), ExitCode::AuthError);
+        // Something resolved, so the run was only partly denied.
+        assert_eq!(dry_run_exit_code(1, &denied), ExitCode::PartialFailure);
     }
 
     // -----------------------------------------------------------------

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -207,7 +207,7 @@ impl fmt::Display for RegistryRole {
 pub(crate) enum MappingResolution {
     /// Ready for the engine, plus any target dropped along the way.
     Resolved(ResolvedMapping, Vec<DroppedTarget>),
-    NoMatchingTags(NoTagsInfo),
+    NoMatchingTags(NoTagsInfo, Vec<DroppedTarget>),
 }
 
 /// A target a mapping could not use.
@@ -322,6 +322,8 @@ impl fmt::Display for NoTagsInfo {
 #[derive(Debug, Default)]
 pub(crate) struct WatchLogState {
     warned_no_tags: HashSet<String>,
+    /// `"{mapping}\0{registry}"` for every target currently reported down.
+    dropped_targets: HashSet<String>,
     last_outcomes: HashMap<String, MappingOutcome>,
     cycle_emit_count: u32,
 }
@@ -343,6 +345,28 @@ impl WatchLogState {
             self.cycle_emit_count = self.cycle_emit_count.saturating_add(1);
         }
         changed
+    }
+
+    /// Record a dropped target. Returns `true` on transition into the dropped
+    /// state (caller emits a WARN); `false` while the same target stays down.
+    ///
+    /// Keyed on mapping plus registry so two mappings losing the same mirror
+    /// each report once, and a second mirror going down still reports.
+    fn observe_dropped_target(&mut self, from: &str, registry: &str) -> bool {
+        let changed = self
+            .dropped_targets
+            .insert(format!("{from}\u{0}{registry}"));
+        if changed {
+            self.cycle_emit_count = self.cycle_emit_count.saturating_add(1);
+        }
+        changed
+    }
+
+    /// Forget every dropped target for `from`, so a mirror coming back
+    /// re-arms the WARN if it goes down again.
+    fn clear_dropped_targets(&mut self, from: &str) {
+        let prefix = format!("{from}\u{0}");
+        self.dropped_targets.retain(|k| !k.starts_with(&prefix));
     }
 
     /// Record a successful resolution. Returns `true` when the mapping was
@@ -611,6 +635,10 @@ fn dry_run_exit_code(
 }
 
 /// Exit code for a run where nothing succeeded.
+///
+/// Only unresolved mappings are consulted. A dropped target never reaches here
+/// (the caller returns `PartialFailure` first, since something did resolve),
+/// so it cannot make an all-denied run report as anything else.
 ///
 /// A run denied everywhere exits with the auth code rather than the generic
 /// failure code, so an operator can tell "fix the credentials" from "fix
@@ -1096,10 +1124,17 @@ async fn resolve_all(
     for mapping in &config.mappings {
         match resolve_mapping(mapping, config, clients, batch_checkers, with_report).await {
             Ok(MappingResolution::Resolved(m, dropped)) => {
+                if dropped.is_empty()
+                    && let Some(state) = watch_log.as_deref_mut()
+                {
+                    // Every target back: re-arm so a future outage warns again.
+                    state.clear_dropped_targets(&mapping.from);
+                }
+                report_dropped_targets(&dropped, watch_log.as_deref_mut());
                 resolved.push(m);
                 dropped_targets.extend(dropped);
             }
-            Ok(MappingResolution::NoMatchingTags(info)) => {
+            Ok(MappingResolution::NoMatchingTags(info, dropped)) => {
                 let should_warn = match watch_log.as_deref_mut() {
                     Some(state) => state.observe_no_match(&info.from),
                     None => true,
@@ -1107,6 +1142,11 @@ async fn resolve_all(
                 if should_warn {
                     emit_no_tags_warn(&info);
                 }
+                // A mapping whose filter matched nothing can still have lost a
+                // real target. Without this, the same outage reports
+                // differently depending on whether any tag happened to match.
+                report_dropped_targets(&dropped, watch_log.as_deref_mut());
+                dropped_targets.extend(dropped);
             }
             Err(err) => {
                 log_unresolved_mapping(&mapping.from, &err);
@@ -1123,6 +1163,28 @@ async fn resolve_all(
     (resolved, unresolved, dropped_targets)
 }
 
+/// WARN once per target that went down, not once per watch cycle.
+///
+/// Without the transition gate a permanently dead mirror warns on every cycle
+/// while `cycle_emit_count` stays at zero, so watch prints "no state changes"
+/// beside the warning it just emitted.
+fn report_dropped_targets(dropped: &[DroppedTarget], mut watch_log: Option<&mut WatchLogState>) {
+    for target in dropped {
+        let should_warn = match watch_log.as_deref_mut() {
+            Some(state) => state.observe_dropped_target(&target.from, &target.registry),
+            None => true,
+        };
+        if should_warn {
+            tracing::warn!(
+                from = %target.from,
+                registry = %target.registry,
+                error = %target.error,
+                "target registry unavailable; syncing the mapping's remaining targets"
+            );
+        }
+    }
+}
+
 /// Report a mapping that could not be turned into work.
 ///
 /// Shared with `analyze`, which drops the same mapping for the same reasons
@@ -1133,6 +1195,46 @@ pub(crate) fn log_unresolved_mapping(from: &str, err: &CliError) {
         error = %err,
         "mapping could not be resolved; continuing with the remaining mappings"
     );
+}
+
+/// Build a mapping's target entries, keeping the ones whose registry works.
+///
+/// One unusable target must not take its siblings with it: a mapping that fans
+/// out to three registries still syncs to the two that work. Mirrors the
+/// per-target degradation the immutable-tag listing already does.
+///
+/// Returns the usable entries, the dropped ones, and the last error, which the
+/// caller needs when nothing is left. Reporting is the caller's job: only it
+/// knows whether any target survived, and `sync` and `analyze` word it
+/// differently.
+fn build_targets(
+    target_names: Vec<String>,
+    clients: &ClientMap,
+    batch_checkers: &HashMap<String, Rc<dyn BatchBlobChecker>>,
+    from: &str,
+) -> (Vec<TargetEntry>, Vec<DroppedTarget>, Option<CliError>) {
+    let mut targets = Vec::with_capacity(target_names.len());
+    let mut dropped = Vec::new();
+    let mut last_err = None;
+    for name in target_names {
+        match client_for(clients, &name, from, RegistryRole::Target) {
+            Ok(client) => targets.push(TargetEntry {
+                batch_checker: batch_checkers.get(&name).cloned(),
+                name: RegistryAlias::new(name),
+                client,
+                existing_tags: HashSet::new(),
+            }),
+            Err(err) => {
+                dropped.push(DroppedTarget {
+                    from: from.to_owned(),
+                    registry: name,
+                    error: err.to_string(),
+                });
+                last_err = Some(err);
+            }
+        }
+    }
+    (targets, dropped, last_err)
 }
 
 /// Resolve a single mapping config into a [`MappingResolution`].
@@ -1166,40 +1268,8 @@ pub(crate) async fn resolve_mapping(
     let known: HashSet<&str> = config.registries.keys().map(String::as_str).collect();
     let target_names = mapping_target_names(mapping, config, &known)?;
 
-    // One unusable target must not take its siblings with it: a mapping that
-    // fans out to three registries still syncs to the two that work. Mirrors
-    // the per-target degradation the immutable-tag listing below already does.
-    // Only when every target is gone does the mapping have nothing to do.
-    let mut targets: Vec<TargetEntry> = Vec::with_capacity(target_names.len());
-    let mut last_target_err = None;
-    let mut dropped = Vec::new();
-    for name in target_names {
-        match client_for(clients, &name, &mapping.from, RegistryRole::Target) {
-            Ok(client) => {
-                let batch_checker = batch_checkers.get(&name).cloned();
-                targets.push(TargetEntry {
-                    name: RegistryAlias::new(name),
-                    client,
-                    batch_checker,
-                    existing_tags: HashSet::new(),
-                });
-            }
-            Err(err) => {
-                tracing::warn!(
-                    from = %mapping.from,
-                    registry = %name,
-                    error = %err,
-                    "target registry unavailable; syncing the mapping's remaining targets"
-                );
-                dropped.push(DroppedTarget {
-                    from: mapping.from.clone(),
-                    registry: name,
-                    error: err.to_string(),
-                });
-                last_target_err = Some(err);
-            }
-        }
-    }
+    let (mut targets, dropped, last_target_err) =
+        build_targets(target_names, clients, batch_checkers, &mapping.from);
     // Every named target failed, so the mapping has nowhere to sync. Surface
     // the underlying cause rather than a generic "no targets". A config that
     // names no targets at all is left alone: that produced a zero-target
@@ -1208,6 +1278,15 @@ pub(crate) async fn resolve_mapping(
         && let Some(err) = last_target_err
     {
         return Err(err);
+    }
+    if targets.is_empty() {
+        // Reachable via `targets: []`. The engine treats it as a degenerate
+        // mapping, but it still costs a source manifest pull per tag, so say
+        // so rather than letting it look like work.
+        tracing::warn!(
+            from = %mapping.from,
+            "mapping names no target registries; nothing will be pushed"
+        );
     }
 
     // --- Fetch and filter tags ---
@@ -1268,7 +1347,7 @@ pub(crate) async fn resolve_mapping(
             filter_desc: describe_filter(mapping_tags, defaults_tags),
             samples: Vec::new(),
         });
-        return Ok(MappingResolution::NoMatchingTags(info));
+        return Ok(MappingResolution::NoMatchingTags(info, dropped));
     }
 
     // --- Target repo ---
@@ -3065,6 +3144,103 @@ mappings:
             *seen.borrow(),
             vec![0, 1],
             "the second line must show the item finished in between"
+        );
+    }
+
+    /// The progress line has to reach its total. The counter previously
+    /// advanced only for ECR registries, so any config without one reported
+    /// `done=0 total=N` forever.
+    #[tokio::test]
+    async fn batch_checker_progress_reaches_its_total_without_ecr() {
+        let config: Config = serde_yaml::from_str(
+            r#"
+registries:
+  src:
+    url: source.test
+    auth_type: static_token
+    token: t
+  dst:
+    url: target.test
+    auth_type: static_token
+    token: t
+defaults:
+  source: src
+  targets: [dst]
+mappings:
+  - from: repo/one
+    tags:
+      glob: ["v1"]
+"#,
+        )
+        .expect("config yaml parses");
+
+        let tracker = PrepareTracker::default();
+        let clients = build_clients(&config, &tracker).await;
+        let checkers = build_batch_checkers(&config, &clients, &tracker).await;
+
+        assert!(checkers.is_empty(), "neither registry is ECR");
+        let p = tracker.state.get();
+        assert_eq!(p.total, 2);
+        assert_eq!(p.done, p.total, "every registry considered must be counted");
+    }
+
+    /// A watch cycle re-reporting the same dead mirror is noise; a different
+    /// mirror going down is not.
+    #[test]
+    fn dropped_target_warnings_fire_once_per_transition() {
+        let mut state = WatchLogState::default();
+
+        assert!(state.observe_dropped_target("repo/one", "mirror-a"));
+        assert!(
+            !state.observe_dropped_target("repo/one", "mirror-a"),
+            "the same target must not warn twice"
+        );
+        assert!(
+            state.observe_dropped_target("repo/one", "mirror-b"),
+            "a second mirror going down is a new transition"
+        );
+        assert!(
+            state.observe_dropped_target("repo/two", "mirror-a"),
+            "the same mirror under another mapping is its own transition"
+        );
+
+        // Recovery re-arms only the mapping that recovered.
+        state.clear_dropped_targets("repo/one");
+        assert!(state.observe_dropped_target("repo/one", "mirror-a"));
+        assert!(!state.observe_dropped_target("repo/two", "mirror-a"));
+    }
+
+    /// A mapping naming no targets at all keeps its old zero-target shape
+    /// rather than becoming an error, which is the case the engine documents
+    /// as degenerate but handles.
+    #[tokio::test]
+    async fn a_mapping_with_no_named_targets_still_resolves() {
+        let config: Config = serde_yaml::from_str(
+            r#"
+registries:
+  src:
+    url: source.test
+defaults:
+  source: src
+  targets: []
+mappings:
+  - from: repo/one
+    tags:
+      glob: ["v1"]
+"#,
+        )
+        .expect("config yaml parses");
+
+        let clients =
+            ClientMap::from([("src".to_string(), Ok(test_client("https://source.test")))]);
+        let (resolved, unresolved, dropped) = resolve(&config, &clients).await;
+
+        assert_eq!(resolved.len(), 1, "no targets is not a resolution failure");
+        assert!(resolved[0].targets.is_empty());
+        assert!(unresolved.is_empty());
+        assert!(
+            dropped.is_empty(),
+            "nothing was dropped; the config named nothing"
         );
     }
 

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -26,7 +26,8 @@ use serde::Serialize;
 
 use crate::SyncArgs;
 use crate::cli::config::{
-    AuthType, Config, GlobOrList, MappingConfig, TagsConfig, load_config, resolve_target_names,
+    AuthType, Config, GlobOrList, MappingConfig, RegistryConfig, TagsConfig, load_config,
+    resolve_target_names,
 };
 use crate::cli::output::{format_bytes, format_duration};
 use crate::cli::{CliError, ExitCode, bare_hostname, build_registry_client};
@@ -52,7 +53,7 @@ const PREPARE_PROGRESS_INTERVAL: Duration = Duration::from_secs(5);
 
 /// A step of the pre-engine phase.
 #[derive(Debug, Clone, Copy, Default)]
-enum PreparePhase {
+pub(crate) enum PreparePhase {
     #[default]
     Registries,
     BatchCheckers,
@@ -91,7 +92,7 @@ pub(crate) struct PrepareTracker {
 
 impl PrepareTracker {
     /// Start a new step, resetting the item counter.
-    fn begin(&self, phase: PreparePhase, total: usize) {
+    pub(crate) fn begin(&self, phase: PreparePhase, total: usize) {
         self.state.set(PrepareProgress {
             phase,
             done: 0,
@@ -100,7 +101,7 @@ impl PrepareTracker {
     }
 
     /// Record one item finished in the current step.
-    fn advance(&self) {
+    pub(crate) fn advance(&self) {
         let mut p = self.state.get();
         p.done += 1;
         self.state.set(p);
@@ -117,27 +118,43 @@ pub(crate) async fn with_prepare_progress<F: Future>(
     tracker: &PrepareTracker,
     work: F,
 ) -> F::Output {
+    tick_while(tracker, PREPARE_PROGRESS_INTERVAL, work, |p, elapsed| {
+        tracing::info!(
+            phase = %p.phase,
+            done = p.done,
+            total = p.total,
+            elapsed_secs = elapsed.as_secs(),
+            "preparing sync"
+        );
+    })
+    .await
+}
+
+/// Poll `work` to completion, calling `emit` with the tracker's state once per
+/// `interval` until it finishes.
+///
+/// Split from [`with_prepare_progress`] so the cadence is testable against a
+/// recording sink rather than a tracing subscriber.
+async fn tick_while<F: Future>(
+    tracker: &PrepareTracker,
+    interval: Duration,
+    work: F,
+    mut emit: impl FnMut(PrepareProgress, Duration),
+) -> F::Output {
     let mut work = std::pin::pin!(work);
     let started = Instant::now();
-    let mut ticker = tokio::time::interval(PREPARE_PROGRESS_INTERVAL);
+    let mut ticker = tokio::time::interval(interval);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     // `interval` yields immediately; push the first tick out a full period so
     // a fast run stays silent.
     ticker.reset();
     loop {
         tokio::select! {
+            // `work` first: a tick that becomes ready on the same poll as a
+            // finished future is dropped rather than logged after the fact.
             biased;
             out = &mut work => return out,
-            _ = ticker.tick() => {
-                let p = tracker.state.get();
-                tracing::info!(
-                    phase = %p.phase,
-                    done = p.done,
-                    total = p.total,
-                    elapsed_secs = started.elapsed().as_secs(),
-                    "preparing sync"
-                );
-            }
+            _ = ticker.tick() => emit(tracker.state.get(), started.elapsed()),
         }
     }
 }
@@ -188,8 +205,24 @@ impl fmt::Display for RegistryRole {
 /// the disparity instead of the allocation traffic.
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum MappingResolution {
-    Resolved(ResolvedMapping),
+    /// Ready for the engine, plus any target dropped along the way.
+    Resolved(ResolvedMapping, Vec<DroppedTarget>),
     NoMatchingTags(NoTagsInfo),
+}
+
+/// A target a mapping could not use.
+///
+/// The mapping still syncs to its other targets, so this is not an
+/// [`UnresolvedMapping`]; it is a hole in an otherwise successful run and has
+/// to be visible as one.
+#[derive(Debug, Serialize)]
+pub(crate) struct DroppedTarget {
+    /// Source repository of the mapping that lost the target.
+    pub from: String,
+    /// Target registry alias that was dropped.
+    pub registry: String,
+    /// Why the target was unusable.
+    pub error: String,
 }
 
 /// A mapping that never became transferable work.
@@ -413,10 +446,10 @@ pub(crate) async fn run(
     // sequential network work with no output of their own. One ticker spans
     // the lot so the run is never silent for longer than the interval.
     let tracker = PrepareTracker::default();
-    let (mappings, unresolved) = with_prepare_progress(&tracker, async {
+    let (mappings, unresolved, dropped_targets) = with_prepare_progress(&tracker, async {
         let clients = build_clients(&config, &tracker).await;
         let batch_checkers = build_batch_checkers(&config, &clients, &tracker).await;
-        let (mappings, unresolved) = resolve_all(
+        let (mappings, unresolved, dropped_targets) = resolve_all(
             &config,
             &clients,
             &batch_checkers,
@@ -425,7 +458,7 @@ pub(crate) async fn run(
             &tracker,
         )
         .await;
-        (mappings, unresolved)
+        (mappings, unresolved, dropped_targets)
     })
     .await;
 
@@ -444,7 +477,11 @@ pub(crate) async fn run(
 
     if args.dry_run {
         crate::cli::commands::dry_run::print(&mappings, verbose);
-        return Ok(dry_run_exit_code(mappings.len(), &unresolved));
+        return Ok(dry_run_exit_code(
+            mappings.len(),
+            &unresolved,
+            &dropped_targets,
+        ));
     }
 
     let (cache_dir, cache_path) = resolve_cache_path(&config, &args.config);
@@ -534,22 +571,38 @@ pub(crate) async fn run(
     // Unresolved mappings always force the tail -- they produce no per-mapping
     // line, so without this a cycle where every mapping 403'd would go quiet.
     let cycle_had_activity = !unresolved.is_empty()
+        || !dropped_targets.is_empty()
         || watch_log
             .as_deref()
             .is_none_or(|s| s.cycle_emit_count() > 0);
     if cycle_had_activity {
-        emit_cycle_tail(&descriptors, unresolved.len(), &report);
+        emit_cycle_tail(
+            &descriptors,
+            unresolved.len(),
+            dropped_targets.len(),
+            &report,
+        );
     }
 
-    write_output(&report, &unresolved, args.json)?;
+    write_output(&report, &unresolved, &dropped_targets, args.json)?;
 
-    Ok(combined_exit_code(&report, &unresolved))
+    Ok(combined_exit_code(&report, &unresolved, &dropped_targets))
 }
 
 /// Exit code for a dry run, which produces no [`SyncReport`] to fold into.
-fn dry_run_exit_code(resolved: usize, unresolved: &[UnresolvedMapping]) -> ExitCode {
+fn dry_run_exit_code(
+    resolved: usize,
+    unresolved: &[UnresolvedMapping],
+    dropped: &[DroppedTarget],
+) -> ExitCode {
     if unresolved.is_empty() {
-        return ExitCode::Success;
+        // A mapping that resolved but lost a target is still short of what
+        // the config asked for.
+        return if dropped.is_empty() {
+            ExitCode::Success
+        } else {
+            ExitCode::PartialFailure
+        };
     }
     if resolved > 0 {
         return ExitCode::PartialFailure;
@@ -575,9 +628,18 @@ fn total_failure_code(unresolved: &[UnresolvedMapping]) -> ExitCode {
 /// A mapping that never reached the engine produces no [`ocync_sync::ImageResult`],
 /// so [`SyncReport::exit_code`] cannot see it. Counting each as a failure is
 /// what keeps a run whose mappings all 403'd from exiting 0.
-fn combined_exit_code(report: &SyncReport, unresolved: &[UnresolvedMapping]) -> ExitCode {
+fn combined_exit_code(
+    report: &SyncReport,
+    unresolved: &[UnresolvedMapping],
+    dropped: &[DroppedTarget],
+) -> ExitCode {
     if unresolved.is_empty() {
-        return ExitCode::from_report(report.exit_code());
+        // A dropped target means images never reached a registry the config
+        // named, so an otherwise clean run is still only partial.
+        return match ExitCode::from_report(report.exit_code()) {
+            ExitCode::Success if !dropped.is_empty() => ExitCode::PartialFailure,
+            other => other,
+        };
     }
     if report.has_success() {
         return ExitCode::PartialFailure;
@@ -731,13 +793,14 @@ fn format_mapping_outcome(d: &MappingDescriptor, o: &MappingOutcome, recovered: 
 fn emit_cycle_tail(
     descriptors: &[MappingDescriptor],
     unresolved_count: usize,
+    dropped_count: usize,
     report: &SyncReport,
 ) {
-    let line = format_cycle_tail(descriptors.len(), unresolved_count, report);
+    let line = format_cycle_tail(descriptors.len(), unresolved_count, dropped_count, report);
     // Counts are already in the message; structured fields would be a
     // verbatim restatement in text output. JSON aggregators parse the
     // message (or use the SyncReport via `--json`).
-    if report.stats.images_failed > 0 || unresolved_count > 0 {
+    if report.stats.images_failed > 0 || unresolved_count > 0 || dropped_count > 0 {
         tracing::warn!("{line}");
     } else {
         tracing::info!("{line}");
@@ -746,17 +809,27 @@ fn emit_cycle_tail(
 
 /// Render the cycle tail. Split from [`emit_cycle_tail`] so the wording is
 /// testable without a tracing subscriber.
-fn format_cycle_tail(mapping_count: usize, unresolved_count: usize, report: &SyncReport) -> String {
+fn format_cycle_tail(
+    mapping_count: usize,
+    unresolved_count: usize,
+    dropped_count: usize,
+    report: &SyncReport,
+) -> String {
     let s = &report.stats;
-    // Unresolved mappings never reached the engine, so they are absent from
-    // every count above and need their own clause.
+    // Neither of these reached the engine, so they are absent from every
+    // count above and need their own clauses.
     let unresolved_clause = if unresolved_count > 0 {
         format!(" | {unresolved_count} unresolved")
     } else {
         String::new()
     };
+    let dropped_clause = if dropped_count > 0 {
+        format!(" | {dropped_count} targets dropped")
+    } else {
+        String::new()
+    };
     format!(
-        "summary: {mapping_count} mappings | {} synced, {} skipped, {} failed{unresolved_clause} | {} in {}",
+        "summary: {mapping_count} mappings | {} synced, {} skipped, {} failed{unresolved_clause}{dropped_clause} | {} in {}",
         s.images_synced,
         s.images_skipped,
         s.images_failed,
@@ -823,7 +896,8 @@ fn parse_size(s: &str) -> Option<u64> {
     None
 }
 
-/// Build a `RegistryClient` for each named registry in config, keyed by name.
+/// Build a `RegistryClient` for each registry at least one mapping references,
+/// keyed by config alias.
 ///
 /// Auth setup reaches the network (ECR, GAR, ACR all mint a token), so any one
 /// registry can fail. Record the failure against that alias instead of
@@ -876,18 +950,35 @@ fn referenced_registries(config: &Config) -> HashSet<String> {
         {
             used.insert(source.to_owned());
         }
-        if let Some(targets) = mapping
-            .targets
-            .as_ref()
-            .or(defaults.and_then(|d| d.targets.as_ref()))
-        {
-            let context = format!("mapping '{}'", mapping.from);
-            if let Ok(names) = resolve_target_names(targets, config, &known, &context) {
-                used.extend(names);
-            }
+        if let Ok(names) = mapping_target_names(mapping, config, &known) {
+            used.extend(names);
         }
     }
     used
+}
+
+/// Target registry aliases a mapping names, with groups expanded.
+///
+/// Shared with [`resolve_mapping`] so the set built here cannot drift from the
+/// set resolved there: a registry present in one and absent from the other
+/// would surface as a misleading "not found in clients".
+fn mapping_target_names(
+    mapping: &MappingConfig,
+    config: &Config,
+    known: &HashSet<&str>,
+) -> Result<Vec<String>, CliError> {
+    let Some(targets) = mapping
+        .targets
+        .as_ref()
+        .or(config.defaults.as_ref().and_then(|d| d.targets.as_ref()))
+    else {
+        return Err(CliError::Input(format!(
+            "mapping '{}': no target registries (set mapping.targets or defaults.targets)",
+            mapping.from,
+        )));
+    };
+    let context = format!("mapping '{}'", mapping.from);
+    resolve_target_names(targets, config, known, &context).map_err(CliError::Config)
 }
 
 /// Look up a usable client for `name`, turning a missing or failed registry
@@ -921,9 +1012,10 @@ fn client_for(
 
 /// Build batch blob checkers for ECR registries.
 ///
-/// Automatically creates a [`BatchChecker`] for every registry detected
-/// as ECR (via explicit `auth_type: ecr` or hostname auto-detection). No
-/// user configuration is needed - if we know it's ECR, we use the batch API.
+/// Creates a [`BatchChecker`] for every registry that a mapping references,
+/// whose client built successfully, and that is detected as ECR (via explicit
+/// `auth_type: ecr` or hostname auto-detection). No user configuration is
+/// needed - if we know it's ECR, we use the batch API.
 async fn build_batch_checkers(
     config: &Config,
     clients: &ClientMap,
@@ -931,13 +1023,17 @@ async fn build_batch_checkers(
 ) -> HashMap<String, Rc<dyn BatchBlobChecker>> {
     let mut checkers: HashMap<String, Rc<dyn BatchBlobChecker>> = HashMap::new();
 
-    // The client map is already the referenced set; deriving it from there
-    // avoids re-resolving every mapping's target groups a second time.
-    tracker.begin(PreparePhase::BatchCheckers, clients.len());
-    for (name, reg) in &config.registries {
-        if !clients.contains_key(name) {
-            continue;
-        }
+    // The client map is already the referenced set, so deriving it from there
+    // avoids re-resolving every mapping's target groups a second time. Only
+    // registries whose client actually built are worth a checker: the rest
+    // have already failed and would just repeat the round trip.
+    let usable: Vec<(&String, &RegistryConfig)> = config
+        .registries
+        .iter()
+        .filter(|(name, _)| matches!(clients.get(*name), Some(Ok(_))))
+        .collect();
+    tracker.begin(PreparePhase::BatchCheckers, usable.len());
+    for (name, reg) in usable {
         let hostname = bare_hostname(&reg.url);
         // Explicit non-Ecr auth_type is a hard opt-out: don't try to build an
         // AWS-SDK-backed batch checker for a registry the user has declared
@@ -950,6 +1046,7 @@ async fn build_batch_checkers(
         };
 
         if !is_ecr {
+            tracker.advance();
             continue;
         }
 
@@ -986,14 +1083,22 @@ async fn resolve_all(
     with_report: bool,
     mut watch_log: Option<&mut WatchLogState>,
     tracker: &PrepareTracker,
-) -> (Vec<ResolvedMapping>, Vec<UnresolvedMapping>) {
+) -> (
+    Vec<ResolvedMapping>,
+    Vec<UnresolvedMapping>,
+    Vec<DroppedTarget>,
+) {
     tracker.begin(PreparePhase::Mappings, config.mappings.len());
     let mut resolved = Vec::new();
     let mut unresolved = Vec::new();
+    let mut dropped_targets = Vec::new();
 
     for mapping in &config.mappings {
         match resolve_mapping(mapping, config, clients, batch_checkers, with_report).await {
-            Ok(MappingResolution::Resolved(m)) => resolved.push(m),
+            Ok(MappingResolution::Resolved(m, dropped)) => {
+                resolved.push(m);
+                dropped_targets.extend(dropped);
+            }
             Ok(MappingResolution::NoMatchingTags(info)) => {
                 let should_warn = match watch_log.as_deref_mut() {
                     Some(state) => state.observe_no_match(&info.from),
@@ -1015,7 +1120,7 @@ async fn resolve_all(
         tracker.advance();
     }
 
-    (resolved, unresolved)
+    (resolved, unresolved, dropped_targets)
 }
 
 /// Report a mapping that could not be turned into work.
@@ -1058,21 +1163,8 @@ pub(crate) async fn resolve_mapping(
     let source_client = client_for(clients, source_name, &mapping.from, RegistryRole::Source)?;
 
     // --- Target registries ---
-    let targets_value = mapping
-        .targets
-        .as_ref()
-        .or(config.defaults.as_ref().and_then(|d| d.targets.as_ref()))
-        .ok_or_else(|| {
-            CliError::Input(format!(
-                "mapping '{}': no target registries (set mapping.targets or defaults.targets)",
-                mapping.from,
-            ))
-        })?;
-
     let known: HashSet<&str> = config.registries.keys().map(String::as_str).collect();
-    let context = format!("mapping '{}'", mapping.from);
-    let target_names =
-        resolve_target_names(targets_value, config, &known, &context).map_err(CliError::Config)?;
+    let target_names = mapping_target_names(mapping, config, &known)?;
 
     // One unusable target must not take its siblings with it: a mapping that
     // fans out to three registries still syncs to the two that work. Mirrors
@@ -1080,6 +1172,7 @@ pub(crate) async fn resolve_mapping(
     // Only when every target is gone does the mapping have nothing to do.
     let mut targets: Vec<TargetEntry> = Vec::with_capacity(target_names.len());
     let mut last_target_err = None;
+    let mut dropped = Vec::new();
     for name in target_names {
         match client_for(clients, &name, &mapping.from, RegistryRole::Target) {
             Ok(client) => {
@@ -1098,16 +1191,23 @@ pub(crate) async fn resolve_mapping(
                     error = %err,
                     "target registry unavailable; syncing the mapping's remaining targets"
                 );
+                dropped.push(DroppedTarget {
+                    from: mapping.from.clone(),
+                    registry: name,
+                    error: err.to_string(),
+                });
                 last_target_err = Some(err);
             }
         }
     }
-    if targets.is_empty() {
-        // Every target failed, so the mapping itself is unresolvable. Surface
-        // one of the causes rather than a generic "no targets" message.
-        return Err(last_target_err.unwrap_or_else(|| {
-            CliError::Input(format!("mapping '{}': no target registries", mapping.from))
-        }));
+    // Every named target failed, so the mapping has nowhere to sync. Surface
+    // the underlying cause rather than a generic "no targets". A config that
+    // names no targets at all is left alone: that produced a zero-target
+    // mapping before, and the engine handles it.
+    if targets.is_empty()
+        && let Some(err) = last_target_err
+    {
+        return Err(err);
     }
 
     // --- Fetch and filter tags ---
@@ -1235,20 +1335,23 @@ pub(crate) async fn resolve_mapping(
         None => ResolvedArtifacts::default(),
     };
 
-    Ok(MappingResolution::Resolved(ResolvedMapping {
-        source_authority,
-        source_client,
-        source_repo: RepositoryName::new(mapping.from.clone())?,
-        target_repo: RepositoryName::new(target_repo)?,
-        targets,
-        tags: filtered.into_iter().map(TagPair::same).collect(),
-        platforms,
-        head_first,
-        immutable_glob,
-        artifacts_config: Rc::new(artifacts),
-        candidate_count,
-        filter_report,
-    }))
+    Ok(MappingResolution::Resolved(
+        ResolvedMapping {
+            source_authority,
+            source_client,
+            source_repo: RepositoryName::new(mapping.from.clone())?,
+            target_repo: RepositoryName::new(target_repo)?,
+            targets,
+            tags: filtered.into_iter().map(TagPair::same).collect(),
+            platforms,
+            head_first,
+            immutable_glob,
+            artifacts_config: Rc::new(artifacts),
+            candidate_count,
+            filter_report,
+        },
+        dropped,
+    ))
 }
 
 /// Emit a tracing WARN for a [`NoTagsInfo`] with both a human-readable
@@ -1393,18 +1496,24 @@ struct SyncOutput<'a> {
     /// so the document shape is unchanged on a clean run.
     #[serde(skip_serializing_if = "<[_]>::is_empty")]
     unresolved_mappings: &'a [UnresolvedMapping],
+    /// Targets a resolved mapping could not use. Absent when none were
+    /// dropped, so the document shape is unchanged on a clean run.
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    dropped_targets: &'a [DroppedTarget],
 }
 
 /// Write sync output as JSON when `--json` is passed.
 fn write_output(
     report: &SyncReport,
     unresolved: &[UnresolvedMapping],
+    dropped: &[DroppedTarget],
     json: bool,
 ) -> Result<(), CliError> {
     if json {
         let output = SyncOutput {
             report,
             unresolved_mappings: unresolved,
+            dropped_targets: dropped,
         };
         let json = serde_json::to_string_pretty(&output)
             .map_err(|e| CliError::Input(format!("failed to serialize report: {e}")))?;
@@ -2563,10 +2672,13 @@ mappings:
         })
     }
 
-    async fn resolve(
-        config: &Config,
-        clients: &ClientMap,
-    ) -> (Vec<ResolvedMapping>, Vec<UnresolvedMapping>) {
+    type Resolution = (
+        Vec<ResolvedMapping>,
+        Vec<UnresolvedMapping>,
+        Vec<DroppedTarget>,
+    );
+
+    async fn resolve(config: &Config, clients: &ClientMap) -> Resolution {
         resolve_all(
             config,
             clients,
@@ -2583,7 +2695,7 @@ mappings:
     #[tokio::test]
     async fn resolve_all_isolates_a_failing_mapping() {
         let config = three_mapping_config();
-        let (resolved, unresolved) = resolve(&config, &working_clients()).await;
+        let (resolved, unresolved, _dropped) = resolve(&config, &working_clients()).await;
 
         assert_eq!(unresolved.len(), 1, "only the bad mapping should fail");
         assert_eq!(unresolved[0].from, "repo/two");
@@ -2630,7 +2742,7 @@ mappings:
             ("dst".to_string(), Ok(test_client("https://target.test"))),
         ]);
 
-        let (resolved, unresolved) = resolve(&config, &clients).await;
+        let (resolved, unresolved, _dropped) = resolve(&config, &clients).await;
 
         assert_eq!(resolved.len(), 1);
         assert_eq!(resolved[0].source_repo.as_str(), "repo/one");
@@ -2671,7 +2783,7 @@ mappings:
         )
         .expect("config yaml parses");
 
-        let (resolved, unresolved) = resolve(&config, &working_clients()).await;
+        let (resolved, unresolved, _dropped) = resolve(&config, &working_clients()).await;
 
         assert_eq!(resolved.len(), 1);
         assert!(unresolved.is_empty());
@@ -2712,7 +2824,7 @@ mappings:
             ),
         ]);
 
-        let (resolved, unresolved) = resolve(&config, &clients).await;
+        let (resolved, unresolved, dropped) = resolve(&config, &clients).await;
 
         assert!(
             unresolved.is_empty(),
@@ -2721,6 +2833,51 @@ mappings:
         assert_eq!(resolved.len(), 1);
         let targets: Vec<&str> = resolved[0].targets.iter().map(|t| &*t.name).collect();
         assert_eq!(targets, vec!["good"], "the healthy target must survive");
+
+        // Surviving is not enough: a target the images never reached has to
+        // stay visible, or the run reports a clean success it did not have.
+        assert_eq!(dropped.len(), 1);
+        assert_eq!(dropped[0].registry, "broken");
+        assert_eq!(dropped[0].from, "repo/one");
+        assert!(dropped[0].error.contains("403 Forbidden"));
+    }
+
+    /// A dropped target is a hole in an otherwise clean run, so it must move
+    /// the exit code off success and appear in both report surfaces.
+    #[test]
+    fn a_dropped_target_is_visible_in_every_surface() {
+        let report = report_from(vec![ocync_sync::ImageStatus::Synced]);
+        let dropped = [DroppedTarget {
+            from: "repo/one".into(),
+            registry: "broken".into(),
+            error: "403 Forbidden".into(),
+        }];
+
+        assert_eq!(
+            combined_exit_code(&report, &[], &dropped),
+            ExitCode::PartialFailure,
+            "an unreached target must not report as a clean run"
+        );
+        assert_eq!(
+            combined_exit_code(&report, &[], &[]),
+            ExitCode::Success,
+            "and must not fire when nothing was dropped"
+        );
+        assert_eq!(
+            dry_run_exit_code(1, &[], &dropped),
+            ExitCode::PartialFailure
+        );
+
+        let line = format_cycle_tail(1, 0, dropped.len(), &report);
+        assert!(line.contains("1 targets dropped"), "{line}");
+
+        let value = serde_json::to_value(SyncOutput {
+            report: &report,
+            unresolved_mappings: &[],
+            dropped_targets: &dropped,
+        })
+        .expect("serializes");
+        assert_eq!(value["dropped_targets"][0]["registry"], "broken");
     }
 
     /// Losing every target is different from losing one: there is nowhere left
@@ -2753,7 +2910,7 @@ mappings:
             ),
         ]);
 
-        let (resolved, unresolved) = resolve(&config, &clients).await;
+        let (resolved, unresolved, _dropped) = resolve(&config, &clients).await;
 
         assert!(resolved.is_empty());
         assert_eq!(unresolved.len(), 1);
@@ -2763,6 +2920,44 @@ mappings:
             unresolved[0].error
         );
         assert!(unresolved[0].auth);
+    }
+
+    /// The guard, not just the helper: `build_clients` must not construct a
+    /// client for a registry no mapping names. `static_token` resolves
+    /// offline, so this stays a unit test.
+    #[tokio::test]
+    async fn build_clients_skips_registries_no_mapping_references() {
+        let config: Config = serde_yaml::from_str(
+            r#"
+registries:
+  src:
+    url: source.test
+    auth_type: static_token
+    token: t
+  dst:
+    url: target.test
+    auth_type: static_token
+    token: t
+  unused:
+    url: unused.test
+    auth_type: static_token
+    token: t
+defaults:
+  source: src
+  targets: [dst]
+mappings:
+  - from: repo/one
+    tags:
+      glob: ["v1"]
+"#,
+        )
+        .expect("config yaml parses");
+
+        let clients = build_clients(&config, &PrepareTracker::default()).await;
+
+        let mut names: Vec<&str> = clients.keys().map(String::as_str).collect();
+        names.sort_unstable();
+        assert_eq!(names, vec!["dst", "src"], "'unused' must not be built");
     }
 
     /// Building a client mints a token for ECR, GAR, and ACR, so a registry no
@@ -2801,6 +2996,78 @@ mappings:
         );
     }
 
+    /// The prepare ticker must fire on wall-clock, not on item boundaries.
+    ///
+    /// The throttle this replaced was evaluated only after a mapping finished,
+    /// so a config with few mappings emitted nothing at all: measured on a
+    /// three-mapping config, zero lines across an 8.6 second run.
+    #[tokio::test(start_paused = true)]
+    async fn prepare_ticker_reports_a_single_slow_step() {
+        let tracker = PrepareTracker::default();
+        tracker.begin(PreparePhase::Mappings, 1);
+        let seen = RefCell::new(Vec::new());
+
+        // One item that never completes within an interval: the boundary
+        // throttle scored exactly this case as silent.
+        tick_while(
+            &tracker,
+            Duration::from_secs(5),
+            tokio::time::sleep(Duration::from_secs(17)),
+            |p, _| seen.borrow_mut().push(p.total),
+        )
+        .await;
+
+        assert_eq!(
+            seen.borrow().len(),
+            3,
+            "17s of work at a 5s cadence must report three times"
+        );
+    }
+
+    /// The negative half: work that finishes inside one interval stays silent,
+    /// so a fast config gains no noise.
+    #[tokio::test(start_paused = true)]
+    async fn prepare_ticker_stays_silent_for_fast_work() {
+        let tracker = PrepareTracker::default();
+        let seen = RefCell::new(0usize);
+
+        tick_while(
+            &tracker,
+            Duration::from_secs(5),
+            tokio::time::sleep(Duration::from_secs(1)),
+            |_, _| *seen.borrow_mut() += 1,
+        )
+        .await;
+
+        assert_eq!(*seen.borrow(), 0);
+    }
+
+    /// The ticker reads live counters, not a snapshot taken when it started.
+    #[tokio::test(start_paused = true)]
+    async fn prepare_ticker_reports_progress_as_it_advances() {
+        let tracker = PrepareTracker::default();
+        tracker.begin(PreparePhase::Registries, 2);
+        let seen = RefCell::new(Vec::new());
+
+        tick_while(
+            &tracker,
+            Duration::from_secs(5),
+            async {
+                tokio::time::sleep(Duration::from_secs(7)).await;
+                tracker.advance();
+                tokio::time::sleep(Duration::from_secs(7)).await;
+            },
+            |p, _| seen.borrow_mut().push(p.done),
+        )
+        .await;
+
+        assert_eq!(
+            *seen.borrow(),
+            vec![0, 1],
+            "the second line must show the item finished in between"
+        );
+    }
+
     // -----------------------------------------------------------------
     // Exit codes
     // -----------------------------------------------------------------
@@ -2827,9 +3094,9 @@ mappings:
     #[test]
     fn combined_exit_code_downgrades_a_clean_report_with_unresolved_mappings() {
         let report = report_from(vec![ocync_sync::ImageStatus::Synced]);
-        assert_eq!(combined_exit_code(&report, &[]), ExitCode::Success);
+        assert_eq!(combined_exit_code(&report, &[], &[]), ExitCode::Success);
         assert_eq!(
-            combined_exit_code(&report, &[unresolved_mapping("repo/two", false)]),
+            combined_exit_code(&report, &[unresolved_mapping("repo/two", false)], &[]),
             ExitCode::PartialFailure
         );
     }
@@ -2842,7 +3109,10 @@ mappings:
             unresolved_mapping("repo/one", false),
             unresolved_mapping("repo/two", true),
         ];
-        assert_eq!(combined_exit_code(&empty, &failures), ExitCode::Failure);
+        assert_eq!(
+            combined_exit_code(&empty, &failures, &[]),
+            ExitCode::Failure
+        );
     }
 
     /// A skipped image still counts as the run having done its job, so an
@@ -2853,7 +3123,7 @@ mappings:
             reason: ocync_sync::SkipReason::DigestMatch,
         }]);
         assert_eq!(
-            combined_exit_code(&report, &[unresolved_mapping("repo/two", false)]),
+            combined_exit_code(&report, &[unresolved_mapping("repo/two", false)], &[]),
             ExitCode::PartialFailure
         );
     }
@@ -2867,7 +3137,10 @@ mappings:
             unresolved_mapping("repo/one", true),
             unresolved_mapping("repo/two", true),
         ];
-        assert_eq!(combined_exit_code(&empty, &denied), ExitCode::AuthError);
+        assert_eq!(
+            combined_exit_code(&empty, &denied, &[]),
+            ExitCode::AuthError
+        );
     }
 
     /// One non-auth failure in the set is enough to make it a generic failure.
@@ -2878,18 +3151,18 @@ mappings:
             unresolved_mapping("repo/one", true),
             unresolved_mapping("repo/two", false),
         ];
-        assert_eq!(combined_exit_code(&empty, &mixed), ExitCode::Failure);
+        assert_eq!(combined_exit_code(&empty, &mixed, &[]), ExitCode::Failure);
     }
 
     #[test]
     fn dry_run_exit_code_maps_resolution_counts() {
-        assert_eq!(dry_run_exit_code(3, &[]), ExitCode::Success);
+        assert_eq!(dry_run_exit_code(3, &[], &[]), ExitCode::Success);
         assert_eq!(
-            dry_run_exit_code(2, &[unresolved_mapping("repo/two", false)]),
+            dry_run_exit_code(2, &[unresolved_mapping("repo/two", false)], &[]),
             ExitCode::PartialFailure
         );
         assert_eq!(
-            dry_run_exit_code(0, &[unresolved_mapping("repo/two", false)]),
+            dry_run_exit_code(0, &[unresolved_mapping("repo/two", false)], &[]),
             ExitCode::Failure
         );
     }
@@ -2903,9 +3176,9 @@ mappings:
             unresolved_mapping("repo/one", true),
             unresolved_mapping("repo/two", true),
         ];
-        assert_eq!(dry_run_exit_code(0, &denied), ExitCode::AuthError);
+        assert_eq!(dry_run_exit_code(0, &denied, &[]), ExitCode::AuthError);
         // Something resolved, so the run was only partly denied.
-        assert_eq!(dry_run_exit_code(1, &denied), ExitCode::PartialFailure);
+        assert_eq!(dry_run_exit_code(1, &denied, &[]), ExitCode::PartialFailure);
     }
 
     // -----------------------------------------------------------------
@@ -2915,14 +3188,14 @@ mappings:
     #[test]
     fn cycle_tail_names_unresolved_mappings() {
         let report = report_with(Vec::new());
-        let line = format_cycle_tail(4, 2, &report);
+        let line = format_cycle_tail(4, 2, 0, &report);
         assert!(line.contains("2 unresolved"), "{line}");
     }
 
     #[test]
     fn cycle_tail_omits_the_clause_when_everything_resolved() {
         let report = report_with(Vec::new());
-        let line = format_cycle_tail(4, 0, &report);
+        let line = format_cycle_tail(4, 0, 0, &report);
         assert!(!line.contains("unresolved"), "{line}");
     }
 
@@ -2939,6 +3212,7 @@ mappings:
         let value = serde_json::to_value(SyncOutput {
             report: &report,
             unresolved_mappings: &failures,
+            dropped_targets: &[],
         })
         .expect("serializes");
 
@@ -2960,6 +3234,7 @@ mappings:
         let value = serde_json::to_value(SyncOutput {
             report: &report,
             unresolved_mappings: &[],
+            dropped_targets: &[],
         })
         .expect("serializes");
 

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -7,7 +7,7 @@ use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use ocync_distribution::auth::detect::{ProviderKind, detect_provider_kind};
 use ocync_distribution::ecr::{BatchBlobChecker, BatchChecker};
@@ -103,6 +103,11 @@ impl PrepareTracker {
         });
     }
 
+    /// The current step and its counts.
+    fn snapshot(&self) -> PrepareProgress {
+        self.state.get()
+    }
+
     /// Record one item finished in the current step.
     pub(crate) fn advance(&self) {
         let mut p = self.state.get();
@@ -119,6 +124,7 @@ impl PrepareTracker {
 /// three-mapping config it emitted nothing across an 8.6 second run.
 pub(crate) async fn with_prepare_progress<F: Future>(
     tracker: &PrepareTracker,
+    what: &'static str,
     work: F,
 ) -> F::Output {
     tick_while(tracker, PREPARE_PROGRESS_INTERVAL, work, |p, elapsed| {
@@ -127,7 +133,7 @@ pub(crate) async fn with_prepare_progress<F: Future>(
             done = p.done,
             total = p.total,
             elapsed_secs = elapsed.as_secs(),
-            "preparing sync"
+            "preparing {what}"
         );
     })
     .await
@@ -145,7 +151,9 @@ async fn tick_while<F: Future>(
     mut emit: impl FnMut(PrepareProgress, Duration),
 ) -> F::Output {
     let mut work = std::pin::pin!(work);
-    let started = Instant::now();
+    // tokio's clock, not `std`: under a paused runtime `std::time::Instant`
+    // does not advance, so the elapsed value would always read zero in tests.
+    let started = tokio::time::Instant::now();
     let mut ticker = tokio::time::interval(interval);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     // `interval` yields immediately; push the first tick out a full period so
@@ -157,7 +165,7 @@ async fn tick_while<F: Future>(
             // finished future is dropped rather than logged after the fact.
             biased;
             out = &mut work => return out,
-            _ = ticker.tick() => emit(tracker.state.get(), started.elapsed()),
+            _ = ticker.tick() => emit(tracker.snapshot(), started.elapsed()),
         }
     }
 }
@@ -171,16 +179,11 @@ pub(crate) type ClientMap = HashMap<String, Result<Arc<RegistryClient>, ClientIn
 
 /// Why a registry's client could not be built.
 ///
-/// Carries the classification alongside the message: recovering it later from
-/// a stringified error is impossible, and losing it downgrades a wholly denied
-/// run from the auth exit code to the generic failure code.
+/// Holds the error itself rather than its text: the classification cannot be
+/// recovered from a string, and losing it downgrades a wholly denied run from
+/// the auth exit code to the generic failure code.
 #[derive(Debug)]
-pub(crate) struct ClientInitError {
-    /// The original error, already formatted.
-    message: String,
-    /// Whether the cause was a credential failure.
-    auth: bool,
-}
+pub(crate) struct ClientInitError(CliError);
 
 /// Which side of a mapping a registry sits on, for error messages.
 #[derive(Debug, Clone, Copy)]
@@ -253,6 +256,7 @@ pub(crate) struct UnresolvedMapping {
 pub(crate) fn shared_failure_code(codes: impl IntoIterator<Item = ExitCode>) -> ExitCode {
     let mut codes = codes.into_iter();
     let Some(first) = codes.next() else {
+        debug_assert!(false, "shared_failure_code called with no failures");
         return ExitCode::Failure;
     };
     if matches!(first, ExitCode::AuthError | ExitCode::ConfigError) && codes.all(|c| c == first) {
@@ -340,8 +344,8 @@ impl fmt::Display for NoTagsInfo {
 #[derive(Debug, Default)]
 pub(crate) struct WatchLogState {
     warned_no_tags: HashSet<String>,
-    /// [`target_key`] for every target currently reported down.
-    dropped_targets: HashSet<String>,
+    /// Registries currently reported down, per mapping.
+    dropped_targets: HashMap<String, HashSet<String>>,
     /// Mappings currently reported as unresolvable.
     unresolved: HashSet<String>,
     last_outcomes: HashMap<String, MappingOutcome>,
@@ -373,7 +377,11 @@ impl WatchLogState {
     /// Keyed on mapping plus registry so two mappings losing the same mirror
     /// each report once, and a second mirror going down still reports.
     fn observe_dropped_target(&mut self, from: &str, registry: &str) -> bool {
-        let changed = self.dropped_targets.insert(target_key(from, registry));
+        let down = match self.dropped_targets.get_mut(from) {
+            Some(down) => down,
+            None => self.dropped_targets.entry(from.to_owned()).or_default(),
+        };
+        let changed = down.insert(registry.to_owned());
         if changed {
             self.cycle_emit_count = self.cycle_emit_count.saturating_add(1);
         }
@@ -386,14 +394,10 @@ impl WatchLogState {
     /// Reconciling rather than clearing wholesale is what makes a partial
     /// recovery work: clearing only when nothing is down leaves a recovered
     /// mirror suppressed for as long as any sibling stays down.
-    fn forget_recovered_targets(&mut self, from: &str, still_down: &HashSet<&str>) {
-        let prefix = target_key(from, "");
-        self.dropped_targets
-            .retain(|key| match key.strip_prefix(&prefix) {
-                // Another mapping's key.
-                None => true,
-                Some(registry) => still_down.contains(registry),
-            });
+    fn forget_recovered_targets(&mut self, from: &str, still_down: &[DroppedTarget]) {
+        if let Some(down) = self.dropped_targets.get_mut(from) {
+            down.retain(|registry| still_down.iter().any(|t| t.registry == *registry));
+        }
     }
 
     /// Record a mapping that could not be resolved. Returns `true` on
@@ -461,22 +465,9 @@ impl WatchLogState {
         self.last_outcomes
             .retain(|k, _| active_set.contains(k.as_str()));
         self.unresolved.retain(|k| active_set.contains(k.as_str()));
-        // Composite keys need a prefix split, which is why this cannot join
-        // the retains above. A mapping removed and later re-added would
-        // otherwise keep a stale key and never warn about its dead mirror.
-        self.dropped_targets.retain(|key| {
-            key.split_once('\u{0}')
-                .is_some_and(|(from, _)| active_set.contains(from))
-        });
+        self.dropped_targets
+            .retain(|k, _| active_set.contains(k.as_str()));
     }
-}
-
-/// Key a dropped target by mapping and registry.
-///
-/// NUL-separated because neither a repository path nor a registry alias can
-/// contain it, so the split back is unambiguous.
-fn target_key(from: &str, registry: &str) -> String {
-    format!("{from}\u{0}{registry}")
 }
 
 /// Resolve the cache directory and file path from config.
@@ -532,9 +523,10 @@ pub(crate) async fn run(
     // sequential network work with no output of their own. One ticker spans
     // the lot so the run is never silent for longer than the interval.
     let tracker = PrepareTracker::default();
-    let resolution = with_prepare_progress(&tracker, async {
-        let clients = build_clients(&config, &tracker).await;
-        let batch_checkers = build_batch_checkers(&config, &clients, &tracker).await;
+    let resolution = with_prepare_progress(&tracker, "sync", async {
+        let referenced = referenced_registries(&config);
+        let clients = build_clients(&config, &referenced, &tracker).await;
+        let batch_checkers = build_batch_checkers(&config, &clients, &referenced, &tracker).await;
         resolve_all(
             &config,
             &clients,
@@ -545,7 +537,7 @@ pub(crate) async fn run(
         )
         .await
     })
-    .await;
+    .await?;
     let Resolution {
         resolved: mappings,
         unresolved,
@@ -655,9 +647,10 @@ pub(crate) async fn run(
         })
         .collect();
 
-    // Anything dropped before the engine started is absent from the mappings
-    // it sees, and the prune cannot tell that from a deletion.
-    let complete = unresolved.is_empty() && dropped_targets.is_empty();
+    // Anything absent from the mappings the engine sees looks deleted to the
+    // prune. That includes a mapping whose tag list came back empty, which a
+    // transient short response is indistinguishable from.
+    let complete = unresolved.is_empty() && dropped_targets.is_empty() && no_match == 0;
     let engine =
         SyncEngine::new(RetryConfig::default(), max_concurrent).with_cache_pruning(complete);
     let report = engine
@@ -702,7 +695,7 @@ pub(crate) async fn run(
 
 /// Exit code for a dry run, which produces no [`SyncReport`] to fold into.
 fn dry_run_exit_code(
-    resolved: usize,
+    succeeded: usize,
     unresolved: &[UnresolvedMapping],
     dropped: &[DroppedTarget],
 ) -> ExitCode {
@@ -715,7 +708,7 @@ fn dry_run_exit_code(
             ExitCode::PartialFailure
         };
     }
-    if resolved > 0 {
+    if succeeded > 0 {
         return ExitCode::PartialFailure;
     }
     total_failure_code(unresolved)
@@ -1031,8 +1024,11 @@ fn parse_size(s: &str) -> Option<u64> {
 /// registry can fail. Record the failure against that alias instead of
 /// aborting: registries the failing one shares no mapping with still sync, and
 /// the mappings that do reference it fail with the original error text.
-pub(crate) async fn build_clients(config: &Config, tracker: &PrepareTracker) -> ClientMap {
-    let referenced = referenced_registries(config);
+pub(crate) async fn build_clients(
+    config: &Config,
+    referenced: &Referenced,
+    tracker: &PrepareTracker,
+) -> ClientMap {
     tracker.begin(PreparePhase::Registries, referenced.len());
     let mut clients = ClientMap::with_capacity(referenced.len());
     for (name, reg) in &config.registries {
@@ -1048,10 +1044,7 @@ pub(crate) async fn build_clients(config: &Config, tracker: &PrepareTracker) -> 
                     error = %err,
                     "registry client setup failed; mappings using this registry will be skipped"
                 );
-                Err(ClientInitError {
-                    auth: matches!(err.exit_code(), ExitCode::AuthError),
-                    message: err.to_string(),
-                })
+                Err(ClientInitError(err))
             }
         };
         clients.insert(name.clone(), entry);
@@ -1066,10 +1059,10 @@ pub(crate) async fn build_clients(config: &Config, tracker: &PrepareTracker) -> 
 /// mapping uses costs an auth round trip against the rate-limit budget and, on
 /// failure, logs an error nothing depends on. A target value that does not
 /// resolve is left out here; `resolve_mapping` reports it per mapping.
-fn referenced_registries(config: &Config) -> HashSet<String> {
+pub(crate) fn referenced_registries(config: &Config) -> Referenced {
     let known: HashSet<&str> = config.registries.keys().map(String::as_str).collect();
     let defaults = config.defaults.as_ref();
-    let mut used = HashSet::new();
+    let mut referenced = Referenced::default();
     for mapping in &config.mappings {
         if let Some(source) = mapping
             .source
@@ -1080,24 +1073,38 @@ fn referenced_registries(config: &Config) -> HashSet<String> {
             // total past the number of clients actually built.
             .filter(|name| known.contains(name))
         {
-            used.insert(source.to_owned());
+            referenced.sources.insert(source.to_owned());
         }
         if let Ok(names) = mapping_target_names(mapping, config, &known) {
-            used.extend(names);
+            referenced.targets.extend(names);
         }
     }
-    used
+    referenced
 }
 
-/// Registry aliases named as a target by at least one mapping.
-fn referenced_targets(config: &Config) -> HashSet<String> {
-    let known: HashSet<&str> = config.registries.keys().map(String::as_str).collect();
-    config
-        .mappings
-        .iter()
-        .filter_map(|m| mapping_target_names(m, config, &known).ok())
-        .flatten()
-        .collect()
+/// Registry aliases the config actually uses, split by role.
+///
+/// Both sets come from one walk: expanding every mapping's target groups is
+/// the most expensive part of the prepare phase, and clients and batch
+/// checkers want different halves of the same answer.
+#[derive(Debug, Default)]
+pub(crate) struct Referenced {
+    /// Aliases named as a source.
+    sources: HashSet<String>,
+    /// Aliases named as a target, with groups expanded.
+    targets: HashSet<String>,
+}
+
+impl Referenced {
+    /// Whether any mapping names this alias at all.
+    fn contains(&self, name: &str) -> bool {
+        self.sources.contains(name) || self.targets.contains(name)
+    }
+
+    /// How many distinct registries need a client.
+    fn len(&self) -> usize {
+        self.sources.union(&self.targets).count()
+    }
 }
 
 /// Target registry aliases a mapping names, with groups expanded.
@@ -1134,17 +1141,15 @@ fn client_for(
 ) -> Result<Arc<RegistryClient>, CliError> {
     match clients.get(name) {
         Some(Ok(client)) => Ok(Arc::clone(client)),
-        Some(Err(err)) => {
+        Some(Err(ClientInitError(cause))) => {
             let msg = format!(
-                "mapping '{mapping_from}': {role} registry '{name}' is unavailable: {}",
-                err.message
+                "mapping '{mapping_from}': {role} registry '{name}' is unavailable: {cause}"
             );
-            // A denied registry stays a denial here, so a run that failed only
-            // on credentials still exits with the auth code.
-            Err(if err.auth {
-                CliError::Auth(msg)
-            } else {
-                CliError::Input(msg)
+            // The cause keeps its classification, so a run that failed only on
+            // credentials still exits with the auth code.
+            Err(match cause.exit_code() {
+                ExitCode::AuthError => CliError::Auth(msg),
+                _ => CliError::Input(msg),
             })
         }
         None => Err(CliError::Input(format!(
@@ -1166,20 +1171,19 @@ fn client_for(
 async fn build_batch_checkers(
     config: &Config,
     clients: &ClientMap,
+    referenced: &Referenced,
     tracker: &PrepareTracker,
 ) -> HashMap<String, Rc<dyn BatchBlobChecker>> {
     let mut checkers: HashMap<String, Rc<dyn BatchBlobChecker>> = HashMap::new();
 
-    // The client map is already the referenced set, so deriving it from there
-    // avoids re-resolving every mapping's target groups a second time. Only
-    // registries whose client actually built are worth a checker: the rest
-    // have already failed and would just repeat the round trip.
-    let targets = referenced_targets(config);
+    // Targets only, and only where the client built: the map is read by
+    // target alias, and a registry that already failed would just repeat the
+    // round trip for a checker nothing can use.
     let usable: Vec<(&String, &RegistryConfig)> = config
         .registries
         .iter()
         .filter(|(name, _)| {
-            targets.contains(name.as_str()) && matches!(clients.get(*name), Some(Ok(_)))
+            referenced.targets.contains(name.as_str()) && matches!(clients.get(*name), Some(Ok(_)))
         })
         .collect();
     tracker.begin(PreparePhase::BatchCheckers, usable.len());
@@ -1221,6 +1225,7 @@ async fn build_batch_checkers(
 }
 
 /// What resolving a whole config produced.
+#[derive(Debug)]
 pub(crate) struct Resolution {
     /// Mappings ready for the engine.
     pub resolved: Vec<ResolvedMapping>,
@@ -1248,7 +1253,7 @@ async fn resolve_all(
     with_report: bool,
     mut watch_log: Option<&mut WatchLogState>,
     tracker: &PrepareTracker,
-) -> Resolution {
+) -> Result<Resolution, CliError> {
     tracker.begin(PreparePhase::Mappings, config.mappings.len());
     let mut resolved = Vec::new();
     let mut unresolved = Vec::new();
@@ -1287,6 +1292,12 @@ async fn resolve_all(
                 // mapping with nothing to do, not a failure.
                 no_match += 1;
             }
+            // A broken config is not a transient failure to route around: a
+            // bad glob, an unparseable platform, an unknown registry alias, or
+            // a `min_tags` tripwire all mean the operator asked for something
+            // the run must not silently do less than. Isolation covers
+            // registries that are down, not configs that are wrong.
+            Err(err) if err.exit_code() == ExitCode::ConfigError => return Err(err),
             Err(err) => {
                 // Gated like every other watch surface: without it a
                 // permanently broken mapping logs an ERROR every cycle while
@@ -1309,12 +1320,12 @@ async fn resolve_all(
         tracker.advance();
     }
 
-    Resolution {
+    Ok(Resolution {
         resolved,
         unresolved,
         dropped_targets,
         no_match,
-    }
+    })
 }
 
 /// WARN once per target that goes down, not once per watch cycle.
@@ -1334,8 +1345,7 @@ fn reconcile_dropped_targets(
         }
         return;
     };
-    let now: HashSet<&str> = dropped.iter().map(|t| t.registry.as_str()).collect();
-    state.forget_recovered_targets(from, &now);
+    state.forget_recovered_targets(from, dropped);
     for target in dropped {
         if state.observe_dropped_target(from, &target.registry) {
             warn_dropped_target(target);
@@ -1383,6 +1393,7 @@ fn build_targets(
 ) -> (Vec<TargetEntry>, Option<CliError>) {
     let mut targets = Vec::with_capacity(target_names.len());
     let mut worst_err: Option<CliError> = None;
+    let mut codes = Vec::new();
     for name in target_names {
         match client_for(clients, &name, from, RegistryRole::Target) {
             Ok(client) => targets.push(TargetEntry {
@@ -1397,23 +1408,27 @@ fn build_targets(
                     registry: name,
                     error: err.to_string(),
                 });
-                // Keep a denial over anything else rather than the last one
-                // seen: target order comes straight from the config file, and
-                // the same outage should not exit 2 or 4 depending on how the
-                // list happens to be written.
-                let replace = match &worst_err {
-                    None => true,
-                    Some(existing) => {
-                        !matches!(existing.exit_code(), ExitCode::AuthError)
-                            && matches!(err.exit_code(), ExitCode::AuthError)
-                    }
-                };
-                if replace {
+                // Order-independent, and folded by the same rule the run-level
+                // code uses: target order comes straight from the config file,
+                // and mixed causes report the generic failure rather than
+                // whichever happened to be written last.
+                codes.push(err.exit_code());
+                if worst_err.is_none() {
                     worst_err = Some(err);
                 }
             }
         }
     }
+    // Re-classify with the shared rule so the error the caller surfaces
+    // carries the folded code rather than the first one seen.
+    let worst_err = worst_err.map(|err| {
+        let folded = shared_failure_code(codes);
+        if folded == err.exit_code() {
+            err
+        } else {
+            CliError::Input(err.to_string())
+        }
+    });
     (targets, worst_err)
 }
 
@@ -1778,13 +1793,13 @@ fn describe_filter(
 struct SyncOutput<'a> {
     #[serde(flatten)]
     report: &'a SyncReport,
-    /// Mappings dropped during resolution. Absent when every mapping resolved,
-    /// so the document shape is unchanged on a clean run.
-    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    /// Mappings dropped during resolution.
+    ///
+    /// Always present, empty on a clean run: `analyze` reports the same key
+    /// the same way, and a consumer reading both should not have to handle a
+    /// missing field on one and not the other.
     unresolved_mappings: &'a [UnresolvedMapping],
-    /// Targets a resolved mapping could not use. Absent when none were
-    /// dropped, so the document shape is unchanged on a clean run.
-    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    /// Targets a resolved mapping could not use.
     dropped_targets: &'a [DroppedTarget],
 }
 
@@ -2975,10 +2990,11 @@ mappings:
 
     /// A registry whose client could not be built, as `build_clients` records it.
     fn broken_client(message: &str, auth: bool) -> Result<Arc<RegistryClient>, ClientInitError> {
-        Err(ClientInitError {
-            message: message.to_string(),
-            auth,
-        })
+        Err(ClientInitError(if auth {
+            CliError::Auth(message.to_string())
+        } else {
+            CliError::Input(message.to_string())
+        }))
     }
 
     async fn resolve(config: &Config, clients: &ClientMap) -> Resolution {
@@ -2991,6 +3007,7 @@ mappings:
             &PrepareTracker::default(),
         )
         .await
+        .expect("no config-class failure in these fixtures")
     }
 
     /// A mapping that cannot be resolved must not cost the run the mappings
@@ -3279,7 +3296,12 @@ mappings:
         )
         .expect("config yaml parses");
 
-        let clients = build_clients(&config, &PrepareTracker::default()).await;
+        let clients = build_clients(
+            &config,
+            &referenced_registries(&config),
+            &PrepareTracker::default(),
+        )
+        .await;
 
         let mut names: Vec<&str> = clients.keys().map(String::as_str).collect();
         names.sort_unstable();
@@ -3314,12 +3336,16 @@ mappings:
 
         let used = referenced_registries(&config);
 
-        assert!(used.contains("src"));
-        assert!(used.contains("dst"), "target groups must be expanded");
+        assert!(used.sources.contains("src"));
+        assert!(
+            used.targets.contains("dst"),
+            "target groups must be expanded"
+        );
         assert!(
             !used.contains("unused"),
             "a registry no mapping names must not be built"
         );
+        assert_eq!(used.len(), 2);
     }
 
     /// The prepare ticker must fire on wall-clock, not on item boundaries.
@@ -3422,11 +3448,12 @@ mappings:
         .expect("config yaml parses");
 
         let tracker = PrepareTracker::default();
-        let clients = build_clients(&config, &tracker).await;
-        let checkers = build_batch_checkers(&config, &clients, &tracker).await;
+        let referenced = referenced_registries(&config);
+        let clients = build_clients(&config, &referenced, &tracker).await;
+        let checkers = build_batch_checkers(&config, &clients, &referenced, &tracker).await;
 
         assert!(checkers.is_empty(), "neither registry is ECR");
-        let p = tracker.state.get();
+        let p = tracker.snapshot();
         assert_eq!(
             p.total, 1,
             "only the target registry is a checker candidate; the map is read by target alias"
@@ -3457,7 +3484,11 @@ mappings:
         // Partial recovery: mirror-a is back, mirror-b is still down. The
         // all-or-nothing clear this replaced left mirror-a suppressed for as
         // long as any sibling stayed down.
-        let still_down: HashSet<&str> = ["mirror-b"].into_iter().collect();
+        let still_down = [DroppedTarget {
+            from: "repo/one".into(),
+            registry: "mirror-b".into(),
+            error: "still down".into(),
+        }];
         state.forget_recovered_targets("repo/one", &still_down);
         assert!(
             state.observe_dropped_target("repo/one", "mirror-a"),
@@ -3567,6 +3598,53 @@ mappings:
         assert!(
             dropped.is_empty(),
             "nothing was dropped; the config named nothing"
+        );
+    }
+
+    /// A broken config must still stop the run. Isolation exists for
+    /// registries that are down, not for configs that are wrong: a bad glob,
+    /// an unparseable platform, an unknown alias, or a `min_tags` tripwire all
+    /// mean the operator asked for something the run must not silently do
+    /// less than.
+    #[tokio::test]
+    async fn a_config_error_is_fatal_rather_than_isolated() {
+        let config: Config = serde_yaml::from_str(
+            r#"
+registries:
+  src:
+    url: source.test
+  dst:
+    url: target.test
+defaults:
+  source: src
+  targets: [dst]
+mappings:
+  - from: repo/one
+    tags:
+      glob: ["v1"]
+  - from: repo/two
+    tags:
+      glob: ["v1"]
+      immutable_tags: "[unclosed"
+"#,
+        )
+        .expect("config yaml parses");
+
+        let err = resolve_all(
+            &config,
+            &working_clients(),
+            &HashMap::new(),
+            false,
+            None,
+            &PrepareTracker::default(),
+        )
+        .await
+        .expect_err("an invalid glob must not be isolated");
+
+        assert_eq!(
+            err.exit_code(),
+            ExitCode::ConfigError,
+            "and it keeps the config exit code"
         );
     }
 
@@ -3736,9 +3814,10 @@ mappings:
         assert!(value.get("stats").is_some(), "{value}");
     }
 
-    /// The key is absent on a clean run so the document shape is unchanged.
+    /// Both keys are always present, so one consumer can read `sync` and
+    /// `analyze` output with the same shape.
     #[test]
-    fn json_output_omits_unresolved_mappings_when_empty() {
+    fn json_output_always_carries_the_failure_keys() {
         let report = report_with(Vec::new());
         let value = serde_json::to_value(SyncOutput {
             report: &report,
@@ -3747,7 +3826,8 @@ mappings:
         })
         .expect("serializes");
 
-        assert!(value.get("unresolved_mappings").is_none(), "{value}");
+        assert_eq!(value["unresolved_mappings"], serde_json::json!([]));
+        assert_eq!(value["dropped_targets"], serde_json::json!([]));
     }
 
     /// Full wire-up: `select_filtered_tags` + `ResolvedMapping` construction +

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -1,7 +1,9 @@
 //! The `sync` subcommand - runs all mappings from config.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
@@ -40,20 +42,141 @@ const CACHE_FILE_NAME: &str = "transfer_state.bin";
 /// example data without overwhelming the log line.
 const NO_TAGS_SAMPLE_CAP: usize = 5;
 
-/// Minimum gap between progress lines while mappings are being resolved.
+/// Cadence of the progress line emitted while the run is preparing.
 ///
-/// Resolution is sequential and network-bound - one tag listing per mapping -
-/// so a large config can spend minutes here before the engine starts and the
-/// first per-image line appears. Emitting on a timer rather than per mapping
-/// keeps fast configs silent and slow ones legible.
-const RESOLVE_PROGRESS_INTERVAL: Duration = Duration::from_secs(5);
+/// Everything before the engine starts is sequential and network-bound: each
+/// client build mints a token for ECR, GAR, and ACR, and each mapping lists a
+/// repository's tags. No per-image output exists yet, so without this a large
+/// config runs for minutes with nothing in the log.
+const PREPARE_PROGRESS_INTERVAL: Duration = Duration::from_secs(5);
+
+/// A step of the pre-engine phase.
+#[derive(Debug, Clone, Copy, Default)]
+enum PreparePhase {
+    #[default]
+    Registries,
+    BatchCheckers,
+    Mappings,
+}
+
+impl fmt::Display for PreparePhase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Registries => f.write_str("registries"),
+            Self::BatchCheckers => f.write_str("batch checkers"),
+            Self::Mappings => f.write_str("mappings"),
+        }
+    }
+}
+
+/// Snapshot of the pre-engine phase, read by the progress ticker.
+#[derive(Debug, Clone, Copy, Default)]
+struct PrepareProgress {
+    /// Which pre-engine step is running.
+    phase: PreparePhase,
+    /// Items finished in this step.
+    done: usize,
+    /// Items this step will process.
+    total: usize,
+}
+
+/// Counter the pre-engine steps advance and the progress ticker reads.
+///
+/// A plain [`Cell`] rather than a channel: the runtime is `current_thread`, so
+/// the ticker and the work it describes never run concurrently.
+#[derive(Debug, Default)]
+pub(crate) struct PrepareTracker {
+    state: Cell<PrepareProgress>,
+}
+
+impl PrepareTracker {
+    /// Start a new step, resetting the item counter.
+    fn begin(&self, phase: PreparePhase, total: usize) {
+        self.state.set(PrepareProgress {
+            phase,
+            done: 0,
+            total,
+        });
+    }
+
+    /// Record one item finished in the current step.
+    fn advance(&self) {
+        let mut p = self.state.get();
+        p.done += 1;
+        self.state.set(p);
+    }
+}
+
+/// Drive `work` to completion, logging its progress every
+/// [`PREPARE_PROGRESS_INTERVAL`].
+///
+/// The ticker fires on wall-clock, not on item boundaries, so a single slow
+/// mapping still reports. A boundary-driven throttle does not: measured on a
+/// three-mapping config it emitted nothing across an 8.6 second run.
+pub(crate) async fn with_prepare_progress<F: Future>(
+    tracker: &PrepareTracker,
+    work: F,
+) -> F::Output {
+    let mut work = std::pin::pin!(work);
+    let started = Instant::now();
+    let mut ticker = tokio::time::interval(PREPARE_PROGRESS_INTERVAL);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // `interval` yields immediately; push the first tick out a full period so
+    // a fast run stays silent.
+    ticker.reset();
+    loop {
+        tokio::select! {
+            biased;
+            out = &mut work => return out,
+            _ = ticker.tick() => {
+                let p = tracker.state.get();
+                tracing::info!(
+                    phase = %p.phase,
+                    done = p.done,
+                    total = p.total,
+                    elapsed_secs = started.elapsed().as_secs(),
+                    "preparing sync"
+                );
+            }
+        }
+    }
+}
 
 /// Registry clients keyed by config alias.
 ///
-/// A registry whose auth provider could not be built is stored as its error
-/// text rather than dropped, so the failure surfaces only on the mappings
-/// that actually reference it.
-pub(crate) type ClientMap = HashMap<String, Result<Arc<RegistryClient>, String>>;
+/// A registry whose auth provider could not be built is stored as its failure
+/// rather than dropped, so the error surfaces only on the mappings that
+/// actually reference it.
+pub(crate) type ClientMap = HashMap<String, Result<Arc<RegistryClient>, ClientInitError>>;
+
+/// Why a registry's client could not be built.
+///
+/// Carries the classification alongside the message: recovering it later from
+/// a stringified error is impossible, and losing it downgrades a wholly denied
+/// run from the auth exit code to the generic failure code.
+#[derive(Debug)]
+pub(crate) struct ClientInitError {
+    /// The original error, already formatted.
+    message: String,
+    /// Whether the cause was a credential failure.
+    auth: bool,
+}
+
+/// Which side of a mapping a registry sits on, for error messages.
+#[derive(Debug, Clone, Copy)]
+enum RegistryRole {
+    Source,
+    Target,
+}
+
+impl fmt::Display for RegistryRole {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Source => f.write_str("source"),
+            Self::Target => f.write_str("target"),
+        }
+    }
+}
 
 /// Outcome of resolving a single mapping. Either the mapping is ready for the
 /// engine, or no source tag survived filtering and the caller decides whether
@@ -74,7 +197,7 @@ pub(crate) enum MappingResolution {
 /// Resolution failures are per-mapping: an unreachable registry or a 403 on
 /// one repository's tag listing must not stop the mappings behind it.
 #[derive(Debug, Serialize)]
-pub(crate) struct MappingFailure {
+pub(crate) struct UnresolvedMapping {
     /// Source repository path from the mapping config.
     pub from: String,
     /// Why the mapping could not be resolved.
@@ -121,8 +244,8 @@ impl NoTagsInfo {
     }
 }
 
-impl std::fmt::Display for NoTagsInfo {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for NoTagsInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let total = self.source_total();
         let total_phrase = if self.artifact_count > 0 {
             format!(
@@ -286,16 +409,24 @@ pub(crate) async fn run(
 ) -> Result<ExitCode, CliError> {
     let config = load_config(&args.config)?;
 
-    let clients = build_clients(&config).await;
-    let batch_checkers = build_batch_checkers(&config).await;
-
-    let (mappings, unresolved) = resolve_all(
-        &config,
-        &clients,
-        &batch_checkers,
-        args.dry_run,
-        watch_log.as_deref_mut(),
-    )
+    // Client construction, batch-checker setup, and mapping resolution are all
+    // sequential network work with no output of their own. One ticker spans
+    // the lot so the run is never silent for longer than the interval.
+    let tracker = PrepareTracker::default();
+    let (mappings, unresolved) = with_prepare_progress(&tracker, async {
+        let clients = build_clients(&config, &tracker).await;
+        let batch_checkers = build_batch_checkers(&config, &clients, &tracker).await;
+        let (mappings, unresolved) = resolve_all(
+            &config,
+            &clients,
+            &batch_checkers,
+            args.dry_run,
+            watch_log.as_deref_mut(),
+            &tracker,
+        )
+        .await;
+        (mappings, unresolved)
+    })
     .await;
 
     if let Some(state) = watch_log.as_mut() {
@@ -416,7 +547,7 @@ pub(crate) async fn run(
 }
 
 /// Exit code for a dry run, which produces no [`SyncReport`] to fold into.
-fn dry_run_exit_code(resolved: usize, unresolved: &[MappingFailure]) -> ExitCode {
+fn dry_run_exit_code(resolved: usize, unresolved: &[UnresolvedMapping]) -> ExitCode {
     if unresolved.is_empty() {
         return ExitCode::Success;
     }
@@ -428,10 +559,10 @@ fn dry_run_exit_code(resolved: usize, unresolved: &[MappingFailure]) -> ExitCode
 
 /// Exit code for a run where nothing succeeded.
 ///
-/// Keeps the dedicated auth code when every mapping was denied. Before
-/// failures were isolated the first 403 aborted with that code, and dropping
-/// to the generic failure code would silently retire it.
-fn total_failure_code(unresolved: &[MappingFailure]) -> ExitCode {
+/// A run denied everywhere exits with the auth code rather than the generic
+/// failure code, so an operator can tell "fix the credentials" from "fix
+/// something else" without reading the log.
+fn total_failure_code(unresolved: &[UnresolvedMapping]) -> ExitCode {
     if !unresolved.is_empty() && unresolved.iter().all(|f| f.auth) {
         ExitCode::AuthError
     } else {
@@ -444,17 +575,11 @@ fn total_failure_code(unresolved: &[MappingFailure]) -> ExitCode {
 /// A mapping that never reached the engine produces no [`ocync_sync::ImageResult`],
 /// so [`SyncReport::exit_code`] cannot see it. Counting each as a failure is
 /// what keeps a run whose mappings all 403'd from exiting 0.
-fn combined_exit_code(report: &SyncReport, unresolved: &[MappingFailure]) -> ExitCode {
+fn combined_exit_code(report: &SyncReport, unresolved: &[UnresolvedMapping]) -> ExitCode {
     if unresolved.is_empty() {
         return ExitCode::from_report(report.exit_code());
     }
-    let has_success = report.images.iter().any(|i| {
-        matches!(
-            i.status,
-            ocync_sync::ImageStatus::Synced | ocync_sync::ImageStatus::Skipped { .. }
-        )
-    });
-    if has_success {
+    if report.has_success() {
         return ExitCode::PartialFailure;
     }
     // Images that ran and failed for non-auth reasons make this a generic
@@ -603,12 +728,16 @@ fn format_mapping_outcome(d: &MappingDescriptor, o: &MappingOutcome, recovered: 
 
 /// One-line cycle tail rolling up totals across all mappings. The caller
 /// is responsible for gating this in watch mode (skip on idle cycles).
-fn emit_cycle_tail(descriptors: &[MappingDescriptor], unresolved: usize, report: &SyncReport) {
-    let line = format_cycle_tail(descriptors.len(), unresolved, report);
+fn emit_cycle_tail(
+    descriptors: &[MappingDescriptor],
+    unresolved_count: usize,
+    report: &SyncReport,
+) {
+    let line = format_cycle_tail(descriptors.len(), unresolved_count, report);
     // Counts are already in the message; structured fields would be a
     // verbatim restatement in text output. JSON aggregators parse the
     // message (or use the SyncReport via `--json`).
-    if report.stats.images_failed > 0 || unresolved > 0 {
+    if report.stats.images_failed > 0 || unresolved_count > 0 {
         tracing::warn!("{line}");
     } else {
         tracing::info!("{line}");
@@ -617,12 +746,12 @@ fn emit_cycle_tail(descriptors: &[MappingDescriptor], unresolved: usize, report:
 
 /// Render the cycle tail. Split from [`emit_cycle_tail`] so the wording is
 /// testable without a tracing subscriber.
-fn format_cycle_tail(mapping_count: usize, unresolved: usize, report: &SyncReport) -> String {
+fn format_cycle_tail(mapping_count: usize, unresolved_count: usize, report: &SyncReport) -> String {
     let s = &report.stats;
     // Unresolved mappings never reached the engine, so they are absent from
     // every count above and need their own clause.
-    let unresolved_clause = if unresolved > 0 {
-        format!(" | {unresolved} unresolved")
+    let unresolved_clause = if unresolved_count > 0 {
+        format!(" | {unresolved_count} unresolved")
     } else {
         String::new()
     };
@@ -700,9 +829,14 @@ fn parse_size(s: &str) -> Option<u64> {
 /// registry can fail. Record the failure against that alias instead of
 /// aborting: registries the failing one shares no mapping with still sync, and
 /// the mappings that do reference it fail with the original error text.
-pub(crate) async fn build_clients(config: &Config) -> ClientMap {
-    let mut clients = ClientMap::with_capacity(config.registries.len());
+pub(crate) async fn build_clients(config: &Config, tracker: &PrepareTracker) -> ClientMap {
+    let referenced = referenced_registries(config);
+    tracker.begin(PreparePhase::Registries, referenced.len());
+    let mut clients = ClientMap::with_capacity(referenced.len());
     for (name, reg) in &config.registries {
+        if !referenced.contains(name) {
+            continue;
+        }
         let hostname = bare_hostname(&reg.url);
         let entry = match build_registry_client(hostname, Some(reg)).await {
             Ok(client) => Ok(Arc::new(client)),
@@ -712,12 +846,48 @@ pub(crate) async fn build_clients(config: &Config) -> ClientMap {
                     error = %err,
                     "registry client setup failed; mappings using this registry will be skipped"
                 );
-                Err(err.to_string())
+                Err(ClientInitError {
+                    auth: matches!(err.exit_code(), ExitCode::AuthError),
+                    message: err.to_string(),
+                })
             }
         };
         clients.insert(name.clone(), entry);
+        tracker.advance();
     }
     clients
+}
+
+/// Registry aliases at least one mapping actually references.
+///
+/// Building a client mints a token for ECR, GAR, and ACR, so a registry no
+/// mapping uses costs an auth round trip against the rate-limit budget and, on
+/// failure, logs an error nothing depends on. A target value that does not
+/// resolve is left out here; `resolve_mapping` reports it per mapping.
+fn referenced_registries(config: &Config) -> HashSet<String> {
+    let known: HashSet<&str> = config.registries.keys().map(String::as_str).collect();
+    let defaults = config.defaults.as_ref();
+    let mut used = HashSet::new();
+    for mapping in &config.mappings {
+        if let Some(source) = mapping
+            .source
+            .as_deref()
+            .or(defaults.and_then(|d| d.source.as_deref()))
+        {
+            used.insert(source.to_owned());
+        }
+        if let Some(targets) = mapping
+            .targets
+            .as_ref()
+            .or(defaults.and_then(|d| d.targets.as_ref()))
+        {
+            let context = format!("mapping '{}'", mapping.from);
+            if let Ok(names) = resolve_target_names(targets, config, &known, &context) {
+                used.extend(names);
+            }
+        }
+    }
+    used
 }
 
 /// Look up a usable client for `name`, turning a missing or failed registry
@@ -726,13 +896,23 @@ fn client_for(
     clients: &ClientMap,
     name: &str,
     mapping_from: &str,
-    role: &str,
+    role: RegistryRole,
 ) -> Result<Arc<RegistryClient>, CliError> {
     match clients.get(name) {
         Some(Ok(client)) => Ok(Arc::clone(client)),
-        Some(Err(err)) => Err(CliError::Input(format!(
-            "mapping '{mapping_from}': {role} registry '{name}' is unavailable: {err}"
-        ))),
+        Some(Err(err)) => {
+            let msg = format!(
+                "mapping '{mapping_from}': {role} registry '{name}' is unavailable: {}",
+                err.message
+            );
+            // A denied registry stays a denial here, so a run that failed only
+            // on credentials still exits with the auth code.
+            Err(if err.auth {
+                CliError::Auth(msg)
+            } else {
+                CliError::Input(msg)
+            })
+        }
         None => Err(CliError::Input(format!(
             "mapping '{mapping_from}': {role} registry '{name}' not found in clients"
         ))),
@@ -744,10 +924,20 @@ fn client_for(
 /// Automatically creates a [`BatchChecker`] for every registry detected
 /// as ECR (via explicit `auth_type: ecr` or hostname auto-detection). No
 /// user configuration is needed - if we know it's ECR, we use the batch API.
-async fn build_batch_checkers(config: &Config) -> HashMap<String, Rc<dyn BatchBlobChecker>> {
+async fn build_batch_checkers(
+    config: &Config,
+    clients: &ClientMap,
+    tracker: &PrepareTracker,
+) -> HashMap<String, Rc<dyn BatchBlobChecker>> {
     let mut checkers: HashMap<String, Rc<dyn BatchBlobChecker>> = HashMap::new();
 
+    // The client map is already the referenced set; deriving it from there
+    // avoids re-resolving every mapping's target groups a second time.
+    tracker.begin(PreparePhase::BatchCheckers, clients.len());
     for (name, reg) in &config.registries {
+        if !clients.contains_key(name) {
+            continue;
+        }
         let hostname = bare_hostname(&reg.url);
         // Explicit non-Ecr auth_type is a hard opt-out: don't try to build an
         // AWS-SDK-backed batch checker for a registry the user has declared
@@ -777,6 +967,7 @@ async fn build_batch_checkers(config: &Config) -> HashMap<String, Rc<dyn BatchBl
                 "ECR batch checker unavailable; manifest commits fall back to retry-on-conflict"
             ),
         }
+        tracker.advance();
     }
 
     checkers
@@ -787,21 +978,20 @@ async fn build_batch_checkers(config: &Config) -> HashMap<String, Rc<dyn BatchBl
 /// One unreachable registry, one 403 on a tag listing, or one bad repository
 /// name must not cost the run every other mapping. Each failure is logged and
 /// recorded; resolution continues. Returns the mappings that are ready for the
-/// engine plus one [`MappingFailure`] per mapping that is not.
+/// engine plus one [`UnresolvedMapping`] per mapping that is not.
 async fn resolve_all(
     config: &Config,
     clients: &ClientMap,
     batch_checkers: &HashMap<String, Rc<dyn BatchBlobChecker>>,
     with_report: bool,
     mut watch_log: Option<&mut WatchLogState>,
-) -> (Vec<ResolvedMapping>, Vec<MappingFailure>) {
-    let total = config.mappings.len();
-    let started = Instant::now();
-    let mut last_progress = started;
+    tracker: &PrepareTracker,
+) -> (Vec<ResolvedMapping>, Vec<UnresolvedMapping>) {
+    tracker.begin(PreparePhase::Mappings, config.mappings.len());
     let mut resolved = Vec::new();
-    let mut failures = Vec::new();
+    let mut unresolved = Vec::new();
 
-    for (index, mapping) in config.mappings.iter().enumerate() {
+    for mapping in &config.mappings {
         match resolve_mapping(mapping, config, clients, batch_checkers, with_report).await {
             Ok(MappingResolution::Resolved(m)) => resolved.push(m),
             Ok(MappingResolution::NoMatchingTags(info)) => {
@@ -814,33 +1004,30 @@ async fn resolve_all(
                 }
             }
             Err(err) => {
-                tracing::error!(
-                    from = %mapping.from,
-                    error = %err,
-                    "mapping could not be resolved; continuing with the remaining mappings"
-                );
-                failures.push(MappingFailure {
+                log_unresolved_mapping(&mapping.from, &err);
+                unresolved.push(UnresolvedMapping {
                     from: mapping.from.clone(),
                     auth: matches!(err.exit_code(), ExitCode::AuthError),
                     error: err.to_string(),
                 });
             }
         }
-
-        // Timer-gated so a config that resolves in a second stays silent while
-        // one that takes minutes reports where it is.
-        if index + 1 < total && last_progress.elapsed() >= RESOLVE_PROGRESS_INTERVAL {
-            tracing::info!(
-                resolved = index + 1,
-                total,
-                elapsed_secs = started.elapsed().as_secs(),
-                "resolving mappings"
-            );
-            last_progress = Instant::now();
-        }
+        tracker.advance();
     }
 
-    (resolved, failures)
+    (resolved, unresolved)
+}
+
+/// Report a mapping that could not be turned into work.
+///
+/// Shared with `analyze`, which drops the same mapping for the same reasons
+/// and should say so the same way.
+pub(crate) fn log_unresolved_mapping(from: &str, err: &CliError) {
+    tracing::error!(
+        from = %from,
+        error = %err,
+        "mapping could not be resolved; continuing with the remaining mappings"
+    );
 }
 
 /// Resolve a single mapping config into a [`MappingResolution`].
@@ -868,7 +1055,7 @@ pub(crate) async fn resolve_mapping(
             ))
         })?;
 
-    let source_client = client_for(clients, source_name, &mapping.from, "source")?;
+    let source_client = client_for(clients, source_name, &mapping.from, RegistryRole::Source)?;
 
     // --- Target registries ---
     let targets_value = mapping
@@ -887,19 +1074,41 @@ pub(crate) async fn resolve_mapping(
     let target_names =
         resolve_target_names(targets_value, config, &known, &context).map_err(CliError::Config)?;
 
-    let mut targets: Vec<TargetEntry> = target_names
-        .into_iter()
-        .map(|name| {
-            let client = client_for(clients, &name, &mapping.from, "target")?;
-            let batch_checker = batch_checkers.get(&name).cloned();
-            Ok(TargetEntry {
-                name: RegistryAlias::new(name),
-                client,
-                batch_checker,
-                existing_tags: HashSet::new(),
-            })
-        })
-        .collect::<Result<Vec<_>, CliError>>()?;
+    // One unusable target must not take its siblings with it: a mapping that
+    // fans out to three registries still syncs to the two that work. Mirrors
+    // the per-target degradation the immutable-tag listing below already does.
+    // Only when every target is gone does the mapping have nothing to do.
+    let mut targets: Vec<TargetEntry> = Vec::with_capacity(target_names.len());
+    let mut last_target_err = None;
+    for name in target_names {
+        match client_for(clients, &name, &mapping.from, RegistryRole::Target) {
+            Ok(client) => {
+                let batch_checker = batch_checkers.get(&name).cloned();
+                targets.push(TargetEntry {
+                    name: RegistryAlias::new(name),
+                    client,
+                    batch_checker,
+                    existing_tags: HashSet::new(),
+                });
+            }
+            Err(err) => {
+                tracing::warn!(
+                    from = %mapping.from,
+                    registry = %name,
+                    error = %err,
+                    "target registry unavailable; syncing the mapping's remaining targets"
+                );
+                last_target_err = Some(err);
+            }
+        }
+    }
+    if targets.is_empty() {
+        // Every target failed, so the mapping itself is unresolvable. Surface
+        // one of the causes rather than a generic "no targets" message.
+        return Err(last_target_err.unwrap_or_else(|| {
+            CliError::Input(format!("mapping '{}': no target registries", mapping.from))
+        }));
+    }
 
     // --- Fetch and filter tags ---
     let source_repo_path = RepositoryName::new(&mapping.from)?;
@@ -1182,19 +1391,14 @@ struct SyncOutput<'a> {
     report: &'a SyncReport,
     /// Mappings dropped during resolution. Absent when every mapping resolved,
     /// so the document shape is unchanged on a clean run.
-    #[serde(skip_serializing_if = "slice_is_empty")]
-    unresolved_mappings: &'a [MappingFailure],
-}
-
-/// Serde predicate for a borrowed slice field.
-fn slice_is_empty<T>(s: &&[T]) -> bool {
-    s.is_empty()
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    unresolved_mappings: &'a [UnresolvedMapping],
 }
 
 /// Write sync output as JSON when `--json` is passed.
 fn write_output(
     report: &SyncReport,
-    unresolved: &[MappingFailure],
+    unresolved: &[UnresolvedMapping],
     json: bool,
 ) -> Result<(), CliError> {
     if json {
@@ -2351,17 +2555,38 @@ mappings:
         ])
     }
 
+    /// A registry whose client could not be built, as `build_clients` records it.
+    fn broken_client(message: &str, auth: bool) -> Result<Arc<RegistryClient>, ClientInitError> {
+        Err(ClientInitError {
+            message: message.to_string(),
+            auth,
+        })
+    }
+
+    async fn resolve(
+        config: &Config,
+        clients: &ClientMap,
+    ) -> (Vec<ResolvedMapping>, Vec<UnresolvedMapping>) {
+        resolve_all(
+            config,
+            clients,
+            &HashMap::new(),
+            false,
+            None,
+            &PrepareTracker::default(),
+        )
+        .await
+    }
+
     /// A mapping that cannot be resolved must not cost the run the mappings
-    /// behind it. Before this, the first failure `?`-returned out of `run` and
-    /// every later mapping was silently dropped.
+    /// behind it: the mapping *after* the failure is the one that proves it.
     #[tokio::test]
     async fn resolve_all_isolates_a_failing_mapping() {
         let config = three_mapping_config();
-        let (resolved, failures) =
-            resolve_all(&config, &working_clients(), &HashMap::new(), false, None).await;
+        let (resolved, unresolved) = resolve(&config, &working_clients()).await;
 
-        assert_eq!(failures.len(), 1, "only the bad mapping should fail");
-        assert_eq!(failures[0].from, "repo/two");
+        assert_eq!(unresolved.len(), 1, "only the bad mapping should fail");
+        assert_eq!(unresolved[0].from, "repo/two");
 
         // The negative half: the mapping *after* the failure still resolved.
         let names: Vec<&str> = resolved.iter().map(|m| m.source_repo.as_str()).collect();
@@ -2400,22 +2625,27 @@ mappings:
             ("src".to_string(), Ok(test_client("https://source.test"))),
             (
                 "broken".to_string(),
-                Err("ECR auth setup for 'broken.test': 403 Forbidden".to_string()),
+                broken_client("ECR auth setup for 'broken.test': 403 Forbidden", true),
             ),
             ("dst".to_string(), Ok(test_client("https://target.test"))),
         ]);
 
-        let (resolved, failures) =
-            resolve_all(&config, &clients, &HashMap::new(), false, None).await;
+        let (resolved, unresolved) = resolve(&config, &clients).await;
 
         assert_eq!(resolved.len(), 1);
         assert_eq!(resolved[0].source_repo.as_str(), "repo/one");
-        assert_eq!(failures.len(), 1);
-        assert_eq!(failures[0].from, "repo/two");
+        assert_eq!(unresolved.len(), 1);
+        assert_eq!(unresolved[0].from, "repo/two");
         assert!(
-            failures[0].error.contains("403 Forbidden"),
+            unresolved[0].error.contains("403 Forbidden"),
             "the setup error must survive to the mapping failure: {}",
-            failures[0].error
+            unresolved[0].error
+        );
+        // The classification has to survive too, or a wholly denied run
+        // silently drops from the auth exit code to the generic one.
+        assert!(
+            unresolved[0].auth,
+            "a denied registry must stay classified as a denial"
         );
     }
 
@@ -2441,11 +2671,134 @@ mappings:
         )
         .expect("config yaml parses");
 
-        let (resolved, failures) =
-            resolve_all(&config, &working_clients(), &HashMap::new(), false, None).await;
+        let (resolved, unresolved) = resolve(&config, &working_clients()).await;
 
         assert_eq!(resolved.len(), 1);
-        assert!(failures.is_empty());
+        assert!(unresolved.is_empty());
+    }
+
+    /// A mapping fanning out to several targets keeps the ones that work.
+    ///
+    /// This is the same principle as per-mapping isolation, one level down: a
+    /// broken mirror must not stop the other mirrors from receiving the image.
+    #[tokio::test]
+    async fn resolve_all_keeps_the_working_targets_when_one_is_unavailable() {
+        let config: Config = serde_yaml::from_str(
+            r#"
+registries:
+  src:
+    url: source.test
+  good:
+    url: good.test
+  broken:
+    url: broken.test
+defaults:
+  source: src
+  targets: [good, broken]
+mappings:
+  - from: repo/one
+    tags:
+      glob: ["v1"]
+"#,
+        )
+        .expect("config yaml parses");
+
+        let clients = ClientMap::from([
+            ("src".to_string(), Ok(test_client("https://source.test"))),
+            ("good".to_string(), Ok(test_client("https://good.test"))),
+            (
+                "broken".to_string(),
+                broken_client("ECR auth setup for 'broken.test': 403 Forbidden", true),
+            ),
+        ]);
+
+        let (resolved, unresolved) = resolve(&config, &clients).await;
+
+        assert!(
+            unresolved.is_empty(),
+            "one dead target must not unresolve the whole mapping"
+        );
+        assert_eq!(resolved.len(), 1);
+        let targets: Vec<&str> = resolved[0].targets.iter().map(|t| &*t.name).collect();
+        assert_eq!(targets, vec!["good"], "the healthy target must survive");
+    }
+
+    /// Losing every target is different from losing one: there is nowhere left
+    /// to sync, so the mapping is unresolvable and keeps its cause.
+    #[tokio::test]
+    async fn resolve_all_fails_the_mapping_when_every_target_is_gone() {
+        let config: Config = serde_yaml::from_str(
+            r#"
+registries:
+  src:
+    url: source.test
+  broken:
+    url: broken.test
+defaults:
+  source: src
+  targets: [broken]
+mappings:
+  - from: repo/one
+    tags:
+      glob: ["v1"]
+"#,
+        )
+        .expect("config yaml parses");
+
+        let clients = ClientMap::from([
+            ("src".to_string(), Ok(test_client("https://source.test"))),
+            (
+                "broken".to_string(),
+                broken_client("ECR auth setup for 'broken.test': 403 Forbidden", true),
+            ),
+        ]);
+
+        let (resolved, unresolved) = resolve(&config, &clients).await;
+
+        assert!(resolved.is_empty());
+        assert_eq!(unresolved.len(), 1);
+        assert!(
+            unresolved[0].error.contains("403 Forbidden"),
+            "the cause must survive, not a generic 'no targets': {}",
+            unresolved[0].error
+        );
+        assert!(unresolved[0].auth);
+    }
+
+    /// Building a client mints a token for ECR, GAR, and ACR, so a registry no
+    /// mapping references must not be contacted at all.
+    #[test]
+    fn referenced_registries_ignores_unused_entries() {
+        let config: Config = serde_yaml::from_str(
+            r#"
+registries:
+  src:
+    url: source.test
+  dst:
+    url: target.test
+  unused:
+    url: unused.test
+target_groups:
+  mirrors: [dst]
+defaults:
+  source: src
+mappings:
+  - from: repo/one
+    targets: mirrors
+    tags:
+      glob: ["v1"]
+"#,
+        )
+        .expect("config yaml parses");
+
+        let used = referenced_registries(&config);
+
+        assert!(used.contains("src"));
+        assert!(used.contains("dst"), "target groups must be expanded");
+        assert!(
+            !used.contains("unused"),
+            "a registry no mapping names must not be built"
+        );
     }
 
     // -----------------------------------------------------------------
@@ -2461,8 +2814,8 @@ mappings:
         )
     }
 
-    fn failure(from: &str, auth: bool) -> MappingFailure {
-        MappingFailure {
+    fn unresolved_mapping(from: &str, auth: bool) -> UnresolvedMapping {
+        UnresolvedMapping {
             from: from.into(),
             error: "boom".into(),
             auth,
@@ -2476,7 +2829,7 @@ mappings:
         let report = report_from(vec![ocync_sync::ImageStatus::Synced]);
         assert_eq!(combined_exit_code(&report, &[]), ExitCode::Success);
         assert_eq!(
-            combined_exit_code(&report, &[failure("repo/two", false)]),
+            combined_exit_code(&report, &[unresolved_mapping("repo/two", false)]),
             ExitCode::PartialFailure
         );
     }
@@ -2485,7 +2838,10 @@ mappings:
     #[test]
     fn combined_exit_code_is_failure_when_nothing_succeeded() {
         let empty = report_with(Vec::new());
-        let failures = [failure("repo/one", false), failure("repo/two", true)];
+        let failures = [
+            unresolved_mapping("repo/one", false),
+            unresolved_mapping("repo/two", true),
+        ];
         assert_eq!(combined_exit_code(&empty, &failures), ExitCode::Failure);
     }
 
@@ -2497,7 +2853,7 @@ mappings:
             reason: ocync_sync::SkipReason::DigestMatch,
         }]);
         assert_eq!(
-            combined_exit_code(&report, &[failure("repo/two", false)]),
+            combined_exit_code(&report, &[unresolved_mapping("repo/two", false)]),
             ExitCode::PartialFailure
         );
     }
@@ -2507,7 +2863,10 @@ mappings:
     #[test]
     fn combined_exit_code_keeps_the_auth_code_when_every_mapping_was_denied() {
         let empty = report_with(Vec::new());
-        let denied = [failure("repo/one", true), failure("repo/two", true)];
+        let denied = [
+            unresolved_mapping("repo/one", true),
+            unresolved_mapping("repo/two", true),
+        ];
         assert_eq!(combined_exit_code(&empty, &denied), ExitCode::AuthError);
     }
 
@@ -2515,7 +2874,10 @@ mappings:
     #[test]
     fn combined_exit_code_does_not_claim_auth_for_a_mixed_failure_set() {
         let empty = report_with(Vec::new());
-        let mixed = [failure("repo/one", true), failure("repo/two", false)];
+        let mixed = [
+            unresolved_mapping("repo/one", true),
+            unresolved_mapping("repo/two", false),
+        ];
         assert_eq!(combined_exit_code(&empty, &mixed), ExitCode::Failure);
     }
 
@@ -2523,11 +2885,11 @@ mappings:
     fn dry_run_exit_code_maps_resolution_counts() {
         assert_eq!(dry_run_exit_code(3, &[]), ExitCode::Success);
         assert_eq!(
-            dry_run_exit_code(2, &[failure("repo/two", false)]),
+            dry_run_exit_code(2, &[unresolved_mapping("repo/two", false)]),
             ExitCode::PartialFailure
         );
         assert_eq!(
-            dry_run_exit_code(0, &[failure("repo/two", false)]),
+            dry_run_exit_code(0, &[unresolved_mapping("repo/two", false)]),
             ExitCode::Failure
         );
     }
@@ -2537,7 +2899,10 @@ mappings:
     /// downgraded a denied dry run from 4 to 2.
     #[test]
     fn dry_run_exit_code_keeps_the_auth_code_when_every_mapping_was_denied() {
-        let denied = [failure("repo/one", true), failure("repo/two", true)];
+        let denied = [
+            unresolved_mapping("repo/one", true),
+            unresolved_mapping("repo/two", true),
+        ];
         assert_eq!(dry_run_exit_code(0, &denied), ExitCode::AuthError);
         // Something resolved, so the run was only partly denied.
         assert_eq!(dry_run_exit_code(1, &denied), ExitCode::PartialFailure);
@@ -2566,7 +2931,7 @@ mappings:
     #[test]
     fn json_output_carries_unresolved_mappings() {
         let report = report_with(Vec::new());
-        let failures = vec![MappingFailure {
+        let failures = vec![UnresolvedMapping {
             from: "repo/two".into(),
             error: "403 Forbidden".into(),
             auth: true,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -377,16 +377,24 @@ pub(crate) fn setup_logging(cli: &Cli) {
         .add_directive("rustls=warn".parse().unwrap())
         .add_directive("tower=warn".parse().unwrap());
 
+    // stderr, not the default stdout: `--json` writes its document to stdout,
+    // and the periodic progress lines would otherwise be interleaved into it
+    // for the whole duration of exactly the long runs `--json` exists for.
     match format {
         LogFormat::Json => {
             fmt()
                 .json()
                 .with_env_filter(env_filter)
                 .with_target(false)
+                .with_writer(std::io::stderr)
                 .init();
         }
         LogFormat::Text => {
-            fmt().with_env_filter(env_filter).with_target(false).init();
+            fmt()
+                .with_env_filter(env_filter)
+                .with_target(false)
+                .with_writer(std::io::stderr)
+                .init();
         }
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -487,6 +487,19 @@ mod tests {
     }
 
     #[test]
+    fn cli_error_exit_code_auth() {
+        // Credential-provider setup failures carry their own exit code so a
+        // run denied everywhere is distinguishable from a generic failure.
+        let err = CliError::Auth("ECR auth setup for 'x': 403 Forbidden".into());
+        assert_eq!(err.exit_code(), ExitCode::AuthError);
+        // The negative half: a plain input error must not claim it.
+        assert_eq!(
+            CliError::Input("bad url".into()).exit_code(),
+            ExitCode::Failure
+        );
+    }
+
+    #[test]
     fn cli_error_exit_code_filter() {
         let err = CliError::Filter(ocync_sync::Error::LatestWithoutSort);
         assert_eq!(err.exit_code(), ExitCode::ConfigError);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -131,6 +131,14 @@ pub(crate) enum CliError {
     /// Invalid user input.
     #[error("{0}")]
     Input(String),
+
+    /// Credential resolution failed for a registry.
+    ///
+    /// Distinct from [`Self::Input`] so that a run whose only failures were
+    /// denials exits with the dedicated auth code. The provider crates return
+    /// their own error types here, so the cause arrives already formatted.
+    #[error("{0}")]
+    Auth(String),
 }
 
 impl CliError {
@@ -140,6 +148,7 @@ impl CliError {
             Self::Config(_) => ExitCode::ConfigError,
             Self::Filter(_) => ExitCode::ConfigError,
             Self::Registry(e) if e.is_auth_error() => ExitCode::AuthError,
+            Self::Auth(_) => ExitCode::AuthError,
             _ => ExitCode::Failure,
         }
     }
@@ -220,7 +229,7 @@ pub(crate) async fn build_registry_client(
             let profile = registry_config.and_then(|r| r.aws_profile.as_deref());
             let auth = EcrAuth::new(bare_host, profile)
                 .await
-                .map_err(|e| CliError::Input(format!("ECR auth setup for '{bare_host}': {e}")))?;
+                .map_err(|e| CliError::Auth(format!("ECR auth setup for '{bare_host}': {e}")))?;
             RegistryClient::builder(url).auth(auth)
         }
         Some(AuthType::Basic) => {
@@ -249,19 +258,22 @@ pub(crate) async fn build_registry_client(
         Some(AuthType::Gar | AuthType::Gcr) => {
             let auth = GcpAuth::new(bare_host, http)
                 .await
-                .map_err(|e| CliError::Input(format!("GCP auth setup for '{bare_host}': {e}")))?;
+                .map_err(|e| CliError::Auth(format!("GCP auth setup for '{bare_host}': {e}")))?;
             RegistryClient::builder(url).auth(auth)
         }
         Some(AuthType::Acr) => {
             let auth = AcrAuth::new(bare_host)
                 .await
-                .map_err(|e| CliError::Input(format!("ACR auth setup for '{bare_host}': {e}")))?;
+                .map_err(|e| CliError::Auth(format!("ACR auth setup for '{bare_host}': {e}")))?;
             RegistryClient::builder(url).auth(auth)
         }
         Some(AuthType::Ghcr | AuthType::DockerConfig) => {
             if matches!(auth_type, Some(AuthType::Ghcr)) {
                 warn_ghcr_deprecation_once(bare_host);
             }
+            // A missing config file is a setup problem, not a rejected
+            // credential: `Input`, not `Auth`. The credential *exchange*
+            // below is the auth-classified step.
             let docker_config = DockerConfig::load_default().map_err(|e| {
                 CliError::Input(format!(
                     "failed to load docker config for '{bare_host}': {e}"
@@ -280,25 +292,25 @@ pub(crate) async fn build_registry_client(
             match detect_provider_kind(bare_host) {
                 Some(ProviderKind::Ecr) => {
                     let auth = EcrAuth::new(bare_host, None).await.map_err(|e| {
-                        CliError::Input(format!("ECR auth setup for '{bare_host}': {e}"))
+                        CliError::Auth(format!("ECR auth setup for '{bare_host}': {e}"))
                     })?;
                     RegistryClient::builder(url).auth(auth)
                 }
                 Some(ProviderKind::EcrPublic) => {
                     let auth = EcrPublicAuth::new(http.clone())
                         .await
-                        .map_err(|e| CliError::Input(format!("ECR Public auth setup: {e}")))?;
+                        .map_err(|e| CliError::Auth(format!("ECR Public auth setup: {e}")))?;
                     RegistryClient::builder(url).auth(auth)
                 }
                 Some(ProviderKind::Gar | ProviderKind::Gcr) => {
                     let auth = GcpAuth::new(bare_host, http).await.map_err(|e| {
-                        CliError::Input(format!("GCP auth setup for '{bare_host}': {e}"))
+                        CliError::Auth(format!("GCP auth setup for '{bare_host}': {e}"))
                     })?;
                     RegistryClient::builder(url).auth(auth)
                 }
                 Some(ProviderKind::Acr) => {
                     let auth = AcrAuth::new(bare_host).await.map_err(|e| {
-                        CliError::Input(format!("ACR auth setup for '{bare_host}': {e}"))
+                        CliError::Auth(format!("ACR auth setup for '{bare_host}': {e}"))
                     })?;
                     RegistryClient::builder(url).auth(auth)
                 }
@@ -310,7 +322,7 @@ pub(crate) async fn build_registry_client(
                             let auth = DockerConfigAuth::new(endpoint, &config, http)
                                 .await
                                 .map_err(|e| {
-                                    CliError::Input(format!(
+                                    CliError::Auth(format!(
                                         "docker config credential resolution for '{bare_host}': {e}"
                                     ))
                                 })?;

--- a/src/cli/progress.rs
+++ b/src/cli/progress.rs
@@ -8,7 +8,7 @@
 use std::cell::RefCell;
 use std::io::{self, Write};
 
-use ocync_sync::progress::ProgressReporter;
+use ocync_sync::progress::{ProgressReporter, RunProgress};
 use ocync_sync::{ImageResult, ImageStatus, SyncReport};
 
 use crate::cli::output::{format_bytes, format_duration};
@@ -89,6 +89,22 @@ impl ProgressReporter for TextProgress {
                 tracing::warn!(error = %e, "failed to write progress to stderr");
             }
         }
+    }
+
+    fn run_progress(&self, p: RunProgress) {
+        // Goes through tracing rather than the stderr writer above: this is a
+        // periodic status line, not per-image output, so it belongs in the log
+        // stream where `--log-format json` and the level filter apply. At
+        // verbosity 0 the per-image lines are suppressed, which makes this the
+        // only thing distinguishing a long run from a hung one.
+        tracing::info!(
+            discovering = p.discovering,
+            pending = p.pending,
+            in_flight = p.in_flight,
+            completed = p.completed,
+            elapsed_secs = p.elapsed.as_secs(),
+            "sync in progress"
+        );
     }
 
     fn run_completed(&self, _report: &SyncReport) {

--- a/src/cli/progress.rs
+++ b/src/cli/progress.rs
@@ -1,6 +1,7 @@
 //! Verbosity-aware progress reporters for sync output.
 //!
-//! [`TextProgress`] writes per-image status lines to stderr. There is no
+//! [`TextProgress`] writes per-image status lines to stderr, and a periodic
+//! liveness line to tracing while a run is still in flight. There is no
 //! per-cycle aggregate stdout line: the CLI driver emits a per-mapping
 //! INFO line via tracing after the engine returns, which carries the
 //! source/target context an aggregate cannot.
@@ -91,18 +92,18 @@ impl ProgressReporter for TextProgress {
         }
     }
 
-    fn run_progress(&self, p: RunProgress) {
+    fn run_heartbeat(&self, snapshot: RunProgress) {
         // Goes through tracing rather than the stderr writer above: this is a
         // periodic status line, not per-image output, so it belongs in the log
         // stream where `--log-format json` and the level filter apply. At
         // verbosity 0 the per-image lines are suppressed, which makes this the
         // only thing distinguishing a long run from a hung one.
         tracing::info!(
-            discovering = p.discovering,
-            pending = p.pending,
-            in_flight = p.in_flight,
-            completed = p.completed,
-            elapsed_secs = p.elapsed.as_secs(),
+            in_discovery = snapshot.in_discovery,
+            pending = snapshot.pending,
+            in_flight = snapshot.in_flight,
+            completed = snapshot.completed,
+            elapsed_secs = snapshot.elapsed.as_secs(),
             "sync in progress"
         );
     }


### PR DESCRIPTION
One denial used to cancel a whole run, and the run said nothing while it worked. This fixes both, and because the fix adds observable surface (new `--json` keys, two periodic log lines, new public API in `ocync-sync`) it lands as `feat` rather than `fix`.

## Failure isolation

`synchronize::run` propagated the first `resolve_mapping` error with `?`. A 403 on one repository's tag listing dropped every mapping behind it; in watch mode the cycle logged `sync cycle failed` and nothing synced. Isolation now applies at every level it can reach.

| Site | Before | After |
| --- | --- | --- |
| mapping resolution | first error aborts the run | logged, recorded, continue |
| target list within a mapping | one bad registry loses **all** targets | bad target dropped, mapping syncs to the rest |
| `build_clients` | one registry's auth setup aborts the run | recorded against that alias |
| `build_batch_checkers` | failure aborts the run | WARN and drop the checker |
| `analyze` per-image | one unreadable image ends the analysis | skipped and counted |
| `analyze` index child | one bad platform discards the image's blobs | skipped and counted |
| `auth check` | one bad config file skips the rest | reported, remaining files still checked |

### Isolated failures stay visible

Silent tolerance would be worse than the abort it replaces, so every dropped thing reaches the exit code and both report surfaces:

- `--json` gains `unresolved_mappings` and `dropped_targets`, and `analyze` gains `images_failed` alongside a corrected `images_analyzed`. All omitted when empty, so a clean run's document shape is unchanged.
- The cycle tail gains `| N unresolved` and `| N targets dropped` clauses.
- Exit codes: `1` when other work succeeded, `2` when none did, `4` when nothing ran and every mapping was denied, and `3` preserved for a broken config file in `auth check`.

The auth code needed real work to keep. `build_clients` stored its error as a `String` and `client_for` re-wrapped it as `CliError::Input`, so a token-mint denial could never reach exit 4. `ClientMap` now carries `ClientInitError { message, auth }` and a new `CliError::Auth` variant covers credential-provider setup. A missing docker config file deliberately stays `Input`: that is a setup problem, not a rejected credential, and two existing tests pin it.

## Progress while it works

At default verbosity nothing was logged between process start and the final summary. Two timer-gated lines fill that:

- `preparing sync` every 5s with `phase` / `done` / `total`, spanning client construction, batch-checker setup, and mapping resolution
- `sync in progress` every 30s with `in_discovery` / `pending` / `in_flight` / `completed`, from a new `ProgressReporter::run_heartbeat` callback

Both fire on wall-clock rather than item boundaries. The first attempt throttled at mapping boundaries and measured **zero lines across an 8.6 second run**; the ticker emits two on the same input.

## Also

Client and batch-checker construction skip registries no mapping references, so an unused entry no longer costs a token mint. `SyncEngine::with_heartbeat_interval` and `SyncReport::has_success` are new. `ProgressReporter` gains a required method, which is breaking for implementors; the crate is `publish = false` and both impls are in-tree.

## Verification

Three close-out iterations found 38 findings on this branch, all fixed. The ones green CI could never have caught:

- the sibling-target bug, introduced by the first round's own fix
- progress logging that fired zero times on a real run
- `analyze` returning exit 0 on incomplete data
- a doc claim about exit 4 that the code did not deliver

Verified end to end against real registries, not just tests. Three mappings with the middle one denied by ghcr.io: `main` exits **4** having processed **zero** mappings; this branch exits **1** having resolved the other two. One denied mapping alone exits **4** on both. `auth check` with a broken config among good ones exits **3** and still reaches the good file.

Local gate: `cargo fmt --check`, `clippy --workspace --all-targets -D warnings`, `cargo deny check`, and 28 suites / **1446 tests** green.