### PR TITLE
perf(prepare): resolve mappings and pull images concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,6 +2394,7 @@ version = "0.7.0"
 dependencies = [
  "anstyle",
  "clap",
+ "futures-util",
  "http 1.5.0",
  "ocync-distribution",
  "ocync-sync",
@@ -2409,6 +2410,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ anstyle = { version = "1", default-features = false }
 clap = { workspace = true, features = ["color"] }
 schemars.workspace = true
 http.workspace = true
+futures-util.workspace = true
 ocync-distribution.workspace = true
 ocync-sync.workspace = true
 serde.workspace = true
@@ -100,6 +101,9 @@ tempfile.workspace = true
 # `test-util` supplies the paused clock the prepare-ticker tests drive.
 tokio = { workspace = true, features = ["test-util"] }
 uuid.workspace = true
+# Backs the prepare-phase concurrency tests and benchmark, which need a
+# registry that answers `tags/list` with a controlled delay.
+wiremock = { version = "0.6", default-features = false }
 
 [profile.release]
 strip = true

--- a/bench/CLAUDE.md
+++ b/bench/CLAUDE.md
@@ -66,6 +66,13 @@ The main corpus is 39 entries chosen for blob sharing. The prepare phase costs o
 
 None of the sync scenario's fairness machinery applies here. Nothing is transferred, so there are no blobs to fall out of page cache, no ECR repos to reset, and no CDN edge to pre-warm. Skipping all of it is what keeps this scenario cheap enough to run often.
 
+Two of those exemptions are explicit in the harness rather than automatic, and both were found by running the scenario rather than by reading the code:
+
+- The tmpfs guard is skipped for `prepare`. It exists because staging writes multi-GB blobs, which a dry-run never does, and applying it refuses the one scenario that can run on a laptop.
+- CDN pre-warm is skipped when `prepare` is the only scenario. Pre-warm buys cross-tool fairness for a workload that pulls blobs; for a single-tool dry-run reading a different corpus it is hundreds of pointless requests against rate-limited registries. A mixed run (`--scenario all`) still warms, because the scenarios beside it do transfer.
+
+**A run whose instance metadata is unknown does not append to `bench/results/{registry}.json`.** That archive is tracked in git and read as a history of comparable runs; a laptop run landing in it puts uncomparable numbers under the same key. The timestamped summary is still written. This matters here more than elsewhere, because `prepare` is the scenario most likely to be run off the rig.
+
 ## Metrics captured per tool per scenario
 
 | Metric | Source | Winner = |

--- a/bench/CLAUDE.md
+++ b/bench/CLAUDE.md
@@ -54,6 +54,18 @@ cargo xtask bench-remote --provider aws --fetch
 - `bench/results/<timestamp>/summary.md` - human-readable comparison table with winners bolded
 - `bench/results/{registry}.json` - compact per-registry run record archive (tracked in git)
 
+## The prepare scenario
+
+`cargo xtask bench prepare` (or `bench-remote --scenario prepare`) measures the pre-engine phase on its own: build a client per registry, list every mapping's tags, filter them, and stop. It runs `ocync sync --dry-run`, so nothing is transferred.
+
+It is ocync-only, for the same reason the scale scenario is: no competitor has a mode that resolves tags and then stops, so there is nothing to compare against.
+
+**It uses its own corpus, `bench/corpus-prepare.yaml`, and that is load-bearing.** Every tag in the main corpus is a literal, so `TagsConfig::exact_tags` returns them verbatim and `resolve_mapping_inner` skips `list_tags` entirely. A prepare run against the main corpus would exit clean, report a plausible time, and measure none of the phase it is named for. The prepare corpus uses wildcard tags to force enumeration, and `prepare_corpus_tags_are_all_wildcards` fails if anyone pins them back to literals.
+
+The main corpus is 39 entries chosen for blob sharing. The prepare phase costs one round trip per mapping, so the shape that exposes it is many mappings, not a few large ones. That is the second reason for a separate file.
+
+None of the sync scenario's fairness machinery applies here. Nothing is transferred, so there are no blobs to fall out of page cache, no ECR repos to reset, and no CDN edge to pre-warm. Skipping all of it is what keeps this scenario cheap enough to run often.
+
 ## Metrics captured per tool per scenario
 
 | Metric | Source | Winner = |

--- a/bench/corpus-prepare.yaml
+++ b/bench/corpus-prepare.yaml
@@ -1,0 +1,89 @@
+# Prepare-phase benchmark corpus.
+#
+# Measures the pre-engine phase in isolation: build a client per registry,
+# list every mapping's tags, and filter them. Nothing is transferred, so this
+# corpus is about mapping count and tag count, not layer size.
+#
+# Two properties matter and both are load-bearing:
+#
+# 1. Every tag entry is a WILDCARD. A mapping whose tags are all literal takes
+#    the exact-tag fast path in `resolve_mapping_inner` and never calls
+#    `list_tags` at all, which is why the main corpus cannot see this phase:
+#    all of its tags are literals. See `TagsConfig::exact_tags`.
+#
+# 2. Many mappings, not a few big ones. The cost being measured is one round
+#    trip per mapping, so the shape that exposes it is a wide config. The main
+#    corpus is 39 entries chosen for blob sharing, which is the wrong shape.
+#
+# Sources are anonymous public ECR mirrors: no rate-limit budget is spent on
+# Docker Hub, and no credentials beyond the ones the harness already needs for
+# the ECR target. The target is never written to, because this scenario runs
+# `--dry-run`.
+
+corpus:
+  target_registry: "${BENCH_TARGET_REGISTRY}"
+  target_prefix: "bench-prepare"
+
+images:
+  # Docker official images mirrored to public ECR. Each has a deep tag list,
+  # so the listing is a real round trip rather than a single small page.
+  - source: "public.ecr.aws/docker/library/alpine"
+    tags: ["3.*"]
+  - source: "public.ecr.aws/docker/library/busybox"
+    tags: ["1.*"]
+  - source: "public.ecr.aws/docker/library/nginx"
+    tags: ["1.*"]
+  - source: "public.ecr.aws/docker/library/redis"
+    tags: ["7.*"]
+  - source: "public.ecr.aws/docker/library/python"
+    tags: ["3.1*"]
+  - source: "public.ecr.aws/docker/library/node"
+    tags: ["2*"]
+  - source: "public.ecr.aws/docker/library/golang"
+    tags: ["1.2*"]
+  - source: "public.ecr.aws/docker/library/ubuntu"
+    tags: ["2*"]
+  - source: "public.ecr.aws/docker/library/debian"
+    tags: ["1*"]
+  - source: "public.ecr.aws/docker/library/postgres"
+    tags: ["1*"]
+  - source: "public.ecr.aws/docker/library/mysql"
+    tags: ["8.*"]
+  - source: "public.ecr.aws/docker/library/mongo"
+    tags: ["7.*"]
+  - source: "public.ecr.aws/docker/library/httpd"
+    tags: ["2.*"]
+  - source: "public.ecr.aws/docker/library/memcached"
+    tags: ["1.*"]
+  - source: "public.ecr.aws/docker/library/rabbitmq"
+    tags: ["3.*"]
+  - source: "public.ecr.aws/docker/library/traefik"
+    tags: ["v2.*"]
+  - source: "public.ecr.aws/docker/library/consul"
+    tags: ["1.*"]
+  - source: "public.ecr.aws/docker/library/influxdb"
+    tags: ["2.*"]
+  - source: "public.ecr.aws/docker/library/telegraf"
+    tags: ["1.*"]
+  - source: "public.ecr.aws/docker/library/haproxy"
+    tags: ["2.*"]
+  - source: "public.ecr.aws/docker/library/maven"
+    tags: ["3.*"]
+  - source: "public.ecr.aws/docker/library/gradle"
+    tags: ["8.*"]
+  - source: "public.ecr.aws/docker/library/tomcat"
+    tags: ["1*"]
+  - source: "public.ecr.aws/docker/library/openjdk"
+    tags: ["1*"]
+  - source: "public.ecr.aws/docker/library/ruby"
+    tags: ["3.*"]
+  - source: "public.ecr.aws/docker/library/perl"
+    tags: ["5.*"]
+  - source: "public.ecr.aws/docker/library/rust"
+    tags: ["1.*"]
+  - source: "public.ecr.aws/docker/library/erlang"
+    tags: ["2*"]
+  - source: "public.ecr.aws/docker/library/elixir"
+    tags: ["1.*"]
+  - source: "public.ecr.aws/docker/library/caddy"
+    tags: ["2.*"]

--- a/crates/ocync-distribution/src/tags.rs
+++ b/crates/ocync-distribution/src/tags.rs
@@ -11,6 +11,26 @@ use crate::spec::RepositoryName;
 /// as broken (e.g. a registry returning a self-referencing `Link: rel="next"`).
 const MAX_TAG_PAGES: usize = 10_000;
 
+// The tag listing deliberately sends no `n`.
+//
+// Asking for a page size can only cost round trips, never save them, because
+// the registries answer a request without `n` at least as generously as one
+// with it. Measured 2026-08-28:
+//
+// - Docker Hub returns every tag in one response with no `Link` header
+//   (`library/python`, 3,911 tags, 1 request). With `n=1000` the same
+//   listing takes 4.
+// - `distribution/distribution` sets its internal limit to -1 when `n` is
+//   absent and lists all tags; `maxtags` is applied only to an explicit `n`.
+//   Harbor, GitLab, Quay and self-hosted `registry:2` inherit that.
+// - ECR Public already pages at 1000 without being asked
+//   (`docker/library/python`), and ECR rejects an `n` above 1000, so the
+//   largest value it would accept changes nothing.
+//
+// So there is no registry where sending `n` helps and two large families
+// where it multiplies the request count. The `Link` loop below still follows
+// pagination for the registries that choose to impose it.
+
 /// Response body from the tag listing API.
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct TagListResponse {

--- a/crates/ocync-distribution/tests/client_integration.rs
+++ b/crates/ocync-distribution/tests/client_integration.rs
@@ -11,7 +11,9 @@ use ocync_distribution::RepositoryName;
 use ocync_distribution::auth::{AuthProvider, Scope, Token};
 use ocync_distribution::client::RegistryClientBuilder;
 use url::Url;
-use wiremock::matchers::{header_exists, method, path, path_regex, query_param};
+use wiremock::matchers::{
+    header_exists, method, path, path_regex, query_param, query_param_is_missing,
+};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// Shared state for [`MockAuth`], allowing assertions after the auth provider
@@ -986,4 +988,39 @@ async fn manifest_pull_requests_pull_scope() {
         has_pull_only,
         "manifest_pull must request pull-only scope, got: {scopes:?}"
     );
+}
+
+/// The tag listing must not ask for a page size.
+///
+/// Sending `n` can only cost round trips. Docker Hub answers a request without
+/// it by returning every tag in one response (`library/python`, 3,911 tags, no
+/// `Link` header), and `distribution/distribution` does the same; adding
+/// `n=1000` turns that single request into four. ECR already pages at 1000
+/// unasked and rejects anything larger, so there is nothing to win there
+/// either. This is a guard, not a preference: the optimization looks obvious
+/// and is backwards.
+#[tokio::test]
+async fn list_tags_does_not_request_a_page_size() {
+    let server = MockServer::start().await;
+
+    // Any `n` at all fails the match, so the mock 404s and the assert below
+    // fires rather than silently passing on a different code path.
+    Mock::given(method("GET"))
+        .and(path("/v2/repo/tags/list"))
+        .and(query_param_is_missing("n"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "name": "repo",
+            "tags": ["v1"]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .build()
+        .unwrap();
+
+    let repo = RepositoryName::new("repo").unwrap();
+    let tags = client.list_tags(&repo).await.unwrap();
+    assert_eq!(tags, vec!["v1"]);
 }

--- a/docs/src/content/design/engine.md
+++ b/docs/src/content/design/engine.md
@@ -22,6 +22,8 @@ Measured on 95 mappings against a single source at 60 ms per tag listing:
 
 The last two rows are identical because a single registry's AIMD window tops out near 13 over 95 requests. That is where the bound of 16 comes from: high enough that AIMD is the constraint for a single-source config, low enough that a wide multi-registry config cannot open an unbounded number of connections at once.
 
+The 60 ms is a synthetic latency chosen to keep the benchmark short. It measures how the speedup scales and where AIMD becomes the ceiling, not any particular config's absolute time. A real config's floor is its single slowest mapping, because overlapping removes the queueing behind that mapping but not its own duration: a run of 675 seconds of serial work holding one 160-second mapping lands near 160 to 200 seconds, not 675 divided by the speedup above. The `slowest` field in the progress line exists to name that mapping.
+
 Results are collected in config order regardless of which registry answered first, so per-mapping warnings, the watch-mode state, and the run's counters stay deterministic. A config error still stops the run at the first offending mapping in config order, though mappings behind it may already have run and logged.
 
 Tag listings deliberately send no `n`. Asking for a page size looks like an optimization and is the opposite of one: a request without `n` is answered at least as generously as one with it, so `n` can only add round trips.

--- a/docs/src/content/design/engine.md
+++ b/docs/src/content/design/engine.md
@@ -4,6 +4,58 @@ description: Pipeline architecture, adaptive concurrency, transfer state cache, 
 order: 2
 ---
 
+## Prepare phase
+
+Everything before the engine starts is preparation: build one client per referenced registry, build the ECR batch checkers, then resolve every mapping into the tags it will sync. Resolution is the expensive part. Each mapping lists its source repository's tags, and a mapping with `immutable_tags` also lists each target's existing tags.
+
+This work is network-bound and independent per mapping, so it runs concurrently, bounded at 16 mappings in flight. The bound is a ceiling on open mappings, not on how hard any registry is hit: every request underneath still passes that registry's AIMD window, which starts at one in flight and widens only as the registry keeps answering. A config whose mappings all share one source therefore self-limits at whatever AIMD has earned, and a config spread across registries goes wider.
+
+Measured on 95 mappings against a single source at 60 ms per tag listing:
+
+| Mappings in flight | Elapsed | Speedup | Peak requests in flight |
+|--------------------|---------|---------|-------------------------|
+| 1 (sequential)     | 6.02s   | 1.0x    | 1                       |
+| 4                  | 1.68s   | 3.6x    | 4                       |
+| 8                  | 1.02s   | 5.9x    | 8                       |
+| 16                 | 0.89s   | 6.8x    | 13                      |
+| 32                 | 0.89s   | 6.7x    | 13                      |
+
+The last two rows are identical because a single registry's AIMD window tops out near 13 over 95 requests. That is where the bound of 16 comes from: high enough that AIMD is the constraint for a single-source config, low enough that a wide multi-registry config cannot open an unbounded number of connections at once.
+
+Results are collected in config order regardless of which registry answered first, so per-mapping warnings, the watch-mode state, and the run's counters stay deterministic. A config error still stops the run at the first offending mapping in config order, though mappings behind it may already have run and logged.
+
+Tag listings deliberately send no `n`. Asking for a page size looks like an optimization and is the opposite of one: a request without `n` is answered at least as generously as one with it, so `n` can only add round trips.
+
+- Docker Hub returns every tag in a single response with no `Link` header. `library/python` is 3,911 tags in 1 request; with `n=1000` the same listing costs 4.
+- `distribution/distribution` sets its internal limit to -1 when `n` is absent and lists everything. Its `maxtags` cap applies only to an explicit `n`. Harbor, GitLab, Quay and self-hosted `registry:2` inherit that behavior.
+- ECR Public already pages at 1000 without being asked, and ECR rejects an `n` above 1000, so the largest value it would accept changes nothing.
+
+The `Link` loop still follows pagination for registries that impose it unasked. Measured 2026-08-28.
+
+While preparation runs, a progress line is emitted every 5 seconds naming the longest-running item:
+
+```
+preparing sync phase=mappings done=75 total=95 in_flight=16 slowest=repo/foo slowest_secs=160 elapsed_secs=490
+```
+
+Without `slowest`, a step that sits at the same `done` count for minutes is unattributable, and an operator cannot tell a huge tag listing from a wedged registry.
+
+### `analyze`
+
+`analyze` has the same shape and the same bound. It resolves mappings concurrently, then pulls image manifests from a single list flattened across every mapping. The flattening is what makes the second walk worth anything: a config of many mappings holding a handful of tags each would otherwise stay serial, because each mapping's walk is only a request or two long. Index children stay sequential within an image, since the images already overlap and AIMD saturates well below the number in flight.
+
+Aggregation stays sequential and in config order. `analysis.blobs` has one owner, and the report must read the same way whichever registry answered first. Shutdown is checked inside each task rather than once before the fan-out, so a signal part way through stops work that has not started while in-flight work finishes.
+
+Measured on 95 mappings holding one tag each, 30 ms per request:
+
+| Concurrency | Elapsed | Speedup |
+|-------------|---------|---------|
+| 1 (sequential) | 6.24s | 1.0x |
+| 4  | 1.71s | 3.7x |
+| 8  | 1.06s | 5.9x |
+| 16 | 0.93s | 6.7x |
+| 32 | 0.94s | 6.7x |
+
 ## Pipeline architecture
 
 The sync engine uses a pipelined architecture where discovery and execution run concurrently in a single `tokio::select!` loop over two `FuturesUnordered` pools. Execution starts the moment the first image is discovered, with no waiting for all discovery to complete. The engine should never be idle when useful work exists.

--- a/src/cli/commands/analyze.rs
+++ b/src/cli/commands/analyze.rs
@@ -12,6 +12,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::PathBuf;
 use std::rc::Rc;
 
+use futures_util::StreamExt;
 use ocync_distribution::ecr::BatchBlobChecker;
 use ocync_distribution::spec::ManifestKind;
 use ocync_distribution::{Digest, RepositoryName};
@@ -77,6 +78,17 @@ struct Analysis {
     interrupted: bool,
 }
 
+/// Mappings resolved, and images pulled, at once.
+///
+/// Analysis is pure read traffic against the source registry: a tag listing
+/// per mapping and a manifest pull per image, all independent. Same value and
+/// same reasoning as `sync`'s
+/// [`PREPARE_MAPPING_CONCURRENCY`](super::synchronize::PREPARE_MAPPING_CONCURRENCY),
+/// kept separate because the two commands can be tuned apart: a ceiling on
+/// open work, not a request rate, with each client's AIMD window still
+/// governing how hard any one registry is hit.
+const ANALYZE_CONCURRENCY: usize = 16;
+
 /// Run the analyze command.
 pub(crate) async fn run(
     args: &AnalyzeArgs,
@@ -93,8 +105,15 @@ pub(crate) async fn run(
     let tracker = PrepareTracker::default();
     let analysis = with_prepare_progress(&tracker, "analysis", async {
         let clients = build_clients(&config, &referenced_registries(&config), &tracker).await;
-        tracker.begin(PreparePhase::Mappings, config.mappings.len());
-        collect_analysis(&config, &clients, &no_checkers, shutdown, &tracker).await
+        collect_analysis(
+            &config,
+            &clients,
+            &no_checkers,
+            shutdown,
+            &tracker,
+            ANALYZE_CONCURRENCY,
+        )
+        .await
     })
     .await;
 
@@ -117,34 +136,62 @@ pub(crate) async fn run(
 }
 
 /// Walk every mapping and tag, recording blobs and what could not be read.
+///
+/// Both walks overlap their network waits: mappings resolve concurrently, then
+/// every image across every mapping is pulled from one flattened list. The
+/// flattening is what makes the second walk worth anything -- a config of many
+/// mappings holding a handful of tags each would otherwise be as serial as
+/// before, because each mapping's walk is only a request or two long.
+///
+/// Aggregation stays sequential and in order. `analysis.blobs` has one owner,
+/// and the report has to read the same way whichever registry answered first.
 async fn collect_analysis(
     config: &Config,
     clients: &ClientMap,
     no_checkers: &HashMap<String, Rc<dyn BatchBlobChecker>>,
     shutdown: &ShutdownSignal,
     tracker: &PrepareTracker,
+    concurrency: usize,
 ) -> Analysis {
     let mut analysis = Analysis::default();
+    // Begun here rather than by the caller so this function owns both of the
+    // steps it runs, the way `sync`'s `resolve_all` does.
+    tracker.begin(PreparePhase::Mappings, config.mappings.len());
 
-    for mapping in &config.mappings {
-        if shutdown.is_triggered() {
-            tracing::info!("shutdown signal received, stopping analysis early");
+    /// One mapping's resolution, or `None` if shutdown reached it first.
+    type MappingOutcome = Option<(Result<MappingResolution, CliError>, Vec<DroppedTarget>)>;
+
+    // --- Resolve every mapping ---
+    //
+    // `None` marks a mapping shutdown reached before it started. Checked
+    // inside the task rather than once before the fan-out so a signal part way
+    // through still stops the work that has not begun, which is what the
+    // sequential loop's `break` did.
+    let outcomes: Vec<MappingOutcome> =
+        futures_util::stream::iter(config.mappings.iter().map(|mapping| async move {
+            if shutdown.is_triggered() {
+                return None;
+            }
+            // Held for the whole task so every exit still counts the mapping:
+            // one that skipped it would strand the progress line short of its
+            // total.
+            let _item = tracker.track(&mapping.from);
+            Some(resolve_mapping(mapping, config, clients, no_checkers, false).await)
+        }))
+        .buffered(concurrency.max(1))
+        .collect()
+        .await;
+
+    let mut resolved_mappings = Vec::new();
+    for (mapping, outcome) in config.mappings.iter().zip(outcomes) {
+        let Some((outcome, dropped)) = outcome else {
             analysis.interrupted = true;
-            break;
-        }
+            continue;
+        };
 
-        // Advanced up front so every exit from the match below still counts
-        // the mapping: a `continue` that skips it strands the progress line
-        // short of its total.
-        tracker.advance();
-
-        // One unresolvable mapping must not cost the analysis every mapping
-        // behind it, same as `sync`.
         // Dropped targets arrive whatever the outcome: analyze reports what a
         // sync would move, so a target it cannot reach changes the answer even
         // when the mapping itself then fails.
-        let (outcome, dropped) =
-            resolve_mapping(mapping, config, clients, no_checkers, false).await;
         for target in &dropped {
             tracing::warn!(
                 from = %target.from,
@@ -155,9 +202,11 @@ async fn collect_analysis(
         }
         analysis.dropped.extend(dropped);
 
-        let resolved = match outcome {
-            Ok(MappingResolution::Resolved(r)) => r,
-            Ok(MappingResolution::NoMatchingTags(_)) => continue,
+        match outcome {
+            Ok(MappingResolution::Resolved(r)) => resolved_mappings.push(r),
+            Ok(MappingResolution::NoMatchingTags(_)) => {}
+            // One unresolvable mapping must not cost the analysis every
+            // mapping behind it, same as `sync`.
             Err(err) => {
                 log_unresolved_mapping(&mapping.from, &err);
                 // A mapping the analysis could not resolve is a hole in the
@@ -169,51 +218,85 @@ async fn collect_analysis(
                     code: err.exit_code(),
                     error: err.to_string(),
                 });
-                continue;
             }
-        };
+        }
+    }
 
-        for tag_pair in &resolved.tags {
+    // --- Walk every image, flattened across mappings ---
+    let images: Vec<(usize, String)> = resolved_mappings
+        .iter()
+        .enumerate()
+        .flat_map(|(idx, m)| m.tags.iter().map(move |t| (idx, t.source.clone())))
+        .collect();
+
+    // Its own step, so the progress line keeps meaning something. Resolution
+    // finishes long before the walk does, and without this the ticker would
+    // report a completed mapping count for the whole of the slower half.
+    tracker.begin(PreparePhase::Images, images.len());
+
+    let mut pulls = futures_util::stream::iter(images.iter().map(|(idx, tag)| {
+        let resolved = &resolved_mappings[*idx];
+        async move {
+            let image_ref = format!("{}:{}", resolved.source_repo, tag);
             if shutdown.is_triggered() {
-                // The outer loop logs it; saying so once is enough.
-                analysis.interrupted = true;
-                break;
+                return (*idx, image_ref, None);
             }
-
-            let image_ref = format!("{}:{}", resolved.source_repo, tag_pair.source);
+            let _item = tracker.track(&image_ref);
             tracing::info!(image = %image_ref, "analyzing");
             // One unreadable image must not end the analysis: the remaining
             // tags and mappings are independent of it.
-            match collect_blobs(
+            let pulled = pull_image_descriptors(
                 &resolved.source_client,
                 &resolved.source_repo,
-                &tag_pair.source,
+                tag,
                 &image_ref,
-                &resolved.targets,
-                &resolved.target_repo,
-                &mut analysis.blobs,
             )
-            .await
-            {
-                Ok(Completeness::Full) => analysis.analyzed += 1,
+            .await;
+            (*idx, image_ref, Some(pulled))
+        }
+    }))
+    .buffered(concurrency.max(1));
+
+    while let Some((idx, image_ref, pulled)) = pulls.next().await {
+        let Some(pulled) = pulled else {
+            analysis.interrupted = true;
+            continue;
+        };
+        let resolved = &resolved_mappings[idx];
+        match pulled {
+            Ok((descriptors, completeness)) => {
+                for descriptor in descriptors {
+                    record_blob(
+                        descriptor.digest,
+                        descriptor.size,
+                        &image_ref,
+                        &resolved.targets,
+                        &resolved.target_repo,
+                        &mut analysis.blobs,
+                    );
+                }
+                analysis.analyzed += 1;
                 // A skipped index child still leaves this image's other
                 // platforms recorded, so it counts as analyzed. Conflating it
                 // with a total failure reported a mostly-complete run as zero
                 // images and exited 2.
-                Ok(Completeness::Partial) => {
-                    analysis.analyzed += 1;
+                if matches!(completeness, Completeness::Partial) {
                     analysis.partial += 1;
                 }
-                Err(err) => {
-                    tracing::error!(
-                        image = %image_ref,
-                        error = %err,
-                        "image could not be analyzed; skipping"
-                    );
-                    analysis.failed += 1;
-                }
+            }
+            Err(err) => {
+                tracing::error!(
+                    image = %image_ref,
+                    error = %err,
+                    "image could not be analyzed; skipping"
+                );
+                analysis.failed += 1;
             }
         }
+    }
+
+    if analysis.interrupted {
+        tracing::info!("shutdown signal received, stopping analysis early");
     }
 
     analysis
@@ -261,34 +344,29 @@ enum Completeness {
     Partial,
 }
 
-/// Pull a manifest (recursively for indexes) and record every blob's
-/// descriptor against the source image reference and target set.
-async fn collect_blobs(
+/// Pull a manifest, recursing into index children, and return every blob
+/// descriptor it references.
+///
+/// Recording is the caller's job. Splitting it out is what lets images be
+/// pulled concurrently: the network half borrows nothing mutable, so the
+/// aggregate map keeps a single owner and one deterministic write order.
+///
+/// Index children stay sequential within an image. The images themselves
+/// already overlap, and the client's AIMD window saturates well below the
+/// number of images in flight, so nesting a second level of concurrency here
+/// would add no throughput.
+async fn pull_image_descriptors(
     source_client: &ocync_distribution::RegistryClient,
     source_repo: &RepositoryName,
     tag: &str,
     image_ref: &str,
-    targets: &[ocync_sync::engine::TargetEntry],
-    target_repo: &RepositoryName,
-    blobs: &mut HashMap<Digest, BlobAggregate>,
-) -> Result<Completeness, CliError> {
+) -> Result<(Vec<BlobDescriptor>, Completeness), CliError> {
     let pulled = source_client
         .manifest_pull(source_repo, tag)
         .await
         .map_err(|e| CliError::Input(format!("manifest_pull {image_ref}: {e}")))?;
 
-    let descriptors = descriptors_of(&pulled.manifest);
-    for descriptor in descriptors {
-        record_blob(
-            descriptor.digest,
-            descriptor.size,
-            image_ref,
-            targets,
-            target_repo,
-            blobs,
-        );
-    }
-
+    let mut descriptors = descriptors_of(&pulled.manifest);
     let mut completeness = Completeness::Full;
 
     // Recurse into index children to collect per-platform manifest blobs.
@@ -296,11 +374,11 @@ async fn collect_blobs(
         for child in &index.manifests {
             // Platforms are independent: a missing arm64 manifest should not
             // discard the amd64 blobs already recorded for this image.
-            let child_pulled = match source_client
+            match source_client
                 .manifest_pull(source_repo, &child.digest.to_string())
                 .await
             {
-                Ok(pulled) => pulled,
+                Ok(child_pulled) => descriptors.extend(descriptors_of(&child_pulled.manifest)),
                 Err(e) => {
                     tracing::warn!(
                         image = %image_ref,
@@ -309,23 +387,12 @@ async fn collect_blobs(
                         "index child could not be pulled; skipping this platform"
                     );
                     completeness = Completeness::Partial;
-                    continue;
                 }
-            };
-            for descriptor in descriptors_of(&child_pulled.manifest) {
-                record_blob(
-                    descriptor.digest,
-                    descriptor.size,
-                    image_ref,
-                    targets,
-                    target_repo,
-                    blobs,
-                );
             }
         }
     }
 
-    Ok(completeness)
+    Ok((descriptors, completeness))
 }
 
 /// Descriptor data extracted from a manifest.
@@ -567,6 +634,281 @@ mod tests {
         assert_eq!(
             analyze_exit_code(&analysis(3, 0, 0, 1)),
             ExitCode::PartialFailure
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Prepare-phase concurrency
+    // -----------------------------------------------------------------------
+
+    use crate::cli::commands::test_support::{
+        Arrivals, SlowRecorder, arrivals, config_yaml, max_in_flight, repo_names, test_client,
+    };
+
+    /// A registry that answers tag listings and manifest pulls after `delay`,
+    /// recording each separately.
+    async fn slow_registry(
+        repos: &[String],
+        tags: &[&str],
+        delay: std::time::Duration,
+    ) -> (wiremock::MockServer, Config, ClientMap, Arrivals, Arrivals) {
+        let server = wiremock::MockServer::start().await;
+        let tag_arrivals = arrivals();
+        let manifest_arrivals = arrivals();
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path_regex(
+                r"^/v2/repo/img\d+/tags/list$",
+            ))
+            .respond_with(SlowRecorder::tag_list(&tag_arrivals, delay, tags))
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path_regex(
+                r"^/v2/repo/img\d+/manifests/.+$",
+            ))
+            .respond_with(SlowRecorder::image_manifest(&manifest_arrivals, delay))
+            .mount(&server)
+            .await;
+
+        let yaml = config_yaml(&server, repos, "      glob: [\"*\"]\n");
+        let config: Config = serde_yaml::from_str(&yaml).expect("generated config parses");
+        let clients = ClientMap::from([
+            ("src".to_string(), Ok(test_client(&server.uri()))),
+            ("dst".to_string(), Ok(test_client(&server.uri()))),
+        ]);
+        (server, config, clients, tag_arrivals, manifest_arrivals)
+    }
+
+    /// Analysis must resolve its mappings concurrently, like `sync` does.
+    #[tokio::test]
+    async fn collect_analysis_resolves_mappings_concurrently() {
+        let delay = std::time::Duration::from_millis(250);
+        let repos = repo_names(8);
+        let (_server, config, clients, tag_arrivals, _) =
+            slow_registry(&repos, &["v1"], delay).await;
+
+        let analysis = collect_analysis(
+            &config,
+            &clients,
+            &HashMap::new(),
+            &ShutdownSignal::new(),
+            &PrepareTracker::default(),
+            ANALYZE_CONCURRENCY,
+        )
+        .await;
+
+        assert_eq!(analysis.analyzed, 8, "every image must be analyzed");
+        let observed = max_in_flight(&tag_arrivals, delay);
+        assert!(
+            observed > 1,
+            "tag listings must overlap; saw at most {observed} in flight"
+        );
+    }
+
+    /// The image walk must overlap across mappings, not just within one.
+    ///
+    /// The shape that matters is many mappings holding few tags each: walking
+    /// one mapping's tags at a time leaves that config as slow as it ever was,
+    /// because each mapping's walk is one request long.
+    #[tokio::test]
+    async fn collect_analysis_pulls_images_concurrently_across_mappings() {
+        let delay = std::time::Duration::from_millis(250);
+        let repos = repo_names(8);
+        let (_server, config, clients, _, manifest_arrivals) =
+            slow_registry(&repos, &["v1"], delay).await;
+
+        let analysis = collect_analysis(
+            &config,
+            &clients,
+            &HashMap::new(),
+            &ShutdownSignal::new(),
+            &PrepareTracker::default(),
+            ANALYZE_CONCURRENCY,
+        )
+        .await;
+
+        assert_eq!(analysis.analyzed, 8);
+        let observed = max_in_flight(&manifest_arrivals, delay);
+        assert!(
+            observed > 1,
+            "manifest pulls must overlap across mappings; saw at most {observed} in flight"
+        );
+    }
+
+    /// Shutdown before the walk starts must stop it, not just flag it.
+    ///
+    /// The negative half is the registry: a check that ran after the fan-out
+    /// would still have listed every mapping's tags before noticing.
+    #[tokio::test]
+    async fn collect_analysis_starts_nothing_once_shutdown_is_triggered() {
+        let delay = std::time::Duration::from_millis(1);
+        let repos = repo_names(8);
+        let (_server, config, clients, tag_arrivals, manifest_arrivals) =
+            slow_registry(&repos, &["v1"], delay).await;
+
+        let shutdown = ShutdownSignal::new();
+        shutdown.trigger();
+
+        let analysis = collect_analysis(
+            &config,
+            &clients,
+            &HashMap::new(),
+            &shutdown,
+            &PrepareTracker::default(),
+            ANALYZE_CONCURRENCY,
+        )
+        .await;
+
+        assert!(analysis.interrupted, "the report must say it is truncated");
+        assert_eq!(analysis.analyzed, 0);
+        assert_eq!(
+            tag_arrivals.lock().expect("no panic in a stub").len(),
+            0,
+            "no mapping should have been resolved"
+        );
+        assert_eq!(
+            manifest_arrivals.lock().expect("no panic in a stub").len(),
+            0,
+            "and no image should have been pulled"
+        );
+    }
+
+    /// Shutdown part way through leaves a truncated report, not a clean one.
+    ///
+    /// More images than the concurrency bound, so the ones past the first
+    /// batch have not started when the signal lands and must not start.
+    #[tokio::test]
+    async fn collect_analysis_stops_pulling_images_after_shutdown() {
+        let delay = std::time::Duration::from_millis(1);
+        let images = ANALYZE_CONCURRENCY * 3;
+        let repos = repo_names(images);
+        let (_server, config, clients, _, manifest_arrivals) =
+            slow_registry(&repos, &["v1"], delay).await;
+
+        let shutdown = ShutdownSignal::new();
+        let no_checkers = HashMap::new();
+        let tracker = PrepareTracker::default();
+        let analysis = {
+            // Triggered once resolution is done and the image walk is under
+            // way, so the walk is what gets cut short.
+            let walk = collect_analysis(
+                &config,
+                &clients,
+                &no_checkers,
+                &shutdown,
+                &tracker,
+                ANALYZE_CONCURRENCY,
+            );
+            let trip = async {
+                while manifest_arrivals
+                    .lock()
+                    .expect("no panic in a stub")
+                    .is_empty()
+                {
+                    tokio::task::yield_now().await;
+                }
+                shutdown.trigger();
+            };
+            let (analysis, ()) = futures_util::future::join(walk, trip).await;
+            analysis
+        };
+
+        assert!(analysis.interrupted, "the report must say it is truncated");
+        assert!(
+            analysis.analyzed < images,
+            "the walk must stop short; analyzed {} of {images}",
+            analysis.analyzed
+        );
+    }
+
+    /// How long an analysis takes as its two walks are widened.
+    ///
+    /// The config shape is the one that exposes the flattened image walk: many
+    /// mappings holding a single tag each, so a per-mapping walk would still
+    /// be one request long and gain nothing. Concurrency 1 is the behaviour
+    /// this replaced.
+    #[tokio::test]
+    #[ignore = "wall-clock benchmark against a latency-injected mock registry"]
+    async fn analyze_benchmark_walk_concurrency() {
+        let mappings = 95;
+        let delay = std::time::Duration::from_millis(30);
+        let repos = repo_names(mappings);
+
+        println!(
+            "\n{mappings} mappings, 1 tag each, {}ms per request (1 tag list + 1 manifest each)\n",
+            delay.as_millis()
+        );
+        println!(
+            "{:>11}  {:>10}  {:>10}",
+            "concurrency", "elapsed", "speedup"
+        );
+
+        let mut baseline: Option<std::time::Duration> = None;
+        for concurrency in [1usize, 4, 8, 16, 32] {
+            // Fresh server and clients per row: AIMD widens as a registry keeps
+            // answering, so reuse would hand later rows a head start.
+            let (_server, config, clients, _, _) = slow_registry(&repos, &["v1"], delay).await;
+
+            let started = std::time::Instant::now();
+            let analysis = collect_analysis(
+                &config,
+                &clients,
+                &HashMap::new(),
+                &ShutdownSignal::new(),
+                &PrepareTracker::default(),
+                concurrency,
+            )
+            .await;
+            let elapsed = started.elapsed();
+            assert_eq!(analysis.analyzed, mappings);
+
+            let base = *baseline.get_or_insert(elapsed);
+            println!(
+                "{concurrency:>11}  {:>9.2}s  {:>9.1}x",
+                elapsed.as_secs_f64(),
+                base.as_secs_f64() / elapsed.as_secs_f64()
+            );
+        }
+        println!(
+            "\nboth walks run at most {ANALYZE_CONCURRENCY} at once; past that each \
+             registry's AIMD window is the binding constraint\n"
+        );
+    }
+
+    /// The image walk has to drive the progress line too.
+    ///
+    /// Resolution finishes long before the walk does. Left on the mapping
+    /// step, the ticker would report `done=N total=N` for the whole of the
+    /// slower half, which reads as a finished run that never ends.
+    #[tokio::test]
+    async fn collect_analysis_reports_the_image_walk_as_its_own_step() {
+        let delay = std::time::Duration::from_millis(1);
+        let repos = repo_names(3);
+        let (_server, config, clients, _, _) = slow_registry(&repos, &["v1", "v2"], delay).await;
+
+        let tracker = PrepareTracker::default();
+        let analysis = collect_analysis(
+            &config,
+            &clients,
+            &HashMap::new(),
+            &ShutdownSignal::new(),
+            &tracker,
+            ANALYZE_CONCURRENCY,
+        )
+        .await;
+
+        assert_eq!(analysis.analyzed, 6, "three mappings, two tags each");
+        let p = tracker.snapshot();
+        assert!(
+            matches!(p.phase, PreparePhase::Images),
+            "the walk must leave the tracker on the image step, got {:?}",
+            p.phase
+        );
+        assert_eq!(
+            (p.done, p.total),
+            (6, 6),
+            "and count every image, not every mapping"
         );
     }
 }

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -7,6 +7,8 @@ pub(crate) mod dry_run;
 pub(crate) mod expand;
 pub(crate) mod synchronize;
 pub(crate) mod tags;
+#[cfg(test)]
+pub(crate) mod test_support;
 pub(crate) mod validate;
 pub(crate) mod version;
 pub(crate) mod watch;

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -9,6 +9,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures_util::StreamExt;
 use ocync_distribution::auth::detect::{ProviderKind, detect_provider_kind};
 use ocync_distribution::ecr::{BatchBlobChecker, BatchChecker};
 use ocync_distribution::{RegistryClient, RepositoryName};
@@ -45,11 +46,24 @@ const NO_TAGS_SAMPLE_CAP: usize = 5;
 
 /// Cadence of the progress line emitted while the run is preparing.
 ///
-/// Everything before the engine starts is sequential and network-bound: each
-/// client build mints a token for ECR, GAR, and ACR, and each mapping lists a
-/// repository's tags. No per-image output exists yet, so without this a large
-/// config runs for minutes with nothing in the log.
+/// Everything before the engine starts is network-bound: each client build
+/// mints a token for ECR, GAR, and ACR, and each mapping lists a repository's
+/// tags. Client and batch-checker construction run one registry at a time;
+/// mapping resolution overlaps up to [`PREPARE_MAPPING_CONCURRENCY`] at once.
+/// No per-image output exists yet, so without this a large config runs for
+/// minutes with nothing in the log.
 const PREPARE_PROGRESS_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Mappings whose resolution may be in flight at once.
+///
+/// Resolution is network-bound and independent per mapping, so running one at
+/// a time makes the prepare phase cost the sum of every registry's latency
+/// rather than its maximum. This is a ceiling on how many mappings are open,
+/// not on how hard any registry is hit: every request underneath still passes
+/// that registry's AIMD window, which starts at one in flight and widens only
+/// as the registry keeps answering, so a wide config cannot turn into a burst
+/// against a single host.
+pub(crate) const PREPARE_MAPPING_CONCURRENCY: usize = 16;
 
 /// A step of the pre-engine phase.
 #[derive(Debug, Clone, Copy, Default)]
@@ -61,6 +75,8 @@ pub(crate) enum PreparePhase {
     BatchCheckers,
     /// Listing and filtering tags, one mapping at a time.
     Mappings,
+    /// Reading image manifests, one per resolved tag. `analyze` only.
+    Images,
 }
 
 impl fmt::Display for PreparePhase {
@@ -69,13 +85,14 @@ impl fmt::Display for PreparePhase {
             Self::Registries => f.write_str("registries"),
             Self::BatchCheckers => f.write_str("batch checkers"),
             Self::Mappings => f.write_str("mappings"),
+            Self::Images => f.write_str("images"),
         }
     }
 }
 
-/// Snapshot of the pre-engine phase, read by the progress ticker.
+/// Counts for the pre-engine phase, held in a [`Cell`].
 #[derive(Debug, Clone, Copy, Default)]
-struct PrepareProgress {
+struct PrepareCounts {
     /// Which pre-engine step is running.
     phase: PreparePhase,
     /// Items finished in this step.
@@ -84,35 +101,120 @@ struct PrepareProgress {
     total: usize,
 }
 
-/// Counter the pre-engine steps advance and the progress ticker reads.
+/// An item the current step has started and not yet finished.
+#[derive(Debug)]
+struct InFlightItem {
+    /// Identity used to remove the item when its guard drops.
+    id: u64,
+    /// What the item is, as the operator named it in config.
+    name: String,
+    /// `tokio`'s clock, not `std`'s, so a paused runtime still ages items.
+    started: tokio::time::Instant,
+}
+
+/// What the progress ticker reports for one tick.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PrepareProgress {
+    /// Which pre-engine step is running.
+    pub(crate) phase: PreparePhase,
+    /// Items finished in this step.
+    pub(crate) done: usize,
+    /// Items this step will process.
+    pub(crate) total: usize,
+    /// Items started and not yet finished.
+    pub(crate) in_flight: usize,
+    /// The in-flight item running longest, and for how long.
+    ///
+    /// This is the whole point of tracking names: a step that sits at the same
+    /// `done` count for minutes is otherwise unattributable, and the operator
+    /// cannot tell a huge tag listing from a wedged registry.
+    pub(crate) slowest: Option<(String, Duration)>,
+}
+
+/// Counters and in-flight set the pre-engine steps update and the progress
+/// ticker reads.
 ///
-/// A plain [`Cell`] rather than a channel: the runtime is `current_thread`, so
-/// the ticker and the work it describes never run concurrently.
+/// Plain [`Cell`] and [`RefCell`] rather than channels or locks: the runtime is
+/// `current_thread`, so the ticker and the work it describes never run
+/// concurrently, and no borrow here is held across an await.
 #[derive(Debug, Default)]
 pub(crate) struct PrepareTracker {
-    state: Cell<PrepareProgress>,
+    counts: Cell<PrepareCounts>,
+    in_flight: RefCell<Vec<InFlightItem>>,
+    next_id: Cell<u64>,
 }
 
 impl PrepareTracker {
-    /// Start a new step, resetting the item counter.
+    /// Start a new step, resetting the item counter and in-flight set.
     pub(crate) fn begin(&self, phase: PreparePhase, total: usize) {
-        self.state.set(PrepareProgress {
+        self.counts.set(PrepareCounts {
             phase,
             done: 0,
             total,
         });
+        self.in_flight.borrow_mut().clear();
     }
 
-    /// The current step and its counts.
-    fn snapshot(&self) -> PrepareProgress {
-        self.state.get()
+    /// Mark `name` in flight until the returned guard drops.
+    ///
+    /// A guard rather than paired calls: resolution has many early exits, and
+    /// every one of them must both retire the item and advance the counter or
+    /// the progress line stalls short of its total forever.
+    pub(crate) fn track(&self, name: &str) -> InFlightGuard<'_> {
+        let id = self.next_id.get();
+        self.next_id.set(id + 1);
+        self.in_flight.borrow_mut().push(InFlightItem {
+            id,
+            name: name.to_owned(),
+            started: tokio::time::Instant::now(),
+        });
+        InFlightGuard { tracker: self, id }
     }
 
-    /// Record one item finished in the current step.
-    pub(crate) fn advance(&self) {
-        let mut p = self.state.get();
-        p.done += 1;
-        self.state.set(p);
+    /// The current step, its counts, and what is still running.
+    pub(crate) fn snapshot(&self) -> PrepareProgress {
+        let counts = self.counts.get();
+        let in_flight = self.in_flight.borrow();
+        let now = tokio::time::Instant::now();
+        let slowest = in_flight
+            .iter()
+            // Earliest start wins, so the report names the item actually
+            // holding the step up rather than whichever was added last.
+            .min_by_key(|item| item.started)
+            .map(|item| {
+                (
+                    item.name.clone(),
+                    now.saturating_duration_since(item.started),
+                )
+            });
+        PrepareProgress {
+            phase: counts.phase,
+            done: counts.done,
+            total: counts.total,
+            in_flight: in_flight.len(),
+            slowest,
+        }
+    }
+
+    /// Retire an in-flight item and count it finished.
+    fn finish(&self, id: u64) {
+        self.in_flight.borrow_mut().retain(|item| item.id != id);
+        let mut counts = self.counts.get();
+        counts.done += 1;
+        self.counts.set(counts);
+    }
+}
+
+/// Guard marking one item in flight for as long as it is held.
+#[derive(Debug)]
+pub(crate) struct InFlightGuard<'a> {
+    tracker: &'a PrepareTracker,
+    id: u64,
+}
+
+impl Drop for InFlightGuard<'_> {
+    fn drop(&mut self) {
+        self.tracker.finish(self.id);
     }
 }
 
@@ -128,10 +230,20 @@ pub(crate) async fn with_prepare_progress<F: Future>(
     work: F,
 ) -> F::Output {
     tick_while(tracker, PREPARE_PROGRESS_INTERVAL, work, |p, elapsed| {
+        // `slowest` is rendered even when nothing is in flight, which only
+        // happens between steps; `in_flight=0` beside it says why.
+        let (slowest, slowest_secs) = p
+            .slowest
+            .as_ref()
+            .map(|(name, age)| (name.as_str(), age.as_secs()))
+            .unwrap_or(("-", 0));
         tracing::info!(
             phase = %p.phase,
             done = p.done,
             total = p.total,
+            in_flight = p.in_flight,
+            slowest = %slowest,
+            slowest_secs = slowest_secs,
             elapsed_secs = elapsed.as_secs(),
             "preparing {what}"
         );
@@ -520,8 +632,8 @@ pub(crate) async fn run(
     let config = load_config(&args.config)?;
 
     // Client construction, batch-checker setup, and mapping resolution are all
-    // sequential network work with no output of their own. One ticker spans
-    // the lot so the run is never silent for longer than the interval.
+    // network work with no output of their own. One ticker spans the lot so
+    // the run is never silent for longer than the interval.
     let tracker = PrepareTracker::default();
     let resolution = with_prepare_progress(&tracker, "sync", async {
         let referenced = referenced_registries(&config);
@@ -534,6 +646,7 @@ pub(crate) async fn run(
             args.dry_run,
             watch_log.as_deref_mut(),
             &tracker,
+            PREPARE_MAPPING_CONCURRENCY,
         )
         .await
     })
@@ -1035,6 +1148,10 @@ pub(crate) async fn build_clients(
         if !referenced.contains(name) {
             continue;
         }
+        // Minting this registry's token is itself a round trip, so a slow or
+        // wedged provider is named in the progress line rather than showing up
+        // as a stalled count.
+        let _item = tracker.track(name);
         let hostname = bare_hostname(&reg.url);
         let entry = match build_registry_client(hostname, Some(reg)).await {
             Ok(client) => Ok(Arc::new(client)),
@@ -1048,7 +1165,6 @@ pub(crate) async fn build_clients(
             }
         };
         clients.insert(name.clone(), entry);
-        tracker.advance();
     }
     clients
 }
@@ -1188,6 +1304,8 @@ async fn build_batch_checkers(
         .collect();
     tracker.begin(PreparePhase::BatchCheckers, usable.len());
     for (name, reg) in usable {
+        // Held for the whole body so every `continue` still retires the item.
+        let _item = tracker.track(name);
         let hostname = bare_hostname(&reg.url);
         // Explicit non-Ecr auth_type is a hard opt-out: don't try to build an
         // AWS-SDK-backed batch checker for a registry the user has declared
@@ -1200,7 +1318,6 @@ async fn build_batch_checkers(
         };
 
         if !is_ecr {
-            tracker.advance();
             continue;
         }
 
@@ -1218,7 +1335,6 @@ async fn build_batch_checkers(
                 "ECR batch checker unavailable; manifest commits fall back to retry-on-conflict"
             ),
         }
-        tracker.advance();
     }
 
     checkers
@@ -1246,6 +1362,10 @@ pub(crate) struct Resolution {
 /// name must not cost the run every other mapping. Each failure is logged and
 /// recorded; resolution continues. Returns the mappings that are ready for the
 /// engine plus one [`UnresolvedMapping`] per mapping that is not.
+///
+/// Up to `concurrency` mappings resolve at once, but the result is always in
+/// config order: callers depend on that for deterministic logs, watch-mode
+/// state, and which config error stops the run.
 async fn resolve_all(
     config: &Config,
     clients: &ClientMap,
@@ -1253,6 +1373,7 @@ async fn resolve_all(
     with_report: bool,
     mut watch_log: Option<&mut WatchLogState>,
     tracker: &PrepareTracker,
+    concurrency: usize,
 ) -> Result<Resolution, CliError> {
     tracker.begin(PreparePhase::Mappings, config.mappings.len());
     let mut resolved = Vec::new();
@@ -1260,13 +1381,32 @@ async fn resolve_all(
     let mut dropped_targets = Vec::new();
     let mut no_match = 0usize;
 
-    for mapping in &config.mappings {
+    // Resolution is independent per mapping and spends nearly all of its time
+    // waiting on a registry, so the waits overlap. `buffered` yields in config
+    // order however the registries answered, which keeps the bookkeeping below
+    // deterministic: it touches `watch_log` and the run's counters, and a log
+    // whose order changed run to run would be unreadable.
+    //
+    // One consequence of overlapping: a mapping that a config error would once
+    // have pre-empted may already have run and emitted its own warnings by the
+    // time the error is reached. The run still stops at the first config error
+    // in config order, which is what the exit code and the operator depend on.
+    let outcomes: Vec<(Result<MappingResolution, CliError>, Vec<DroppedTarget>)> =
+        futures_util::stream::iter(config.mappings.iter().map(|mapping| async move {
+            // The guard both names the mapping while it runs and counts it
+            // finished when it ends, however it ends.
+            let _item = tracker.track(&mapping.from);
+            resolve_mapping(mapping, config, clients, batch_checkers, with_report).await
+        }))
+        .buffered(concurrency.max(1))
+        .collect()
+        .await;
+
+    for (mapping, (outcome, dropped)) in config.mappings.iter().zip(outcomes) {
         // Dropped targets come back whatever the outcome, so a mapping that
         // loses a mirror and then fails on its tag listing still reports the
         // outage. Reconciled against the previous cycle before anything else,
         // so a mirror that recovered re-arms even if the mapping then failed.
-        let (outcome, dropped) =
-            resolve_mapping(mapping, config, clients, batch_checkers, with_report).await;
         reconcile_dropped_targets(&mapping.from, &dropped, watch_log.as_deref_mut());
         dropped_targets.extend(dropped);
 
@@ -1317,7 +1457,6 @@ async fn resolve_all(
                 });
             }
         }
-        tracker.advance();
     }
 
     Ok(Resolution {
@@ -1607,11 +1746,37 @@ async fn resolve_mapping_inner(
         let glob_set = build_glob_set(&[pattern.to_owned()])?;
 
         let target_repo_path = RepositoryName::new(&target_repo)?;
-        for entry in &mut targets {
-            match entry.client.list_tags(&target_repo_path).await {
+
+        // One read-only listing per mirror, all independent, so they overlap
+        // rather than making a mapping's prepare cost scale with its fan-out.
+        // Unbounded across the mapping's own targets on purpose: each target
+        // is a distinct registry with its own AIMD window, so widening here
+        // cannot concentrate load on any one host.
+        // Cloned out first so the listings borrow this vec rather than
+        // `targets`, which has to be mutably reborrowed to store the results.
+        let target_clients: Vec<Arc<RegistryClient>> =
+            targets.iter().map(|e| Arc::clone(&e.client)).collect();
+        let listings: Vec<Result<Vec<String>, ocync_distribution::Error>> =
+            futures_util::stream::iter(
+                target_clients
+                    .iter()
+                    .map(|client| client.list_tags(&target_repo_path)),
+            )
+            .buffered(target_clients.len().max(1))
+            .collect()
+            .await;
+
+        // Applied in target order, so a mapping's warnings read the same way
+        // whichever mirror answered first.
+        for (entry, listing) in targets.iter_mut().zip(listings) {
+            match listing {
                 Ok(tags) => entry.existing_tags = tags.into_iter().collect(),
                 Err(e) => {
                     tracing::warn!(
+                        // Without `from` this warning names a registry but not
+                        // the mapping, and mappings now resolve concurrently,
+                        // so neighbouring log lines no longer identify it.
+                        from = %mapping.from,
                         registry = %entry.name,
                         error = %e,
                         "failed to list target tags; immutable skip disabled for this target"
@@ -3005,6 +3170,7 @@ mappings:
             false,
             None,
             &PrepareTracker::default(),
+            PREPARE_MAPPING_CONCURRENCY,
         )
         .await
         .expect("no config-class failure in these fixtures")
@@ -3405,8 +3571,9 @@ mappings:
             &tracker,
             Duration::from_secs(5),
             async {
+                let item = tracker.track("registry-a");
                 tokio::time::sleep(Duration::from_secs(7)).await;
-                tracker.advance();
+                drop(item);
                 tokio::time::sleep(Duration::from_secs(7)).await;
             },
             |p, _| seen.borrow_mut().push(p.done),
@@ -3637,6 +3804,7 @@ mappings:
             false,
             None,
             &PrepareTracker::default(),
+            PREPARE_MAPPING_CONCURRENCY,
         )
         .await
         .expect_err("an invalid glob must not be isolated");
@@ -3889,5 +4057,476 @@ mappings:
         // And carries the full pipeline trace.
         assert!(out.contains("source tags: 10"), "{out}");
         assert!(out.contains("dropped (10):"), "{out}");
+    }
+
+    // -----------------------------------------------------------------------
+    // Prepare-phase concurrency
+    // -----------------------------------------------------------------------
+
+    use crate::cli::commands::test_support::{
+        Arrivals, SlowRecorder, arrivals, config_yaml, max_in_flight, repo_names,
+    };
+
+    /// A source registry that answers every mapping's tag listing after
+    /// `delay`, plus the config and clients pointed at it.
+    async fn slow_tag_registry(
+        mappings: usize,
+        delay: Duration,
+    ) -> (wiremock::MockServer, Config, ClientMap, Arrivals) {
+        let server = wiremock::MockServer::start().await;
+        let arrivals = arrivals();
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path_regex(
+                r"^/v2/repo/img\d+/tags/list$",
+            ))
+            .respond_with(SlowRecorder::tag_list(&arrivals, delay, &["v1"]))
+            .mount(&server)
+            .await;
+
+        let yaml = config_yaml(&server, &repo_names(mappings), "      glob: [\"*\"]\n");
+        let config: Config = serde_yaml::from_str(&yaml).expect("generated config parses");
+        let clients = ClientMap::from([
+            ("src".to_string(), Ok(test_client(&server.uri()))),
+            ("dst".to_string(), Ok(test_client(&server.uri()))),
+        ]);
+        (server, config, clients, arrivals)
+    }
+
+    /// Mapping resolution must overlap its network waits.
+    ///
+    /// Every mapping's tag listing is an independent round trip, so resolving
+    /// them one at a time makes the prepare phase cost the sum of every
+    /// registry's latency. Measured on a 95-mapping config that was 11 minutes
+    /// before the engine started.
+    #[tokio::test]
+    async fn resolve_all_resolves_mappings_concurrently() {
+        let delay = Duration::from_millis(250);
+        let (_server, config, clients, arrivals) = slow_tag_registry(8, delay).await;
+
+        let resolution = resolve_all(
+            &config,
+            &clients,
+            &HashMap::new(),
+            false,
+            None,
+            &PrepareTracker::default(),
+            PREPARE_MAPPING_CONCURRENCY,
+        )
+        .await
+        .expect("no config-class failure in this fixture");
+
+        assert_eq!(resolution.resolved.len(), 8, "every mapping must resolve");
+        let observed = max_in_flight(&arrivals, delay);
+        assert!(
+            observed > 1,
+            "tag listings must overlap; saw at most {observed} in flight"
+        );
+    }
+
+    /// Concurrency is a ceiling, not an invitation to open every mapping at
+    /// once.
+    ///
+    /// A config with hundreds of mappings pointed at one registry must not
+    /// become a burst of hundreds of simultaneous tag listings. The limit is
+    /// what stands between the two, so it is asserted exactly: reaching it
+    /// proves resolution overlaps, and never passing it proves the ceiling is
+    /// real.
+    #[tokio::test]
+    async fn resolve_all_never_exceeds_its_concurrency_limit() {
+        let delay = Duration::from_millis(250);
+        let limit = 2;
+        let (_server, config, clients, arrivals) = slow_tag_registry(8, delay).await;
+
+        resolve_all(
+            &config,
+            &clients,
+            &HashMap::new(),
+            false,
+            None,
+            &PrepareTracker::default(),
+            limit,
+        )
+        .await
+        .expect("no config-class failure in this fixture");
+
+        let observed = max_in_flight(&arrivals, delay);
+        assert_eq!(
+            observed, limit,
+            "resolution must run exactly {limit} mappings at a time"
+        );
+    }
+
+    /// A zero limit must still make progress rather than stall forever.
+    ///
+    /// `buffered(0)` yields nothing and never completes, so the floor is not
+    /// cosmetic: without it a miscomputed limit hangs the run before the
+    /// engine starts, with a progress line reporting `done=0` forever.
+    #[tokio::test]
+    async fn resolve_all_treats_a_zero_limit_as_one() {
+        let (_server, config, clients, _arrivals) =
+            slow_tag_registry(2, Duration::from_millis(1)).await;
+
+        let resolution = resolve_all(
+            &config,
+            &clients,
+            &HashMap::new(),
+            false,
+            None,
+            &PrepareTracker::default(),
+            0,
+        )
+        .await
+        .expect("no config-class failure in this fixture");
+
+        assert_eq!(resolution.resolved.len(), 2);
+    }
+
+    /// A mapping's targets must be listed concurrently.
+    ///
+    /// The immutable-tag optimization lists every target's existing tags
+    /// before the engine starts. Walking the mirrors one at a time makes a
+    /// mapping's prepare cost scale with its fan-out, which is the opposite of
+    /// what fanning out is for: the listings are independent and read-only.
+    #[tokio::test]
+    async fn resolve_mapping_lists_target_tags_concurrently() {
+        let delay = Duration::from_millis(250);
+        let server = wiremock::MockServer::start().await;
+        let arrivals = Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        // The source listing is fast and on its own path, so only the target
+        // listings land in the recorder.
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/repo/img0/tags/list"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"name": "repo/img0", "tags": ["v1"]})),
+            )
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/mirror/img0/tags/list"))
+            .respond_with(SlowRecorder::tag_list(&arrivals, delay, &["v1"]))
+            .mount(&server)
+            .await;
+
+        let config: Config = serde_yaml::from_str(&format!(
+            r#"
+registries:
+  src:
+    url: {uri}
+  dst1:
+    url: {uri}
+  dst2:
+    url: {uri}
+  dst3:
+    url: {uri}
+defaults:
+  source: src
+  targets: [dst1, dst2, dst3]
+mappings:
+  - from: repo/img0
+    to: mirror/img0
+    tags:
+      glob: ["*"]
+      immutable_tags: "v*"
+"#,
+            uri = server.uri()
+        ))
+        .expect("config yaml parses");
+
+        let clients = ClientMap::from([
+            ("src".to_string(), Ok(test_client(&server.uri()))),
+            ("dst1".to_string(), Ok(test_client(&server.uri()))),
+            ("dst2".to_string(), Ok(test_client(&server.uri()))),
+            ("dst3".to_string(), Ok(test_client(&server.uri()))),
+        ]);
+
+        let (outcome, _dropped) = resolve_mapping(
+            &config.mappings[0],
+            &config,
+            &clients,
+            &HashMap::new(),
+            false,
+        )
+        .await;
+        assert!(matches!(
+            outcome.expect("the mapping resolves"),
+            MappingResolution::Resolved(_)
+        ));
+
+        let observed = max_in_flight(&arrivals, delay);
+        assert_eq!(
+            observed, 3,
+            "all three target listings must be open at once"
+        );
+    }
+
+    /// The progress line must name the item holding the step up.
+    ///
+    /// A count alone leaves a stall unattributable: a step that sits at the
+    /// same `done` for minutes could be one huge tag listing or a wedged
+    /// registry, and the operator cannot tell which without the name.
+    #[tokio::test(start_paused = true)]
+    async fn prepare_ticker_names_the_item_holding_the_step_up() {
+        let tracker = PrepareTracker::default();
+        tracker.begin(PreparePhase::Mappings, 2);
+        let seen = RefCell::new(Vec::new());
+
+        tick_while(
+            &tracker,
+            Duration::from_secs(5),
+            async {
+                let slow = tracker.track("repo/slow");
+                tokio::time::sleep(Duration::from_secs(4)).await;
+                // Started later, so it must never be the one reported even
+                // though it is the most recent thing to begin.
+                let quick = tracker.track("repo/quick");
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                drop(quick);
+                tokio::time::sleep(Duration::from_secs(6)).await;
+                drop(slow);
+            },
+            |p, _| seen.borrow_mut().push(p.slowest.clone()),
+        )
+        .await;
+
+        let reported: Vec<(String, u64)> = seen
+            .borrow()
+            .iter()
+            .map(|s| {
+                let (name, age) = s.as_ref().expect("a mapping is in flight at every tick");
+                (name.clone(), age.as_secs())
+            })
+            .collect();
+        assert_eq!(
+            reported,
+            vec![("repo/slow".to_string(), 5), ("repo/slow".to_string(), 10),],
+            "the oldest in-flight item must be reported, with how long it has been running"
+        );
+    }
+
+    /// Retiring an item both counts it and takes it out of the in-flight set.
+    ///
+    /// The guard is what makes that unconditional. Resolution has many early
+    /// exits, and one that forgot to count would strand the progress line
+    /// short of its total for the rest of the run.
+    #[tokio::test]
+    async fn prepare_tracker_retires_an_item_when_its_guard_drops() {
+        let tracker = PrepareTracker::default();
+        tracker.begin(PreparePhase::Mappings, 1);
+
+        let item = tracker.track("repo/one");
+        let during = tracker.snapshot();
+        assert_eq!((during.done, during.in_flight), (0, 1));
+
+        drop(item);
+        let after = tracker.snapshot();
+        assert_eq!((after.done, after.in_flight), (1, 0));
+        assert!(
+            after.slowest.is_none(),
+            "nothing is running, so nothing is reported as slow"
+        );
+    }
+
+    /// A new step starts from a clean in-flight set.
+    ///
+    /// Steps run back to back under one ticker, so a leaked item from the
+    /// previous step would be reported as the thing holding up the next one.
+    #[tokio::test]
+    async fn prepare_tracker_clears_in_flight_items_between_steps() {
+        let tracker = PrepareTracker::default();
+        tracker.begin(PreparePhase::Registries, 1);
+        let leaked = tracker.track("registry-a");
+        std::mem::forget(leaked);
+
+        tracker.begin(PreparePhase::Mappings, 1);
+
+        let p = tracker.snapshot();
+        assert_eq!(p.in_flight, 0);
+        assert!(p.slowest.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Prepare-phase benchmarks
+    //
+    // Ignored by default: they measure wall-clock against a mock registry with
+    // injected latency, which is too slow for the normal test run. Run with:
+    //
+    //   cargo test --bin ocync -- --ignored --nocapture prepare_phase
+    // -----------------------------------------------------------------------
+
+    /// Tag count the pagination benchmark serves.
+    const BENCH_REPO_TAGS: usize = 3000;
+
+    /// A `tags/list` that behaves the way the real registries do: a request
+    /// carrying no `n` gets every tag in one response with no `Link` header,
+    /// and only an explicit `n` produces pages.
+    ///
+    /// Measured against Docker Hub and matching `distribution/distribution`,
+    /// which sets its internal limit to -1 when `n` is absent.
+    struct PaginatedTagList {
+        requests: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl wiremock::Respond for PaginatedTagList {
+        fn respond(&self, req: &wiremock::Request) -> wiremock::ResponseTemplate {
+            self.requests
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let all: Vec<String> = (0..BENCH_REPO_TAGS).map(|i| format!("tag{i:04}")).collect();
+            // No `n` means no paging at all, which is the whole point.
+            let mut page = all.len();
+            let mut last: Option<String> = None;
+            for (k, v) in req.url.query_pairs() {
+                match k.as_ref() {
+                    "n" => page = v.parse().unwrap_or(all.len()),
+                    "last" => last = Some(v.into_owned()),
+                    _ => {}
+                }
+            }
+
+            let start = match &last {
+                Some(l) => all.iter().position(|t| t == l).map_or(0, |i| i + 1),
+                None => 0,
+            };
+            let end = (start + page).min(all.len());
+            let mut resp = wiremock::ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"name": "repo/paged", "tags": &all[start..end]}));
+            if end < all.len() {
+                resp = resp.append_header(
+                    "link",
+                    format!(
+                        r#"</v2/repo/paged/tags/list?n={page}&last={}>; rel="next""#,
+                        all[end - 1]
+                    )
+                    .as_str(),
+                );
+            }
+            resp
+        }
+    }
+
+    /// How long the prepare phase takes as mapping resolution is widened.
+    ///
+    /// Concurrency 1 is the behaviour this replaced, so the first row is the
+    /// baseline every other row is measured against.
+    #[tokio::test]
+    #[ignore = "wall-clock benchmark against a latency-injected mock registry"]
+    async fn prepare_phase_benchmark_resolution_concurrency() {
+        let mappings = 95;
+        let delay = Duration::from_millis(60);
+
+        println!(
+            "\n{mappings} mappings, {}ms per tag listing\n",
+            delay.as_millis()
+        );
+        println!(
+            "{:>11}  {:>10}  {:>10}  {:>12}",
+            "concurrency", "elapsed", "speedup", "max in flight"
+        );
+
+        let mut baseline: Option<Duration> = None;
+        for concurrency in [1usize, 4, 8, 16, 32] {
+            // A fresh server and fresh clients per row: AIMD widens as a
+            // registry keeps answering, so reusing them would hand later rows
+            // a head start the first row never had.
+            let (_server, config, clients, arrivals) = slow_tag_registry(mappings, delay).await;
+
+            let started = std::time::Instant::now();
+            let resolution = resolve_all(
+                &config,
+                &clients,
+                &HashMap::new(),
+                false,
+                None,
+                &PrepareTracker::default(),
+                concurrency,
+            )
+            .await
+            .expect("no config-class failure in this fixture");
+            let elapsed = started.elapsed();
+            assert_eq!(resolution.resolved.len(), mappings);
+
+            let observed = max_in_flight(&arrivals, delay);
+            let base = *baseline.get_or_insert(elapsed);
+            println!(
+                "{concurrency:>11}  {:>9.2}s  {:>9.1}x  {observed:>12}",
+                elapsed.as_secs_f64(),
+                base.as_secs_f64() / elapsed.as_secs_f64()
+            );
+        }
+        println!(
+            "\nresolution runs at most {PREPARE_MAPPING_CONCURRENCY} mappings at once; \
+             past that each registry's AIMD window is the binding constraint\n"
+        );
+    }
+
+    /// How many round trips one repository's tag listing costs, with and
+    /// without asking for a page size.
+    ///
+    /// Both walks hit the same registry over the same tag set. This is the
+    /// evidence for not sending `n`: the request that asks for nothing gets
+    /// everything in one response, and the one that asks for a page size pays
+    /// per page. It reproduces what Docker Hub does with `library/python`.
+    #[tokio::test]
+    #[ignore = "benchmark: counts round trips against a paginated mock registry"]
+    async fn prepare_phase_benchmark_tag_list_pagination() {
+        let server = wiremock::MockServer::start().await;
+        let requests = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/repo/paged/tags/list"))
+            .respond_with(PaginatedTagList {
+                requests: Arc::clone(&requests),
+            })
+            .mount(&server)
+            .await;
+
+        // What sending an explicit page size would cost: follow the pagination
+        // it creates, one round trip per page.
+        let http = ocync_distribution::test_http_client();
+        let mut url = format!("{}/v2/repo/paged/tags/list?n=1000", server.uri());
+        let mut paged_tags = 0usize;
+        loop {
+            let resp = http.get(&url).send().await.expect("mock answers");
+            // The mock emits exactly one link-value, so the path is whatever
+            // sits between the angle brackets. The client's own parser is
+            // crate-private and stays that way: this baseline deliberately
+            // does not share code with the thing it is measuring.
+            let next = resp
+                .headers()
+                .get("link")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|h| {
+                    let start = h.find('<')? + 1;
+                    let end = h[start..].find('>')? + start;
+                    Some(h[start..end].to_owned())
+                });
+            let body: serde_json::Value = resp.json().await.expect("mock returns json");
+            paged_tags += body["tags"].as_array().map_or(0, |a| a.len());
+            match next {
+                Some(path) => url = format!("{}{path}", server.uri()),
+                None => break,
+            }
+        }
+        let paged_requests = requests.swap(0, std::sync::atomic::Ordering::Relaxed);
+
+        let client = test_client(&server.uri());
+        let tags = client
+            .list_tags(&RepositoryName::new("repo/paged").unwrap())
+            .await
+            .expect("the listing succeeds");
+        let ocync_requests = requests.load(std::sync::atomic::Ordering::Relaxed);
+
+        assert_eq!(tags.len(), BENCH_REPO_TAGS, "the whole listing is walked");
+        assert_eq!(paged_tags, BENCH_REPO_TAGS, "and so is the paged walk");
+
+        println!("\n{BENCH_REPO_TAGS} tags in one repository\n");
+        println!("{:>24}  {:>9}", "request", "round trips");
+        println!("{:>24}  {ocync_requests:>9}", "no n (ocync)");
+        println!("{:>24}  {paged_requests:>9}", "n=1000");
+        println!(
+            "\nasking for a page size costs {:.0}x the round trips\n",
+            paged_requests as f64 / ocync_requests as f64
+        );
     }
 }

--- a/src/cli/commands/test_support.rs
+++ b/src/cli/commands/test_support.rs
@@ -1,0 +1,134 @@
+//! Shared scaffolding for the prepare-phase concurrency tests.
+//!
+//! `sync` and `analyze` resolve mappings through the same code and have to
+//! prove the same property: that independent network work overlaps. Both need
+//! a registry that answers slowly and records when each request arrived, so it
+//! lives here rather than being written twice.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use ocync_distribution::{RegistryClient, RegistryClientBuilder};
+use wiremock::{MockServer, Request, Respond, ResponseTemplate};
+
+/// Instants at which requests reached a stub, shared with the test.
+pub(crate) type Arrivals = Arc<Mutex<Vec<Instant>>>;
+
+/// A fresh arrival recorder.
+pub(crate) fn arrivals() -> Arrivals {
+    Arc::new(Mutex::new(Vec::new()))
+}
+
+/// The largest number of requests that were in flight at once.
+///
+/// A request is in flight from its arrival until `delay` later, so the answer
+/// is the most arrivals falling inside any window of that length. Under
+/// sequential work consecutive arrivals are at least `delay` apart, so every
+/// window holds exactly one and this returns 1.
+pub(crate) fn max_in_flight(recorded: &Arrivals, delay: Duration) -> usize {
+    let arrivals = recorded.lock().expect("no panic in a stub");
+    arrivals
+        .iter()
+        .map(|start| {
+            arrivals
+                .iter()
+                .filter(|other| **other >= *start && other.duration_since(*start) < delay)
+                .count()
+        })
+        .max()
+        .unwrap_or(0)
+}
+
+/// Responds with a fixed body after `delay`, recording when each request
+/// arrived.
+pub(crate) struct SlowRecorder {
+    arrivals: Arrivals,
+    delay: Duration,
+    body: serde_json::Value,
+    content_type: Option<&'static str>,
+}
+
+impl SlowRecorder {
+    /// A `tags/list` response carrying `tags`.
+    pub(crate) fn tag_list(arrivals: &Arrivals, delay: Duration, tags: &[&str]) -> Self {
+        Self {
+            arrivals: Arc::clone(arrivals),
+            delay,
+            body: serde_json::json!({"name": "repo", "tags": tags}),
+            content_type: None,
+        }
+    }
+
+    /// A single-layer OCI image manifest.
+    ///
+    /// The client computes the digest from the bytes it receives, so nothing
+    /// here has to agree with a header.
+    pub(crate) fn image_manifest(arrivals: &Arrivals, delay: Duration) -> Self {
+        Self {
+            arrivals: Arc::clone(arrivals),
+            delay,
+            body: serde_json::json!({
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "config": {
+                    "mediaType": "application/vnd.oci.image.config.v1+json",
+                    "digest": format!("sha256:{}", "a".repeat(64)),
+                    "size": 100,
+                },
+                "layers": [{
+                    "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                    "digest": format!("sha256:{}", "b".repeat(64)),
+                    "size": 200,
+                }],
+            }),
+            content_type: Some("application/vnd.oci.image.manifest.v1+json"),
+        }
+    }
+}
+
+impl Respond for SlowRecorder {
+    fn respond(&self, _req: &Request) -> ResponseTemplate {
+        self.arrivals
+            .lock()
+            .expect("no panic in a stub")
+            .push(Instant::now());
+        // `set_body_raw` rather than `set_body_json`: the latter forces
+        // `application/json`, and the client picks its manifest parser from
+        // the content type, so a manifest served that way is rejected as an
+        // unsupported media type.
+        let body = serde_json::to_vec(&self.body).expect("stub body serializes");
+        ResponseTemplate::new(200)
+            .set_body_raw(body, self.content_type.unwrap_or("application/json"))
+            .set_delay(self.delay)
+    }
+}
+
+/// A config whose `mappings` entries all point at `server`.
+///
+/// `tags` is the filter each mapping carries, written as it would appear under
+/// a mapping's `tags:` block.
+pub(crate) fn config_yaml(server: &MockServer, repos: &[String], tags: &str) -> String {
+    let mut yaml = format!(
+        "registries:\n  src:\n    url: {uri}\n  dst:\n    url: {uri}\n\
+         defaults:\n  source: src\n  targets: [dst]\nmappings:\n",
+        uri = server.uri()
+    );
+    for repo in repos {
+        yaml.push_str(&format!("  - from: {repo}\n    tags:\n{tags}"));
+    }
+    yaml
+}
+
+/// `count` repository names of the shape the stubs match.
+pub(crate) fn repo_names(count: usize) -> Vec<String> {
+    (0..count).map(|i| format!("repo/img{i}")).collect()
+}
+
+/// An anonymous client pointed at a mock server.
+pub(crate) fn test_client(url: &str) -> Arc<RegistryClient> {
+    Arc::new(
+        RegistryClientBuilder::new(url::Url::parse(url).expect("mock server url parses"))
+            .build()
+            .expect("client builds"),
+    )
+}

--- a/xtask/src/bench/corpus.rs
+++ b/xtask/src/bench/corpus.rs
@@ -493,4 +493,42 @@ images:
         assert_eq!(partial.images[1].tags, vec!["latest", "3.12"]);
         assert_eq!(partial.images[2].tags, vec!["2023", "2"]);
     }
+
+    /// The prepare corpus is only worth running if it defeats the exact-tag
+    /// fast path.
+    ///
+    /// `TagsConfig::exact_tags` returns the tags verbatim when every pattern
+    /// is a literal, and `resolve_mapping_inner` then skips `list_tags`
+    /// entirely. A prepare corpus pinned to literal tags would run clean, take
+    /// a plausible-looking time, and measure none of the phase it is named
+    /// for. The main corpus is exactly that shape, which is why this one
+    /// exists.
+    #[test]
+    fn prepare_corpus_tags_are_all_wildcards() {
+        // Env var only has to expand; the prepare scenario never writes here.
+        unsafe { std::env::set_var("BENCH_TARGET_REGISTRY", "example.invalid") };
+        let corpus = load("../bench/corpus-prepare.yaml")
+            .or_else(|_| load("bench/corpus-prepare.yaml"))
+            .expect("the prepare corpus parses");
+
+        assert!(
+            corpus.images.len() >= 20,
+            "the phase costs one round trip per mapping, so a narrow corpus \
+             cannot show it; got {} mappings",
+            corpus.images.len()
+        );
+
+        let literal: Vec<&str> = corpus
+            .images
+            .iter()
+            .flat_map(|img| img.tags.iter())
+            .filter(|tag| !tag.contains(['*', '?', '[']))
+            .map(String::as_str)
+            .collect();
+        assert!(
+            literal.is_empty(),
+            "every prepare-corpus tag must be a wildcard or the tag listing is \
+             never issued; these are literals: {literal:?}"
+        );
+    }
 }

--- a/xtask/src/bench/mod.rs
+++ b/xtask/src/bench/mod.rs
@@ -266,7 +266,14 @@ pub(crate) async fn run(args: BenchArgs) -> Result<(), Box<dyn std::error::Error
     // Guard: refuse to run if TMPDIR resolves to tmpfs. Staging writes
     // multi-GB blobs and tmpfs is RAM-backed, causing OOM/ENOSPC.
     // The bench-remote xtask sets TMPDIR=$HOME/ocync/bench/.tmp (on EBS).
-    reject_tmpfs_tmpdir()?;
+    //
+    // The prepare scenario is exempt because it stages nothing: `--dry-run`
+    // resolves mappings and stops, so there is no blob to write anywhere.
+    // Applying the guard to it would refuse the one scenario cheap enough to
+    // run on a laptop, for a disk cost it does not have.
+    if !matches!(args.scenario, Scenario::Prepare) {
+        reject_tmpfs_tmpdir()?;
+    }
 
     // 1. Parse corpus (apply skip-registries filter, then limit).
     let loaded = corpus::load(&args.corpus)?;
@@ -388,8 +395,16 @@ pub(crate) async fn run(args: BenchArgs) -> Result<(), Box<dyn std::error::Error
     };
 
     // Pre-warm CDN so all tools see identically cached source manifests.
+    //
+    // The prepare scenario needs none of it. It runs one tool, pulls no blobs,
+    // and reads a different corpus than the one warmed here, so warming for it
+    // is hundreds of pointless requests against registries that rate-limit.
+    // A mixed run still warms, because the scenarios beside it do transfer.
+    let transfers = scenarios.iter().any(|s| !matches!(s, Scenario::Prepare));
     if args.skip_prewarm {
         eprintln!("bench: skipping CDN pre-warm (--skip-prewarm)");
+    } else if !transfers {
+        eprintln!("bench: skipping CDN pre-warm (prepare transfers nothing)");
     } else {
         cdn_prewarm(&corpus).await;
     }
@@ -518,9 +533,22 @@ pub(crate) async fn run(args: BenchArgs) -> Result<(), Box<dyn std::error::Error
             })
             .collect(),
     };
+    // The archive is tracked in git and read as a history of comparable runs.
+    // A run whose machine could not be identified is not comparable to one on
+    // a known instance, and the harness already says so with a WARNING per
+    // missing field. Appending it anyway puts a laptop's numbers next to the
+    // rig's under the same key, where nothing downstream can tell them apart.
+    // The summary is still written; only the shared history is protected.
     let results_dir = Path::new("bench/results");
-    report::append_record(results_dir, reg_key, record)?;
-    eprintln!("bench: run record appended to bench/results/{reg_key}.json");
+    if record.machine.instance_type == "unknown" {
+        eprintln!(
+            "bench: run record NOT appended (instance metadata unknown, so this \
+             run is not comparable to the archived ones); summary only"
+        );
+    } else {
+        report::append_record(results_dir, reg_key, record)?;
+        eprintln!("bench: run record appended to bench/results/{reg_key}.json");
+    }
 
     // 9. Handle regression mode.
     if args.regression {

--- a/xtask/src/bench/mod.rs
+++ b/xtask/src/bench/mod.rs
@@ -40,6 +40,14 @@ pub(crate) struct BenchArgs {
     #[arg(long, default_value = "bench/corpus-partial-overrides.yaml")]
     pub(crate) partial_overrides: String,
 
+    /// Path to the prepare-scenario corpus YAML.
+    ///
+    /// Separate from `--corpus` because the two measure opposite things: the
+    /// main corpus is a handful of entries chosen for blob sharing and pinned
+    /// to literal tags, which skips tag enumeration entirely.
+    #[arg(long, default_value = "bench/corpus-prepare.yaml")]
+    pub(crate) prepare_corpus: String,
+
     /// Use first N images only.
     #[arg(long)]
     pub(crate) limit: Option<usize>,
@@ -99,6 +107,8 @@ pub(crate) enum Scenario {
     Partial,
     /// Run at increasing corpus sizes -- measures scaling behavior (ocync only).
     Scale,
+    /// Resolve every mapping and stop -- measures the prepare phase (ocync only).
+    Prepare,
     /// Run all scenarios in sequence.
     All,
 }
@@ -368,7 +378,12 @@ pub(crate) async fn run(args: BenchArgs) -> Result<(), Box<dyn std::error::Error
 
     // 6. Expand All into individual scenarios, then dispatch each.
     let scenarios: Vec<Scenario> = match args.scenario {
-        Scenario::All => vec![Scenario::Sync, Scenario::Partial, Scenario::Scale],
+        Scenario::All => vec![
+            Scenario::Sync,
+            Scenario::Partial,
+            Scenario::Scale,
+            Scenario::Prepare,
+        ],
         other => vec![other],
     };
 
@@ -434,6 +449,17 @@ pub(crate) async fn run(args: BenchArgs) -> Result<(), Box<dyn std::error::Error
                     report.scale = points;
                 } else {
                     eprintln!("bench: scale scenario requires ocync (skipping)");
+                }
+            }
+            Scenario::Prepare => {
+                // ocync only: no competitor has a mode that resolves tags and
+                // stops, so there is nothing to compare against. Same reason
+                // the scale scenario runs alone.
+                if tools.contains(&Tool::Ocync) {
+                    let result = run_prepare(&args, &output_dir).await?;
+                    report.scenarios.push(result);
+                } else {
+                    eprintln!("bench: prepare scenario requires ocync (skipping)");
                 }
             }
             Scenario::All => unreachable!("expanded above"),
@@ -562,6 +588,7 @@ async fn run_single_tool(
     config_dir: &Path,
     output_dir: &Path,
     phase: &str,
+    dry_run: bool,
 ) -> Result<ToolRun, Box<dyn std::error::Error>> {
     // 1. Generate config.
     let config_content = match tool {
@@ -609,7 +636,14 @@ async fn run_single_tool(
     // update-ca-trust on AL2023) so that rustls-native-certs and OpenSSL
     // both trust the MITM'd connections. HTTPS_PROXY alone is sufficient.
     let workspace_root = Path::new(".");
-    let result = runner::run_tool(tool, &config_path, proxy_url.as_deref(), workspace_root).await?;
+    let result = runner::run_tool(
+        tool,
+        &config_path,
+        proxy_url.as_deref(),
+        workspace_root,
+        dry_run,
+    )
+    .await?;
 
     // 6. Stop proxy, parse log, aggregate metrics. Abort on source
     //    registry errors that indicate tainted benchmark data.
@@ -748,8 +782,16 @@ async fn run_sync(
         // Cold run.
         progress(&format!("  cold: {tool}"));
         let run_result: Result<(), Box<dyn std::error::Error>> = async {
-            let cold =
-                run_single_tool(args, tool, corpus, config_dir.path(), output_dir, "cold").await?;
+            let cold = run_single_tool(
+                args,
+                tool,
+                corpus,
+                config_dir.path(),
+                output_dir,
+                "cold",
+                false,
+            )
+            .await?;
             if cold.exit_code != Some(0) {
                 return Err(format!(
                     "{tool} cold sync failed (exit {:?}); aborting -- \
@@ -770,8 +812,16 @@ async fn run_sync(
 
             // Warm run: target still populated, same config_dir.
             progress(&format!("  warm: {tool}"));
-            let warm =
-                run_single_tool(args, tool, corpus, config_dir.path(), output_dir, "warm").await?;
+            let warm = run_single_tool(
+                args,
+                tool,
+                corpus,
+                config_dir.path(),
+                output_dir,
+                "warm",
+                false,
+            )
+            .await?;
             if warm.exit_code != Some(0) {
                 return Err(format!(
                     "{tool} warm sync failed (exit {:?}); aborting -- \
@@ -848,6 +898,7 @@ async fn run_partial(
                 config_dir.path(),
                 output_dir,
                 "prime",
+                false,
             )
             .await?;
             if prime.exit_code != Some(0) {
@@ -867,6 +918,7 @@ async fn run_partial(
                 config_dir.path(),
                 output_dir,
                 "partial",
+                false,
             )
             .await?;
             if run.exit_code != Some(0) {
@@ -932,9 +984,16 @@ async fn run_scale(
 
             let run_result: Result<(), Box<dyn std::error::Error>> = async {
                 let config_dir = tempfile::tempdir()?;
-                let run =
-                    run_single_tool(args, tool, &subset, config_dir.path(), output_dir, "scale")
-                        .await?;
+                let run = run_single_tool(
+                    args,
+                    tool,
+                    &subset,
+                    config_dir.path(),
+                    output_dir,
+                    "scale",
+                    false,
+                )
+                .await?;
                 if run.exit_code != Some(0) {
                     return Err(format!(
                         "{tool} scale sync failed at {size} images (exit {:?}); aborting",
@@ -961,6 +1020,65 @@ async fn run_scale(
     }
 
     Ok(points)
+}
+
+/// Measure the pre-engine phase on its own.
+///
+/// `--dry-run` resolves every mapping and stops, so the run is a client build
+/// per registry plus a tag listing per mapping and nothing else. That is the
+/// whole point: in a full sync this work is a rounding error beside gigabytes
+/// of blob transfer, which is why a regression here went unnoticed long enough
+/// to cost eleven minutes on a 95-mapping config.
+///
+/// None of the sync scenario's fairness machinery applies. Nothing is
+/// transferred, so there are no blobs to fall out of page cache, no ECR repos
+/// to reset, and no CDN edge to pre-warm. Skipping it is what keeps this
+/// scenario cheap enough to run often.
+async fn run_prepare(
+    args: &BenchArgs,
+    output_dir: &Path,
+) -> Result<ScenarioResult, Box<dyn std::error::Error>> {
+    progress("bench: running prepare scenario (ocync, --dry-run)");
+
+    // Its own corpus: wildcard tags, so resolution actually enumerates. A
+    // corpus of literal tags takes the exact-tag fast path and measures
+    // nothing. See `bench/corpus-prepare.yaml`.
+    let corpus = corpus::load(&args.prepare_corpus)?;
+    let corpus = match args.limit {
+        Some(n) => corpus.limit(n),
+        None => corpus,
+    };
+    progress(&format!("  prepare: {} mappings", corpus.images.len()));
+
+    let config_dir = tempfile::tempdir()?;
+    let run = run_single_tool(
+        args,
+        Tool::Ocync,
+        &corpus,
+        config_dir.path(),
+        output_dir,
+        "prepare",
+        true,
+    )
+    .await?;
+
+    // `--dry-run` exits non-zero when a mapping could not be resolved. That is
+    // the measurement failing, not a finding: a run that skipped mappings did
+    // less work and its wall clock means nothing.
+    if run.exit_code != Some(0) {
+        return Err(format!(
+            "ocync prepare dry-run failed (exit {:?}); the timing would not be comparable",
+            run.exit_code
+        )
+        .into());
+    }
+
+    Ok(ScenarioResult {
+        scenario: "Prepare (dry-run)".to_string(),
+        runs: vec![run],
+        shuffle_seed: 0,
+        tool_order: Vec::new(),
+    })
 }
 
 /// Sleep for 30 seconds between benchmark runs to let rate limits recover.
@@ -1711,6 +1829,7 @@ impl std::fmt::Display for Scenario {
             Scenario::Sync => f.write_str("sync"),
             Scenario::Partial => f.write_str("partial"),
             Scenario::Scale => f.write_str("scale"),
+            Scenario::Prepare => f.write_str("prepare"),
             Scenario::All => f.write_str("all"),
         }
     }

--- a/xtask/src/bench/runner.rs
+++ b/xtask/src/bench/runner.rs
@@ -462,13 +462,25 @@ pub(crate) async fn run_tool(
     config_path: &Path,
     proxy_url: Option<&str>,
     workspace_root: &Path,
+    dry_run: bool,
 ) -> Result<RunResult, String> {
     let config_str = config_path.to_string_lossy();
-    let args: Vec<&str> = match tool {
+    let mut args: Vec<&str> = match tool {
         Tool::Ocync => vec!["sync", "--config", &config_str, "--json", "-v"],
         Tool::Dregsy => vec!["-config", &config_str],
         Tool::Regsync => vec!["once", "-c", &config_str],
     };
+    // Only ocync has a mode that resolves every mapping and then stops, which
+    // is what isolates the prepare phase. The scenario that asks for it runs
+    // ocync alone for exactly that reason.
+    if dry_run {
+        assert_eq!(
+            tool,
+            Tool::Ocync,
+            "dry-run is an ocync-only mode; no competitor has an equivalent"
+        );
+        args.push("--dry-run");
+    }
 
     let binary = tool_path(tool, workspace_root);
 


### PR DESCRIPTION
## Problem

The pre-engine phase resolved one mapping at a time. Every mapping's tag listing is an independent round trip, so a run cost the sum of every registry's latency rather than its maximum. On a 95-mapping config that was 11 minutes before the engine started, with a progress line that reported a count and named nothing:

```
INFO preparing sync phase=mappings done=75 total=95 elapsed_secs=490
INFO preparing sync phase=mappings done=75 total=95 elapsed_secs=645
```

160 seconds on one mapping, and no way to tell which one, or whether it was a huge tag listing or a wedged registry.

## Changes

**Mapping resolution overlaps**, bounded at 16 in flight. The bound is a ceiling on open mappings, not a request rate: every request underneath still passes its registry's AIMD window, which starts at one in flight and widens only as the registry keeps answering, so a wide config cannot become a burst against one host. Results are collected in config order however the registries reply, so per-mapping warnings, watch state, and which config error stops the run stay deterministic.

**A mapping's target listings overlap.** The immutable-tag optimization walked each mirror one at a time, making prepare cost scale with fan-out. The failure warning also gained the `from` field it was missing, which concurrent logs need in order to attribute it.

**`analyze` had the same defect twice.** It now resolves mappings concurrently, then pulls image manifests from a single list flattened across every mapping. The flattening is what makes the second walk worth anything: a config of many mappings holding a handful of tags each would otherwise stay serial, because each mapping's walk is only a request or two long. Aggregation stays sequential and ordered, since `analysis.blobs` has one owner and the report must read the same way whichever registry answered first. Shutdown is checked inside each task rather than once before the fan-out, so a signal part way through stops work that has not started while in-flight work finishes. The image walk also became its own progress step, since resolution finishes long before the walk does.

**The progress line names the item holding a step up:**

```
preparing sync phase=mappings done=75 total=95 in_flight=16 slowest=repo/foo slowest_secs=160 elapsed_secs=490
```

An RAII guard marks each item in flight, so every early exit both retires it and advances the counter.

## What did not change, and why

Tag listings still send no `n`. Asking for a page size looks like an optimization and is the reverse. Measured 2026-08-28:

- Docker Hub answers a request without `n` by returning every tag in one response (`library/python`, 3,911 tags, no `Link` header). With `n=1000` the same listing costs 4 requests.
- `distribution/distribution` sets its internal limit to `-1` when `n` is absent and lists everything; `maxtags` applies only to an explicit `n`. Harbor, GitLab, Quay and self-hosted `registry:2` inherit that.
- ECR Public already pages at 1000 unasked, and ECR rejects an `n` above 1000.

So there is no registry where sending `n` helps and two large families where it multiplies the request count. `list_tags_does_not_request_a_page_size` guards against reintroducing it.

## Measurements

`cargo test --bin ocync -- --ignored --nocapture prepare_phase` and `analyze_benchmark`.

95 mappings against one source, **60 ms per request** (chosen to keep the benchmark under 15 seconds; it measures the shape and the ceiling, not any particular config's absolute time):

| Concurrency | sync | speedup | peak requests in flight | analyze | speedup |
|---|---|---|---|---|---|
| 1 (previous behavior) | 6.02s | 1.0x | 1 | 6.24s | 1.0x |
| 4 | 1.68s | 3.6x | 4 | 1.71s | 3.7x |
| 8 | 1.02s | 5.9x | 8 | 1.06s | 5.9x |
| 16 | 0.89s | 6.8x | 13 | 0.93s | 6.7x |
| 32 | 0.89s | 6.7x | 13 | 0.94s | 6.7x |

16 and 32 tie because a single registry's AIMD window tops out near 13 over 95 requests. That is where the bound of 16 comes from: high enough that AIMD is the constraint for a single-source config, low enough that a wide multi-registry config cannot open an unbounded number of connections at once.

**Against live registries**, 20 mappings on `public.ecr.aws`, `--dry-run`: `63.26s` before, `14.27s` after, with byte-identical output across 24,965 lines.

A real config's gain is bounded below by its single slowest mapping, since concurrency removes the queueing behind it but not its own duration. The 95-mapping config above is the worked example: 675 seconds of serial work, but one mapping alone accounts for about 160 of them (`done=75` held from `elapsed_secs=490` to `645`). Its floor is therefore that mapping, roughly 160 to 200 seconds rather than 675 divided by the speedup above. The `slowest` field exists to name that mapping so the next question can be asked.

## Benchmark harness

The existing harness could not see this phase, which is the reason a regression this size went unnoticed. Two causes, both in the corpus:

- Every tag in `corpus.yaml` is a literal, so `TagsConfig::exact_tags` (`src/cli/config.rs:474`) returns them verbatim and `resolve_mapping_inner` takes the fast path that never calls `list_tags`.
- The corpus is 39 entries chosen for blob sharing. This phase costs one round trip per mapping, so the shape that exposes it is many mappings, not a few large ones.

Adds a `prepare` scenario: `ocync sync --dry-run` over `bench/corpus-prepare.yaml`, which uses wildcard tags so resolution has to enumerate, across 30 mappings against anonymous public ECR mirrors. `prepare_corpus_tags_are_all_wildcards` fails if those tags are ever pinned back to literals, because that mistake is invisible at runtime: the run would exit clean, report a plausible time, and measure nothing.

Nothing is transferred, so none of the sync scenario's fairness machinery applies: no page-cache drop, no ECR repo reset, no CDN pre-warm. That is what keeps it cheap enough to run often. It is ocync-only for the same reason `Scenario::Scale` is, that no competitor has a mode which resolves tags and stops.

Running it found three defects that reading the code did not, all in the same direction, the scenario claiming to be cheap while doing the expensive thing:

- The tmpfs guard rejected the run. It exists for multi-GB staging that a dry-run never does, so it refused the one scenario cheap enough to run on a laptop.
- CDN pre-warm ran anyway, warming 133 blobs before a scenario that pulls none, against the wrong corpus.
- The run appended its record to the git-tracked `bench/results/ecr.json`, putting a laptop's numbers beside the rig's with nothing able to tell them apart. The harness already warned about the missing instance metadata; it now acts on it and writes the summary without touching the shared archive.

**Verified end to end** against public ECR with `--limit 3 --no-proxy`: pre-warm skipped, `exit 0` in 2.8s, archive untouched. The concurrency is visible in that run's own log, with two token exchanges opening 8 ms apart before either completed.

Still worth a `cargo xtask bench-remote --scenario prepare` on the rig to get a comparable archived number; the local run proves the scenario works, not what the numbers are.

## Tests

11 new, 1275 passing, 0 failing.

- `resolve_all_resolves_mappings_concurrently`, `resolve_all_never_exceeds_its_concurrency_limit`, `resolve_all_treats_a_zero_limit_as_one`
- `resolve_mapping_lists_target_tags_concurrently`
- `prepare_ticker_names_the_item_holding_the_step_up`, `prepare_tracker_retires_an_item_when_its_guard_drops`, `prepare_tracker_clears_in_flight_items_between_steps`
- `collect_analysis_resolves_mappings_concurrently`, `collect_analysis_pulls_images_concurrently_across_mappings`, `collect_analysis_starts_nothing_once_shutdown_is_triggered`, `collect_analysis_stops_pulling_images_after_shutdown`, `collect_analysis_reports_the_image_walk_as_its_own_step`
- `list_tags_does_not_request_a_page_size`

Every test that could not be written fail-first (those covering newly added API) was mutation-checked: 8 mutations introduced, all 8 caught. The existing `resolve_all_isolates_a_failing_mapping` now also covers ordering under concurrency.

Gate: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo deny check`, all green.
