### PR TITLE
fix(prepare): keep the concurrency window full and retry transient failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2423,6 +2423,7 @@ dependencies = [
  "aws-sdk-ecrpublic",
  "base64 0.23.1",
  "bytes",
+ "fastrand",
  "futures-util",
  "google-cloud-auth",
  "hex",

--- a/crates/ocync-distribution/CLAUDE.md
+++ b/crates/ocync-distribution/CLAUDE.md
@@ -50,10 +50,21 @@ When `auth_type` IS set in config, it overrides detection. Valid values: `ecr`, 
 - GHCR: 1 window. GitHub enforces a single 2000 RPM aggregate cap per authenticated principal across reads and writes; separate read/write windows would silently exceed the cap.
 - ACR: 2 windows (separate ReadOps and WriteOps quotas).
 - Unknown (Chainguard, Quay, generic): 5-window coarse grouping (heads, reads, uploads, manifest-write, tag-list).
-- AIMD congestion epochs: 100ms epoch prevents cascade collapse from burst 429s.
+- AIMD congestion epochs: 100ms epoch prevents cascade collapse from burst 429s. Halving is only half the 429 response; see "Retry" below for the other half.
+- ECR Public's shared read window includes `TagList`, and its bucket value (8 TPS) is derived from AWS's 10 TPS authenticated *pull* quota. AWS publishes no TPS quota for tag listing, and a 2026-08-28 probe drew repeated 429s on `TagList` at that pacing with credentials loaded. Treat that value as measured-and-insufficient, not documented. See `docs/src/content/registries/ecr-public.md`.
 - Token-bucket layer (`TokenBucket` in `aimd.rs`) sits in front of the AIMD windows for registries with documented per-account TPS caps. Configured per `WindowKey` via `bucket_config_for_window()` returning a `BucketConfig { rate_per_sec, burst }`; ECR / ECR Public / GHCR / GAR / ACR get buckets, others fall back to AIMD-only. Bucket pacing happens BEFORE concurrency permits so a paced action does not occupy a slot another window could service.
 - AIMD halving rebuilds the per-action semaphore but preserves the bucket: rate-cap state is independent of concurrency state. Restoring burst tokens during throttle would defeat the purpose.
 - Cap values were verified against AWS service quotas, Google Artifact Registry quotas, and Microsoft historical SKU defaults on 2026-04-26. GHCR's value is community-measured against the visible 2000 RPM enforcement.
+
+## Retry
+
+`src/retry.rs` owns the transient-failure contract for this crate, and `retrying()` is the one shape every caller uses.
+
+- The client surfaces failures to its caller; `ocync-sync`'s engine retries the ones it drives via `with_retry`. The **prepare phase runs before the engine exists**, so anything reachable from it has to retry itself or a single throttle fails a whole mapping.
+- Retrying in the prepare phase: `list_tags` (body read included, so a mid-page reset is re-sent), `token_exchange::exchange` (both the `/v2/` ping and the realm token request), and `acr::exchange_post`. `analyze`'s manifest walk retries at its call site in `src/cli/commands/analyze.rs` using `ocync_sync::retry::with_retry`, because `manifest_pull` is shared with the engine and must not double-retry.
+- `is_transient_transport` is `pub` and is the **single** definition of the transient-transport predicate for the workspace. `ocync_sync::retry::should_retry_transport` delegates to it. Do not add a second copy: `is_request()` already covers connect failures and timeouts on the async hyper path, which is easy to get wrong from first principles.
+- Backoff is jittered. Up to 16 mappings hit one registry concurrently, so an unjittered schedule sends every throttled retry back in lockstep.
+- Do NOT add retry inside `send_with_aimd` or `manifest_pull`. Those are on the engine's path, which already retries; `tests/client_integration.rs::get_429_retries_and_succeeds` pins that layering.
 
 ## Upload protocol quirks
 

--- a/crates/ocync-distribution/Cargo.toml
+++ b/crates/ocync-distribution/Cargo.toml
@@ -26,6 +26,7 @@ aws-sdk-ecr = { workspace = true }
 aws-sdk-ecrpublic = { workspace = true }
 base64 = { version = "0.23", default-features = false, features = ["alloc"] }
 bytes.workspace = true
+fastrand.workspace = true
 futures-util = { version = "0.3", default-features = false }
 google-cloud-auth.workspace = true
 http.workspace = true

--- a/crates/ocync-distribution/src/aimd.rs
+++ b/crates/ocync-distribution/src/aimd.rs
@@ -231,7 +231,11 @@ pub enum WindowKey {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[allow(missing_docs)] // Variants are self-describing.
 pub enum EcrPublicGroup {
-    /// Manifest reads/heads, blob reads/heads, and tag list (10 TPS).
+    /// Manifest reads/heads, blob reads/heads, and tag list.
+    ///
+    /// Paced from the 10 TPS authenticated pull quota. AWS publishes no TPS
+    /// quota for tag listing, and tag listing has been measured throttling
+    /// below this pacing; see `bucket_config_for_window`.
     Read,
     ManifestWrite,
     BlobUploadInit,
@@ -356,7 +360,17 @@ fn bucket_config_for_window(key: WindowKey) -> Option<BucketConfig> {
         WindowKey::Ecr(BlobUploadChunk) => cfg(400.0, 50.0),
         // ECR Public (per-account, per-region; AWS docs).
         // PutImage / InitiateLayerUpload / CompleteLayerUpload / authenticated
-        // pulls 10 TPS each, UploadLayerPart 260 TPS.
+        // pulls 10 TPS each, UploadLayerPart 260 TPS. Unauthenticated pulls
+        // are 1 TPS and not adjustable, which this table does not model
+        // because the window key is derived from host and action only.
+        //
+        // The read value is measured-insufficient, not documented: a
+        // 95-mapping run on 2026-08-28 with credentials loaded drew repeated
+        // 429s on TagList at this pacing, halving the window 11 -> 6 -> 3.
+        // AWS documents no TPS quota for tag listing at all, so grouping it
+        // with pulls is an assumption. `list_tags` retries the 429 rather
+        // than failing the mapping; lowering this value is the other half and
+        // wants its own measurement rather than a guess.
         WindowKey::EcrPublic(EcrPublicGroup::BlobUploadChunk) => cfg(200.0, 30.0),
         WindowKey::EcrPublic(_) => cfg(8.0, 10.0),
         // GHCR: single 2000 RPM (~33 RPS) aggregate cap per authenticated

--- a/crates/ocync-distribution/src/auth/acr.rs
+++ b/crates/ocync-distribution/src/auth/acr.rs
@@ -181,15 +181,26 @@ async fn exchange_post<T: serde::de::DeserializeOwned>(
     form: &[(&str, &str)],
 ) -> Result<T, Error> {
     let url = format!("{base_url}{endpoint}");
-    let response = http
-        .post(&url)
-        .form(form)
-        .send()
-        .await
-        .map_err(|e| Error::AuthFailed {
-            registry: service.to_owned(),
-            reason: format!("ACR {endpoint} request failed: {e}"),
-        })?;
+
+    // Retried like the other prepare-phase auth paths. A dropped connection
+    // or a throttle here fails every mapping on this registry, not one, and
+    // nothing above the prepare phase would re-send it.
+    //
+    // The throttled response is returned rather than raised, so the non-success
+    // branch below still reads the body: ACR names the exhausted quota there.
+    let response =
+        crate::retry::send_retrying(http.post(&url).form(form), &format!("ACR {endpoint}"))
+            .await
+            .map_err(|e| Error::AuthFailed {
+                registry: service.to_owned(),
+                // Unwrapped so the reason reads as it always has: `Error::Http`
+                // Displays as "HTTP request failed: ..." and would double the
+                // prefix this line already writes.
+                reason: match &e {
+                    Error::Http(inner) => format!("ACR {endpoint} request failed: {inner}"),
+                    other => format!("ACR {endpoint} request failed: {other}"),
+                },
+            })?;
 
     let status = response.status();
     if !status.is_success() {

--- a/crates/ocync-distribution/src/auth/token_exchange.rs
+++ b/crates/ocync-distribution/src/auth/token_exchange.rs
@@ -19,6 +19,7 @@ use url::Host;
 
 use super::{Credentials, Scope, Token};
 use crate::error::Error;
+use crate::retry::send_retrying;
 
 /// Cached `WWW-Authenticate` challenge for a registry.
 ///
@@ -403,7 +404,7 @@ pub(crate) async fn exchange(
         cached.clone()
     } else {
         let v2_url = format!("{base_url}/v2/");
-        let resp = http.get(&v2_url).send().await?;
+        let resp = send_retrying(http.get(&v2_url), "registry ping").await?;
 
         if resp.status().is_success() {
             tracing::debug!(base_url, "registry requires no auth, returning empty token");
@@ -460,7 +461,7 @@ pub(crate) async fn exchange(
         request = request.header("Authorization", basic_header_value(creds));
     }
 
-    let resp = request.send().await?;
+    let resp = send_retrying(request, "token endpoint").await?;
 
     if resp.status().is_redirection() {
         let status = resp.status();
@@ -838,6 +839,77 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("WWW-Authenticate"));
+    }
+
+    /// A throttled token endpoint must be re-sent, not fail the mapping.
+    ///
+    /// 95 mappings against one registry need 95 scoped tokens, so this
+    /// endpoint is high-volume exactly when a run is widest. Surfacing its
+    /// 429 loses a mapping the registry never refused.
+    #[tokio::test]
+    async fn exchange_retries_a_throttled_token_endpoint() {
+        let mock = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/"))
+            .respond_with(wiremock::ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!(r#"Bearer realm="{}/token""#, mock.uri()),
+            ))
+            .mount(&mock)
+            .await;
+
+        // Throttled once, then answered.
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/token"))
+            .respond_with(wiremock::ResponseTemplate::new(429))
+            .up_to_n_times(1)
+            .mount(&mock)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/token"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"token": "issued"})),
+            )
+            .mount(&mock)
+            .await;
+
+        let http = crate::test_http_client();
+        let (token, _) = exchange(&http, &mock.uri(), &[Scope::pull("repo")], None, None)
+            .await
+            .expect("a throttled token endpoint must be retried, not surfaced");
+        assert_eq!(token.value(), "issued");
+    }
+
+    /// Retries are bounded: an endpoint that only throttles still returns.
+    #[tokio::test]
+    async fn exchange_gives_up_on_a_persistently_throttled_endpoint() {
+        let mock = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/v2/"))
+            .respond_with(wiremock::ResponseTemplate::new(401).insert_header(
+                "WWW-Authenticate",
+                format!(r#"Bearer realm="{}/token""#, mock.uri()),
+            ))
+            .mount(&mock)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/token"))
+            .respond_with(wiremock::ResponseTemplate::new(429))
+            .expect(u64::from(crate::retry::MAX_TRANSIENT_RETRIES) + 1)
+            .mount(&mock)
+            .await;
+
+        let http = crate::test_http_client();
+        let err = exchange(&http, &mock.uri(), &[Scope::pull("repo")], None, None)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("429"),
+            "the surfaced error must still say it was throttled: {err}"
+        );
     }
 
     #[tokio::test]

--- a/crates/ocync-distribution/src/lib.rs
+++ b/crates/ocync-distribution/src/lib.rs
@@ -18,6 +18,8 @@ pub mod error;
 pub mod manifest;
 /// OCI image reference parser.
 pub mod reference;
+/// Bounded retry for transient failures in the prepare phase.
+pub mod retry;
 /// SHA-256 wrapper backed by aws-lc-rs.
 pub mod sha256;
 /// OCI image spec types - manifests, descriptors, and platforms.

--- a/crates/ocync-distribution/src/retry.rs
+++ b/crates/ocync-distribution/src/retry.rs
@@ -1,0 +1,309 @@
+//! Bounded retry for transient failures in the prepare phase.
+//!
+//! The client surfaces most failures to its caller, and the sync engine
+//! retries the ones it drives. The prepare phase has no such layer above it:
+//! it runs before the engine exists, so a transient failure there fails a
+//! whole mapping or image. The operations that run there retry themselves,
+//! through [`retrying`], and share one schedule and one predicate so they
+//! cannot drift apart.
+
+use std::cell::Cell;
+use std::future::Future;
+use std::time::Duration;
+
+use crate::error::Error;
+
+/// How many times a transient failure is re-sent before it surfaces.
+///
+/// Bounded so a registry that never recovers still returns rather than
+/// holding a mapping open forever.
+pub const MAX_TRANSIENT_RETRIES: u32 = 4;
+
+/// Total retries allowed across one multi-page tag listing.
+///
+/// [`MAX_TRANSIENT_RETRIES`] still caps any single page, which keeps that
+/// page's backoff ladder short. This is the ceiling on the walk as a whole:
+/// a long listing may legitimately meet a throttle on several different
+/// pages, but four retries on each of up to `MAX_TAG_PAGES` pages is a bound
+/// only on paper.
+pub const MAX_LISTING_RETRIES: u32 = 32;
+
+/// Delay before the first retry.
+const INITIAL_BACKOFF: Duration = Duration::from_millis(250);
+
+/// Upper bound on a single backoff, before jitter.
+const MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+/// Whether a transport-level failure is worth re-sending.
+///
+/// # Predicate set
+///
+/// `is_request()` covers errors raised during request dispatch, which on the
+/// async hyper path includes connect failures and timeouts: reqwest wraps both
+/// as `Kind::Request`. `is_body()` and `is_decode()` cover the response-body
+/// and decoder phases, which are not classified as `Kind::Request`. A status
+/// error means the registry answered, so whether to re-send it is the status
+/// arm of [`is_transient`] rather than this.
+///
+/// This is the single definition of the transient-transport surface for the
+/// workspace. `ocync_sync::retry::should_retry_transport` delegates here
+/// rather than repeating the predicate, because two copies drift.
+pub fn is_transient_transport(error: &reqwest::Error) -> bool {
+    error.is_request() || error.is_body() || error.is_decode()
+}
+
+/// Whether an error is worth re-sending: a throttle, or a transport failure.
+///
+/// A 429 is backpressure rather than a refusal. AIMD has already halved the
+/// window by the time one surfaces, so the retry is paced by the throttle it
+/// caused.
+pub(crate) fn is_transient(error: &Error) -> bool {
+    match error {
+        Error::Http(e) => is_transient_transport(e),
+        other => other.status_code() == Some(http::StatusCode::TOO_MANY_REQUESTS),
+    }
+}
+
+/// Exponential backoff for attempt `attempt` (0-indexed), jittered.
+///
+/// Jitter is not decoration here. The prepare phase runs up to 16 mappings at
+/// once against one registry, so a burst of 429s throttles them together; an
+/// unjittered schedule would send all 16 retries back in lockstep and produce
+/// the next burst. The factor is drawn from `[0.75, 1.25)`, matching
+/// `ocync_sync::retry`.
+fn backoff(attempt: u32) -> Duration {
+    let base = INITIAL_BACKOFF
+        .saturating_mul(1u32 << attempt.min(16))
+        .min(MAX_BACKOFF);
+    base.mul_f64(0.75 + fastrand::f64() * 0.5)
+}
+
+/// Run `op`, re-running it while it fails transiently.
+///
+/// `what` names the operation in the retry log. `op` must be idempotent: the
+/// callers are reads and token exchanges, which are.
+///
+/// `budget` is drawn down by every retry and may be shared across calls, which
+/// is the bound that matters for an operation made of many of them. A tag
+/// listing may walk thousands of pages, and four retries on each of them is a
+/// bound only on paper: it permits hours of backing off against a registry that
+/// is plainly refusing to serve the listing.
+pub(crate) async fn retrying<T, F, Fut>(what: &str, budget: &Cell<u32>, op: F) -> Result<T, Error>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, Error>>,
+{
+    let mut attempt: u32 = 0;
+    loop {
+        match op().await {
+            Ok(value) => return Ok(value),
+            Err(e) if is_transient(&e) && attempt < MAX_TRANSIENT_RETRIES && budget.get() > 0 => {
+                budget.set(budget.get() - 1);
+                let delay = backoff(attempt);
+                tracing::debug!(
+                    what,
+                    attempt,
+                    delay_ms = delay.as_millis(),
+                    error = %e,
+                    "transient failure; backing off and retrying"
+                );
+                tokio::time::sleep(delay).await;
+                attempt += 1;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+/// Send `request`, re-sending it while the answer looks transient.
+///
+/// Returns the **final response**, including a throttled one, rather than
+/// turning a 429 into an error. That distinction is load-bearing for the auth
+/// paths: their callers collapse any non-success into `Error::AuthFailed`,
+/// which carries no `status_code()`, and the engine's `with_retry` therefore
+/// cannot classify it as retryable. Surfacing a 429 as a typed error instead
+/// would hand the engine a retryable auth failure and multiply this retry by
+/// the engine's own, aiming 4x the requests at a registry that is already
+/// asking for less.
+///
+/// `Err` is only for a transport failure that outlived its attempts.
+pub(crate) async fn send_retrying(
+    request: reqwest::RequestBuilder,
+    what: &str,
+) -> Result<reqwest::Response, Error> {
+    // Bodyless requests always clone. The guard keeps a future request with a
+    // streaming body correct rather than silently replaying something that
+    // cannot be replayed.
+    let Some(probe) = request.try_clone() else {
+        return Ok(request.send().await?);
+    };
+    drop(probe);
+
+    let mut attempt: u32 = 0;
+    loop {
+        let this_attempt = request
+            .try_clone()
+            .expect("request was confirmed cloneable above");
+        let outcome = this_attempt.send().await;
+
+        let transient = match &outcome {
+            Ok(resp) => resp.status() == http::StatusCode::TOO_MANY_REQUESTS,
+            Err(e) => is_transient_transport(e),
+        };
+        if !transient || attempt >= MAX_TRANSIENT_RETRIES {
+            return Ok(outcome?);
+        }
+
+        let delay = backoff(attempt);
+        tracing::debug!(
+            what,
+            attempt,
+            delay_ms = delay.as_millis(),
+            "transient failure; backing off and retrying"
+        );
+        tokio::time::sleep(delay).await;
+        attempt += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Bounds rather than equality: the schedule is jittered on purpose.
+    #[test]
+    fn backoff_grows_and_is_capped() {
+        for attempt in 0..4u32 {
+            let base = INITIAL_BACKOFF * (1 << attempt);
+            let observed = backoff(attempt);
+            assert!(
+                observed >= base.mul_f64(0.75) && observed < base.mul_f64(1.25),
+                "attempt {attempt}: {observed:?} outside the jitter band around {base:?}"
+            );
+        }
+        // Far past any real attempt count: must saturate, not overflow.
+        assert!(backoff(u32::MAX) <= MAX_BACKOFF.mul_f64(1.25));
+    }
+
+    /// Sixteen mappings throttled together must not retry in lockstep.
+    #[test]
+    fn backoff_is_decorrelated() {
+        let draws: Vec<Duration> = (0..16).map(|_| backoff(1)).collect();
+        let distinct = draws
+            .iter()
+            .collect::<std::collections::BTreeSet<_>>()
+            .len();
+        assert!(
+            distinct > 1,
+            "an unjittered schedule sends every concurrent retry back together: {draws:?}"
+        );
+    }
+
+    /// The predicate has to match the failure that actually shows up.
+    ///
+    /// A run against a live registry lost a mapping to "error sending request
+    /// for url (.../token/...)". Asserting against a hand-built error would
+    /// prove nothing, so this provokes a real one from a closed port.
+    #[tokio::test]
+    async fn a_refused_connection_is_transient() {
+        let err = crate::test_http_client()
+            .get("http://127.0.0.1:1/v2/")
+            .send()
+            .await
+            .expect_err("port 1 refuses connections");
+        assert!(
+            is_transient_transport(&err),
+            "a refused connection must be retryable: {err:?}"
+        );
+        assert!(
+            is_transient(&Error::Http(err)),
+            "and must stay retryable once wrapped"
+        );
+    }
+
+    /// A status error means the registry answered, so it is not a transport
+    /// failure. Whether it is re-sent at all is the status arm's business.
+    #[tokio::test]
+    async fn a_status_error_is_not_a_transport_failure() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .respond_with(wiremock::ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        let err = crate::test_http_client()
+            .get(server.uri())
+            .send()
+            .await
+            .expect("the server answered")
+            .error_for_status()
+            .expect_err("500 is an error status");
+        assert!(
+            !is_transient_transport(&err),
+            "a status error is not a transport failure: {err:?}"
+        );
+    }
+
+    /// Only a 429 is re-sent; other registry statuses are the caller's answer.
+    #[test]
+    fn only_a_throttle_is_transient_among_statuses() {
+        let throttled = Error::RegistryError {
+            status: http::StatusCode::TOO_MANY_REQUESTS,
+            message: "Rate exceeded".into(),
+        };
+        assert!(is_transient(&throttled));
+
+        for status in [
+            http::StatusCode::NOT_FOUND,
+            http::StatusCode::FORBIDDEN,
+            http::StatusCode::INTERNAL_SERVER_ERROR,
+        ] {
+            let err = Error::RegistryError {
+                status,
+                message: "no".into(),
+            };
+            assert!(!is_transient(&err), "{status} must not be re-sent");
+        }
+    }
+
+    #[tokio::test]
+    async fn retrying_gives_up_and_surfaces_the_last_error() {
+        let calls = Cell::new(0u32);
+        let err = retrying::<(), _, _>(
+            "always throttled",
+            &Cell::new(MAX_TRANSIENT_RETRIES),
+            || {
+                calls.set(calls.get() + 1);
+                async {
+                    Err(Error::RegistryError {
+                        status: http::StatusCode::TOO_MANY_REQUESTS,
+                        message: "Rate exceeded".into(),
+                    })
+                }
+            },
+        )
+        .await
+        .expect_err("a permanently throttled op must surface");
+        assert_eq!(
+            calls.get(),
+            MAX_TRANSIENT_RETRIES + 1,
+            "one initial attempt plus every retry"
+        );
+        assert_eq!(err.status_code(), Some(http::StatusCode::TOO_MANY_REQUESTS));
+    }
+
+    #[tokio::test]
+    async fn retrying_does_not_re_run_a_permanent_failure() {
+        let calls = Cell::new(0u32);
+        let _ = retrying::<(), _, _>("not found", &Cell::new(MAX_TRANSIENT_RETRIES), || {
+            calls.set(calls.get() + 1);
+            async {
+                Err(Error::RegistryError {
+                    status: http::StatusCode::NOT_FOUND,
+                    message: "absent".into(),
+                })
+            }
+        })
+        .await;
+        assert_eq!(calls.get(), 1, "a 404 must be surfaced on the first answer");
+    }
+}

--- a/crates/ocync-distribution/src/tags.rs
+++ b/crates/ocync-distribution/src/tags.rs
@@ -1,10 +1,13 @@
 //! Tag listing with pagination for OCI repositories.
 
+use std::cell::Cell;
+
 use serde::Deserialize;
 
 use crate::aimd::RegistryAction;
 use crate::client::RegistryClient;
 use crate::error::Error;
+use crate::retry::{MAX_LISTING_RETRIES, retrying};
 use crate::spec::RepositoryName;
 
 /// Maximum number of tag list pages to follow before treating the pagination
@@ -92,6 +95,11 @@ impl RegistryClient {
         let mut all_tags = Vec::new();
         let mut path = "tags/list".to_owned();
         let mut page_count: usize = 0;
+        // One budget for the whole walk. Per-page retries would bound the
+        // worst case only nominally: a listing may run to MAX_TAG_PAGES, and
+        // four retries on each of those is hours of backing off at a registry
+        // that has stopped serving the listing.
+        let retry_budget = Cell::new(MAX_LISTING_RETRIES);
 
         loop {
             page_count += 1;
@@ -102,18 +110,27 @@ impl RegistryClient {
                     ),
                 });
             }
-            let resp = self
-                .get(repository, &path, None, RegistryAction::TagList)
-                .await?;
+            // Retried as one unit, body included. A throttle or a dropped
+            // connection here is transient, and nothing above the prepare
+            // phase would re-send it: the mapping would just fail. Reading
+            // the body inside the retry matters because a connection reset
+            // part way through a page is exactly the failure a re-send fixes.
+            let (next_url, tag_list) = retrying("tag listing", &retry_budget, || async {
+                let resp = self
+                    .get(repository, &path, None, RegistryAction::TagList)
+                    .await?;
 
-            // Check for Link header before consuming the body.
-            let next_url = resp
-                .headers()
-                .get("link")
-                .and_then(|v| v.to_str().ok())
-                .and_then(parse_next_link);
+                // Check for the Link header before consuming the body.
+                let next_url = resp
+                    .headers()
+                    .get("link")
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(parse_next_link);
 
-            let tag_list: TagListResponse = resp.json().await?;
+                let tag_list: TagListResponse = resp.json().await?;
+                Ok((next_url, tag_list))
+            })
+            .await?;
             all_tags.extend(tag_list.tags);
 
             match next_url {

--- a/crates/ocync-distribution/tests/client_integration.rs
+++ b/crates/ocync-distribution/tests/client_integration.rs
@@ -636,6 +636,79 @@ async fn list_tags_returns_all_tags() {
     assert_eq!(tags, vec!["v1", "v2", "latest"]);
 }
 
+/// A 429 is backpressure, not a verdict on the request.
+///
+/// AIMD halves the window when a registry throttles, which paces everything
+/// that comes after. The request that absorbed the 429 still has to be sent
+/// again: dropping it turns a rate limit into a failed mapping, and a wide
+/// config against a rate-limited registry then reports failures for work the
+/// registry never refused, only deferred.
+#[tokio::test]
+async fn list_tags_retries_after_a_429() {
+    let server = MockServer::start().await;
+
+    // Throttled once, then answered. Mounted first so it takes priority
+    // until its single use is spent.
+    Mock::given(method("GET"))
+        .and(path("/v2/repo/tags/list"))
+        .respond_with(ResponseTemplate::new(429).set_body_json(serde_json::json!({
+            "errors": [{"code": "TOOMANYREQUESTS", "message": "Rate exceeded"}]
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/v2/repo/tags/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "name": "repo",
+            "tags": ["v1", "v2"]
+        })))
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .build()
+        .unwrap();
+
+    let repo = RepositoryName::new("repo").unwrap();
+    let tags = client
+        .list_tags(&repo)
+        .await
+        .expect("a throttled listing must be retried, not surfaced as a failure");
+    assert_eq!(tags, vec!["v1", "v2"]);
+}
+
+/// Retries are bounded: a registry that only ever throttles must still return.
+#[tokio::test]
+async fn list_tags_gives_up_after_persistent_429s() {
+    let server = MockServer::start().await;
+
+    // The exact count is the bound. Without it this test passes just as well
+    // against an unbounded retry, which is the thing it exists to prevent.
+    Mock::given(method("GET"))
+        .and(path("/v2/repo/tags/list"))
+        .respond_with(ResponseTemplate::new(429).set_body_json(serde_json::json!({
+            "errors": [{"code": "TOOMANYREQUESTS", "message": "Rate exceeded"}]
+        })))
+        .expect(u64::from(ocync_distribution::retry::MAX_TRANSIENT_RETRIES) + 1)
+        .mount(&server)
+        .await;
+
+    let client = RegistryClientBuilder::new(mock_base_url(&server))
+        .build()
+        .unwrap();
+
+    let repo = RepositoryName::new("repo").unwrap();
+    let err = client
+        .list_tags(&repo)
+        .await
+        .expect_err("a registry that never stops throttling must surface the failure");
+    assert!(
+        format!("{err}").contains("429"),
+        "the surfaced error must still say it was throttled: {err}"
+    );
+}
+
 #[tokio::test]
 async fn list_tags_follows_pagination() {
     let server = MockServer::start().await;

--- a/crates/ocync-sync/CLAUDE.md
+++ b/crates/ocync-sync/CLAUDE.md
@@ -137,3 +137,11 @@ cargo test --package ocync-sync
 # Run a single test file (fast iteration during development)
 cargo test --package ocync-sync --test sync_artifacts
 ```
+
+## Retry
+
+`with_retry` lives in `src/retry.rs` (moved there from `engine.rs` so it sits with `RetryConfig` and the `should_retry*` predicates) and is `pub`, because the CLI's `analyze` walk needs it too.
+
+It is not the only retry layer any more. The prepare phase runs before the engine exists, so tag listing, token exchange, and ACR's OAuth exchanges retry themselves inside `ocync-distribution` (see that crate's CLAUDE.md). A 429 during tag listing therefore no longer surfaces as an unresolved mapping and never reaches `with_retry`.
+
+`should_retry_transport` delegates to `ocync_distribution::retry::is_transient_transport` rather than repeating the predicate. Keep it that way; two copies drift.

--- a/crates/ocync-sync/src/engine.rs
+++ b/crates/ocync-sync/src/engine.rs
@@ -45,7 +45,7 @@ use uuid::Uuid;
 
 use crate::cache::{PlatformFilterKey, SnapshotKey, SourceSnapshot, TransferStateCache};
 use crate::progress::RunProgress;
-use crate::retry::{self, RetryConfig};
+use crate::retry::{RetryConfig, with_retry};
 use crate::shutdown::ShutdownSignal;
 use crate::staging::BlobStage;
 use crate::{
@@ -3206,57 +3206,6 @@ fn file_read_stream(
             Err(e) => Some((Err(e), (file, buf))),
         }
     })
-}
-
-/// Retry an async operation with exponential backoff on transient errors.
-///
-/// Calls `f()` in a loop. Retries on HTTP 408/429/5xx, transport-level
-/// errors (connection refused, DNS failure, request timeout), and the
-/// ECR-specific 404 `BLOB_UPLOAD_UNKNOWN` body marker via
-/// [`retry::is_blob_upload_unknown`] (ECR returns this code on manifest
-/// push when blob upload PUT-201s haven't fully propagated).
-/// Waits with jittered exponential backoff up to `config.max_retries` times.
-/// Returns the first `Ok` or the final `Err`.
-async fn with_retry<T, F, Fut>(
-    config: &RetryConfig,
-    operation: &str,
-    f: F,
-) -> Result<T, ocync_distribution::Error>
-where
-    F: Fn() -> Fut,
-    Fut: Future<Output = Result<T, ocync_distribution::Error>>,
-{
-    let mut attempt = 0;
-    loop {
-        match f().await {
-            Ok(val) => return Ok(val),
-            Err(e) => {
-                let retryable = if let Some(status) = e.status_code() {
-                    retry::should_retry(status, attempt, config.max_retries)
-                        || (attempt < config.max_retries && retry::is_blob_upload_unknown(&e))
-                } else {
-                    // Transport-level errors (connection refused, DNS failure,
-                    // request timeout) are retryable when attempts remain.
-                    attempt < config.max_retries && retry::should_retry_transport(&e)
-                };
-
-                if retryable {
-                    let backoff = config.backoff_for(attempt);
-                    warn!(
-                        operation,
-                        attempt,
-                        error = %e,
-                        backoff_ms = backoff.as_millis(),
-                        "retrying"
-                    );
-                    tokio::time::sleep(backoff).await;
-                    attempt += 1;
-                    continue;
-                }
-                return Err(e);
-            }
-        }
-    }
 }
 
 /// Compute aggregate statistics from a list of image results.

--- a/crates/ocync-sync/src/retry.rs
+++ b/crates/ocync-sync/src/retry.rs
@@ -1,5 +1,6 @@
 //! Retry configuration and backoff logic for transient failures.
 
+use std::future::Future;
 use std::time::Duration;
 
 use http::StatusCode;
@@ -152,7 +153,10 @@ struct OciError {
 /// show which variant was encountered so the match can be extended.
 pub fn should_retry_transport(error: &ocync_distribution::Error) -> bool {
     if let ocync_distribution::Error::Http(reqwest_err) = error {
-        reqwest_err.is_request() || reqwest_err.is_body() || reqwest_err.is_decode()
+        // One definition, in the crate that owns the reqwest surface. Two
+        // copies of this predicate drift; the prepare-phase retry in
+        // `ocync_distribution::retry` needs the same answer this does.
+        ocync_distribution::retry::is_transient_transport(reqwest_err)
     } else {
         tracing::debug!(
             error = %error,
@@ -171,6 +175,57 @@ pub fn should_retry_transport(error: &ocync_distribution::Error) -> bool {
 fn jitter(base: Duration) -> Duration {
     let factor = 0.75 + fastrand::f64() * 0.5;
     base.mul_f64(factor)
+}
+
+/// Retry an async operation with exponential backoff on transient errors.
+///
+/// Calls `f()` in a loop. Retries on HTTP 408/429/5xx, transport-level
+/// errors (connection refused, DNS failure, request timeout), and the
+/// ECR-specific 404 `BLOB_UPLOAD_UNKNOWN` body marker via
+/// [`is_blob_upload_unknown`] (ECR returns this code on manifest
+/// push when blob upload PUT-201s haven't fully propagated).
+/// Waits with jittered exponential backoff up to `config.max_retries` times.
+/// Returns the first `Ok` or the final `Err`.
+pub async fn with_retry<T, F, Fut>(
+    config: &RetryConfig,
+    operation: &str,
+    f: F,
+) -> Result<T, ocync_distribution::Error>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, ocync_distribution::Error>>,
+{
+    let mut attempt = 0;
+    loop {
+        match f().await {
+            Ok(val) => return Ok(val),
+            Err(e) => {
+                let retryable = if let Some(status) = e.status_code() {
+                    should_retry(status, attempt, config.max_retries)
+                        || (attempt < config.max_retries && is_blob_upload_unknown(&e))
+                } else {
+                    // Transport-level errors (connection refused, DNS failure,
+                    // request timeout) are retryable when attempts remain.
+                    attempt < config.max_retries && should_retry_transport(&e)
+                };
+
+                if retryable {
+                    let backoff = config.backoff_for(attempt);
+                    tracing::warn!(
+                        operation,
+                        attempt,
+                        error = %e,
+                        backoff_ms = backoff.as_millis(),
+                        "retrying"
+                    );
+                    tokio::time::sleep(backoff).await;
+                    attempt += 1;
+                    continue;
+                }
+                return Err(e);
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/docs/src/content/design/engine.md
+++ b/docs/src/content/design/engine.md
@@ -10,6 +10,8 @@ Everything before the engine starts is preparation: build one client per referen
 
 This work is network-bound and independent per mapping, so it runs concurrently, bounded at 16 mappings in flight. The bound is a ceiling on open mappings, not on how hard any registry is hit: every request underneath still passes that registry's AIMD window, which starts at one in flight and widens only as the registry keeps answering. A config whose mappings all share one source therefore self-limits at whatever AIMD has earned, and a config spread across registries goes wider.
 
+The bound is also a floor, and that half is load-bearing. A slot frees when its own mapping finishes, not when the oldest one does. An ordered queue gives back almost all of the benefit on a real config: one mapping listing a repository with tens of thousands of tags pins its slot, every mapping that finished behind it keeps its own, and the window sits at 2 or 3 of 16 while the rest of the config waits. Measured on a 95-mapping run, that shape spent 625 seconds to do 442 seconds of work. Config order is restored after collection instead, by carrying each outcome's index and sorting once every result is in.
+
 Measured on 95 mappings against a single source at 60 ms per tag listing:
 
 | Mappings in flight | Elapsed | Speedup | Peak requests in flight |
@@ -20,11 +22,13 @@ Measured on 95 mappings against a single source at 60 ms per tag listing:
 | 16                 | 0.89s   | 6.8x    | 13                      |
 | 32                 | 0.89s   | 6.7x    | 13                      |
 
+Every mapping in that benchmark has the same latency, which is the one shape that cannot tell an ordered queue apart from a window that refills as work finishes: when nothing is slower than anything else, the head is never the straggler. `prepare_phase_benchmark_skewed_resolution` covers the shape that can, one deep repository per window among shallow ones, where the same run costs 4.84s ordered against 1.09s unordered.
+
 The last two rows are identical because a single registry's AIMD window tops out near 13 over 95 requests. That is where the bound of 16 comes from: high enough that AIMD is the constraint for a single-source config, low enough that a wide multi-registry config cannot open an unbounded number of connections at once.
 
 The 60 ms is a synthetic latency chosen to keep the benchmark short. It measures how the speedup scales and where AIMD becomes the ceiling, not any particular config's absolute time. A real config's floor is its single slowest mapping, because overlapping removes the queueing behind that mapping but not its own duration: a run of 675 seconds of serial work holding one 160-second mapping lands near 160 to 200 seconds, not 675 divided by the speedup above. The `slowest` field in the progress line exists to name that mapping.
 
-Results are collected in config order regardless of which registry answered first, so per-mapping warnings, the watch-mode state, and the run's counters stay deterministic. A config error still stops the run at the first offending mapping in config order, though mappings behind it may already have run and logged.
+Results are put back in config order after collection, so the watch-mode state and the run's counters stay deterministic. Warnings emitted inside a mapping's own resolution interleave in completion order; it is the bookkeeping after collection that is ordered. A config error still stops the run at the first offending mapping in config order, though mappings behind it may already have run and logged.
 
 Tag listings deliberately send no `n`. Asking for a page size looks like an optimization and is the opposite of one: a request without `n` is answered at least as generously as one with it, so `n` can only add round trips.
 
@@ -33,6 +37,14 @@ Tag listings deliberately send no `n`. Asking for a page size looks like an opti
 - ECR Public already pages at 1000 without being asked, and ECR rejects an `n` above 1000, so the largest value it would accept changes nothing.
 
 The `Link` loop still follows pagination for registries that impose it unasked. Measured 2026-08-28.
+
+### Retry in the prepare phase
+
+The engine retries the work it drives, through `with_retry`. The prepare phase runs before the engine exists, so nothing above it would re-send anything: a single throttle or dropped connection there fails a whole mapping or image. Tag listing, token exchange, ACR's OAuth exchanges, and `analyze`'s manifest walk therefore retry themselves.
+
+A 429 is backpressure, not a refusal. AIMD has already halved the window by the time one surfaces, so a retry is paced by the throttle that caused it. The schedule is bounded at 4 attempts and jittered: up to 16 mappings hit one registry at once, so an unjittered schedule would send every throttled retry back in lockstep and produce the next burst.
+
+`ocync_distribution::retry` owns the transient predicate for the whole workspace, and `ocync_sync::retry::should_retry_transport` delegates to it, because two copies of that predicate drift.
 
 While preparation runs, a progress line is emitted every 5 seconds naming the longest-running item:
 
@@ -46,7 +58,7 @@ Without `slowest`, a step that sits at the same `done` count for minutes is unat
 
 `analyze` has the same shape and the same bound. It resolves mappings concurrently, then pulls image manifests from a single list flattened across every mapping. The flattening is what makes the second walk worth anything: a config of many mappings holding a handful of tags each would otherwise stay serial, because each mapping's walk is only a request or two long. Index children stay sequential within an image, since the images already overlap and AIMD saturates well below the number in flight.
 
-Aggregation stays sequential and in config order. `analysis.blobs` has one owner, and the report must read the same way whichever registry answered first. Shutdown is checked inside each task rather than once before the fan-out, so a signal part way through stops work that has not started while in-flight work finishes.
+Aggregation stays sequential: `analysis.blobs` has one owner and one consumer loop. It no longer runs in config order, which the report does not need, because every figure it prints is a count, a sum, or a sorted container. Mapping-level outcomes are re-sorted because the bookkeeping does need config order. Shutdown is checked inside each task rather than once before the fan-out, so a signal part way through stops work that has not started while in-flight work finishes.
 
 Measured on 95 mappings holding one tag each, 30 ms per request:
 

--- a/docs/src/content/performance.md
+++ b/docs/src/content/performance.md
@@ -44,7 +44,7 @@ Measured 2026-04-26 on c6in.4xlarge (x86_64, 16 vCPUs, 32 GiB, Up to 50 Gigabit)
 
 | Tool | Default concurrency | Adaptive backoff | Rate limit strategy |
 |------|:---:|:---:|-----|
-| `ocync` | 5 initial, 50 cap ([AIMD](/design/overview#adaptive-concurrency-aimd) adaptive) | Yes (per-registry, per-action) | [AIMD](/design/overview#adaptive-concurrency-aimd) congestion control on 429 |
+| `ocync` | 1 initial, 50 cap ([AIMD](/design/overview#adaptive-concurrency-aimd) adaptive) | Yes (per-registry, per-action) | [AIMD](/design/overview#adaptive-concurrency-aimd) congestion control on 429, plus bounded jittered retry (4 attempts) of throttled prepare-phase reads |
 | containerd | 3 layers | No | Lock-based dedup, retries on 429 (no backoff) |
 | regsync | 3 per registry | No | Reads `RateLimit-Remaining` header, pauses proactively |
 | crane | 4 jobs | Retry with backoff (0.1s-0.9s transport, 1s-9s operation) | Retry on 408/5xx, 3 attempts |

--- a/docs/src/content/registries/ecr-public.md
+++ b/docs/src/content/registries/ecr-public.md
@@ -14,13 +14,17 @@ Authenticated path:
 - The returned token is base64-decoded to extract the password half (`AWS:<password>`).
 - That password is used as HTTP Basic credentials in the standard OCI `/v2/token` Bearer exchange.
 
-Anonymous pulls work without AWS credentials but have lower per-IP rate limits. Use authenticated access for any non-trivial sync workload.
+Anonymous pulls work without AWS credentials but have lower per-IP rate limits: AWS documents unauthenticated pulls at 1 per second and not adjustable, against 10 per second authenticated. Use authenticated access for any non-trivial sync workload.
+
+Authenticating does not buy an exemption on tag listing, though. See below.
 
 Notable behaviors:
 
 - No `auth_type` value exists for ECR Public; it is reachable only via auto-detection on `public.ecr.aws`. Setting `auth_type: ecr_public` is a parse error.
 - No `BatchCheckLayerAvailability`. ECR Public uses per-blob HEADs via the OCI Distribution path, not the ECR SDK batch API.
 - Lower rate limits than ECR private. Read paths share a single window; write window caps are 10x lower than ECR private.
+- **Tag listing throttles below the documented pull rate.** Measured 2026-08-28: a 95-mapping `--dry-run` against `public.ecr.aws` with AWS credentials loaded drew repeated 429s on `TagList`, halving the AIMD window from 11 to 6 to 3, while ocync's token bucket for ECR Public reads was pacing at 8 requests per second. AWS publishes no TPS quota for tag listing at all; the 8 is derived from the 10 TPS authenticated *pull* quota, and the read window groups tag listing in with pulls. Treat the read pacing for this registry as measured rather than documented.
+- Because of the above, `list_tags` retries a 429 rather than surfacing it. Before that, each throttle failed a whole mapping: the same run lost 5 mappings and exited 1. With the retry it exits 0 and loses none.
 
 ## CLI example
 

--- a/src/cli/commands/analyze.rs
+++ b/src/cli/commands/analyze.rs
@@ -18,6 +18,7 @@ use ocync_distribution::spec::ManifestKind;
 use ocync_distribution::{Digest, RepositoryName};
 
 use ocync_sync::ShutdownSignal;
+use ocync_sync::retry::{RetryConfig, with_retry};
 
 use crate::cli::commands::synchronize::{
     ClientMap, DroppedTarget, MappingResolution, PreparePhase, PrepareTracker, UnresolvedMapping,
@@ -143,8 +144,18 @@ pub(crate) async fn run(
 /// mappings holding a handful of tags each would otherwise be as serial as
 /// before, because each mapping's walk is only a request or two long.
 ///
-/// Aggregation stays sequential and in order. `analysis.blobs` has one owner,
-/// and the report has to read the same way whichever registry answered first.
+/// Both walks free each slot as its own work finishes rather than when the
+/// oldest one does. An ordered queue would let a single mapping listing a
+/// repository with tens of thousands of tags hold its slot while everything
+/// that finished behind it holds theirs, which leaves the window slack and
+/// gives back most of the overlap.
+///
+/// Aggregation stays sequential: `analysis.blobs` has one owner and one
+/// consumer loop. It no longer runs in config order, which the report does not
+/// need -- every figure it prints is a count, a sum, or a sorted container, so
+/// it reads the same whichever registry answered first. Mapping bookkeeping
+/// does need config order, so those outcomes are put back in order once they
+/// are all in.
 async fn collect_analysis(
     config: &Config,
     clients: &ClientMap,
@@ -167,20 +178,27 @@ async fn collect_analysis(
     // inside the task rather than once before the fan-out so a signal part way
     // through still stops the work that has not begun, which is what the
     // sequential loop's `break` did.
-    let outcomes: Vec<MappingOutcome> =
-        futures_util::stream::iter(config.mappings.iter().map(|mapping| async move {
-            if shutdown.is_triggered() {
-                return None;
+    let mut indexed: Vec<(usize, MappingOutcome)> =
+        futures_util::stream::iter(config.mappings.iter().enumerate().map(|(idx, mapping)| {
+            async move {
+                if shutdown.is_triggered() {
+                    return (idx, None);
+                }
+                // Held for the whole task so every exit still counts the mapping:
+                // one that skipped it would strand the progress line short of its
+                // total.
+                let _item = tracker.track(&mapping.from);
+                (
+                    idx,
+                    Some(resolve_mapping(mapping, config, clients, no_checkers, false).await),
+                )
             }
-            // Held for the whole task so every exit still counts the mapping:
-            // one that skipped it would strand the progress line short of its
-            // total.
-            let _item = tracker.track(&mapping.from);
-            Some(resolve_mapping(mapping, config, clients, no_checkers, false).await)
         }))
-        .buffered(concurrency.max(1))
+        .buffer_unordered(concurrency.max(1))
         .collect()
         .await;
+    indexed.sort_by_key(|(idx, _)| *idx);
+    let outcomes: Vec<MappingOutcome> = indexed.into_iter().map(|(_, o)| o).collect();
 
     let mut resolved_mappings = Vec::new();
     for (mapping, outcome) in config.mappings.iter().zip(outcomes) {
@@ -234,6 +252,11 @@ async fn collect_analysis(
     // report a completed mapping count for the whole of the slower half.
     tracker.begin(PreparePhase::Images, images.len());
 
+    // The engine owns the retry policy for the transfer phase; this walk runs
+    // before the engine exists, so it carries the same defaults itself.
+    let retry = RetryConfig::default();
+    let retry = &retry;
+
     let mut pulls = futures_util::stream::iter(images.iter().map(|(idx, tag)| {
         let resolved = &resolved_mappings[*idx];
         async move {
@@ -250,12 +273,13 @@ async fn collect_analysis(
                 &resolved.source_repo,
                 tag,
                 &image_ref,
+                retry,
             )
             .await;
             (*idx, image_ref, Some(pulled))
         }
     }))
-    .buffered(concurrency.max(1));
+    .buffer_unordered(concurrency.max(1));
 
     while let Some((idx, image_ref, pulled)) = pulls.next().await {
         let Some(pulled) = pulled else {
@@ -355,16 +379,27 @@ enum Completeness {
 /// already overlap, and the client's AIMD window saturates well below the
 /// number of images in flight, so nesting a second level of concurrency here
 /// would add no throughput.
+///
+/// Every pull is retried here. This walk is the highest-volume request path in
+/// the prepare phase, one manifest read per tag plus one per platform, all
+/// against the same source registry at `ANALYZE_CONCURRENCY`, so it is exactly
+/// the shape that provokes a throttle. The retry lives at this call site
+/// rather than inside `manifest_pull` because the engine wraps its own
+/// `manifest_pull` calls in `with_retry`; putting one further down would
+/// multiply the two. `analyze` runs before the engine exists, so it brings its
+/// own.
 async fn pull_image_descriptors(
     source_client: &ocync_distribution::RegistryClient,
     source_repo: &RepositoryName,
     tag: &str,
     image_ref: &str,
+    retry: &RetryConfig,
 ) -> Result<(Vec<BlobDescriptor>, Completeness), CliError> {
-    let pulled = source_client
-        .manifest_pull(source_repo, tag)
-        .await
-        .map_err(|e| CliError::Input(format!("manifest_pull {image_ref}: {e}")))?;
+    let pulled = with_retry(retry, "analyze manifest pull", || {
+        source_client.manifest_pull(source_repo, tag)
+    })
+    .await
+    .map_err(|e| CliError::Input(format!("manifest_pull {image_ref}: {e}")))?;
 
     let mut descriptors = descriptors_of(&pulled.manifest);
     let mut completeness = Completeness::Full;
@@ -374,9 +409,11 @@ async fn pull_image_descriptors(
         for child in &index.manifests {
             // Platforms are independent: a missing arm64 manifest should not
             // discard the amd64 blobs already recorded for this image.
-            match source_client
-                .manifest_pull(source_repo, &child.digest.to_string())
-                .await
+            let child_ref = child.digest.to_string();
+            match with_retry(retry, "analyze child manifest pull", || {
+                source_client.manifest_pull(source_repo, &child_ref)
+            })
+            .await
             {
                 Ok(child_pulled) => descriptors.extend(descriptors_of(&child_pulled.manifest)),
                 Err(e) => {

--- a/src/cli/commands/synchronize.rs
+++ b/src/cli/commands/synchronize.rs
@@ -1382,25 +1382,49 @@ async fn resolve_all(
     let mut no_match = 0usize;
 
     // Resolution is independent per mapping and spends nearly all of its time
-    // waiting on a registry, so the waits overlap. `buffered` yields in config
-    // order however the registries answered, which keeps the bookkeeping below
-    // deterministic: it touches `watch_log` and the run's counters, and a log
-    // whose order changed run to run would be unreadable.
+    // waiting on a registry, so the waits overlap.
+    //
+    // `buffer_unordered` rather than `buffered`, and the difference is the
+    // whole point of the concurrency. An ordered queue frees a slot only when
+    // the head yields, so one mapping listing a repository with tens of
+    // thousands of tags pins its slot and every mapping that finished behind
+    // it keeps its own, leaving the window slack while the rest of the config
+    // waits. On a 95-mapping run that held the window at 2 or 3 of 16 for
+    // minutes at a time and gave back almost all of the speedup.
+    //
+    // Config order is still what the bookkeeping below needs, so each outcome
+    // carries its index and the results are put back in order once they are
+    // all in. That keeps `watch_log`, the run's counters, and the warning
+    // stream identical run to run however the registries answered.
     //
     // One consequence of overlapping: a mapping that a config error would once
     // have pre-empted may already have run and emitted its own warnings by the
     // time the error is reached. The run still stops at the first config error
     // in config order, which is what the exit code and the operator depend on.
-    let outcomes: Vec<(Result<MappingResolution, CliError>, Vec<DroppedTarget>)> =
-        futures_util::stream::iter(config.mappings.iter().map(|mapping| async move {
-            // The guard both names the mapping while it runs and counts it
-            // finished when it ends, however it ends.
-            let _item = tracker.track(&mapping.from);
-            resolve_mapping(mapping, config, clients, batch_checkers, with_report).await
+    /// One mapping's resolution alongside the targets it lost on the way.
+    ///
+    /// Named for what it holds rather than `MappingOutcome`, which is already
+    /// a `pub(crate)` struct in this file with an unrelated shape.
+    type ResolutionAndDropped = (Result<MappingResolution, CliError>, Vec<DroppedTarget>);
+
+    let mut indexed: Vec<(usize, ResolutionAndDropped)> =
+        futures_util::stream::iter(config.mappings.iter().enumerate().map(|(idx, mapping)| {
+            async move {
+                // The guard both names the mapping while it runs and counts it
+                // finished when it ends, however it ends.
+                let _item = tracker.track(&mapping.from);
+                (
+                    idx,
+                    resolve_mapping(mapping, config, clients, batch_checkers, with_report).await,
+                )
+            }
         }))
-        .buffered(concurrency.max(1))
+        .buffer_unordered(concurrency.max(1))
         .collect()
         .await;
+    indexed.sort_by_key(|(idx, _)| *idx);
+    let outcomes: Vec<ResolutionAndDropped> =
+        indexed.into_iter().map(|(_, outcome)| outcome).collect();
 
     for (mapping, (outcome, dropped)) in config.mappings.iter().zip(outcomes) {
         // Dropped targets come back whatever the outcome, so a mapping that
@@ -4182,6 +4206,134 @@ mappings:
         assert_eq!(resolution.resolved.len(), 2);
     }
 
+    /// A registry whose repositories do not all answer at the same speed.
+    ///
+    /// `slow` repositories answer after `slow_delay`, the rest after
+    /// `fast_delay`, and the slow ones come first in config order.
+    ///
+    /// The uniform fixture above cannot expose an ordered queue. When every
+    /// mapping takes the same time the head is never the straggler, so a
+    /// combinator that frees its slot only at the head behaves exactly like
+    /// one that frees each slot as it finishes. Real configs are the opposite
+    /// of uniform: a repository with tens of thousands of tags sits beside one
+    /// with three.
+    async fn skewed_tag_registry(
+        total: usize,
+        slow: &[usize],
+        slow_delay: Duration,
+        fast_delay: Duration,
+    ) -> (wiremock::MockServer, Config, ClientMap) {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path_regex(
+                r"^/v2/repo/slow\d+/tags/list$",
+            ))
+            .respond_with(SlowRecorder::tag_list(&arrivals(), slow_delay, &["v1"]))
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path_regex(
+                r"^/v2/repo/img[\w-]+/tags/list$",
+            ))
+            .respond_with(SlowRecorder::tag_list(&arrivals(), fast_delay, &["v1"]))
+            .mount(&server)
+            .await;
+
+        // Position matters: the queue is built in config order, so where the
+        // slow mappings sit is the whole variable.
+        let repos: Vec<String> = (0..total)
+            .map(|i| {
+                if slow.contains(&i) {
+                    format!("repo/slow{i}")
+                } else {
+                    format!("repo/img{i}")
+                }
+            })
+            .collect();
+
+        let yaml = config_yaml(&server, &repos, "      glob: [\"*\"]\n");
+        let config: Config = serde_yaml::from_str(&yaml).expect("generated config parses");
+        let src = test_client(&server.uri());
+
+        // Warm the registry's AIMD window before the measured run.
+        //
+        // The window opens at 1 and widens by `1/w` per success, so a cold
+        // client hands the first mapping the only permit and every other
+        // mapping waits on it regardless of how the queue above is built.
+        // That hides the queue's own behaviour behind the ramp. A real run
+        // reaches this phase against a registry that has been answering for
+        // minutes, so a warm window is the honest starting state.
+        // The window opens at 1 and grows by `1/w` per success, so it reaches
+        // `sqrt(1 + 2n)` after n of them: 8 successes give ~4.3, which only
+        // just clears a limit of 4. 16 give ~5.7, so AIMD is comfortably not
+        // the binding constraint and a slack window can only mean the queue.
+        let warmup = RepositoryName::new("repo/img-warmup").expect("fixture repo name is valid");
+        for _ in 0..16 {
+            src.list_tags(&warmup)
+                .await
+                .expect("warmup listing succeeds");
+        }
+
+        let clients = ClientMap::from([
+            ("src".to_string(), Ok(src)),
+            ("dst".to_string(), Ok(test_client(&server.uri()))),
+        ]);
+        (server, config, clients)
+    }
+
+    /// A slow mapping must not hold the window closed behind it.
+    ///
+    /// The concurrency limit is a ceiling on open mappings, but it is also a
+    /// floor: while any mapping has not started, the window has to be full,
+    /// or the run pays for slots it is not using. This is the half that
+    /// `resolve_all_never_exceeds_its_concurrency_limit` cannot see, because
+    /// a maximum is reached in the first instant and never contradicted after.
+    #[tokio::test]
+    async fn resolve_all_keeps_its_window_full_while_mappings_wait() {
+        let limit = 4;
+        let (_server, config, clients) = skewed_tag_registry(
+            12,
+            &[0],
+            Duration::from_millis(600),
+            Duration::from_millis(20),
+        )
+        .await;
+
+        let tracker = PrepareTracker::default();
+        let starved: Rc<Cell<Option<(usize, usize)>>> = Rc::new(Cell::new(None));
+        let checkers = HashMap::new();
+
+        let work = resolve_all(&config, &clients, &checkers, false, None, &tracker, limit);
+
+        let observer = {
+            let starved = Rc::clone(&starved);
+            let tracker = &tracker;
+            async move {
+                loop {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                    let p = tracker.snapshot();
+                    let unstarted = p.total.saturating_sub(p.done + p.in_flight);
+                    if unstarted > 0 && p.in_flight < limit {
+                        starved.set(Some((p.in_flight, unstarted)));
+                    }
+                }
+            }
+        };
+
+        let resolution = tokio::select! {
+            r = work => r.expect("no config-class failure in this fixture"),
+            _ = observer => unreachable!("the observer loops until resolution finishes"),
+        };
+
+        assert_eq!(resolution.resolved.len(), 12, "every mapping must resolve");
+        assert_eq!(
+            starved.get(),
+            None,
+            "the window went slack while mappings waited: (in_flight, unstarted)"
+        );
+    }
+
     /// A mapping's targets must be listed concurrently.
     ///
     /// The immutable-tag optimization lists every target's existing tags
@@ -4459,6 +4611,77 @@ mappings:
             "\nresolution runs at most {PREPARE_MAPPING_CONCURRENCY} mappings at once; \
              past that each registry's AIMD window is the binding constraint\n"
         );
+    }
+
+    /// What the prepare phase costs when the mappings are not all the same
+    /// size, which is the only shape that tells an ordered queue apart from a
+    /// window that refills as work finishes.
+    ///
+    /// `prepare_phase_benchmark_resolution_concurrency` gives every mapping
+    /// the same latency. Under uniform latency the head of a queue is never
+    /// the straggler, so both behave identically and the benchmark reports the
+    /// same speedup either way. Real configs are the opposite: a repository
+    /// with tens of thousands of tags sits beside one with three, and the slow
+    /// ones are scattered rather than bunched at the front.
+    ///
+    /// The floor is the slowest single mapping, since concurrency removes the
+    /// queueing behind it but not its own duration. A run landing at a
+    /// multiple of the floor is paying for slots it is not using.
+    #[tokio::test]
+    #[ignore = "wall-clock benchmark against a latency-injected mock registry"]
+    async fn prepare_phase_benchmark_skewed_resolution() {
+        let mappings = 95;
+        let slow_delay = Duration::from_millis(800);
+        let fast_delay = Duration::from_millis(20);
+        // One slow mapping per window: the shape a run actually hits, and the
+        // one an ordered queue handles worst, because each slow mapping pins
+        // its own window instead of sharing one with the others.
+        let slow: Vec<usize> = (0..mappings).step_by(PREPARE_MAPPING_CONCURRENCY).collect();
+
+        println!(
+            "\n{mappings} mappings, {} slow at {}ms, rest at {}ms, one slow per window\n",
+            slow.len(),
+            slow_delay.as_millis(),
+            fast_delay.as_millis()
+        );
+        println!(
+            "{:>11}  {:>10}  {:>10}  {:>14}",
+            "concurrency", "elapsed", "floor", "over floor"
+        );
+
+        for concurrency in [1usize, 8, 16, 32] {
+            let (_server, config, clients) =
+                skewed_tag_registry(mappings, &slow, slow_delay, fast_delay).await;
+
+            let started = std::time::Instant::now();
+            let resolution = resolve_all(
+                &config,
+                &clients,
+                &HashMap::new(),
+                false,
+                None,
+                &PrepareTracker::default(),
+                concurrency,
+            )
+            .await
+            .expect("no config-class failure in this fixture");
+            let elapsed = started.elapsed();
+            assert_eq!(resolution.resolved.len(), mappings);
+
+            // Every mapping still has to run, so the floor is whichever is
+            // larger: the slowest single mapping, or the total work spread
+            // evenly across the window.
+            let total_work = slow_delay.mul_f64(slow.len() as f64)
+                + fast_delay.mul_f64((mappings - slow.len()) as f64);
+            let floor = slow_delay.max(total_work.div_f64(concurrency as f64));
+            println!(
+                "{concurrency:>11}  {:>9.2}s  {:>9.2}s  {:>13.1}x",
+                elapsed.as_secs_f64(),
+                floor.as_secs_f64(),
+                elapsed.as_secs_f64() / floor.as_secs_f64()
+            );
+        }
+        println!();
     }
 
     /// How many round trips one repository's tag listing costs, with and


### PR DESCRIPTION
## Problem

Two defects, found from a v0.8.0 run whose prepare phase was unchanged from before #123 made it concurrent.

**The concurrency window collapsed.** `resolve_all` used an ordered `buffered` queue, which frees a slot only when the head yields. One mapping listing a deep repository pinned its slot, every mapping that finished behind it kept its own, and the window sat at 2 or 3 of 16 while the config waited:

```
done=74 total=95 in_flight=3  slowest=docker.io/postgres slowest_secs=98  elapsed_secs=255
done=75 total=95 in_flight=2  slowest=docker.io/postgres slowest_secs=358 elapsed_secs=515
done=84 total=95 in_flight=7  slowest=docker.io/rsyslog-fips                elapsed_secs=520
```

Nine mappings did not complete during that final tick. They had finished minutes earlier and were waiting to be released. 625 seconds to do 442 seconds of work.

**Nothing in the prepare phase retried.** The engine retries the work it drives through `with_retry`, but the prepare phase runs before the engine exists. A single 429 failed a whole mapping.

## Why the benchmark missed it

Two blind spots, both needed:

1. `slow_tag_registry(mappings, delay)` gives every mapping the **same** delay. Under uniform latency an ordered queue and a window that refills on completion are indistinguishable, because the head is never the straggler.
2. `resolve_all_never_exceeds_its_concurrency_limit` asserts a **ceiling**. `buffered` reaches 16 in the first instant, so that assertion passes while the window collapses behind it.

Both are fixed. `skewed_tag_registry` places deep repositories deliberately, and `resolve_all_keeps_its_window_full_while_mappings_wait` asserts the floor: while any mapping is unstarted, the window must be full. It fails on the old code with `Some((1, 8))`, three slots idle and eight mappings blocked.

The fixture also warms the AIMD window first. Cold, the window opens at 1, so the first mapping holds the only permit and nothing else can issue regardless of the queue above it. That hid the bug on the first attempt at this test.

## Changes

**Mappings and both analyze walks use `buffer_unordered`**, carrying each outcome's index and sorting once every result is in, so `watch_log`, the counters, and config-order bookkeeping are unchanged. Blob aggregation in `analyze` now runs in completion order, which the report does not need: every figure it prints is a count, a sum, or a sorted container.

The target-listing fan-out at `synchronize.rs` is deliberately left as `buffered`. Its concurrency equals its item count, so no queue can form.

**Retry in the prepare phase**, through one shape in a new `ocync_distribution::retry`:

- `list_tags`, including the body read, so a connection reset part way through a page is re-sent rather than failing the listing.
- `token_exchange::exchange`, both the `/v2/` ping and the realm token request.
- `acr::exchange_post`.
- `analyze`'s manifest walk, at its call site via `ocync_sync::retry::with_retry`, because `manifest_pull` is shared with the engine and a retry further down would multiply the two.

Three details are load-bearing:

- **Backoff is jittered.** Up to 16 mappings hit one registry at once, so an unjittered schedule sends every throttled retry back in lockstep and produces the next burst.
- **The auth paths return the throttled response rather than raising it.** An earlier revision raised a 429 as a typed error, which gave it a `status_code()` and let the engine's `with_retry` classify an auth failure as retryable, multiplying this retry by the engine's own and aiming four times the requests at a registry already asking for less.
- **A tag listing draws from one budget for the whole walk.** Four retries per page across up to `MAX_TAG_PAGES` pages is a bound only on paper.

`is_transient_transport` is now the single transient-transport predicate for the workspace, and `ocync_sync::retry::should_retry_transport` delegates to it. The previous two copies disagreed: one listed `is_timeout() || is_connect()`, which `is_request()` already covers on the async hyper path, and omitted `is_body()`/`is_decode()`, which it does not. `with_retry` moved from `engine.rs` to `retry.rs` beside `RetryConfig` and the `should_retry*` predicates, and is now `pub` so `analyze` can use it.

## Measurements

**Skewed benchmark**, 95 mappings, one deep repository per window among shallow ones, same run both ways:

| Concurrency | ordered `buffered` | `buffer_unordered` |
|---|---|---|
| 1 | 6.92s | 6.92s |
| 8 | 4.97s | 1.21s |
| **16** | **4.84s** | **1.09s** |
| 32 | 2.49s | 1.09s |

The first column is the reported defect: serial to 16-way bought 1.4x.

**Live, 95 mappings against `public.ecr.aws`, `--dry-run`:**

| | before | after |
|---|---|---|
| exit code | 1 | 0 |
| failed mappings | 5 | 0 |
| AIMD halvings | 5 | 2 |
| retries fired and recovered | n/a | 2 |

**Live, 21 mappings**, before and after the concurrency change: byte-identical dry-run output, `md5 451e274b429a43d41ea3270e5dbc968a` both.

## Registry behavior

Measured 2026-08-28, and recorded in `docs/src/content/registries/ecr-public.md` per the rule in CLAUDE.md: ECR Public draws repeated 429s on `TagList` while ocync paces it at 8 requests per second **with credentials loaded**, halving the AIMD window 11 to 6 to 3. AWS publishes no TPS quota for tag listing at all; the 8 is derived from the 10 TPS authenticated *pull* quota, and the read window groups tag listing in with pulls.

The value is documented as measured-insufficient rather than replaced with a guess. Lowering it wants its own measurement, and the retry makes the current pacing survivable in the meantime.

## Not changed, deliberately

- **The docker credential helper has no retry.** Its timeout path is documented as a possible wait for interactive input, and `build_clients` is a serial loop, so retrying would turn a 30s hang into a 150s stall of the whole prepare phase. A helper that fails for real already falls back to anonymous.
- **`send_with_aimd` and `manifest_pull` still do not retry.** They are on the engine's path, which already does. `get_429_retries_and_succeeds` pins that layering.

## Tests

15 new, 1488 passing, 0 failing.

- `resolve_all_keeps_its_window_full_while_mappings_wait`, plus the `skewed_tag_registry` fixture and `prepare_phase_benchmark_skewed_resolution`
- `list_tags_retries_after_a_429`, `list_tags_gives_up_after_persistent_429s` (pinning the exact attempt count, so an unbounded retry fails it)
- `exchange_retries_a_throttled_token_endpoint`, `exchange_gives_up_on_a_persistently_throttled_endpoint`
- `retrying_gives_up_and_surfaces_the_last_error`, `retrying_does_not_re_run_a_permanent_failure`, `only_a_throttle_is_transient_among_statuses`, `backoff_grows_and_is_capped`, `backoff_is_decorrelated`, `a_refused_connection_is_transient`, `a_status_error_is_not_a_transport_failure`

`a_refused_connection_is_transient` provokes a real error from a closed port rather than asserting against a hand-built one, because the predicate has to match the failure that actually shows up: the run that motivated the token-exchange fix died on "error sending request for url (.../token/...)".

Every new test was mutation-checked. Reverting `buffer_unordered`, zeroing the retry bound, and inverting the transport predicate each fail the test that covers them.

Gate: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo deny check`, all green.
